### PR TITLE
fix(rent-payments): gate calculate_late_fees with RENT_PAYMENTS_ENABLED

### DIFF
--- a/supabase/migrations/20260417130000_late_fees_rent_payments_enabled_gate.sql
+++ b/supabase/migrations/20260417130000_late_fees_rent_payments_enabled_gate.sql
@@ -1,0 +1,105 @@
+-- =============================================================================
+-- migration: add RENT_PAYMENTS_ENABLED gate to calculate_late_fees()
+-- purpose: defense-in-depth. `calculate_late_fees` runs daily at 00:01 UTC
+--   and mutates `rent_payments.status` + inserts `late_fees` rows even though
+--   no money moves. This is the same class of unsupervised state mutation
+--   that motivated PR #593's autopay gate.
+--
+-- Primary kill-switch (NOT applied by this migration; operator decision):
+--   SELECT cron.unschedule('calculate-late-fees');
+--
+-- This migration adds a second gate so that if the job is ever rescheduled,
+-- it short-circuits unless app.settings.RENT_PAYMENTS_ENABLED = 'true'.
+-- Reuses the same Postgres config var as process_autopay_charges() — one
+-- toggle flips both.
+--
+-- Postgres-level toggle (manual, when ready to re-enable both rent flows):
+--   ALTER DATABASE postgres SET "app.settings.RENT_PAYMENTS_ENABLED" = 'true';
+-- And to turn back off:
+--   ALTER DATABASE postgres SET "app.settings.RENT_PAYMENTS_ENABLED" = 'false';
+-- Default (unset) is OFF.
+--
+-- depends on:
+--   20260222120000_phase56_pg_cron_jobs.sql (function this replaces)
+--   20260417120000_autopay_rent_payments_enabled_gate.sql (sibling gate, PR #593)
+-- =============================================================================
+
+create or replace function public.calculate_late_fees()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_payment record;
+  v_days_overdue integer;
+  v_new_status text;
+  v_rent_enabled text;
+begin
+  -- RENT_PAYMENTS_ENABLED gate (defense-in-depth).
+  v_rent_enabled := current_setting('app.settings.RENT_PAYMENTS_ENABLED', true);
+  if coalesce(v_rent_enabled, '') <> 'true' then
+    raise notice 'calculate_late_fees: RENT_PAYMENTS_ENABLED is not "true" (value=%), skipping', coalesce(v_rent_enabled, '<unset>');
+    return;
+  end if;
+
+  -- loop over overdue payments using skip locked to avoid contention on re-run
+  for v_payment in
+    select
+      rp.id,
+      rp.lease_id,
+      rp.due_date,
+      rp.status,
+      (current_date - rp.due_date) as days_overdue
+    from public.rent_payments rp
+    where
+      rp.status in ('pending', 'late', 'severely_delinquent')
+      and rp.due_date < (current_date - interval '3 days')
+      -- include severely_delinquent: fees accumulate every day until payment is resolved
+      -- (context.md locked decision: "Daily — each day past grace period creates a new fee record; fees accumulate")
+    for update skip locked
+  loop
+    v_days_overdue := current_date - v_payment.due_date;
+
+    -- insert a late fee record for today (unique index prevents duplicates on same day)
+    insert into public.late_fees (
+      rent_payment_id,
+      lease_id,
+      fee_amount,
+      days_overdue,
+      assessed_date
+    )
+    values (
+      v_payment.id,
+      v_payment.lease_id,
+      5000,            -- $50.00 in cents
+      v_days_overdue,
+      current_date
+    )
+    on conflict (rent_payment_id, assessed_date) do nothing;
+
+    -- determine new status based on days overdue
+    if v_days_overdue > 14 then
+      v_new_status := 'severely_delinquent';
+    else
+      v_new_status := 'late';
+    end if;
+
+    -- update payment status only if it has changed (avoids unnecessary writes)
+    if v_payment.status != v_new_status then
+      update public.rent_payments
+      set
+        status = v_new_status,
+        updated_at = now()
+      where id = v_payment.id;
+    end if;
+  end loop;
+end;
+$$;
+
+comment on function public.calculate_late_fees() is
+  'pg_cron job: runs daily at 00:01 UTC when scheduled. Gated by '
+  'app.settings.RENT_PAYMENTS_ENABLED (must equal "true" to execute). '
+  'Assesses $50/day late fees on rent_payments overdue >3 days. Sets '
+  'status=late (4-14 days) or severely_delinquent (>14 days). Inserts '
+  'one late_fees record per payment per day.';


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mDefense-in-depth sibling to PR #593. `calculate_late_fees()` runs daily at 00:01 UTC and mutates `rent_payments.status` plus inserts `late_fees` rows — same class of unsupervised state mutation as autopay, one tier less severe (no money moves, only DB state).[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37mThis migration adds a short-circuit on `app.settings.RENT_PAYMENTS_ENABLED` to the function body. Reuses the flag from PR #593 — one toggle flips both rent-state-mutating crons.[0m
[38;5;8m   6[0m 
[38;5;8m   7[0m [37m**Primary kill-switch remains `SELECT cron.unschedule('calculate-late-fees');` — NOT applied by this migration.** That's an operator decision after review.[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37m## What changes[0m
[38;5;8m  10[0m 
[38;5;8m  11[0m [37mSingle file: `supabase/migrations/20260417130000_late_fees_rent_payments_enabled_gate.sql`[0m
[38;5;8m  12[0m 
[38;5;8m  13[0m [37m`CREATE OR REPLACE FUNCTION public.calculate_late_fees()` with:[0m
[38;5;8m  14[0m [37m- New local: `v_rent_enabled text`[0m
[38;5;8m  15[0m [37m- New first-statement gate: `if coalesce(current_setting('app.settings.RENT_PAYMENTS_ENABLED', true), '') <> 'true' then raise notice...; return; end if;`[0m
[38;5;8m  16[0m [37m- Updated COMMENT[0m
[38;5;8m  17[0m 
[38;5;8m  18[0m [37m**Function body below the gate is byte-identical** to `supabase/migrations/20260222120000_phase56_pg_cron_jobs.sql:49-112` and to the live `pg_get_functiondef()` output. Verified via diff against both source and live. No other edits.[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37m## Default behavior after merge + apply[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m- Flag unset (default) → cron fires daily, raises notice, returns without mutating. `cron.job_run_details` records success. `check-cron-health` does NOT page.[0m
[38;5;8m  23[0m [37m- No `rent_payments` status transitions.[0m
[38;5;8m  24[0m [37m- No new `late_fees` rows.[0m
[38;5;8m  25[0m [37m- No user-facing behavior change (no money was moving anyway).[0m
[38;5;8m  26[0m 
[38;5;8m  27[0m [37m## `expire-leases` verification (per reviewer request)[0m
[38;5;8m  28[0m 
[38;5;8m  29[0m [37mConfirmed `expire-leases` cron has **no Stripe side effects**. Will NOT be gated in this PR.[0m
[38;5;8m  30[0m 
[38;5;8m  31[0m [37mChecked:[0m
[38;5;8m  32[0m 
[38;5;8m  33[0m [37m| Check | Result |[0m
[38;5;8m  34[0m [37m|---|---|[0m
[38;5;8m  35[0m [37m| Triggers on `public.leases` | 1 trigger: `sync_unit_status_on_lease_change` AFTER UPDATE OF lease_status. Function `sync_unit_status_from_lease()` only branches on `'active'` and `'ended'/'terminated'` — `'expired'` takes **no branch**, so no side effect |[0m
[38;5;8m  36[0m [37m| Supabase DB Webhooks (`supabase_functions.hooks`) targeting `leases` | **0 rows** |[0m
[38;5;8m  37[0m [37m| Foreign keys from `leases` to Stripe tables | `leases.stripe_connected_account_id` → `stripe_connected_accounts` is `ON DELETE SET NULL`; no cascade on UPDATE. Safe. |[0m
[38;5;8m  38[0m [37m| Functions referencing `lease_status = 'expired'` | `expire_leases` (self), `get_dashboard_data_v2` (read-only filter), `get_dashboard_stats` (read-only filter). All safe. |[0m
[38;5;8m  39[0m [37m| Edge Function invocations referencing expire-leases | None. Not called by any Edge Function or frontend code. |[0m
[38;5;8m  40[0m [37m| `expire_leases()` function body effects | Only: (1) `UPDATE leases SET lease_status='expired'` + `updated_at`, (2) `INSERT INTO notifications` (in-app only). No Stripe, no `pg_net`, no webhook. |[0m
[38;5;8m  41[0m 
[38;5;8m  42[0m [37m**Side observation (not in scope of this PR):** the `sync_unit_status_on_lease_change` trigger does NOT flip `units.status = 'available'` when a lease transitions to `'expired'` (only on `'ended'` / `'terminated'`). Units stay `'occupied'` after lease expiry. Either intentional (manual review required) or a pre-existing gap. Flagging for future consideration only.[0m
[38;5;8m  43[0m 
[38;5;8m  44[0m [37m## Full pg_cron inventory (state as of this PR)[0m
[38;5;8m  45[0m 
[38;5;8m  46[0m [37mDurable reference. 11 jobs scheduled, all active.[0m
[38;5;8m  47[0m 
[38;5;8m  48[0m [37m| # | Job | Schedule (UTC) | Touches rent state? | Status |[0m
[38;5;8m  49[0m [37m|---|---|---|---|---|[0m
[38;5;8m  50[0m [37m| 16 | **calculate-late-fees** | `1 0 * * *` | YES — writes `late_fees` + mutates `rent_payments.status` | **Gated by this PR** |[0m
[38;5;8m  51[0m [37m| 20 | **process-autopay-charges** | `0 7 * * *` | YES — fires Stripe charges via Edge Function | Gated by PR #593 |[0m
[38;5;8m  52[0m [37m| 17 | queue-lease-reminders | `0 6 * * *` | Reads leases only; writes `lease_reminders` email queue | Safe |[0m
[38;5;8m  53[0m [37m| 19 | payment-reminders | `0 9 * * *` | Reads `rent_due`; writes `notifications` | Email-only, no state/money |[0m
[38;5;8m  54[0m [37m| 23 | expire-leases | `0 23 * * *` | Writes `leases.lease_status='expired'` + `notifications` | **Verified clean, NOT gated** (see above) |[0m
[38;5;8m  55[0m [37m| 27 | check-cron-health | `0 * * * *` | No | Ops monitoring |[0m
[38;5;8m  56[0m [37m| 24 | cleanup-security-events | `0 3 * * *` | No | Data retention |[0m
[38;5;8m  57[0m [37m| 25 | cleanup-errors | `15 3 * * *` | No | Data retention |[0m
[38;5;8m  58[0m [37m| 26 | cleanup-webhook-events | `30 3 * * *` | No | Data retention |[0m
[38;5;8m  59[0m [37m| 28 | process-account-deletions | `45 3 * * *` | No | GDPR |[0m
[38;5;8m  60[0m [37m| 30 | cleanup-email-deliverability | `0 4 * * *` | No | Data retention |[0m
[38;5;8m  61[0m 
[38;5;8m  62[0m [37mOnly 2 jobs are rent-state-mutating. After this PR + PR #593 merge, both are gated by `app.settings.RENT_PAYMENTS_ENABLED`.[0m
[38;5;8m  63[0m 
[38;5;8m  64[0m [37m## Test plan[0m
[38;5;8m  65[0m 
[38;5;8m  66[0m [37mAfter merge + `supabase db push`:[0m
[38;5;8m  67[0m 
[38;5;8m  68[0m [37m- [ ] Verify function body updated: `SELECT pg_get_functiondef('public.calculate_late_fees'::regproc);` — should show the new `v_rent_enabled` check at the top[0m
[38;5;8m  69[0m [37m- [ ] Confirm flag is unset: `SELECT current_setting('app.settings.RENT_PAYMENTS_ENABLED', true);` returns NULL or empty[0m
[38;5;8m  70[0m [37m- [ ] Manual dry-run: `SELECT public.calculate_late_fees();` — should complete quickly with a `NOTICE` in the output, no new rows in `late_fees`, no status changes in `rent_payments`[0m
[38;5;8m  71[0m [37m- [ ] After next 00:01 UTC window: `SELECT * FROM cron.job_run_details WHERE jobname='calculate-late-fees' ORDER BY start_time DESC LIMIT 1;` — should show `succeeded`[0m
[38;5;8m  72[0m [37m- [ ] Pre-commit: no unit tests affected by this (pure SQL migration); hook passes[0m
[38;5;8m  73[0m 
[38;5;8m  74[0m [37m## Do NOT merge until[0m
[38;5;8m  75[0m 
[38;5;8m  76[0m [37m- [ ] PR #593 is merged first (dependency: shares the flag + migration naming convention)[0m
[38;5;8m  77[0m [37m- [ ] You've reviewed the migration diff and confirmed the function body below the gate is byte-identical to the current production version[0m
[38;5;8m  78[0m [37m- [ ] You're ready to `supabase db push` after merge (or approve me running `apply_migration` via MCP)[0m
[38;5;8m  79[0m 
[38;5;8m  80[0m [37m## Rules acknowledged[0m
[38;5;8m  81[0m 
[38;5;8m  82[0m [37m- No `cron.unschedule` included — operator decision post-merge[0m
[38;5;8m  83[0m [37m- No Edge Function changes[0m
[38;5;8m  84[0m [37m- No RLS changes[0m
[38;5;8m  85[0m [37m- No schema changes[0m
[38;5;8m  86[0m 
[38;5;8m  87[0m [37m[hudsor01][0m