### PR TITLE
fix: add resetCounters() to UUID mock for test isolation

### DIFF
--- a/apps/backend/__mocks__/uuid.js
+++ b/apps/backend/__mocks__/uuid.js
@@ -4,7 +4,7 @@
 //
 // IMPORTANT: Call resetCounters() in your test's beforeEach hook to ensure test isolation:
 //
-//   import { v4, resetCounters } from 'uuid'
+//   const { v4, resetCounters } = require('uuid')
 //
 //   describe('MyService', () => {
 //     beforeEach(() => {


### PR DESCRIPTION
Module-level counters (v4Counter, v1Counter, v3Counter, v5Counter) persist across tests causing interdependent/non-deterministic behavior.

Added:
- resetCounters() function that resets all four counters to 0
- Exported alongside existing v1/v3/v4/v5 functions
- File header documentation instructing test files to call resetCounters() in beforeEach hooks for proper test isolation

This ensures deterministic UUID generation across test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced UUID mock utilities with a new public reset function to clear internal counters for improved test isolation and predictable state across test runs.
  * Added usage documentation and an example to guide test setup and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->