### PR TITLE
fix(build): Resolve production build initialization error

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -90,7 +90,7 @@ export default defineConfig(({ command, mode }: ConfigEnv): UserConfig => {
 					if (id.includes('node_modules')) {
 						// CRITICAL: Keep React ecosystem together in MAIN bundle with HIGHEST priority
 						// This prevents React.Children undefined errors by ensuring React loads SYNCHRONOUSLY first
-						if (id.includes('react') || 
+						if (id.includes('react') ||
 							id.includes('react-dom') ||
 							id.includes('react/') ||
 							id.includes('react-dom/') ||
@@ -99,6 +99,7 @@ export default defineConfig(({ command, mode }: ConfigEnv): UserConfig => {
 							id.includes('react/jsx-runtime') ||
 							id.includes('react/jsx-dev-runtime') ||
 							id.includes('use-sync-external-store') ||
+							id.includes('@supabase/ssr') ||
 							id.includes('react-is')) {
 							return undefined // MUST stay in main bundle for immediate availability
 						}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "tenantflow",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -38,7 +39,6 @@
         "eslint-plugin-turbo": "^2.5.5",
         "globals": "^16.3.0",
         "jsdom": "^26.1.0",
-        "lightningcss-linux-x64-gnu": "^1.29.0",
         "prettier": "^3.6.2",
         "tsx": "^4.20.3",
         "turbo": "^2.5.5",


### PR DESCRIPTION
This commit fixes a critical production issue where the application would hang on an infinite loading spinner due to a JavaScript ReferenceError.

The root cause was the manual chunking strategy in `vite.config.ts`. The `@supabase/ssr` package, which has a dependency on React, was being incorrectly bundled into a generic `vendor` chunk. In the production build, this vendor chunk was being loaded and executed before the main application chunk containing React, leading to a "Cannot access uninitialized variable" error.

The fix involves updating the `manualChunks` logic in `vite.config.ts` to explicitly include `@supabase/ssr` in the main application bundle, alongside React and its ecosystem. This ensures that all critical dependencies are available synchronously at startup, resolving the initialization race condition.