### PR TITLE
chore(deps): pin node engine to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"version": "1.0.1",
 	"type": "module",
 	"engines": {
-		"node": ">=24",
-		"pnpm": ">=10"
+		"node": "24.x",
+		"pnpm": "10.x"
 	},
 	"packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
 	"imports": {


### PR DESCRIPTION
## Summary

Pin `engines.node` to `24.x` (from `>=24`) to silence Vercel's auto-upgrade warning and lock the production runtime to Node 24 LTS.

## Why

Vercel surfaces this warning on every build:

> Detected `"engines": { "node": ">=24" }` in your `package.json` that will automatically upgrade when a new major Node.js Version is released.

Open-ended `>=24` means Vercel will silently jump to Node 25, 26, etc. as they ship, which can break the build without any code change on our side. Project target per `CLAUDE.md` is Node 24.x, so pinning matches stated intent.

Pnpm range pinned to `10.x` for the same reason.

## Test Plan

- [x] Pre-commit hooks pass locally (typecheck, lint, 1,610 unit tests, gitleaks)
- [ ] CI green on PR
- [ ] Vercel preview deploys cleanly without the engine warning

[hudsor01]
