### PR TITLE
fix: metrics service optimization

### DIFF
--- a/apps/backend/src/health/metrics.service.ts
+++ b/apps/backend/src/health/metrics.service.ts
@@ -46,24 +46,13 @@ export class MetricsService implements OnModuleDestroy {
 		{ result: ServiceHealth; timestamp: number }
 	>()
 	
-	private readonly thresholds: MetricsThresholds
-	private readonly MAX_CACHE_SIZE: number
-
-	constructor(thresholds?: Partial<MetricsThresholds>) {
-		const defaultThresholds: MetricsThresholds = {
-			memory: { warning: 80, critical: 95 },
-			cache: { maxEntries: 100 },
-			responseTime: { warning: 100, critical: 200 }
-		}
-
-		this.thresholds = {
-			memory: thresholds?.memory ?? defaultThresholds.memory,
-			cache: thresholds?.cache ?? defaultThresholds.cache,
-			responseTime: thresholds?.responseTime ?? defaultThresholds.responseTime
-		}
-
-		this.MAX_CACHE_SIZE = this.thresholds.cache.maxEntries
+	private readonly thresholds: MetricsThresholds = {
+		memory: { warning: 80, critical: 95 },
+		cache: { maxEntries: 100 },
+		responseTime: { warning: 100, critical: 200 }
 	}
+
+	private readonly MAX_CACHE_SIZE = this.thresholds.cache.maxEntries
 
 	/**
 	 * Cleanup cache on module destruction to prevent memory leaks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal initialization flow for the metrics service configuration to use inline defaults instead of constructor parameters, maintaining existing threshold behavior and cache size semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->