### PR TITLE
ci(claude): add timeout + concurrency cancel to prevent hung review runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,22 +3,18 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+# Cancel any in-progress review when new commits are pushed so stuck runs
+# do not accumulate against the PR's status checks.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
+    # Hard cap so a hung upstream Claude action cannot run for GitHub's 6h default.
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # Hard cap so a hung upstream Claude action cannot run for GitHub's 6h default.
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37m- PR #596's \`claude-review\` check hung in_progress for 20+ min with no timeout, blocking merge visibility.[0m
[38;5;8m   3[0m [37m- Root cause: \`claude-code-review.yml\` and \`claude.yml\` have no \`timeout-minutes\` (GitHub default = 6h) and no \`concurrency\` group — a stuck run would sit forever and new pushes queue alongside it instead of cancelling it.[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37m## Fix[0m
[38;5;8m   6[0m [37m- \`claude-code-review.yml\`: add \`concurrency: { group: claude-review-\${pr.number}, cancel-in-progress: true }\` and \`timeout-minutes: 15\` on the job.[0m
[38;5;8m   7[0m [37m- \`claude.yml\`: add \`timeout-minutes: 15\` on the \`@claude\`-mention job.[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37m## Test plan[0m
[38;5;8m  10[0m [37m- [x] Workflow YAML parses (committed through lefthook lint hooks)[0m
[38;5;8m  11[0m [37m- [ ] Next PR run cancels stale claude-review within 15 min[0m
[38;5;8m  12[0m [37m- [ ] Pushing a new commit to an in-progress PR cancels the prior review run[0m
[38;5;8m  13[0m 
[38;5;8m  14[0m [37m[hudsor01][0m