### PR TITLE
fix: resolve Vercel deployment build error with SubscriptionStatus im…

### DIFF
--- a/apps/frontend/src/hooks/api/use-billing.ts
+++ b/apps/frontend/src/hooks/api/use-billing.ts
@@ -18,10 +18,10 @@ import type {
   CreateCheckoutSessionRequest,
   CreateCheckoutSessionResponse,
   SubscriptionUpdateParams,
-  Plan
+  Plan,
+  SubscriptionStatus
 } from '@repo/shared'
 import { createMutationAdapter } from '@repo/shared'
-import type { SubscriptionStatus } from '@repo/shared/types/stripe-pricing'
 import { toast } from 'sonner'
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -86,12 +86,14 @@
       "cache": true
     },
     "@repo/frontend#build": {
-      "dependsOn": ["@repo/shared#build"],
+      "dependsOn": ["@repo/shared#build", "@repo/database#generate"],
       "inputs": [
         "src/**",
+        "app/**",
+        "components/**",
+        "lib/**",
         "public/**",
-        "index.html",
-        "vite.config.ts",
+        "next.config.mjs",
         "tsconfig*.json",
         "package.json",
         "!**/*.md",
@@ -102,12 +104,12 @@
         "!**/playwright-report/**"
       ],
       "outputs": [
-        "dist/**",
+        ".next/**",
         ".turbo/**"
       ],
       "env": [
         "NODE_ENV",
-        "VITE_*"
+        "NEXT_PUBLIC_*"
       ],
       "cache": true
     },


### PR DESCRIPTION
…port

- Fix TypeScript import error in use-billing.ts by importing SubscriptionStatus from @repo/shared main export
- Update turbo.json configuration for @repo/frontend#build task with correct Next.js settings
- Add missing dependency on @repo/database#generate for frontend build
- Fix output directory from dist/** to .next/** for Next.js builds
- Update environment variables from VITE_* to NEXT_PUBLIC_* for Next.js

This resolves the CI/CD deployment failure where Vercel couldn't find the @repo/shared/types/stripe-pricing module during the build process.

🤖 Generated with [Claude Code](https://claude.ai/code)