### PR TITLE
Fix: Vercel deployment path issue in workflow

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -256,7 +256,6 @@ jobs:
         run: npm install -g vercel@latest
         
       - name: Pull Vercel environment
-        working-directory: apps/frontend
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -265,7 +264,6 @@ jobs:
           vercel pull --yes --environment=${{ needs.validate.outputs.is_production == 'true' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
           
       - name: Build for Vercel
-        working-directory: apps/frontend
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -275,7 +273,6 @@ jobs:
           
       - name: Deploy to Vercel
         id: deploy
-        working-directory: apps/frontend
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Problem
The Vercel deployment was failing with:
```
Error: ENOENT: no such file or directory, open '/home/runner/work/tenant-flow/tenant-flow/apps/frontend/apps/frontend/package.json'
```

## Root Cause
The workflow was using `working-directory: apps/frontend` for Vercel CLI commands, but Vercel should be run from the repository root since `vercel.json` already specifies the project location.

## Solution
Removed `working-directory` from the Vercel deployment steps (Pull Vercel environment, Build for Vercel, Deploy to Vercel) so commands run from the repository root.

## Testing
This should fix the deployment workflow that was failing after the optimize/bundle-chunking merge.