### PR TITLE
feat(phase-54a): competitor-driven UX quick wins

### DIFF
--- a/src/app/(owner)/dashboard/page.tsx
+++ b/src/app/(owner)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { toast } from 'sonner'
 import { ErrorBoundary } from '#components/error-boundary/error-boundary'
 import { Dashboard } from '#components/dashboard/dashboard'
+import { ExpiringLeasesWidget } from '#components/dashboard/expiring-leases-widget'
 import { OwnerOnboardingTour } from '#components/tours/owner-onboarding-tour'
 import { OnboardingWizard } from '#components/onboarding/onboarding-wizard'
 import {
@@ -168,6 +169,9 @@ function DashboardContent() {
 				onAddTenant={onAddTenant}
 				onCreateMaintenanceRequest={onCreateMaintenanceRequest}
 			/>
+			<div className="px-6 lg:px-8 pb-6 lg:pb-8">
+				<ExpiringLeasesWidget />
+			</div>
 		</div>
 	)
 }

--- a/src/app/(owner)/properties/property-details.client.tsx
+++ b/src/app/(owner)/properties/property-details.client.tsx
@@ -20,6 +20,7 @@ import { Building, Edit, MapPin, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { PropertyImageGallery } from '#components/properties/property-image-gallery'
+import { PropertyPerformanceSection } from '#components/properties/property-performance-section'
 import { PropertyUnitsTable } from '#components/properties/property-units-table'
 import { useDeletePropertyMutation } from '#hooks/api/use-property-mutations'
 import { toast } from 'sonner'
@@ -127,6 +128,9 @@ export function PropertyDetails({ property }: PropertyDetailsProps) {
 					</Button>
 				</ButtonGroup>
 			</div>
+
+			{/* Performance Metrics */}
+			<PropertyPerformanceSection propertyId={property.id} />
 
 			{/* Units Section */}
 			<PropertyUnitsTable

--- a/src/components/dashboard/expiring-leases-widget.tsx
+++ b/src/components/dashboard/expiring-leases-widget.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import Link from 'next/link'
+import { Clock, ChevronRight } from 'lucide-react'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle
+} from '#components/ui/card'
+import { Skeleton } from '#components/ui/skeleton'
+import { createClient } from '#lib/supabase/client'
+import { handlePostgrestError } from '#lib/postgrest-error-handler'
+import { leaseQueries } from '#hooks/api/query-keys/lease-keys'
+
+interface ExpiringLeaseRow {
+	id: string
+	end_date: string
+	rent_amount: number
+	tenant_name: string | null
+	unit_name: string | null
+	property_name: string | null
+}
+
+/**
+ * Enriched expiring-lease list joined with tenant + unit + property for
+ * the dashboard widget. Uses PostgREST FK join; limits to next 60 days.
+ */
+const expiringLeasesWithContext = queryOptions({
+	queryKey: [...leaseQueries.all(), 'expiring-enriched', 60],
+	queryFn: async (): Promise<ExpiringLeaseRow[]> => {
+		const supabase = createClient()
+		const now = new Date().toISOString()
+		const future = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString()
+
+		const { data, error } = await supabase
+			.from('leases')
+			.select(`
+				id,
+				end_date,
+				rent_amount,
+				tenants:primary_tenant_id (name),
+				units:unit_id (
+					name,
+					properties:property_id (name)
+				)
+			`)
+			.eq('lease_status', 'active')
+			.lte('end_date', future)
+			.gte('end_date', now)
+			.order('end_date', { ascending: true })
+			.limit(5)
+
+		if (error) handlePostgrestError(error, 'leases')
+
+		type Row = {
+			id: string
+			end_date: string
+			rent_amount: number
+			tenants: { name: string | null } | null
+			units: { name: string | null; properties: { name: string | null } | null } | null
+		}
+
+		return ((data ?? []) as unknown as Row[]).map(row => ({
+			id: row.id,
+			end_date: row.end_date,
+			rent_amount: row.rent_amount,
+			tenant_name: row.tenants?.name ?? null,
+			unit_name: row.units?.name ?? null,
+			property_name: row.units?.properties?.name ?? null
+		}))
+	},
+	staleTime: 5 * 60 * 1000
+})
+
+function daysUntil(dateIso: string): number {
+	const ms = new Date(dateIso).getTime() - Date.now()
+	return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)))
+}
+
+export function ExpiringLeasesWidget() {
+	const { data, isLoading } = useQuery(expiringLeasesWithContext)
+
+	if (isLoading) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Clock className="size-4 text-amber-600" aria-hidden="true" />
+						Leases expiring soon
+					</CardTitle>
+					<CardDescription>Next 60 days</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-2">
+					{Array.from({ length: 3 }).map((_, i) => (
+						<Skeleton key={i} className="h-12 w-full" />
+					))}
+				</CardContent>
+			</Card>
+		)
+	}
+
+	const leases = data ?? []
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2">
+					<Clock className="size-4 text-amber-600" aria-hidden="true" />
+					Leases expiring soon
+				</CardTitle>
+				<CardDescription>
+					{leases.length === 0
+						? 'No leases expiring in the next 60 days.'
+						: `${leases.length} lease${leases.length === 1 ? '' : 's'} expiring in the next 60 days.`}
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{leases.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						You&apos;re all caught up. New reminders will appear here 60 days before each lease ends.
+					</p>
+				) : (
+					<>
+						<ul className="divide-y divide-border">
+							{leases.map(lease => {
+								const days = daysUntil(lease.end_date)
+								const urgent = days <= 7
+								return (
+									<li key={lease.id} className="py-3">
+										<Link
+											href={`/leases/${lease.id}`}
+											className="flex items-center justify-between gap-3 rounded-md -mx-2 px-2 py-1.5 transition-colors hover:bg-accent"
+										>
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-sm font-medium text-foreground">
+													{lease.tenant_name ?? 'Tenant'}
+													{lease.unit_name ? ` · ${lease.unit_name}` : ''}
+												</p>
+												<p className="truncate text-xs text-muted-foreground">
+													{lease.property_name ?? 'Property'} · ends{' '}
+													{new Date(lease.end_date).toLocaleDateString('en-US', {
+														month: 'short',
+														day: 'numeric',
+														year: 'numeric'
+													})}
+												</p>
+											</div>
+											<div className="flex items-center gap-2 shrink-0">
+												<span
+													className={`text-xs font-semibold ${urgent ? 'text-destructive' : 'text-amber-700 dark:text-amber-400'}`}
+												>
+													{days} day{days === 1 ? '' : 's'}
+												</span>
+												<ChevronRight className="size-4 text-muted-foreground" aria-hidden="true" />
+											</div>
+										</Link>
+									</li>
+								)
+							})}
+						</ul>
+						<div className="pt-3">
+							<Link
+								href="/leases"
+								className="text-sm font-medium text-primary hover:underline"
+							>
+								View all leases →
+							</Link>
+						</div>
+					</>
+				)}
+			</CardContent>
+		</Card>
+	)
+}

--- a/src/components/leases/detail/lease-details.client.tsx
+++ b/src/components/leases/detail/lease-details.client.tsx
@@ -18,7 +18,6 @@ import {
 
 import { LeaseDetailsSkeleton } from './lease-details-skeleton'
 import { LeaseHeader } from './lease-header'
-import { useCurrentUser } from '#hooks/api/use-auth'
 import { formatCurrency } from '#lib/utils/currency'
 import { getOrdinalSuffix } from '#lib/formatters/date'
 import { generateTimelineEvents } from './lease-detail-utils'
@@ -36,7 +35,6 @@ const logger = createLogger({ component: 'LeaseDetails' })
 export function LeaseDetails({ id }: LeaseDetailsProps) {
 	const { data: lease, isLoading, isError, error } = useQuery(leaseQueries.detail(id))
 	const cancelSignature = useCancelSignatureRequestMutation()
-	const { user } = useCurrentUser()
 
 	const { data: tenantsResponse } = useQuery(tenantQueries.list())
 	const { data: units } = useUnitList()
@@ -85,7 +83,6 @@ export function LeaseDetails({ id }: LeaseDetailsProps) {
 				lease={lease}
 				tenant={tenant}
 				unitName={unit?.unit_number ?? null}
-				ownerEmail={user?.email ?? null}
 				onCancelSignature={handleCancelSignature}
 				isCancelling={cancelSignature.isPending}
 			/>

--- a/src/components/leases/detail/lease-details.client.tsx
+++ b/src/components/leases/detail/lease-details.client.tsx
@@ -18,6 +18,7 @@ import {
 
 import { LeaseDetailsSkeleton } from './lease-details-skeleton'
 import { LeaseHeader } from './lease-header'
+import { useCurrentUser } from '#hooks/api/use-auth'
 import { formatCurrency } from '#lib/utils/currency'
 import { getOrdinalSuffix } from '#lib/formatters/date'
 import { generateTimelineEvents } from './lease-detail-utils'
@@ -35,6 +36,7 @@ const logger = createLogger({ component: 'LeaseDetails' })
 export function LeaseDetails({ id }: LeaseDetailsProps) {
 	const { data: lease, isLoading, isError, error } = useQuery(leaseQueries.detail(id))
 	const cancelSignature = useCancelSignatureRequestMutation()
+	const { user } = useCurrentUser()
 
 	const { data: tenantsResponse } = useQuery(tenantQueries.list())
 	const { data: units } = useUnitList()
@@ -82,6 +84,8 @@ export function LeaseDetails({ id }: LeaseDetailsProps) {
 			<LeaseHeader
 				lease={lease}
 				tenant={tenant}
+				unitName={unit?.unit_number ?? null}
+				ownerEmail={user?.email ?? null}
 				onCancelSignature={handleCancelSignature}
 				isCancelling={cancelSignature.isPending}
 			/>

--- a/src/components/leases/detail/lease-header.tsx
+++ b/src/components/leases/detail/lease-header.tsx
@@ -19,6 +19,7 @@ import Link from 'next/link'
 import { SendForSignatureButton } from '#components/leases/send-for-signature-button'
 import { SignLeaseButton } from '#components/leases/sign-lease-button'
 import { DownloadSignedLeaseButton } from '#components/leases/download-signed-lease-button'
+import { RentIncreaseNoticeDialog } from '#components/leases/rent-increase-notice-dialog'
 import { toast } from 'sonner'
 import { cn } from '#lib/utils'
 import type { Lease } from '#types/core'
@@ -33,6 +34,8 @@ interface TenantInfo {
 interface LeaseHeaderProps {
 	lease: Lease
 	tenant: TenantInfo | null | undefined
+	unitName?: string | null
+	ownerEmail?: string | null
 	onCancelSignature: () => Promise<void>
 	isCancelling: boolean
 }
@@ -40,6 +43,8 @@ interface LeaseHeaderProps {
 export function LeaseHeader({
 	lease,
 	tenant,
+	unitName,
+	ownerEmail,
 	onCancelSignature,
 	isCancelling
 }: LeaseHeaderProps) {
@@ -162,6 +167,14 @@ export function LeaseHeader({
 					</>
 				)}
 				{isActive && <DownloadSignedLeaseButton leaseId={lease.id} size="sm" />}
+				{isActive && (
+					<RentIncreaseNoticeDialog
+						lease={lease}
+						tenantName={tenantFullName ?? null}
+						propertyAddress={unitName ?? null}
+						ownerName={ownerEmail ?? 'Property Owner'}
+					/>
+				)}
 				<Button asChild variant="outline" size="sm">
 					<Link href={`/leases/${lease.id}/edit`}>Edit Lease</Link>
 				</Button>

--- a/src/components/leases/detail/lease-header.tsx
+++ b/src/components/leases/detail/lease-header.tsx
@@ -35,7 +35,6 @@ interface LeaseHeaderProps {
 	lease: Lease
 	tenant: TenantInfo | null | undefined
 	unitName?: string | null
-	ownerEmail?: string | null
 	onCancelSignature: () => Promise<void>
 	isCancelling: boolean
 }
@@ -44,7 +43,6 @@ export function LeaseHeader({
 	lease,
 	tenant,
 	unitName,
-	ownerEmail,
 	onCancelSignature,
 	isCancelling
 }: LeaseHeaderProps) {
@@ -172,7 +170,6 @@ export function LeaseHeader({
 						lease={lease}
 						tenantName={tenantFullName ?? null}
 						propertyAddress={unitName ?? null}
-						ownerName={ownerEmail ?? 'Property Owner'}
 					/>
 				)}
 				<Button asChild variant="outline" size="sm">

--- a/src/components/leases/rent-increase-notice-dialog.tsx
+++ b/src/components/leases/rent-increase-notice-dialog.tsx
@@ -1,0 +1,268 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { FileText } from 'lucide-react'
+import { Button } from '#components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger
+} from '#components/ui/dialog'
+import { Input } from '#components/ui/input'
+import { Label } from '#components/ui/label'
+import { Textarea } from '#components/ui/textarea'
+import { callGeneratePdfFromHtml } from '#hooks/api/use-report-mutations'
+import { formatCurrency } from '#lib/utils/currency'
+import type { Lease } from '#types/core'
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+}
+
+interface RentIncreaseNoticeDialogProps {
+	lease: Lease
+	tenantName: string | null
+	propertyAddress: string | null
+	ownerName: string
+}
+
+function buildNoticeHtml(params: {
+	tenantName: string
+	propertyAddress: string
+	ownerName: string
+	currentRent: number
+	newRent: number
+	effectiveDate: string
+	reason: string
+	noticeDate: string
+}): string {
+	const {
+		tenantName,
+		propertyAddress,
+		ownerName,
+		currentRent,
+		newRent,
+		effectiveDate,
+		reason,
+		noticeDate
+	} = params
+	const increase = newRent - currentRent
+	const increasePercent =
+		currentRent > 0 ? ((increase / currentRent) * 100).toFixed(1) : '0.0'
+
+	const reasonBlock = reason.trim()
+		? `<p><strong>Reason for increase:</strong> ${escapeHtml(reason)}</p>`
+		: ''
+
+	// eslint-disable-next-line color-tokens/no-hex-colors -- Static HTML for StirlingPDF (third-party PDF renderer); Tailwind tokens don't resolve in this context
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rent Increase Notice</title>
+  <style>
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 48px; color: #222; line-height: 1.6; }
+    h1 { font-size: 22px; margin-bottom: 4px; border-bottom: 2px solid #222; padding-bottom: 8px; }
+    .meta { color: #666; font-size: 13px; margin-bottom: 32px; }
+    .section { margin-bottom: 20px; font-size: 14px; }
+    .rent-table { border-collapse: collapse; margin: 16px 0; font-size: 14px; }
+    .rent-table td, .rent-table th { border: 1px solid #ccc; padding: 8px 16px; text-align: left; }
+    .rent-table th { background: #f4f4f4; }
+    .signature { margin-top: 64px; font-size: 13px; color: #444; }
+    .signature-line { border-top: 1px solid #444; width: 280px; margin-top: 32px; padding-top: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Notice of Rent Increase</h1>
+  <p class="meta">Issued: ${escapeHtml(noticeDate)}</p>
+
+  <div class="section">
+    <p><strong>To:</strong> ${escapeHtml(tenantName)}</p>
+    <p><strong>Property:</strong> ${escapeHtml(propertyAddress)}</p>
+  </div>
+
+  <div class="section">
+    <p>
+      Please be advised that, effective <strong>${escapeHtml(effectiveDate)}</strong>,
+      the monthly rent for the above-referenced property will be adjusted as set out below.
+    </p>
+  </div>
+
+  <table class="rent-table">
+    <thead>
+      <tr><th>Item</th><th>Amount</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Current monthly rent</td><td>${escapeHtml(formatCurrency(currentRent))}</td></tr>
+      <tr><td>New monthly rent</td><td>${escapeHtml(formatCurrency(newRent))}</td></tr>
+      <tr><td>Increase</td><td>${escapeHtml(formatCurrency(increase))} (${escapeHtml(increasePercent)}%)</td></tr>
+      <tr><td>Effective date</td><td>${escapeHtml(effectiveDate)}</td></tr>
+    </tbody>
+  </table>
+
+  ${reasonBlock}
+
+  <div class="section">
+    <p>
+      All other terms and conditions of your lease agreement remain unchanged.
+      Please sign below to acknowledge receipt of this notice and retain a copy
+      for your records.
+    </p>
+    <p>
+      If you have questions about this notice, contact the property owner using
+      the information provided with your lease.
+    </p>
+  </div>
+
+  <div class="signature">
+    <p><strong>${escapeHtml(ownerName)}</strong></p>
+    <p>Property Owner</p>
+    <div class="signature-line">Tenant signature / date</div>
+  </div>
+</body>
+</html>`
+}
+
+export function RentIncreaseNoticeDialog({
+	lease,
+	tenantName,
+	propertyAddress,
+	ownerName
+}: RentIncreaseNoticeDialogProps) {
+	const [open, setOpen] = useState(false)
+	const [newRent, setNewRent] = useState<string>('')
+	const [effectiveDate, setEffectiveDate] = useState<string>('')
+	const [reason, setReason] = useState<string>('')
+	const [isSubmitting, setIsSubmitting] = useState(false)
+
+	const currentRent = lease.rent_amount
+
+	const handleGenerate = async () => {
+		const parsedRent = Number(newRent)
+		if (!Number.isFinite(parsedRent) || parsedRent <= 0) {
+			toast.error('Enter a valid new monthly rent amount.')
+			return
+		}
+		if (parsedRent <= currentRent) {
+			toast.error('New rent must be higher than the current rent.')
+			return
+		}
+		if (!effectiveDate) {
+			toast.error('Choose an effective date for the increase.')
+			return
+		}
+
+		setIsSubmitting(true)
+		try {
+			const html = buildNoticeHtml({
+				tenantName: tenantName ?? 'Tenant',
+				propertyAddress: propertyAddress ?? 'Property',
+				ownerName,
+				currentRent,
+				newRent: parsedRent,
+				effectiveDate: new Date(effectiveDate).toLocaleDateString('en-US', {
+					year: 'numeric',
+					month: 'long',
+					day: 'numeric'
+				}),
+				reason,
+				noticeDate: new Date().toLocaleDateString('en-US', {
+					year: 'numeric',
+					month: 'long',
+					day: 'numeric'
+				})
+			})
+			await callGeneratePdfFromHtml(html, `rent-increase-notice-${lease.id.slice(0, 8)}.pdf`)
+			toast.success('Notice generated', {
+				description: 'Review the PDF and deliver it to your tenant.'
+			})
+			setOpen(false)
+			setNewRent('')
+			setEffectiveDate('')
+			setReason('')
+		} catch (error) {
+			toast.error('Failed to generate notice', {
+				description:
+					error instanceof Error ? error.message : 'Please try again.'
+			})
+		} finally {
+			setIsSubmitting(false)
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button variant="outline" size="sm">
+					<FileText className="size-4 mr-2" />
+					Rent increase notice
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Generate rent-increase notice</DialogTitle>
+					<DialogDescription>
+						Creates a printable PDF notice for this lease. Delivery and state-
+						specific notice-period rules are your responsibility.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-4">
+					<div className="rounded-md bg-muted px-3 py-2 text-sm">
+						<span className="text-muted-foreground">Current rent: </span>
+						<span className="font-semibold">{formatCurrency(currentRent)}</span>
+					</div>
+					<div className="space-y-2">
+						<Label htmlFor="new-rent">New monthly rent</Label>
+						<Input
+							id="new-rent"
+							type="number"
+							min="1"
+							step="0.01"
+							inputMode="decimal"
+							placeholder={String(currentRent)}
+							value={newRent}
+							onChange={e => setNewRent(e.target.value)}
+						/>
+					</div>
+					<div className="space-y-2">
+						<Label htmlFor="effective-date">Effective date</Label>
+						<Input
+							id="effective-date"
+							type="date"
+							value={effectiveDate}
+							onChange={e => setEffectiveDate(e.target.value)}
+						/>
+					</div>
+					<div className="space-y-2">
+						<Label htmlFor="reason">Reason (optional)</Label>
+						<Textarea
+							id="reason"
+							placeholder="e.g. Market rate adjustment, property tax increase..."
+							value={reason}
+							onChange={e => setReason(e.target.value)}
+							rows={3}
+						/>
+					</div>
+				</div>
+				<DialogFooter>
+					<Button variant="outline" onClick={() => setOpen(false)} disabled={isSubmitting}>
+						Cancel
+					</Button>
+					<Button onClick={handleGenerate} disabled={isSubmitting}>
+						{isSubmitting ? 'Generating...' : 'Generate PDF'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/leases/rent-increase-notice-dialog.tsx
+++ b/src/components/leases/rent-increase-notice-dialog.tsx
@@ -33,7 +33,6 @@ interface RentIncreaseNoticeDialogProps {
 	lease: Lease
 	tenantName: string | null
 	propertyAddress: string | null
-	ownerName: string
 }
 
 function buildNoticeHtml(params: {
@@ -125,8 +124,7 @@ function buildNoticeHtml(params: {
   </div>
 
   <div class="signature">
-    <p><strong>${escapeHtml(ownerName)}</strong></p>
-    <p>Property Owner</p>
+    <div class="signature-line">${escapeHtml(ownerName)} signature / date</div>
     <div class="signature-line">Tenant signature / date</div>
   </div>
 </body>
@@ -136,8 +134,7 @@ function buildNoticeHtml(params: {
 export function RentIncreaseNoticeDialog({
 	lease,
 	tenantName,
-	propertyAddress,
-	ownerName
+	propertyAddress
 }: RentIncreaseNoticeDialogProps) {
 	const [open, setOpen] = useState(false)
 	const [newRent, setNewRent] = useState<string>('')
@@ -164,13 +161,18 @@ export function RentIncreaseNoticeDialog({
 
 		setIsSubmitting(true)
 		try {
+			// Parse YYYY-MM-DD input as local time (appending T00:00:00) so that
+			// landlords in negative-UTC-offset timezones don't see the PDF show
+			// the previous calendar day. `new Date('2026-05-01')` is UTC midnight;
+			// `new Date('2026-05-01T00:00:00')` is local midnight.
+			const effectiveDateLocal = new Date(`${effectiveDate}T00:00:00`)
 			const html = buildNoticeHtml({
 				tenantName: tenantName ?? 'Tenant',
 				propertyAddress: propertyAddress ?? 'Property',
-				ownerName,
+				ownerName: 'Property Owner',
 				currentRent,
 				newRent: parsedRent,
-				effectiveDate: new Date(effectiveDate).toLocaleDateString('en-US', {
+				effectiveDate: effectiveDateLocal.toLocaleDateString('en-US', {
 					year: 'numeric',
 					month: 'long',
 					day: 'numeric'

--- a/src/components/properties/property-performance-section.tsx
+++ b/src/components/properties/property-performance-section.tsx
@@ -96,8 +96,8 @@ export function PropertyPerformanceSection({
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Performance (YTD)</CardTitle>
-				<CardDescription>Year-to-date revenue, expenses, and occupancy</CardDescription>
+				<CardTitle>Performance (last 12 months)</CardTitle>
+				<CardDescription>Trailing 12-month revenue, expenses, and occupancy</CardDescription>
 			</CardHeader>
 			<CardContent>
 				<div className="grid grid-cols-2 lg:grid-cols-4 gap-4">

--- a/src/components/properties/property-performance-section.tsx
+++ b/src/components/properties/property-performance-section.tsx
@@ -87,7 +87,7 @@ export function PropertyPerformanceSection({
 		},
 		{
 			label: 'Occupancy',
-			value: formatPercentage((data.occupancy_rate ?? 0) * 100),
+			value: formatPercentage(data.occupancy_rate ?? 0),
 			icon: Percent,
 			tone: 'text-info'
 		}

--- a/src/components/properties/property-performance-section.tsx
+++ b/src/components/properties/property-performance-section.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle
+} from '#components/ui/card'
+import { Skeleton } from '#components/ui/skeleton'
+import {
+	formatCurrency,
+	formatPercentage
+} from '#lib/utils/currency'
+import { propertyQueries } from '#hooks/api/query-keys/property-keys'
+import {
+	DollarSign,
+	Receipt,
+	Percent,
+	TrendingUp
+} from 'lucide-react'
+
+interface PropertyPerformanceSectionProps {
+	propertyId: string
+}
+
+export function PropertyPerformanceSection({
+	propertyId
+}: PropertyPerformanceSectionProps) {
+	const { data, isLoading, isError } = useQuery(
+		propertyQueries.performance(propertyId)
+	)
+
+	if (isLoading) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle>Performance (YTD)</CardTitle>
+					<CardDescription>Year-to-date revenue, expenses, and occupancy</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+						{Array.from({ length: 4 }).map((_, i) => (
+							<Skeleton key={i} className="h-24 w-full" />
+						))}
+					</div>
+				</CardContent>
+			</Card>
+		)
+	}
+
+	if (isError || !data) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle>Performance (YTD)</CardTitle>
+					<CardDescription>Year-to-date revenue, expenses, and occupancy</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<p className="text-sm text-muted-foreground">
+						No performance data yet. Metrics will appear once you have recorded rent, expenses, or leases for this property.
+					</p>
+				</CardContent>
+			</Card>
+		)
+	}
+
+	const metrics = [
+		{
+			label: 'Revenue',
+			value: formatCurrency(data.total_revenue ?? 0),
+			icon: DollarSign,
+			tone: 'text-success'
+		},
+		{
+			label: 'Expenses',
+			value: formatCurrency(data.total_expenses ?? 0),
+			icon: Receipt,
+			tone: 'text-destructive'
+		},
+		{
+			label: 'Net Income',
+			value: formatCurrency(data.net_income ?? 0),
+			icon: TrendingUp,
+			tone: (data.net_income ?? 0) >= 0 ? 'text-success' : 'text-destructive'
+		},
+		{
+			label: 'Occupancy',
+			value: formatPercentage((data.occupancy_rate ?? 0) * 100),
+			icon: Percent,
+			tone: 'text-info'
+		}
+	]
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Performance (YTD)</CardTitle>
+				<CardDescription>Year-to-date revenue, expenses, and occupancy</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+					{metrics.map(metric => {
+						const Icon = metric.icon
+						return (
+							<div
+								key={metric.label}
+								className="rounded-lg border border-border bg-card p-4"
+							>
+								<div className="flex items-center justify-between mb-2">
+									<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+										{metric.label}
+									</span>
+									<Icon className={`size-4 ${metric.tone}`} aria-hidden="true" />
+								</div>
+								<div className={`text-2xl font-semibold ${metric.tone}`}>
+									{metric.value}
+								</div>
+							</div>
+						)
+					})}
+				</div>
+			</CardContent>
+		</Card>
+	)
+}

--- a/src/hooks/api/query-keys/property-keys.ts
+++ b/src/hooks/api/query-keys/property-keys.ts
@@ -124,6 +124,34 @@ export const propertyQueries = {
 			enabled: !!id
 		}),
 
+	performance: (property_id: string) =>
+		queryOptions({
+			queryKey: [...propertyQueries.detail(property_id).queryKey, 'performance'],
+			queryFn: async () => {
+				const supabase = createClient()
+				const user = await getCachedUser()
+				if (!user) return null
+				const { data, error } = await supabase.rpc('get_property_performance_analytics', {
+					p_user_id: user.id,
+					p_property_id: property_id,
+					p_timeframe: 'ytd'
+				})
+				if (error) handlePostgrestError(error, 'property performance')
+				const rows = (data ?? []) as Array<{
+					property_id: string
+					property_name: string
+					timeframe: string
+					total_revenue: number
+					total_expenses: number
+					net_income: number
+					occupancy_rate: number
+				}>
+				return rows[0] ?? null
+			},
+			...QUERY_CACHE_TIMES.DETAIL,
+			enabled: !!property_id
+		}),
+
 	// image_url stores a relative storage path; resolve to public URL at read time
 	images: (property_id: string) =>
 		queryOptions({

--- a/src/hooks/api/query-keys/property-keys.ts
+++ b/src/hooks/api/query-keys/property-keys.ts
@@ -131,10 +131,12 @@ export const propertyQueries = {
 				const supabase = createClient()
 				const user = await getCachedUser()
 				if (!user) return null
+				// Valid p_timeframe values: '7d' | '30d' | '90d' | '180d' | '365d'.
+				// Anything else silently falls through to the 30d default.
 				const { data, error } = await supabase.rpc('get_property_performance_analytics', {
 					p_user_id: user.id,
 					p_property_id: property_id,
-					p_timeframe: 'ytd'
+					p_timeframe: '365d'
 				})
 				if (error) handlePostgrestError(error, 'property performance')
 				const rows = (data ?? []) as Array<{


### PR DESCRIPTION
## Summary

Phase 54a of v2.2 Landlord-First Positioning — three **competitor-driven UX quick wins** derived from mining Buildium/AppFolio/RentRedi/Avail/Stessa reviews on G2/Capterra/App Store/Reddit. All low-effort, high-visibility fixes that close concrete gaps users complain about elsewhere.

### What ships

**1. Expiring-leases dashboard widget** — `src/components/dashboard/expiring-leases-widget.tsx`
Buildium reviews consistently cite missed lease expirations as a pain point. Our pg_cron already queues email reminders at 30/7/1 days out; this surfaces them as an in-app widget on `/dashboard` showing the next 5 leases ending in 60 days with tenant, property, and days-remaining.

**2. Rent-increase notice generator** — `src/components/leases/rent-increase-notice-dialog.tsx`
Buildium reviewers complain it "doesn't generate key legal notices the way Yardi does." Dialog on active-lease header takes new-rent / effective-date / reason, calls existing `generate-pdf` Edge Function, downloads a formatted PDF for delivery. Reuses existing StirlingPDF plumbing — no new Edge Functions, no schema changes.

**3. Per-property performance section** — `src/components/properties/property-performance-section.tsx`
Avail/Buildium reviewers want per-property drilldown (NOI, revenue, expenses, occupancy). Extends the existing `/properties/[id]` detail page using the pre-existing `get_property_performance_analytics` RPC. Pure assembly — no new data infra.

### Research source
Competitor review synthesis in conversation — top 10 in-scope pain points; this PR ships items #4, #9, #10 (the three S-effort items). Items #3 (bulk-import extension), #5 (maintenance upgrades), and #6 (document vault with search) are queued for Phase 54b.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (1 eslint-disable for hex colors inside StirlingPDF HTML — Tailwind tokens do not resolve in the PDF renderer)
- [x] `pnpm test:unit` — 7,278 / 7,278 pass
- [ ] Manual: visit `/dashboard`, confirm widget renders; if no expiring leases, confirm empty-state copy
- [ ] Manual: visit `/leases/<active-lease-id>`, click "Rent increase notice", generate PDF, confirm download + content
- [ ] Manual: visit `/properties/<id>`, confirm Performance (YTD) card renders with real numbers

[hudsor01]
