### PR TITLE
fix: update OAuth divider styling to prevent line through text

### DIFF
--- a/apps/frontend/src/components/auth/auth-form-factory.tsx
+++ b/apps/frontend/src/components/auth/auth-form-factory.tsx
@@ -623,16 +623,13 @@ export function AuthFormFactory({ config, onSuccess }: AuthFormFactoryProps) {
           {/* OAuth Section */}
           {showOAuth && (
             <>
-              {/* Divider */}
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-background px-2 text-muted-foreground">
-                    Or continue with
-                  </span>
-                </div>
+              {/* Divider with proper spacing */}
+              <div className="relative flex items-center">
+                <div className="flex-grow border-t border-gray-300" />
+                <span className="flex-shrink mx-4 text-xs text-muted-foreground uppercase tracking-wider">
+                  Or continue with
+                </span>
+                <div className="flex-grow border-t border-gray-300" />
               </div>
 
               {/* OAuth Providers */}

--- a/apps/frontend/src/components/auth/forms/supabase-login-form.tsx
+++ b/apps/frontend/src/components/auth/forms/supabase-login-form.tsx
@@ -175,16 +175,13 @@ export function SupabaseLoginForm({
 						</Button>
 					</form>
 
-					{/* Divider */}
-					<div className="relative">
-						<div className="absolute inset-0 flex items-center">
-							<span className="w-full border-t" />
-						</div>
-						<div className="relative flex justify-center text-xs uppercase">
-							<span className="bg-background px-2 text-muted-foreground">
-								Or continue with
-							</span>
-						</div>
+					{/* Divider with proper spacing */}
+					<div className="relative flex items-center">
+						<div className="flex-grow border-t border-gray-300" />
+						<span className="flex-shrink mx-4 text-xs text-muted-foreground uppercase tracking-wider">
+							Or continue with
+						</span>
+						<div className="flex-grow border-t border-gray-300" />
 					</div>
 
 					{/* Social Login */}

--- a/apps/frontend/src/components/auth/signup-form-fields.tsx
+++ b/apps/frontend/src/components/auth/signup-form-fields.tsx
@@ -134,15 +134,13 @@ export function SignupFormFields({
       </form>
 
       {/* Divider */}
-      <div className="relative">
-        <div className="absolute inset-0 flex items-center">
-          <span className="w-full border-t" />
-        </div>
-        <div className="relative flex justify-center text-xs uppercase">
-          <span className="bg-background px-2 text-muted-foreground">
-            Or continue with
-          </span>
-        </div>
+      {/* Divider with proper spacing */}
+      <div className="relative flex items-center">
+        <div className="flex-grow border-t border-gray-300" />
+        <span className="flex-shrink mx-4 text-xs text-muted-foreground uppercase tracking-wider">
+          Or continue with
+        </span>
+        <div className="flex-grow border-t border-gray-300" />
       </div>
 
       {/* Social Signup */}


### PR DESCRIPTION
- Replace absolute positioning approach with flexbox layout
- Use flex-grow for divider lines on either side of text
- Apply consistent spacing with mx-4 for text margins
- Update all auth forms (login, signup, auth-form-factory)
- Ensures divider lines stop and start properly around text