### PR TITLE
perf: add ISR caching + timeout to blog metadata queries

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -15,9 +15,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const supabase = await createClient()
 
 	// Race against 5s timeout to prevent Supabase cold-start hangs (80-398s observed in Sentry)
-	const timeout = new Promise<never>((_, reject) =>
-		setTimeout(() => reject(new Error('Blog metadata query timed out')), 5000)
-	)
+	let timer: ReturnType<typeof setTimeout>
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error('Blog metadata query timed out')), 5000)
+	})
 	const query = supabase
 		.from('blogs')
 		.select('title, excerpt, meta_description, featured_image, published_at, category')
@@ -26,8 +27,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 		.single()
 
 	const post = await Promise.race([query, timeout])
-		.then(result => result.data)
+		.then(({ data, error }) => {
+			if (error) console.error('Blog metadata query failed:', error.message)
+			return data
+		})
 		.catch(() => null)
+		.finally(() => clearTimeout(timer!))
 
 	if (!post) {
 		return { title: 'Blog Post Not Found | TenantFlow' }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,10 @@ import { createClient } from '#lib/supabase/server'
 import type { Metadata } from 'next'
 import BlogPostPage from './blog-post-page'
 
+// Cache blog pages for 1 hour via ISR — generateMetadata only runs during
+// background revalidation, not on every request (27K+ requests/month)
+export const revalidate = 3600
+
 interface Props {
 	params: Promise<{ slug: string }>
 }
@@ -10,12 +14,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { slug } = await params
 	const supabase = await createClient()
 
-	const { data: post } = await supabase
+	// Race against 5s timeout to prevent Supabase cold-start hangs (80-398s observed in Sentry)
+	const timeout = new Promise<never>((_, reject) =>
+		setTimeout(() => reject(new Error('Blog metadata query timed out')), 5000)
+	)
+	const query = supabase
 		.from('blogs')
 		.select('title, excerpt, meta_description, featured_image, published_at, category')
 		.eq('slug', slug)
 		.eq('status', 'published')
 		.single()
+
+	const post = await Promise.race([query, timeout])
+		.then(result => result.data)
+		.catch(() => null)
 
 	if (!post) {
 		return { title: 'Blog Post Not Found | TenantFlow' }


### PR DESCRIPTION
## Summary

- Add `revalidate = 3600` (1h ISR) to `/blog/[slug]` — `generateMetadata` only runs during background revalidation, not on every request
- Add 5s timeout to the Supabase query to prevent cold-start hangs (80-398s observed in Sentry traces)
- `/blog/[slug]` handles 27K requests/month (96% of all traffic) — this eliminates uncached DB hits on the hottest route

## Context

Sentry performance audit revealed every `/blog/[slug]` request was making an uncached Supabase query in `generateMetadata`. On April 2, multiple traces showed the query hanging for 80-398 seconds (likely Supabase cold starts). ISR caching means the query only runs once per hour during background revalidation.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] 1,519 unit tests pass
- [ ] Verify blog pages still render with correct metadata
- [ ] Confirm ISR headers in Vercel response (`x-vercel-cache: HIT` after first request)