### PR TITLE
feat(phase-54b): maintenance multi-file upload + work-order PDF

### DIFF
--- a/src/components/maintenance/detail/maintenance-details.client.tsx
+++ b/src/components/maintenance/detail/maintenance-details.client.tsx
@@ -10,9 +10,13 @@ import { createClient } from '#lib/supabase/client'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { useDeleteMaintenanceRequest } from '#hooks/api/use-maintenance'
+import { callGeneratePdfFromHtml } from '#hooks/api/use-report-mutations'
+import { formatCurrency } from '#lib/utils/currency'
+import { buildWorkOrderHtml } from './work-order-template'
 import type { ExpenseRecord } from '#types/core'
+import { useState } from 'react'
 
-import { User, Edit2, Trash2 } from 'lucide-react'
+import { User, Edit2, Trash2, Printer, Loader2 } from 'lucide-react'
 
 import { MaintenanceHeaderCard } from './maintenance-header-card'
 import { ExpensesCard } from './expenses-card'
@@ -98,6 +102,37 @@ export function MaintenanceDetails({ id }: MaintenanceDetailsProps) {
 	const timeline = generateTimeline(request)
 	const totalExpenses = expenses.reduce((sum, e) => sum + (e.amount ?? 0), 0)
 
+	const [isGeneratingPdf, setIsGeneratingPdf] = useState(false)
+	const handleDownloadWorkOrder = async () => {
+		if (!request) return
+		setIsGeneratingPdf(true)
+		try {
+			const html = buildWorkOrderHtml({
+				request,
+				propertyName: property?.name ?? null,
+				unitNumber: unit?.unit_number ?? null,
+				expenses: expenses.map(e => ({
+					vendor_name: e.vendor_name ?? 'Vendor',
+					amount: formatCurrency(e.amount ?? 0),
+					expense_date: e.expense_date ?? ''
+				})),
+				totalExpenses: formatCurrency(totalExpenses)
+			})
+			await callGeneratePdfFromHtml(
+				html,
+				`work-order-${request.id.slice(0, 8)}.pdf`
+			)
+			toast.success('Work order PDF downloaded')
+		} catch (err) {
+			toast.error('Failed to generate work order', {
+				description:
+					err instanceof Error ? err.message : 'Please try again.'
+			})
+		} finally {
+			setIsGeneratingPdf(false)
+		}
+	}
+
 	return (
 		<div className="grid gap-6 lg:grid-cols-3">
 			{/* Main Content */}
@@ -168,6 +203,24 @@ export function MaintenanceDetails({ id }: MaintenanceDetailsProps) {
 						>
 							<Edit2 className="size-4" />
 							Edit Request
+						</Button>
+						<Button
+							variant="outline"
+							className="w-full justify-start gap-2"
+							onClick={handleDownloadWorkOrder}
+							disabled={isGeneratingPdf}
+						>
+							{isGeneratingPdf ? (
+								<>
+									<Loader2 className="size-4 animate-spin" />
+									Generating...
+								</>
+							) : (
+								<>
+									<Printer className="size-4" />
+									Print work order
+								</>
+							)}
 						</Button>
 						<Button
 							variant="outline"

--- a/src/components/maintenance/detail/photos-card.tsx
+++ b/src/components/maintenance/detail/photos-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
 	Card,
 	CardContent,
@@ -8,6 +8,7 @@ import {
 	CardHeader,
 	CardTitle
 } from '#components/ui/card'
+import { Button } from '#components/ui/button'
 import {
 	Dialog,
 	DialogContent,
@@ -15,18 +16,54 @@ import {
 	DialogTrigger
 } from '#components/ui/dialog'
 import { Skeleton } from '#components/ui/skeleton'
-import { maintenanceQueries } from '#hooks/api/query-keys/maintenance-keys'
+import {
+	maintenanceQueries,
+	maintenanceMutations
+} from '#hooks/api/query-keys/maintenance-keys'
 import { createClient } from '#lib/supabase/client'
-import { Camera } from 'lucide-react'
-import { useState } from 'react'
+import { Camera, Plus, Trash2, Loader2 } from 'lucide-react'
+import { useRef, useState } from 'react'
+import { toast } from 'sonner'
 
 interface PhotosCardProps {
 	requestId: string
 }
 
+const ACCEPTED_MIME_TYPES = [
+	'image/jpeg',
+	'image/png',
+	'image/webp',
+	'video/mp4',
+	'video/quicktime'
+]
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024 // 25 MB per file
+
 export function PhotosCard({ requestId }: PhotosCardProps) {
-	const { data: photos, isLoading } = useQuery(maintenanceQueries.photos(requestId))
+	const queryClient = useQueryClient()
+	const fileInputRef = useRef<HTMLInputElement>(null)
 	const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
+
+	const { data: photos, isLoading } = useQuery(
+		maintenanceQueries.photos(requestId)
+	)
+
+	const uploadMutation = useMutation({
+		...maintenanceMutations.uploadPhoto(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: maintenanceQueries.photos(requestId).queryKey
+			})
+		}
+	})
+
+	const deleteMutation = useMutation({
+		...maintenanceMutations.deletePhoto(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: maintenanceQueries.photos(requestId).queryKey
+			})
+		}
+	})
 
 	const getPublicUrl = (storagePath: string) => {
 		const supabase = createClient()
@@ -35,15 +72,106 @@ export function PhotosCard({ requestId }: PhotosCardProps) {
 			.getPublicUrl(storagePath).data.publicUrl
 	}
 
+	const handleFilesSelected = async (fileList: FileList | null) => {
+		if (!fileList || fileList.length === 0) return
+
+		const files = Array.from(fileList)
+		const invalidType = files.find(
+			f => !ACCEPTED_MIME_TYPES.includes(f.type)
+		)
+		if (invalidType) {
+			toast.error('Unsupported file type', {
+				description: `${invalidType.name} — accepted: JPG, PNG, WebP, MP4, MOV.`
+			})
+			return
+		}
+		const oversize = files.find(f => f.size > MAX_FILE_SIZE_BYTES)
+		if (oversize) {
+			toast.error('File too large', {
+				description: `${oversize.name} exceeds the 25 MB limit.`
+			})
+			return
+		}
+
+		let uploaded = 0
+		const failures: string[] = []
+		for (const file of files) {
+			try {
+				await uploadMutation.mutateAsync({ requestId, file })
+				uploaded++
+			} catch (err) {
+				failures.push(
+					`${file.name}: ${err instanceof Error ? err.message : 'unknown error'}`
+				)
+			}
+		}
+
+		if (uploaded > 0) {
+			toast.success(`Uploaded ${uploaded} file${uploaded === 1 ? '' : 's'}`)
+		}
+		if (failures.length > 0) {
+			toast.error(`Failed to upload ${failures.length} file(s)`, {
+				description: failures.join('\n')
+			})
+		}
+
+		// Reset the input so re-selecting the same file re-triggers change.
+		if (fileInputRef.current) fileInputRef.current.value = ''
+	}
+
+	const handleDelete = async (photoId: string, storagePath: string) => {
+		try {
+			await deleteMutation.mutateAsync({ photoId, storagePath })
+			toast.success('Photo removed')
+			setSelectedIndex(null)
+		} catch (err) {
+			toast.error('Failed to remove photo', {
+				description: err instanceof Error ? err.message : 'Please try again.'
+			})
+		}
+	}
+
 	const photoCount = photos?.length ?? 0
+	const isUploading = uploadMutation.isPending
 
 	return (
 		<Card>
-			<CardHeader>
-				<CardTitle className="text-base">
-					Photos{photoCount > 0 ? ` (${photoCount})` : ''}
-				</CardTitle>
-				<CardDescription>Photo documentation for this request</CardDescription>
+			<CardHeader className="flex flex-row items-start justify-between space-y-0 gap-3">
+				<div>
+					<CardTitle className="text-base">
+						Photos &amp; videos{photoCount > 0 ? ` (${photoCount})` : ''}
+					</CardTitle>
+					<CardDescription>
+						Attach before/after photos, videos of the issue, or receipts.
+					</CardDescription>
+				</div>
+				<Button
+					size="sm"
+					variant="outline"
+					onClick={() => fileInputRef.current?.click()}
+					disabled={isUploading}
+				>
+					{isUploading ? (
+						<>
+							<Loader2 className="size-4 mr-2 animate-spin" />
+							Uploading...
+						</>
+					) : (
+						<>
+							<Plus className="size-4 mr-2" />
+							Add
+						</>
+					)}
+				</Button>
+				<input
+					ref={fileInputRef}
+					type="file"
+					multiple
+					accept={ACCEPTED_MIME_TYPES.join(',')}
+					onChange={e => handleFilesSelected(e.target.files)}
+					className="sr-only"
+					aria-label="Upload maintenance photos or videos"
+				/>
 			</CardHeader>
 			<CardContent>
 				{isLoading ? (
@@ -55,39 +183,88 @@ export function PhotosCard({ requestId }: PhotosCardProps) {
 				) : photoCount === 0 ? (
 					<div className="text-center py-8 text-muted-foreground">
 						<Camera className="size-8 mx-auto mb-2 opacity-50" />
-						<p>No photos attached</p>
+						<p className="mb-3">No photos attached</p>
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => fileInputRef.current?.click()}
+							disabled={isUploading}
+						>
+							<Plus className="size-4 mr-2" />
+							Add photos or videos
+						</Button>
 					</div>
 				) : (
 					<div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-						{photos?.map((photo, index) => (
-							<Dialog
-								key={photo.id}
-								open={selectedIndex === index}
-								onOpenChange={(open) => setSelectedIndex(open ? index : null)}
-							>
-								<DialogTrigger asChild>
-									<button
-										type="button"
-										className="overflow-hidden rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-										aria-label={`View ${photo.file_name}`}
-									>
-										<img
-											src={getPublicUrl(photo.storage_path)}
-											alt={photo.file_name}
-											className="rounded-md object-cover aspect-square w-full hover:opacity-90 transition-opacity"
-										/>
-									</button>
-								</DialogTrigger>
-								<DialogContent className="max-w-3xl p-2">
-									<DialogTitle className="sr-only">{photo.file_name}</DialogTitle>
-									<img
-										src={getPublicUrl(photo.storage_path)}
-										alt={photo.file_name}
-										className="w-full rounded-md"
-									/>
-								</DialogContent>
-							</Dialog>
-						))}
+						{photos?.map((photo, index) => {
+							const isVideo = photo.mime_type.startsWith('video/')
+							const url = getPublicUrl(photo.storage_path)
+							return (
+								<Dialog
+									key={photo.id}
+									open={selectedIndex === index}
+									onOpenChange={open => setSelectedIndex(open ? index : null)}
+								>
+									<DialogTrigger asChild>
+										<button
+											type="button"
+											className="overflow-hidden rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring relative group"
+											aria-label={`View ${photo.file_name}`}
+										>
+											{isVideo ? (
+												<video
+													src={url}
+													className="rounded-md object-cover aspect-square w-full"
+													preload="metadata"
+												/>
+											) : (
+												<img
+													src={url}
+													alt={photo.file_name}
+													className="rounded-md object-cover aspect-square w-full hover:opacity-90 transition-opacity"
+												/>
+											)}
+										</button>
+									</DialogTrigger>
+									<DialogContent className="max-w-3xl p-2">
+										<DialogTitle className="sr-only">
+											{photo.file_name}
+										</DialogTitle>
+										{isVideo ? (
+											<video
+												src={url}
+												className="w-full rounded-md"
+												controls
+												autoPlay
+											/>
+										) : (
+											<img
+												src={url}
+												alt={photo.file_name}
+												className="w-full rounded-md"
+											/>
+										)}
+										<div className="flex items-center justify-between p-2">
+											<span className="text-sm text-muted-foreground truncate">
+												{photo.file_name}
+											</span>
+											<Button
+												size="sm"
+												variant="outline"
+												onClick={() =>
+													handleDelete(photo.id, photo.storage_path)
+												}
+												disabled={deleteMutation.isPending}
+												className="text-destructive hover:text-destructive hover:bg-destructive/10"
+											>
+												<Trash2 className="size-4 mr-2" />
+												{deleteMutation.isPending ? 'Removing...' : 'Remove'}
+											</Button>
+										</div>
+									</DialogContent>
+								</Dialog>
+							)
+						})}
 					</div>
 				)}
 			</CardContent>

--- a/src/components/maintenance/detail/photos-card.tsx
+++ b/src/components/maintenance/detail/photos-card.tsx
@@ -76,26 +76,30 @@ export function PhotosCard({ requestId }: PhotosCardProps) {
 		if (!fileList || fileList.length === 0) return
 
 		const files = Array.from(fileList)
-		const invalidType = files.find(
-			f => !ACCEPTED_MIME_TYPES.includes(f.type)
-		)
-		if (invalidType) {
-			toast.error('Unsupported file type', {
-				description: `${invalidType.name} — accepted: JPG, PNG, WebP, MP4, MOV.`
-			})
-			return
+		const valid: File[] = []
+		const rejected: string[] = []
+
+		// Partition files into valid/rejected so one bad file doesn't block the
+		// rest of a multi-file selection from uploading.
+		for (const file of files) {
+			if (!ACCEPTED_MIME_TYPES.includes(file.type)) {
+				rejected.push(`${file.name} — unsupported type`)
+			} else if (file.size > MAX_FILE_SIZE_BYTES) {
+				rejected.push(`${file.name} — exceeds 25 MB`)
+			} else {
+				valid.push(file)
+			}
 		}
-		const oversize = files.find(f => f.size > MAX_FILE_SIZE_BYTES)
-		if (oversize) {
-			toast.error('File too large', {
-				description: `${oversize.name} exceeds the 25 MB limit.`
+
+		if (rejected.length > 0) {
+			toast.error(`Skipped ${rejected.length} file${rejected.length === 1 ? '' : 's'}`, {
+				description: rejected.join('\n')
 			})
-			return
 		}
 
 		let uploaded = 0
 		const failures: string[] = []
-		for (const file of files) {
+		for (const file of valid) {
 			try {
 				await uploadMutation.mutateAsync({ requestId, file })
 				uploaded++

--- a/src/components/maintenance/detail/work-order-template.ts
+++ b/src/components/maintenance/detail/work-order-template.ts
@@ -1,0 +1,157 @@
+/* eslint-disable color-tokens/no-hex-colors -- Static HTML served to StirlingPDF (third-party PDF renderer); Tailwind design tokens don't resolve in this rendering context. */
+
+import type { MaintenanceRequest } from '#types/core'
+
+interface WorkOrderExpense {
+	vendor_name: string
+	amount: string
+	expense_date: string
+}
+
+interface WorkOrderInput {
+	request: MaintenanceRequest
+	propertyName: string | null
+	unitNumber: string | null
+	expenses: WorkOrderExpense[]
+	totalExpenses: string
+}
+
+function escapeHtml(text: string | null | undefined): string {
+	if (text === null || text === undefined) return ''
+	return String(text)
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+}
+
+function formatDate(iso: string | null | undefined): string {
+	if (!iso) return '—'
+	try {
+		return new Date(iso).toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		})
+	} catch {
+		return '—'
+	}
+}
+
+/**
+ * Build printable work-order HTML for the generate-pdf Edge Function.
+ *
+ * StirlingPDF (the downstream renderer) doesn't understand Tailwind CSS
+ * variables, so we use static hex colors here. Hex colors are file-level
+ * eslint-disabled above, consistent with rent-increase-notice-dialog.tsx.
+ */
+export function buildWorkOrderHtml(input: WorkOrderInput): string {
+	const { request, propertyName, unitNumber, expenses, totalExpenses } = input
+	const hasExpenses = expenses.length > 0
+
+	const expenseRows = expenses
+		.map(
+			e => `<tr>
+  <td>${escapeHtml(formatDate(e.expense_date))}</td>
+  <td>${escapeHtml(e.vendor_name)}</td>
+  <td style="text-align:right;">${escapeHtml(e.amount)}</td>
+</tr>`
+		)
+		.join('')
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Work Order — ${escapeHtml(request.id.slice(0, 8))}</title>
+  <style>
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 48px; color: #222; line-height: 1.5; }
+    h1 { font-size: 22px; margin-bottom: 4px; border-bottom: 2px solid #222; padding-bottom: 8px; }
+    .meta { color: #666; font-size: 12px; margin-bottom: 24px; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px 32px; margin-bottom: 24px; }
+    .field-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: #666; margin-bottom: 2px; }
+    .field-value { font-size: 14px; color: #222; }
+    .section-title { font-size: 14px; font-weight: 600; margin: 24px 0 8px; text-transform: uppercase; letter-spacing: 0.05em; color: #444; }
+    .description { background: #f4f4f4; padding: 12px 16px; border-radius: 4px; font-size: 14px; white-space: pre-wrap; }
+    table { border-collapse: collapse; width: 100%; font-size: 13px; }
+    th { border-bottom: 2px solid #222; padding: 8px; text-align: left; background: #f4f4f4; }
+    td { border-bottom: 1px solid #ddd; padding: 8px; }
+    tfoot td { font-weight: 600; border-top: 2px solid #222; border-bottom: none; }
+    .signature { margin-top: 48px; display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+    .signature-line { border-top: 1px solid #444; padding-top: 4px; font-size: 12px; color: #444; }
+  </style>
+</head>
+<body>
+  <h1>Work Order</h1>
+  <p class="meta">
+    Request ID: ${escapeHtml(request.id)} · Printed ${escapeHtml(new Date().toLocaleDateString())}
+  </p>
+
+  <div class="grid">
+    <div>
+      <div class="field-label">Title</div>
+      <div class="field-value">${escapeHtml(request.title ?? request.description ?? '—')}</div>
+    </div>
+    <div>
+      <div class="field-label">Status</div>
+      <div class="field-value">${escapeHtml(request.status ?? '—')}</div>
+    </div>
+    <div>
+      <div class="field-label">Priority</div>
+      <div class="field-value">${escapeHtml(request.priority ?? '—')}</div>
+    </div>
+    <div>
+      <div class="field-label">Property</div>
+      <div class="field-value">${escapeHtml(propertyName ?? '—')}</div>
+    </div>
+    <div>
+      <div class="field-label">Unit</div>
+      <div class="field-value">${escapeHtml(unitNumber ?? '—')}</div>
+    </div>
+    <div>
+      <div class="field-label">Reported</div>
+      <div class="field-value">${escapeHtml(formatDate(request.created_at))}</div>
+    </div>
+    <div>
+      <div class="field-label">Scheduled</div>
+      <div class="field-value">${escapeHtml(formatDate(request.scheduled_date))}</div>
+    </div>
+    <div>
+      <div class="field-label">Completed</div>
+      <div class="field-value">${escapeHtml(formatDate(request.completed_at))}</div>
+    </div>
+    <div>
+      <div class="field-label">Assigned to</div>
+      <div class="field-value">${escapeHtml(request.assigned_to ?? '—')}</div>
+    </div>
+  </div>
+
+  <div class="section-title">Description</div>
+  <div class="description">${escapeHtml(request.description ?? '—')}</div>
+
+  ${
+		hasExpenses
+			? `<div class="section-title">Expenses</div>
+  <table>
+    <thead>
+      <tr><th>Date</th><th>Vendor</th><th style="text-align:right;">Amount</th></tr>
+    </thead>
+    <tbody>${expenseRows}</tbody>
+    <tfoot>
+      <tr>
+        <td colspan="2">Total</td>
+        <td style="text-align:right;">${escapeHtml(totalExpenses)}</td>
+      </tr>
+    </tfoot>
+  </table>`
+			: ''
+	}
+
+  <div class="signature">
+    <div class="signature-line">Vendor signature / date</div>
+    <div class="signature-line">Property owner signature / date</div>
+  </div>
+</body>
+</html>`
+}

--- a/src/hooks/api/mutation-keys.ts
+++ b/src/hooks/api/mutation-keys.ts
@@ -53,7 +53,9 @@ export const mutationKeys = {
 		complete: ['mutations', 'maintenance', 'complete'] as const,
 		assign: ['mutations', 'maintenance', 'assign'] as const,
 		addComment: ['mutations', 'maintenance', 'addComment'] as const,
-		updateStatus: ['mutations', 'maintenance', 'updateStatus'] as const
+		updateStatus: ['mutations', 'maintenance', 'updateStatus'] as const,
+		uploadPhoto: ['mutations', 'maintenance', 'uploadPhoto'] as const,
+		deletePhoto: ['mutations', 'maintenance', 'deletePhoto'] as const
 	},
 
 	// Units

--- a/src/hooks/api/query-keys/maintenance-keys.ts
+++ b/src/hooks/api/query-keys/maintenance-keys.ts
@@ -313,6 +313,71 @@ export const maintenanceMutations = {
 
 				if (error) handlePostgrestError(error, 'maintenance_requests')
 			}
+		}),
+
+	uploadPhoto: () =>
+		mutationOptions<
+			{ id: string; storage_path: string; file_name: string },
+			Error,
+			{ requestId: string; file: File }
+		>({
+			mutationKey: mutationKeys.maintenance.uploadPhoto,
+			mutationFn: async ({ requestId, file }) => {
+				const supabase = createClient()
+				const user = await getCachedUser()
+				const uploaderId = requireOwnerUserId(user?.id)
+
+				// Generate a unique storage path under requestId folder.
+				const timestamp = Date.now()
+				const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
+				const storagePath = `${requestId}/${timestamp}-${safeName}`
+
+				const { error: uploadError } = await supabase.storage
+					.from('maintenance-photos')
+					.upload(storagePath, file, { contentType: file.type, upsert: false })
+				if (uploadError) throw uploadError
+
+				const { data: row, error: dbError } = await supabase
+					.from('maintenance_request_photos')
+					.insert({
+						maintenance_request_id: requestId,
+						storage_path: storagePath,
+						file_name: file.name,
+						file_size: file.size,
+						mime_type: file.type,
+						uploaded_by: uploaderId
+					})
+					.select('id, storage_path, file_name')
+					.single()
+				if (dbError) {
+					// Rollback storage upload on DB failure so we don't orphan blobs.
+					await supabase.storage
+						.from('maintenance-photos')
+						.remove([storagePath])
+					handlePostgrestError(dbError, 'maintenance_request_photos')
+				}
+				return row as { id: string; storage_path: string; file_name: string }
+			}
+		}),
+
+	deletePhoto: () =>
+		mutationOptions<void, Error, { photoId: string; storagePath: string }>({
+			mutationKey: mutationKeys.maintenance.deletePhoto,
+			mutationFn: async ({ photoId, storagePath }) => {
+				const supabase = createClient()
+				const { error: dbError } = await supabase
+					.from('maintenance_request_photos')
+					.delete()
+					.eq('id', photoId)
+				if (dbError) handlePostgrestError(dbError, 'maintenance_request_photos')
+
+				// Storage remove is best-effort — if RLS blocks, we still dropped
+				// the DB row so the UI reflects the intended state.
+				await supabase.storage
+					.from('maintenance-photos')
+					.remove([storagePath])
+					.catch(() => {})
+			}
 		})
 }
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -701,6 +701,54 @@ export type Database = {
           },
         ]
       }
+      maintenance_request_photos: {
+        Row: {
+          created_at: string
+          file_name: string
+          file_size: number | null
+          id: string
+          maintenance_request_id: string
+          mime_type: string
+          storage_path: string
+          uploaded_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          file_name: string
+          file_size?: number | null
+          id?: string
+          maintenance_request_id: string
+          mime_type?: string
+          storage_path: string
+          uploaded_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          file_name?: string
+          file_size?: number | null
+          id?: string
+          maintenance_request_id?: string
+          mime_type?: string
+          storage_path?: string
+          uploaded_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "maintenance_request_photos_maintenance_request_id_fkey"
+            columns: ["maintenance_request_id"]
+            isOneToOne: false
+            referencedRelation: "maintenance_requests"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "maintenance_request_photos_uploaded_by_fkey"
+            columns: ["uploaded_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       maintenance_requests: {
         Row: {
           actual_cost: number | null
@@ -2726,3 +2774,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/supabase/migrations/20260420000000_restore_maintenance_photos_landlord_only.sql
+++ b/supabase/migrations/20260420000000_restore_maintenance_photos_landlord_only.sql
@@ -1,0 +1,97 @@
+-- Phase 54b: restore maintenance_request_photos with landlord-only RLS.
+--
+-- Background:
+--   The original table + RLS (migration 20260318120000) was created for the
+--   tenant-portal era, when tenants authenticated and could attach photos.
+--   The landlord-only pivot (PR #596) dropped the table along with the rest
+--   of the tenant-portal surfaces. The app still renders PhotosCard on
+--   maintenance detail, so queries have been failing silently in prod.
+--
+--   This migration re-creates the table with **owner-only** RLS — the same
+--   storage bucket as before (maintenance-photos), now expanded to allow
+--   webp/jpeg/png photos + short mp4/mov videos for the multi-file upload
+--   work that RentRedi reviewers specifically complain about.
+
+begin;
+
+create table if not exists public.maintenance_request_photos (
+  id uuid primary key default gen_random_uuid(),
+  maintenance_request_id uuid not null references public.maintenance_requests(id) on delete cascade,
+  storage_path text not null,
+  file_name text not null,
+  file_size integer,
+  mime_type text not null default 'image/jpeg'
+    check (mime_type in (
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'video/mp4',
+      'video/quicktime'
+    )),
+  uploaded_by uuid references public.users(id) on delete set null,
+  created_at timestamptz default now() not null
+);
+
+alter table public.maintenance_request_photos enable row level security;
+
+-- Owner SELECT: can view attachments for their own maintenance requests.
+drop policy if exists owner_select_maintenance_photos on public.maintenance_request_photos;
+create policy owner_select_maintenance_photos on public.maintenance_request_photos
+  for select to authenticated
+  using (
+    exists (
+      select 1 from public.maintenance_requests mr
+      where mr.id = maintenance_request_photos.maintenance_request_id
+        and mr.owner_user_id = (select auth.uid())
+    )
+  );
+
+-- Owner INSERT: can attach files to their own maintenance requests.
+drop policy if exists owner_insert_maintenance_photos on public.maintenance_request_photos;
+create policy owner_insert_maintenance_photos on public.maintenance_request_photos
+  for insert to authenticated
+  with check (
+    exists (
+      select 1 from public.maintenance_requests mr
+      where mr.id = maintenance_request_photos.maintenance_request_id
+        and mr.owner_user_id = (select auth.uid())
+    )
+  );
+
+-- Owner DELETE: can remove their own attachments.
+drop policy if exists owner_delete_maintenance_photos on public.maintenance_request_photos;
+create policy owner_delete_maintenance_photos on public.maintenance_request_photos
+  for delete to authenticated
+  using (
+    exists (
+      select 1 from public.maintenance_requests mr
+      where mr.id = maintenance_request_photos.maintenance_request_id
+        and mr.owner_user_id = (select auth.uid())
+    )
+  );
+
+create index if not exists idx_maintenance_request_photos_request_id
+  on public.maintenance_request_photos(maintenance_request_id);
+
+-- Storage bucket — public so Supabase can serve signed-ish URLs to owners.
+insert into storage.buckets (id, name, public)
+values ('maintenance-photos', 'maintenance-photos', true)
+on conflict (id) do nothing;
+
+-- Storage policies: authenticated owners only (no tenant writes; landlord-only).
+drop policy if exists "Authenticated users can upload maintenance photos" on storage.objects;
+create policy "Owners upload maintenance photos"
+  on storage.objects for insert to authenticated
+  with check (bucket_id = 'maintenance-photos');
+
+drop policy if exists "Authenticated users can view maintenance photos" on storage.objects;
+create policy "Owners view maintenance photos"
+  on storage.objects for select to authenticated
+  using (bucket_id = 'maintenance-photos');
+
+drop policy if exists "Owners delete maintenance photos" on storage.objects;
+create policy "Owners delete maintenance photos"
+  on storage.objects for delete to authenticated
+  using (bucket_id = 'maintenance-photos');
+
+commit;

--- a/supabase/migrations/20260420010000_secure_maintenance_photos_storage.sql
+++ b/supabase/migrations/20260420010000_secure_maintenance_photos_storage.sql
@@ -1,0 +1,54 @@
+-- Phase 54b follow-up: path-based ownership check for maintenance-photos
+-- storage bucket.
+--
+-- Background:
+--   The first 54b migration (20260420000000) created storage policies that
+--   only gated writes on `bucket_id = 'maintenance-photos'`. Sentry Seer
+--   correctly flagged this as HIGH severity — any authenticated user could
+--   upload into or delete another owner's folder by calling the storage API
+--   directly with a known maintenance_request_id.
+--
+-- Fix mirrors the inspection-photos pattern (20260220110001): extract the
+-- first path segment (maintenance_request_id) via storage.foldername(name)[1]
+-- and confirm it belongs to a maintenance_request the caller owns.
+--
+-- Also: bucket stays public=true so existing .getPublicUrl() calls keep
+-- returning usable URLs for the owner's own photos. If we later need true
+-- privacy, flip to public=false and migrate the frontend to signed URLs.
+
+begin;
+
+drop policy if exists "Owners upload maintenance photos" on storage.objects;
+create policy "Owners upload maintenance photos"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'maintenance-photos'
+    and (storage.foldername(name))[1] in (
+      select id::text from public.maintenance_requests
+      where owner_user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists "Owners view maintenance photos" on storage.objects;
+create policy "Owners view maintenance photos"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'maintenance-photos'
+    and (storage.foldername(name))[1] in (
+      select id::text from public.maintenance_requests
+      where owner_user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists "Owners delete maintenance photos" on storage.objects;
+create policy "Owners delete maintenance photos"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'maintenance-photos'
+    and (storage.foldername(name))[1] in (
+      select id::text from public.maintenance_requests
+      where owner_user_id = (select auth.uid())
+    )
+  );
+
+commit;


### PR DESCRIPTION
## Summary

Phase 54b of v2.2 Landlord-First Positioning — closes two of the loudest maintenance-tracking complaints surfaced in Phase 54 competitor review mining (RentRedi multi-file upload gap; work-order PDF as a differentiator across Buildium/Hemlane/Stessa).

Scope notes:
- **Originally planned items** #3 (bulk-import extension) and #6 (document vault) were deferred to a future Phase 54c after recon showed each would need its own migration + stepper/page. This PR is maintenance-only to keep the change surface small.
- **Discovered incidentally**: the `maintenance_request_photos` table was dropped in prod during the landlord-only pivot (PR #596) while `PhotosCard` is still rendered on maintenance detail — `.from(maintenance_request_photos)` has been returning PostgREST relation-does-not-exist silently for weeks. Re-creating the table restores the feature.

### Changes

**Migration `20260420000000_restore_maintenance_photos_landlord_only.sql`** — re-creates the table with **owner-only** RLS (select/insert/delete), expanded MIME check to include `video/mp4` and `video/quicktime` alongside image types, re-registers the `maintenance-photos` storage bucket. Idempotent (`if not exists`, `drop policy if exists`). Applied to prod via MCP before this commit; types regenerated.

**Photo upload + multi-file UI** — `photos-card.tsx` rewritten with:
- Add button in card header + in empty state
- Hidden `<input type=\"file\" multiple accept=\"...\">` loops selected files through a new `uploadPhoto` mutation that uploads to storage then inserts the DB row; on DB failure rolls back the storage blob to avoid orphans.
- Per-file size cap (25 MB) and MIME-type validation with toast surfacing.
- Video support: tiles render `<video>` thumbnails for MP4/MOV; preview dialog shows controls + autoplay.
- Per-photo Remove button in the preview dialog.

**Work-order PDF** — `work-order-template.ts` builds a structured HTML document (title, priority, property/unit, created/scheduled/completed dates, description, expense table with totals, dual signature lines) that the existing `generate-pdf` Edge Function renders via StirlingPDF. New Print work order button in the Quick Actions card. Closes the Buildium/Yardi notice-generation gap that reviewers repeatedly cite.

### What did NOT change

- No new Edge Functions; reuses `generate-pdf` + `callGeneratePdfFromHtml`.
- No new RPCs.
- No changes to `maintenance_requests` schema — attachments live in the separate `maintenance_request_photos` table.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (file-level eslint-disable for hex colors inside StirlingPDF HTML; Tailwind tokens do not resolve in the PDF renderer)
- [x] `pnpm test:unit` — 7,292 / 7,292 pass
- [x] Migration applied to prod before commit; types regenerated
- [ ] Manual: visit `/maintenance/<id>`, click Add in PhotosCard, multi-select photos/videos, confirm upload + preview + delete
- [ ] Manual: click Print work order in Quick Actions, confirm PDF downloads with correct fields

[hudsor01]
