### PR TITLE
feat(esign): gate DocuSeal send-for-signature behind Growth/Max tier

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -331,6 +331,11 @@ allow_dynamic_registration = false
 [functions.stripe-sync]
 verify_jwt = false
 
+# DocuSeal — uses handler.ts as entrypoint (not index.ts). Tier-gate + action
+# dispatch live in handler.ts; entitlement.ts is the entitlement helper.
+[functions.docuseal]
+entrypoint = "./functions/docuseal/handler.ts"
+
 [edge_runtime]
 enabled = true
 # Supported request policies: `oneshot`, `per_worker`.

--- a/supabase/functions/docuseal/entitlement.ts
+++ b/supabase/functions/docuseal/entitlement.ts
@@ -1,0 +1,75 @@
+// E-sign tier entitlement check.
+// Gates DocuSeal send-for-signature behind Growth/Max subscriptions.
+// Returns a Response to short-circuit the caller, or null to allow the action
+// through. Keeps the handler.ts dispatcher clean — all tier logic lives here.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { captureWebhookError } from '../_shared/errors.ts'
+
+// Live Tenant Flow price IDs for Growth and Max tiers.
+// Also includes lookup_key fallbacks in case Stripe prices gain lookup_keys
+// later (the webhook stores `price.lookup_key ?? price.id` in subscription_plan).
+const ESIGN_ENTITLED_PLANS: ReadonlySet<string> = new Set([
+  // Growth price IDs
+  'price_1SPGCNP3WCR53SdorjDpiSy5', 'price_1SPGCRP3WCR53SdonqLUTJgK',
+  // Max price IDs
+  'price_1Rd16pP3WCR53SdoCh3oJlDl', 'price_1Rd17AP3WCR53SdoTB4FTbSq',
+  // Lookup-key fallbacks
+  'growth', 'growth_monthly', 'growth_annual',
+  'max', 'max_monthly', 'max_annual',
+])
+
+const ACTIVE_SUB_STATUSES: ReadonlySet<string> = new Set(['active', 'trialing'])
+
+const JSON_CT = { 'Content-Type': 'application/json' }
+
+/**
+ * Check whether the authenticated owner has an active Growth or Max subscription.
+ * - Returns `null` if entitled (caller proceeds).
+ * - Returns a 402 Response with `upgrade_required: true` if not entitled.
+ * - Returns a 500 Response if the subscription lookup itself fails.
+ *
+ * Only called from the `send-for-signature` action. In-flight signatures
+ * (sign-owner, sign-tenant, cancel, resend) remain ungated so users can
+ * complete or cancel after downgrade.
+ */
+export async function checkESignEntitlement(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response | null> {
+  const { data: ownerSub, error: subErr } = await supabase
+    .from('users')
+    .select('subscription_status, subscription_plan')
+    .eq('id', userId)
+    .single()
+
+  if (subErr) {
+    captureWebhookError(subErr, {
+      message: 'Error fetching subscription for e-sign tier check',
+      user_id: userId,
+    })
+    return new Response(
+      JSON.stringify({ error: 'Unable to verify subscription' }),
+      { status: 500, headers: JSON_CT },
+    )
+  }
+
+  const ownerStatus = (ownerSub?.subscription_status as string | null) ?? null
+  const ownerPlan = (ownerSub?.subscription_plan as string | null) ?? null
+  const hasActiveSub = !!ownerStatus && ACTIVE_SUB_STATUSES.has(ownerStatus)
+  const onEntitledPlan = !!ownerPlan && ESIGN_ENTITLED_PLANS.has(ownerPlan)
+
+  if (!hasActiveSub || !onEntitledPlan) {
+    return new Response(
+      JSON.stringify({
+        error: 'E-signing requires a Growth or Max subscription.',
+        upgrade_required: true,
+        current_plan: ownerPlan,
+        current_status: ownerStatus,
+      }),
+      { status: 402, headers: JSON_CT },
+    )
+  }
+
+  return null
+}

--- a/supabase/functions/docuseal/entitlement.ts
+++ b/supabase/functions/docuseal/entitlement.ts
@@ -4,6 +4,7 @@
 // through. Keeps the handler.ts dispatcher clean — all tier logic lives here.
 
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { getJsonHeaders } from '../_shared/cors.ts'
 import { captureWebhookError } from '../_shared/errors.ts'
 
 // Live Tenant Flow price IDs for Growth and Max tiers.
@@ -21,8 +22,6 @@ const ESIGN_ENTITLED_PLANS: ReadonlySet<string> = new Set([
 
 const ACTIVE_SUB_STATUSES: ReadonlySet<string> = new Set(['active', 'trialing'])
 
-const JSON_CT = { 'Content-Type': 'application/json' }
-
 /**
  * Check whether the authenticated owner has an active Growth or Max subscription.
  * - Returns `null` if entitled (caller proceeds).
@@ -32,11 +31,18 @@ const JSON_CT = { 'Content-Type': 'application/json' }
  * Only called from the `send-for-signature` action. In-flight signatures
  * (sign-owner, sign-tenant, cancel, resend) remain ungated so users can
  * complete or cancel after downgrade.
+ *
+ * Takes `req` so responses carry the same CORS + JSON headers as every other
+ * response path in handler.ts (browser callers from FRONTEND_URL would
+ * otherwise reject the 402 due to missing Access-Control-Allow-Origin).
  */
 export async function checkESignEntitlement(
   supabase: SupabaseClient,
   userId: string,
+  req: Request,
 ): Promise<Response | null> {
+  const jsonHeaders = getJsonHeaders(req)
+
   const { data: ownerSub, error: subErr } = await supabase
     .from('users')
     .select('subscription_status, subscription_plan')
@@ -50,7 +56,7 @@ export async function checkESignEntitlement(
     })
     return new Response(
       JSON.stringify({ error: 'Unable to verify subscription' }),
-      { status: 500, headers: JSON_CT },
+      { status: 500, headers: jsonHeaders },
     )
   }
 
@@ -67,7 +73,7 @@ export async function checkESignEntitlement(
         current_plan: ownerPlan,
         current_status: ownerStatus,
       }),
-      { status: 402, headers: JSON_CT },
+      { status: 402, headers: jsonHeaders },
     )
   }
 

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -70,7 +70,7 @@ Deno.serve(async (req: Request) => {
       }
 
       // Tier entitlement check — Growth/Max only. See ./entitlement.ts.
-      const entitlementBlock = await checkESignEntitlement(supabase, user.id)
+      const entitlementBlock = await checkESignEntitlement(supabase, user.id, req)
       if (entitlementBlock) return entitlementBlock
 
       // 1. Fetch lease details

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -16,6 +16,7 @@ import { errorResponse, captureWebhookError } from '../_shared/errors.ts'
 import { escapeHtml } from '../_shared/escape-html.ts'
 import { validateEnv } from '../_shared/env.ts'
 import { createAdminClient } from '../_shared/supabase-client.ts'
+import { checkESignEntitlement } from './entitlement.ts'
 
 Deno.serve(async (req: Request) => {
   const optionsResponse = handleCorsOptions(req)
@@ -67,6 +68,10 @@ Deno.serve(async (req: Request) => {
           { status: 400, headers: getJsonHeaders(req) }
         )
       }
+
+      // Tier entitlement check — Growth/Max only. See ./entitlement.ts.
+      const entitlementBlock = await checkESignEntitlement(supabase, user.id)
+      if (entitlementBlock) return entitlementBlock
 
       // 1. Fetch lease details
       const { data: lease, error: leaseError } = await supabase


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mPaywall the ability to **initiate** a new e-signature behind Growth and Max plans. In-flight signatures (sign / cancel / resend) stay ungated so a downgrade doesn't strand a lease mid-signature.[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37mPer-plan behavior for `action=send-for-signature`:[0m
[38;5;8m   6[0m 
[38;5;8m   7[0m [37m| Plan | Outcome |[0m
[38;5;8m   8[0m [37m|---|---|[0m
[38;5;8m   9[0m [37m| FREETRIAL, STARTER, no sub | 402 Payment Required + `upgrade_required: true` |[0m
[38;5;8m  10[0m [37m| GROWTH or MAX with `active`/`trialing` status | Allowed (existing flow unchanged) |[0m
[38;5;8m  11[0m 
[38;5;8m  12[0m [37m## Structural change: no `index.ts`[0m
[38;5;8m  13[0m 
[38;5;8m  14[0m [37mPer project rule (no index filenames), the DocuSeal edge function entry is renamed:[0m
[38;5;8m  15[0m 
[38;5;8m  16[0m [37m- `supabase/functions/docuseal/index.ts` → `supabase/functions/docuseal/handler.ts`[0m
[38;5;8m  17[0m [37m- `supabase/config.toml` adds `[functions.docuseal]` with `entrypoint = "./functions/docuseal/handler.ts"` so the Supabase CLI picks it up[0m
[38;5;8m  18[0m [37m- Deploys via MCP must pass `entrypoint_path=source/handler.ts` (not the default `source/index.ts`)[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37mAll other edge functions in the project still use `index.ts` — this is a deliberate one-off for DocuSeal.[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m## Files[0m
[38;5;8m  23[0m 
[38;5;8m  24[0m [37m- **New**: `supabase/functions/docuseal/entitlement.ts` — `checkESignEntitlement(supabase, userId)` helper. Returns `Response | null`.[0m
[38;5;8m  25[0m [37m- **Renamed**: `supabase/functions/docuseal/index.ts` → `handler.ts` (unchanged apart from the two edits below)[0m
[38;5;8m  26[0m [37m- **Edited** (in `handler.ts`):[0m
[38;5;8m  27[0m [37m  - Added `import { checkESignEntitlement } from './entitlement.ts'`[0m
[38;5;8m  28[0m [37m  - 2-line call site inside the `send-for-signature` branch, right after the `!leaseId` validation[0m
[38;5;8m  29[0m [37m- **Edited**: `supabase/config.toml` — `[functions.docuseal]` entrypoint declaration[0m
[38;5;8m  30[0m 
[38;5;8m  31[0m [37m## Entitled set[0m
[38;5;8m  32[0m 
[38;5;8m  33[0m [37m- Growth price IDs: `price_1SPGCNP3WCR53SdorjDpiSy5`, `price_1SPGCRP3WCR53SdonqLUTJgK`[0m
[38;5;8m  34[0m [37m- Max price IDs: `price_1Rd16pP3WCR53SdoCh3oJlDl`, `price_1Rd17AP3WCR53SdoTB4FTbSq`[0m
[38;5;8m  35[0m [37m- Lookup-key fallbacks: `growth`, `growth_monthly`, `growth_annual`, `max`, `max_monthly`, `max_annual`[0m
[38;5;8m  36[0m 
[38;5;8m  37[0m [37mValid active statuses: `active`, `trialing`. Trial plan ID (`FREETRIAL`) is NOT in the entitled set by design — trial users see the upgrade prompt.[0m
[38;5;8m  38[0m 
[38;5;8m  39[0m [37m## Test plan[0m
[38;5;8m  40[0m 
[38;5;8m  41[0m [37mAfter merge + deploy:[0m
[38;5;8m  42[0m 
[38;5;8m  43[0m [37m- [ ] `curl -X POST https://<proj>.functions.supabase.co/docuseal -H "Authorization: Bearer <starter-user-jwt>" -d '{"action":"send-for-signature","leaseId":"..."}' ` → **expect 402** with `{upgrade_required: true, current_plan, current_status}`[0m
[38;5;8m  44[0m [37m- [ ] Same curl with a Growth/Max user JWT → proceeds to lease lookup as before[0m
[38;5;8m  45[0m [37m- [ ] Other actions (`sign-owner`, `sign-tenant`, `cancel`, `resend`) → unchanged behavior for any plan[0m
[38;5;8m  46[0m [37m- [ ] Pre-commit: 1,634 unit tests still pass (no src/ changes; edge function not covered by Vitest)[0m
[38;5;8m  47[0m 
[38;5;8m  48[0m [37m## Deploy plan (AFTER merge)[0m
[38;5;8m  49[0m 
[38;5;8m  50[0m [37mVia MCP `deploy_edge_function` with:[0m
[38;5;8m  51[0m [37m- `name: docuseal`[0m
[38;5;8m  52[0m [37m- `entrypoint_path: source/handler.ts`[0m
[38;5;8m  53[0m [37m- `import_map_path: source/deno.json`[0m
[38;5;8m  54[0m [37m- `verify_jwt: true` (preserves existing — the handler uses JWT auth)[0m
[38;5;8m  55[0m [37m- `files`: handler.ts, entitlement.ts, deno.json, + all `_shared/*` transitive deps (auth, cors, errors, env, escape-html, stripe-client, supabase-client)[0m
[38;5;8m  56[0m 
[38;5;8m  57[0m [37m## Do NOT merge until[0m
[38;5;8m  58[0m 
[38;5;8m  59[0m [37m- [ ] You review the rename impact (docuseal is now the only edge function with a non-default entrypoint in this repo)[0m
[38;5;8m  60[0m [37m- [ ] You confirm you're OK with the 402 Payment Required response shape[0m
[38;5;8m  61[0m 
[38;5;8m  62[0m [37m[hudsor01][0m