### PR TITLE
Fix: Resolve React.Children undefined error causing production loading spinner

### DIFF
--- a/apps/frontend/src/components/layout/PropertyManagementLayout.tsx
+++ b/apps/frontend/src/components/layout/PropertyManagementLayout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils/css.utils'
 

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -9,8 +9,13 @@ import { EnvironmentCheck } from './components/error/EnvironmentCheck'
 import './index.css'
 
 // Ensure React is available globally for any libraries that might need it
-if (typeof window !== 'undefined' && !window.React) {
+// This is critical for production builds where React.Children might be accessed
+if (typeof window !== 'undefined') {
   window.React = React
+  // Ensure React.Children is explicitly available
+  if (!window.React.Children) {
+    window.React.Children = React.Children
+  }
 }
 
 // Log initialization info in development only

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -199,6 +199,8 @@ export default defineConfig(({ command, mode }: ConfigEnv): UserConfig => {
 		},
 		// Dedupe packages to reduce bundle size
 		dedupe: ['react', 'react-dom', '@tanstack/react-query'],
+		// Preserve React for dynamic access
+		preserveSymlinks: false,
 	},
 	server: {
 		host: env.VITE_HOST || '0.0.0.0',
@@ -259,8 +261,10 @@ export default defineConfig(({ command, mode }: ConfigEnv): UserConfig => {
 		// ESBuild options
 		esbuildOptions: {
 			target: 'esnext',
-			// Remove console.log in production
+			// Remove console.log in production but preserve React structure
 			drop: isProd ? ['console', 'debugger'] : [],
+			// Ensure React is not tree-shaken
+			keepNames: true,
 		},
 	},
 	// Define environment variables with types


### PR DESCRIPTION
## Summary
- Fixes the production loading spinner issue where the landing page gets stuck showing the static HTML loading state
- Resolves React.Children undefined error preventing React from mounting properly

## Changes Made
- **Fixed React import**: Changed `import * as React from 'react'` to `import React from 'react'` in PropertyManagementLayout.tsx
- **Enhanced global React assignment**: Ensure `window.React` and `window.React.Children` are explicitly available in production
- **Updated Vite config**: Added `keepNames: true` to esbuildOptions to prevent React from being tree-shaken incorrectly

## Root Cause
The static loading spinner in `index.html` (lines 80-84) was showing because React wasn't mounting properly due to a React.Children undefined error in production builds. This prevented the React app from replacing the static HTML with the actual application.

## Test Plan
- [x] Build completes successfully with new configuration
- [ ] Production deployment shows landing page without stuck loading spinner
- [ ] Verify React.Children functionality works in production
- [ ] Confirm no regressions in other pages

🤖 Generated with [Claude Code](https://claude.ai/code)