### PR TITLE
fix(db): drop before replace on get_subscription_status migration

### DIFF
--- a/supabase/migrations/20260419210000_restore_subscription_rpc_and_source_tracking.sql
+++ b/supabase/migrations/20260419210000_restore_subscription_rpc_and_source_tracking.sql
@@ -35,6 +35,14 @@ create index if not exists idx_users_subscription_source
 -- ============================================================================
 -- 2. get_subscription_status(p_customer_id) — IDOR-guarded RPC
 -- ============================================================================
+-- Drop-then-create to survive `supabase db reset` replay. A prior migration
+-- (20260414120000_get_subscription_status_rpc.sql) defined this function with
+-- `RETURNS TABLE(...)`; we're changing the return shape to jsonb. Postgres
+-- rejects that via CREATE OR REPLACE (42P13 cannot change return type).
+-- Prod-applied version survived because MCP apply_migration pre-processes,
+-- but a fresh dev / CI replay would fail without the explicit drop.
+drop function if exists public.get_subscription_status(text);
+
 create or replace function public.get_subscription_status(p_customer_id text)
 returns jsonb
 language plpgsql


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mP1 finding from the superpowers review of PR #605. Migration \`20260419210000_restore_subscription_rpc_and_source_tracking.sql\` uses \`CREATE OR REPLACE FUNCTION public.get_subscription_status(text)\` to change the return type from \`RETURNS TABLE(...)\` (defined by prior migration \`20260414120000_get_subscription_status_rpc.sql\`) to \`RETURNS jsonb\`. Postgres rejects that via \`42P13 cannot change return type of existing function\`.[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37m**Prod survived** because Supabase MCP's \`apply_migration\` pre-processes this case. Fresh replays break:[0m
[38;5;8m   6[0m [37m- \`supabase db reset\`[0m
[38;5;8m   7[0m [37m- New developer cloning the repo and bringing up a local stack[0m
[38;5;8m   8[0m [37m- CI fresh environment spinning up migrations from zero[0m
[38;5;8m   9[0m [37m- Branch databases[0m
[38;5;8m  10[0m 
[38;5;8m  11[0m [37mFix is one line: \`DROP FUNCTION IF EXISTS public.get_subscription_status(text);\` before the \`CREATE OR REPLACE\`.[0m
[38;5;8m  12[0m 
[38;5;8m  13[0m [37m## Trade-off[0m
[38;5;8m  14[0m 
[38;5;8m  15[0m [37mEditing an already-applied migration violates the "migrations are immutable" convention. In this case the edit:[0m
[38;5;8m  16[0m [37m- Doesn't change prod state (function body is identical; prod already has the jsonb version)[0m
[38;5;8m  17[0m [37m- Only affects future replay paths[0m
[38;5;8m  18[0m [37m- Has no risk of dev/prod drift[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37mThe alternative — adding a new migration to drop-and-recreate — doesn't work because the bad CREATE OR REPLACE in 20260419210000 would still fail on replay before any subsequent migration runs.[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m## Test plan[0m
[38;5;8m  23[0m [37m- [x] typecheck ✅[0m
[38;5;8m  24[0m [37m- [x] lint ✅[0m
[38;5;8m  25[0m [37m- [ ] Next CI replay succeeds (can't verify from dev box — watch CI on this PR)[0m
[38;5;8m  26[0m 
[38;5;8m  27[0m [37m[hudsor01][0m