### PR TITLE
fix(rent-payments): gate rent charge paths with RENT_PAYMENTS_ENABLED

### DIFF
--- a/supabase/functions/stripe-autopay-charge/index.ts
+++ b/supabase/functions/stripe-autopay-charge/index.ts
@@ -36,6 +36,20 @@ Deno.serve(async (req: Request) => {
   const jsonHeaders = { 'Content-Type': 'application/json' }
 
   // ---------------------------------------------------------------------------
+  // RENT_PAYMENTS_ENABLED flag — defense in depth.
+  // Primary kill-switch is cron.unschedule('process-autopay-charges').
+  // This guard stops any ad-hoc invocation (manual curl, rescheduled cron,
+  // anything else that reaches the function) from firing real charges.
+  // Default: OFF. Set RENT_PAYMENTS_ENABLED=true in Supabase secrets to enable.
+  // ---------------------------------------------------------------------------
+  if (Deno.env.get('RENT_PAYMENTS_ENABLED') !== 'true') {
+    return new Response(
+      JSON.stringify({ skipped: true, reason: 'Rent payments disabled (RENT_PAYMENTS_ENABLED flag off)' }),
+      { status: 200, headers: jsonHeaders }
+    )
+  }
+
+  // ---------------------------------------------------------------------------
   // Environment variables
   // ---------------------------------------------------------------------------
   let env: Record<string, string>
@@ -259,6 +273,7 @@ Deno.serve(async (req: Request) => {
         destination: connectedAccount.stripe_account_id,
       },
       metadata: {
+        kind: 'rent',
         tenant_id,
         lease_id,
         property_id: propertyId,

--- a/supabase/functions/stripe-autopay-charge/index.ts
+++ b/supabase/functions/stripe-autopay-charge/index.ts
@@ -43,6 +43,7 @@ Deno.serve(async (req: Request) => {
   // Default: OFF. Set RENT_PAYMENTS_ENABLED=true in Supabase secrets to enable.
   // ---------------------------------------------------------------------------
   if (Deno.env.get('RENT_PAYMENTS_ENABLED') !== 'true') {
+    logEvent('[AUTOPAY] Skipped: RENT_PAYMENTS_ENABLED flag is off', {})
     return new Response(
       JSON.stringify({ skipped: true, reason: 'Rent payments disabled (RENT_PAYMENTS_ENABLED flag off)' }),
       { status: 200, headers: jsonHeaders }

--- a/supabase/functions/stripe-rent-checkout/index.ts
+++ b/supabase/functions/stripe-rent-checkout/index.ts
@@ -18,6 +18,29 @@ Deno.serve(async (req: Request) => {
   const jsonHeaders = getJsonHeaders(req)
 
   // ---------------------------------------------------------------------------
+  // PHASE3 GATE — hard disable of tenant-initiated rent checkout.
+  // This returns 503 regardless of RENT_PAYMENTS_ENABLED. Tenant rent checkout
+  // is intentionally locked off until an explicit Phase 3 code change + deploy
+  // re-enables it (after LLC formation and compliance review). Grep for
+  // "PHASE3 GATE" to locate before removing.
+  // ---------------------------------------------------------------------------
+  return new Response(
+    JSON.stringify({ error: 'Rent payments are not currently available.' }),
+    { status: 503, headers: jsonHeaders }
+  )
+
+  // ---------------------------------------------------------------------------
+  // RENT_PAYMENTS_ENABLED flag (defense in depth — unreachable while PHASE3 GATE above is active)
+  // ---------------------------------------------------------------------------
+  // deno-lint-ignore no-unreachable
+  if (Deno.env.get('RENT_PAYMENTS_ENABLED') !== 'true') {
+    return new Response(
+      JSON.stringify({ error: 'Rent payments are temporarily disabled.' }),
+      { status: 503, headers: jsonHeaders }
+    )
+  }
+
+  // ---------------------------------------------------------------------------
   // Environment variables
   // ---------------------------------------------------------------------------
   let env: Record<string, string>
@@ -317,6 +340,7 @@ Deno.serve(async (req: Request) => {
         },
         setup_future_usage: 'off_session',
         metadata: {
+          kind: 'rent',
           tenant_id: tenant.id,
           lease_id: lease.id,
           property_id: propertyId,

--- a/supabase/functions/stripe-webhooks/handlers/payment-intent-succeeded.ts
+++ b/supabase/functions/stripe-webhooks/handlers/payment-intent-succeeded.ts
@@ -19,6 +19,32 @@ export async function handlePaymentIntentSucceeded(
   const pi = event.data.object as Stripe.PaymentIntent
   const metadata = pi.metadata ?? {}
 
+  // ---------------------------------------------------------------------------
+  // RENT_PAYMENTS_ENABLED flag — refuse to record a rent payment while the
+  // feature is disabled. This branch should be UNREACHABLE in normal operation
+  // (cron is unscheduled, tenant checkout returns 503). If we see it fire, it
+  // means real money moved through Stripe while the platform was supposed to
+  // be off — surface loudly for manual reconciliation rather than silently
+  // persisting DB state for it.
+  // Gated on metadata.kind === 'rent' (affirmative marker set at every rent
+  // PI creation site) rather than inferring from tenant_id/lease_id presence.
+  // ---------------------------------------------------------------------------
+  if (Deno.env.get('RENT_PAYMENTS_ENABLED') !== 'true' && metadata['kind'] === 'rent') {
+    captureWebhookError(
+      new Error('Rent payment_intent.succeeded received while RENT_PAYMENTS_ENABLED is off'),
+      {
+        message: '[WEBHOOK] Rent payment succeeded while feature disabled — manual reconciliation required',
+        event_id: event.id,
+        pi_id: pi.id,
+        pi_amount: pi.amount,
+        tenant_id: metadata['tenant_id'],
+        lease_id: metadata['lease_id'],
+        rent_due_id: metadata['rent_due_id'],
+      }
+    )
+    return
+  }
+
   // PAY-10: Validate required metadata — reject empty strings
   const tenantId = metadata['tenant_id']
   const leaseId = metadata['lease_id']

--- a/supabase/migrations/20260417120000_autopay_rent_payments_enabled_gate.sql
+++ b/supabase/migrations/20260417120000_autopay_rent_payments_enabled_gate.sql
@@ -1,0 +1,183 @@
+-- =============================================================================
+-- migration: add RENT_PAYMENTS_ENABLED gate to process_autopay_charges()
+-- purpose: defense-in-depth. The primary kill-switch is
+--   SELECT cron.unschedule('process-autopay-charges');
+-- This adds a second gate so that if the job is ever rescheduled, it still
+-- short-circuits unless app.settings.RENT_PAYMENTS_ENABLED = 'true'.
+--
+-- Postgres-level config toggle (run manually when ready to re-enable):
+--   ALTER DATABASE postgres SET "app.settings.RENT_PAYMENTS_ENABLED" = 'true';
+-- And to turn back off:
+--   ALTER DATABASE postgres SET "app.settings.RENT_PAYMENTS_ENABLED" = 'false';
+-- Default (unset) is OFF.
+--
+-- depends on:
+--   20260304160000_autopay_cron_retry.sql (function this replaces)
+-- =============================================================================
+
+create or replace function public.process_autopay_charges()
+returns void
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_record             record;
+  v_supabase_url       text;
+  v_service_key        text;
+  v_edge_fn_url        text;
+  v_rent_enabled       text;
+begin
+  -- RENT_PAYMENTS_ENABLED gate (defense-in-depth against accidental re-scheduling).
+  v_rent_enabled := current_setting('app.settings.RENT_PAYMENTS_ENABLED', true);
+  if coalesce(v_rent_enabled, '') <> 'true' then
+    raise notice 'process_autopay_charges: RENT_PAYMENTS_ENABLED is not "true" (value=%), skipping', coalesce(v_rent_enabled, '<unset>');
+    return;
+  end if;
+
+  -- Read supabase configuration from database settings.
+  v_supabase_url := current_setting('app.settings.SUPABASE_URL', true);
+  v_service_key  := current_setting('app.settings.SUPABASE_SERVICE_ROLE_KEY', true);
+
+  if v_supabase_url is null or v_supabase_url = '' then
+    raise notice 'process_autopay_charges: SUPABASE_URL not configured, skipping';
+    return;
+  end if;
+
+  if v_service_key is null or v_service_key = '' then
+    raise notice 'process_autopay_charges: SUPABASE_SERVICE_ROLE_KEY not configured, skipping';
+    return;
+  end if;
+
+  v_edge_fn_url := v_supabase_url || '/functions/v1/stripe-autopay-charge';
+
+  -- =========================================================================
+  -- Cursor 1: Due-date charges (unchanged from 20260304160000)
+  -- =========================================================================
+  for v_record in
+    select
+      rd.id as rent_due_id,
+      rd.amount as full_amount,
+      round((rd.amount * lt.responsibility_percentage / 100)::numeric, 2) as tenant_amount,
+      rd.due_date,
+      rd.unit_id,
+      lt.responsibility_percentage,
+      l.id as lease_id,
+      l.owner_user_id,
+      l.autopay_payment_method_id,
+      l.unit_id as lease_unit_id,
+      t.id as tenant_id,
+      t.stripe_customer_id
+    from public.rent_due rd
+    join public.leases l
+      on l.id = rd.lease_id
+      and l.auto_pay_enabled = true
+      and l.lease_status = 'active'
+      and l.autopay_payment_method_id is not null
+    join public.lease_tenants lt
+      on lt.lease_id = l.id
+    join public.tenants t
+      on t.id = lt.tenant_id
+      and t.stripe_customer_id is not null
+    where
+      rd.due_date = current_date
+      and rd.status = 'pending'
+      and not exists (
+        select 1 from public.rent_payments rp
+        where rp.rent_due_id = rd.id
+          and rp.tenant_id = t.id
+          and rp.status in ('succeeded', 'processing')
+      )
+  loop
+    perform net.http_post(
+      url     := v_edge_fn_url,
+      body    := jsonb_build_object(
+        'tenant_id',                  v_record.tenant_id,
+        'lease_id',                   v_record.lease_id,
+        'rent_due_id',                v_record.rent_due_id,
+        'amount',                     v_record.tenant_amount,
+        'stripe_customer_id',         v_record.stripe_customer_id,
+        'autopay_payment_method_id',  v_record.autopay_payment_method_id,
+        'owner_user_id',              v_record.owner_user_id,
+        'unit_id',                    v_record.unit_id
+      ),
+      headers := jsonb_build_object(
+        'Content-Type',  'application/json',
+        'Authorization', 'Bearer ' || v_service_key
+      ),
+      timeout_milliseconds := 15000
+    );
+  end loop;
+
+  -- =========================================================================
+  -- Cursor 2: Retry charges (unchanged from 20260304160000)
+  -- =========================================================================
+  for v_record in
+    select
+      rd.id as rent_due_id,
+      rd.amount as full_amount,
+      round((rd.amount * lt.responsibility_percentage / 100)::numeric, 2) as tenant_amount,
+      rd.due_date,
+      rd.unit_id,
+      rd.autopay_attempts,
+      lt.responsibility_percentage,
+      l.id as lease_id,
+      l.owner_user_id,
+      l.autopay_payment_method_id,
+      l.unit_id as lease_unit_id,
+      t.id as tenant_id,
+      t.stripe_customer_id
+    from public.rent_due rd
+    join public.leases l
+      on l.id = rd.lease_id
+      and l.auto_pay_enabled = true
+      and l.lease_status = 'active'
+      and l.autopay_payment_method_id is not null
+    join public.lease_tenants lt
+      on lt.lease_id = l.id
+    join public.tenants t
+      on t.id = lt.tenant_id
+      and t.stripe_customer_id is not null
+    where
+      rd.autopay_next_retry_at is not null
+      and rd.autopay_next_retry_at <= now()
+      and rd.autopay_attempts < 3
+      and rd.status != 'paid'
+      and not exists (
+        select 1 from public.rent_payments rp
+        where rp.rent_due_id = rd.id
+          and rp.tenant_id = t.id
+          and rp.status in ('succeeded', 'processing')
+      )
+  loop
+    perform net.http_post(
+      url     := v_edge_fn_url,
+      body    := jsonb_build_object(
+        'tenant_id',                  v_record.tenant_id,
+        'lease_id',                   v_record.lease_id,
+        'rent_due_id',                v_record.rent_due_id,
+        'amount',                     v_record.tenant_amount,
+        'stripe_customer_id',         v_record.stripe_customer_id,
+        'autopay_payment_method_id',  v_record.autopay_payment_method_id,
+        'owner_user_id',              v_record.owner_user_id,
+        'unit_id',                    v_record.unit_id
+      ),
+      headers := jsonb_build_object(
+        'Content-Type',  'application/json',
+        'Authorization', 'Bearer ' || v_service_key
+      ),
+      timeout_milliseconds := 15000
+    );
+  end loop;
+end;
+$$;
+
+comment on function public.process_autopay_charges() is
+  'pg_cron job: runs daily at 07:00 UTC when scheduled. Gated by '
+  'app.settings.RENT_PAYMENTS_ENABLED (must equal "true" to execute). '
+  'Two cursors: (1) initial charges for rent_due records due today with '
+  'autopay enabled, computing per-tenant amounts from '
+  'lease_tenants.responsibility_percentage; (2) retry charges for failed '
+  'autopay where autopay_next_retry_at <= now() and autopay_attempts < 3. '
+  'Retry schedule: day 1 initial, day 3 retry 1, day 7 retry 2. '
+  'Invokes stripe-autopay-charge Edge Function via pg_net. Idempotent.';

--- a/supabase/migrations/20260417120000_autopay_rent_payments_enabled_gate.sql
+++ b/supabase/migrations/20260417120000_autopay_rent_payments_enabled_gate.sql
@@ -39,6 +39,7 @@ begin
   v_supabase_url := current_setting('app.settings.SUPABASE_URL', true);
   v_service_key  := current_setting('app.settings.SUPABASE_SERVICE_ROLE_KEY', true);
 
+  -- Abort gracefully if not configured.
   if v_supabase_url is null or v_supabase_url = '' then
     raise notice 'process_autopay_charges: SUPABASE_URL not configured, skipping';
     return;
@@ -52,7 +53,8 @@ begin
   v_edge_fn_url := v_supabase_url || '/functions/v1/stripe-autopay-charge';
 
   -- =========================================================================
-  -- Cursor 1: Due-date charges (unchanged from 20260304160000)
+  -- Cursor 1: Due-date charges (initial autopay for today's rent)
+  -- Per-tenant amounts computed from lease_tenants.responsibility_percentage.
   -- =========================================================================
   for v_record in
     select
@@ -82,6 +84,7 @@ begin
     where
       rd.due_date = current_date
       and rd.status = 'pending'
+      -- Skip if a payment already exists for this tenant + rent_due
       and not exists (
         select 1 from public.rent_payments rp
         where rp.rent_due_id = rd.id
@@ -110,7 +113,9 @@ begin
   end loop;
 
   -- =========================================================================
-  -- Cursor 2: Retry charges (unchanged from 20260304160000)
+  -- Cursor 2: Retry charges (failed autopay from previous days)
+  -- Queries rent_due records where autopay_next_retry_at has arrived
+  -- and fewer than 3 attempts have been made.
   -- =========================================================================
   for v_record in
     select
@@ -143,6 +148,7 @@ begin
       and rd.autopay_next_retry_at <= now()
       and rd.autopay_attempts < 3
       and rd.status != 'paid'
+      -- Skip if a payment already exists for this tenant + rent_due
       and not exists (
         select 1 from public.rent_payments rp
         where rp.rent_due_id = rd.id


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mDefense-in-depth kill-switch for tenant rent facilitation. The rent-payment[0m
[38;5;8m   4[0m [37msurface is held off production until Phase 3 (post-LLC formation,[0m
[38;5;8m   5[0m [37mpost-compliance review). Landlord SaaS subscription billing is unaffected.[0m
[38;5;8m   6[0m 
[38;5;8m   7[0m [37m**Primary kill-switch remains `SELECT cron.unschedule('process-autopay-charges');` run separately against the DB.** This PR adds belt-and-suspenders gates so that a re-scheduled cron, a manual curl, or any other invocation of the rent paths is blocked until the flag is explicitly flipped on.[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37m### Changes[0m
[38;5;8m  10[0m 
[38;5;8m  11[0m [37m- `stripe-rent-checkout/index.ts` — unconditional 503 at top of handler (PHASE3 GATE, tagged in comment for greppable Phase 3 removal), followed by a defense-in-depth `RENT_PAYMENTS_ENABLED` flag check.[0m
[38;5;8m  12[0m [37m- `stripe-autopay-charge/index.ts` — flag check returns `200 {skipped: true}` to avoid pg_net retry noise from cron.[0m
[38;5;8m  13[0m [37m- `stripe-webhooks/handlers/payment-intent-succeeded.ts` — skips rent PI recording when flag is off. Gated on affirmative `metadata.kind === 'rent'` marker (not inferred from `tenant_id`/`lease_id` presence). Logs to Sentry via `captureWebhookError` for manual reconciliation if it ever fires.[0m
[38;5;8m  14[0m [37m- New migration `20260417120000_autopay_rent_payments_enabled_gate.sql` — `CREATE OR REPLACE` for `process_autopay_charges()` with an `app.settings.RENT_PAYMENTS_ENABLED` short-circuit as the first check.[0m
[38;5;8m  15[0m [37m- Adds `kind: 'rent'` to rent PaymentIntent metadata at both creation sites (`stripe-rent-checkout`, `stripe-autopay-charge`) so the webhook gate has a reliable affirmative signal.[0m
[38;5;8m  16[0m 
[38;5;8m  17[0m [37m### Default behavior[0m
[38;5;8m  18[0m 
[38;5;8m  19[0m [37mFlag unset in all envs → rent paths disabled. No production behavior change until:[0m
[38;5;8m  20[0m [37m- `RENT_PAYMENTS_ENABLED=true` is set in Supabase Edge Function secrets, AND[0m
[38;5;8m  21[0m [37m- `ALTER DATABASE postgres SET "app.settings.RENT_PAYMENTS_ENABLED" = 'true';` is run in Postgres[0m
[38;5;8m  22[0m 
[38;5;8m  23[0m [37mSubscription billing (`stripe-checkout`, `stripe-billing-portal`, `stripe-cancel-subscription`, `invoice.*` webhooks) is NOT gated by this flag.[0m
[38;5;8m  24[0m 
[38;5;8m  25[0m [37m## Test plan[0m
[38;5;8m  26[0m 
[38;5;8m  27[0m [37mAfter merge + deploy + `supabase db push`:[0m
[38;5;8m  28[0m 
[38;5;8m  29[0m [37m- [ ] `curl -X POST https://<project>.functions.supabase.co/stripe-rent-checkout -H "Authorization: Bearer <tenant_jwt>" -d '{"rent_due_id":"..."}' ` → **expect 503** with `{"error":"Rent payments are not currently available."}`[0m
[38;5;8m  30[0m [37m- [ ] `curl -X POST https://<project>.functions.supabase.co/stripe-autopay-charge -H "Authorization: Bearer <service_role_key>" -d '{"tenant_id":"...","lease_id":"...","rent_due_id":"...","amount":1,"stripe_customer_id":"...","autopay_payment_method_id":"...","owner_user_id":"...","unit_id":"..."}'` → **expect 200** with `{"skipped":true,"reason":"Rent payments disabled..."}`[0m
[38;5;8m  31[0m [37m- [ ] `SELECT * FROM cron.job WHERE jobname='process-autopay-charges';` → zero rows (after separate `cron.unschedule`)[0m
[38;5;8m  32[0m [37m- [ ] Landlord SaaS subscription checkout flow still works end-to-end (unaffected)[0m
[38;5;8m  33[0m [37m- [ ] Pre-commit: 1,634 unit tests pass (verified locally)[0m
[38;5;8m  34[0m 
[38;5;8m  35[0m [37m## Do NOT merge until[0m
[38;5;8m  36[0m 
[38;5;8m  37[0m [37m- [ ] You've run the A-I blast-radius queries and confirmed production has zero autopay-configured leases and zero charge-ready connected accounts (or documented the exceptions)[0m
[38;5;8m  38[0m [37m- [ ] You've run `SELECT cron.unschedule('process-autopay-charges');` in Supabase[0m
[38;5;8m  39[0m [37m- [ ] `SELECT jobid FROM cron.job WHERE jobname='process-autopay-charges';` returns zero rows[0m
[38;5;8m  40[0m 
[38;5;8m  41[0m [37m[hudsor01][0m