### PR TITLE
fix(phase-54): resolve remaining Sentry findings properly

### DIFF
--- a/src/components/maintenance/detail/photos-card.tsx
+++ b/src/components/maintenance/detail/photos-card.tsx
@@ -20,7 +20,6 @@ import {
 	maintenanceQueries,
 	maintenanceMutations
 } from '#hooks/api/query-keys/maintenance-keys'
-import { createClient } from '#lib/supabase/client'
 import { Camera, Plus, Trash2, Loader2 } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -64,13 +63,6 @@ export function PhotosCard({ requestId }: PhotosCardProps) {
 			})
 		}
 	})
-
-	const getPublicUrl = (storagePath: string) => {
-		const supabase = createClient()
-		return supabase.storage
-			.from('maintenance-photos')
-			.getPublicUrl(storagePath).data.publicUrl
-	}
 
 	const handleFilesSelected = async (fileList: FileList | null) => {
 		if (!fileList || fileList.length === 0) return
@@ -202,7 +194,21 @@ export function PhotosCard({ requestId }: PhotosCardProps) {
 					<div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
 						{photos?.map((photo, index) => {
 							const isVideo = photo.mime_type.startsWith('video/')
-							const url = getPublicUrl(photo.storage_path)
+							const url = photo.signed_url
+							if (!url) {
+								// Signed URL generation failed (e.g. RLS gap or network).
+								// Render a placeholder tile so owners still see the file
+								// exists and can remove it via the preview dialog.
+								return (
+									<div
+										key={photo.id}
+										className="rounded-md bg-muted aspect-square w-full flex items-center justify-center text-xs text-muted-foreground text-center px-2"
+										title={photo.file_name}
+									>
+										{photo.file_name}
+									</div>
+								)
+							}
 							return (
 								<Dialog
 									key={photo.id}

--- a/src/components/properties/property-performance-section.tsx
+++ b/src/components/properties/property-performance-section.tsx
@@ -36,8 +36,8 @@ export function PropertyPerformanceSection({
 		return (
 			<Card>
 				<CardHeader>
-					<CardTitle>Performance (YTD)</CardTitle>
-					<CardDescription>Year-to-date revenue, expenses, and occupancy</CardDescription>
+					<CardTitle>Performance (last 12 months)</CardTitle>
+					<CardDescription>Trailing 12-month revenue, expenses, and occupancy</CardDescription>
 				</CardHeader>
 				<CardContent>
 					<div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
@@ -54,8 +54,8 @@ export function PropertyPerformanceSection({
 		return (
 			<Card>
 				<CardHeader>
-					<CardTitle>Performance (YTD)</CardTitle>
-					<CardDescription>Year-to-date revenue, expenses, and occupancy</CardDescription>
+					<CardTitle>Performance (last 12 months)</CardTitle>
+					<CardDescription>Trailing 12-month revenue, expenses, and occupancy</CardDescription>
 				</CardHeader>
 				<CardContent>
 					<p className="text-sm text-muted-foreground">

--- a/src/hooks/api/query-keys/maintenance-keys.ts
+++ b/src/hooks/api/query-keys/maintenance-keys.ts
@@ -209,7 +209,7 @@ export const maintenanceQueries = {
 
 				if (error) handlePostgrestError(error, 'maintenance_request_photos')
 
-				return (data ?? []) as Array<{
+				type PhotoRow = {
 					id: string
 					maintenance_request_id: string
 					storage_path: string
@@ -218,7 +218,30 @@ export const maintenanceQueries = {
 					mime_type: string
 					uploaded_by: string | null
 					created_at: string
-				}>
+				}
+				const rows = (data ?? []) as PhotoRow[]
+
+				// Bucket is private — getPublicUrl() would return a 403 URL. Batch-sign
+				// all storage paths in one round-trip so <img>/<video> tags can render
+				// without the client having to attach a JWT header on each request.
+				if (rows.length === 0) {
+					return rows.map(r => ({ ...r, signed_url: null as string | null }))
+				}
+				const paths = rows.map(r => r.storage_path)
+				const { data: signed } = await supabase.storage
+					.from('maintenance-photos')
+					.createSignedUrls(paths, 3600)
+
+				const urlByPath = new Map<string, string>()
+				for (const entry of signed ?? []) {
+					if (entry.path && entry.signedUrl) {
+						urlByPath.set(entry.path, entry.signedUrl)
+					}
+				}
+				return rows.map(r => ({
+					...r,
+					signed_url: urlByPath.get(r.storage_path) ?? null
+				}))
 			},
 			...QUERY_CACHE_TIMES.DETAIL,
 			enabled: !!requestId

--- a/supabase/migrations/20260420020000_align_maintenance_photos_bucket.sql
+++ b/supabase/migrations/20260420020000_align_maintenance_photos_bucket.sql
@@ -1,0 +1,34 @@
+-- Phase 54b follow-up (#3): align maintenance-photos bucket config with
+-- frontend validation.
+--
+-- Audit uncovered three mismatches vs the PhotosCard upload code:
+--   1. Bucket's allowed_mime_types list only has image types — MP4/MOV
+--      would be rejected by Supabase Storage even though the UI accepts
+--      them. Users would hit a silent 415.
+--   2. Bucket's file_size_limit is 10 MB but the UI validates up to 25 MB.
+--      Files between 10–25 MB would upload from the UI perspective but
+--      fail at storage.
+--   3. The initial 54b migration used `on conflict do nothing` which
+--      didn't patch the pre-existing bucket created in 2026-03. So the
+--      bucket still has the old restrictive config.
+--
+-- This migration UPDATE-s the bucket in place so the settings match the
+-- landlord-only intent: images + short videos up to 25 MB, private, with
+-- path-based RLS already in place from migration 20260420010000.
+
+begin;
+
+update storage.buckets
+set
+  allowed_mime_types = array[
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/webp',
+    'video/mp4',
+    'video/quicktime'
+  ]::text[],
+  file_size_limit = 26214400 -- 25 MB, matches MAX_FILE_SIZE_BYTES in photos-card.tsx
+where id = 'maintenance-photos';
+
+commit;


### PR DESCRIPTION
## Summary

Properly resolves the remaining findings from Phase 54a (#612) and Phase 54b (#613) that were identified in a post-merge audit after the user asked to **fix all findings perfectly and properly before continuing**.

### Finding 1 — Stale "Performance (YTD)" label in 2 of 3 render branches

Sentry Seer finding on #612 (LOW severity). Fix commit `ade1d80` renamed the success-state card to "Performance (last 12 months)" but only `replace_all` hit the success branch; the loading skeleton and the error/no-data branches still rendered `Performance (YTD)` / `Year-to-date revenue...`. Slow network or cache-miss users saw the old, inaccurate label. All three branches now match.

### Finding 2 — Private bucket + `getPublicUrl()` = broken feature

Post-merge audit of the `maintenance-photos` feature surfaced three gaps:

1. **Signed URLs required.** Bucket is `public=false` in prod. `getPublicUrl()` returns a URL that Supabase serves at `/storage/v1/object/public/...` — that endpoint returns 403 without a JWT header, and `<img src>` does not attach JWTs. Every photo tile was silently broken. Switched to `createSignedUrls()` batched once per photos query with a 1-hour TTL.
2. **MIME-type mismatch.** Bucket `allowed_mime_types` was images-only; the UI accepts `video/mp4` + `video/quicktime`. Migration `20260420020000` expands the bucket list.
3. **File-size mismatch.** Bucket `file_size_limit` was 10 MB; UI validates up to 25 MB. Migration bumps to 26214400 bytes.

The path-based storage RLS that Sentry flagged on the first 54b migration was already fixed via the `20260420010000` follow-up; this PR completes the chain so the private-bucket + RLS + signed-URL pattern actually works end-to-end.

The bucket config migration (`20260420020000`) was applied to prod before this commit.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 7,292 / 7,292 pass
- [x] SQL verifies prod bucket now has video MIME types + 25 MB limit and stays `public=false`
- [x] SQL verifies prod storage RLS policies on `maintenance-photos` all enforce `owner_user_id` ownership via path-extracted `maintenance_request_id`
- [ ] Manual: visit `/properties/<id>` during initial load, confirm loading skeleton reads "Performance (last 12 months)"
- [ ] Manual: visit `/maintenance/<id>`, upload an image and a video, confirm both tiles render (signed URL paths)
- [ ] Manual: upload a 20 MB video, confirm it succeeds (both UI and bucket now allow up to 25 MB)

[hudsor01]
