### PR TITLE
docs(gsd): mark v2.2 Phase 53 shipped

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -107,7 +107,7 @@ TenantFlow is a multi-tenant property management SaaS platform for property owne
 **v2.2 Landlord-First Positioning** — Phases 52-54 (scoped 2026-04-20, target ship 2026-05-11).
 
 - [x] Phase 52: Dashboard copy + component rename (3d) — rename `invite-tenant-*` to `add-tenant-*`, empty-state rewrites, trial banner (shipped 2026-04-20, PR #609)
-- [ ] Phase 53: Public-facing value-prop reframe (1w) — homepage, features, pricing, FAQ, SEO, blog audit
+- [x] Phase 53: Public-facing value-prop reframe (1w) — homepage, features, pricing, FAQ, SEO, blog audit + positioning sweep `small landlord → property owner` (shipped 2026-04-20, PR #610)
 - [ ] Phase 54: Dashboard UX polish (2w, gated on user feedback) — empty states, sidebar reorg, settings IA
 
 v2.0 Phase 46 (premium reports gate) stays paused.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v2.2
 milestone_name: Landlord-First Positioning
 status: active
-stopped_at: v2.2 Phase 52 shipped 2026-04-20 (PR #609). Next up Phase 53 public-facing value-prop reframe. v2.1 Production Integrity shipped 2026-04-19/20. v2.0 Phase 46 (premium reports gate) still paused.
-last_updated: "2026-04-20T04:30:00.000Z"
+stopped_at: v2.2 Phase 52 shipped 2026-04-20 (PR #609) + Phase 53 shipped 2026-04-20 (PR #610). Phase 54 (dashboard UX polish) pending, gated on real-user feedback per roadmap.
+last_updated: "2026-04-20T05:00:00.000Z"
 last_activity: 2026-04-20
 progress:
   total_phases: 3
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 0
   completed_plans: 0
-  percent: 33
+  percent: 67
 ---
 
 # Project State: TenantFlow
@@ -26,10 +26,10 @@ See: .planning/PROJECT.md (updated 2026-04-13)
 
 ## Current Position
 
-Phase: 53 (pending — public-facing value-prop reframe)
+Phase: 54 (pending — dashboard UX polish, gated on trial-user feedback)
 Plan: -- (phase not yet started)
 Milestone: v2.2 Landlord-First Positioning — active. See `milestones/v2.2-ROADMAP.md` for scope.
-Status: Phase 52 shipped 2026-04-20 (PR #609): invite-tenant-* renamed to add-tenant-*, trial banner reads users.trial_ends_at, empty-states rewritten, regression test expanded to src/components/**. Next: homepage/pricing/features/FAQ/blog audit + rewrite to landlord-only positioning.
+Status: Phases 52 + 53 shipped 2026-04-20 (PRs #609 + #610). Public site + dashboard now aligned with landlord-only product; positioning scoped up from "small landlords" to "property owners" (size-neutral) per user direction. Phase 54 gated per roadmap kill-criterion: if no specific UX complaints in 2 weeks post-53, treat as "designed but not built" and defer.
 Last activity: 2026-04-20
 
 ## Shipped Milestones
@@ -50,7 +50,7 @@ Last activity: 2026-04-20
 |---------|------|--------|-------|--------|
 | v2.0 | Revenue Gates | 2 | 0 | Phase 45 shipped, Phase 46 PAUSED pending v2.2 |
 | v2.1 | Production Integrity Hardening | 4 | 0 | All 4 phases shipped 2026-04-19/20 (PRs #605, #606, #607) |
-| v2.2 | Landlord-First Positioning | 3 | 0 | Phase 52 shipped (PR #609), Phase 53 pending |
+| v2.2 | Landlord-First Positioning | 3 | 0 | Phases 52+53 shipped (PRs #609, #610), Phase 54 gated on feedback |
 
 ## Accumulated Context
 

--- a/.planning/milestones/v2.2-ROADMAP.md
+++ b/.planning/milestones/v2.2-ROADMAP.md
@@ -19,8 +19,8 @@ This milestone realigns what the product *says* with what it *does*.
 ## Phases (strict ordering — 53 depends on 52, 54 can wait for feedback)
 
 - [x] **Phase 52: Dashboard copy + component rename** (shipped 2026-04-20, PR #609)
-- [ ] **Phase 53: Public-facing value-prop reframe** (1 week)
-- [ ] **Phase 54: Dashboard UX polish** (2 weeks)
+- [x] **Phase 53: Public-facing value-prop reframe** (shipped 2026-04-20, PR #610)
+- [ ] **Phase 54: Dashboard UX polish** (2 weeks, gated on real-user feedback)
 
 ## Phase 52: Dashboard Copy + Component Rename
 


### PR DESCRIPTION
Updates STATE.md, ROADMAP.md, and v2.2-ROADMAP.md to reflect Phase 53 (PR #610) shipped 2026-04-20. Phase 54 pending, gated on real-user feedback per roadmap kill-criterion.

[hudsor01]