### PR TITLE
fix: ensure session established before rendering property creation form

### DIFF
--- a/apps/frontend/src/app/(protected)/manage/properties/new/page.tsx
+++ b/apps/frontend/src/app/(protected)/manage/properties/new/page.tsx
@@ -1,5 +1,16 @@
+import { requireSession } from '#lib/server-auth'
 import { CreatePropertyForm } from '../create-property-form.client'
 
-export default function NewPropertyPage() {
+/**
+ * New Property Page - Server Component
+ * 
+ * Ensures session is established before rendering client form.
+ * This prevents 401 errors from TanStack Query trying to refetch
+ * persisted cache before browser session is ready.
+ */
+export default async function NewPropertyPage() {
+	// ✅ Server-side auth - ensures session exists before client hydration
+	await requireSession()
+	
 	return <CreatePropertyForm />
 }


### PR DESCRIPTION
Prevents 401 errors from TanStack Query cache refetching before browser session is ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced server-side session enforcement on the property management page to ensure secure access before rendering.

* **Documentation**
  * Added documentation comments describing implementation details and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->