### PR TITLE
fix: prevent null description in property creation

### DIFF
--- a/packages/shared/src/validation/properties.ts
+++ b/packages/shared/src/validation/properties.ts
@@ -163,7 +163,7 @@ export const transformPropertyFormData = (
 	ownerId: string = ''
 ) => ({
 	name: data.name,
-	description: data.description || null,
+	description: data.description || '',
 	propertyType:
 		data.propertyType as Database['public']['Enums']['PropertyType'],
 	address: data.address,


### PR DESCRIPTION
- Change transformPropertyFormData to keep empty string instead of null
- Backend DTO expects string | undefined, not string | null
- Fixes validation error: 'expected string, received null'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property description handling to consistently treat missing descriptions as empty strings rather than null values, ensuring better application stability and compatibility across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->