### PR TITLE
feat(v2.0/phase-46): premium reports tier gate

### DIFF
--- a/src/hooks/api/query-keys/report-keys.ts
+++ b/src/hooks/api/query-keys/report-keys.ts
@@ -134,6 +134,48 @@ export const reportQueries = {
 		})
 }
 
+/**
+ * Thrown when the reports tier gate returns 402. Caller mutations detect this
+ * via `instanceof PaywallError` to surface an upgrade CTA instead of a generic
+ * error toast.
+ */
+export class PaywallError extends Error {
+	readonly upgradeUrl: string
+	readonly feature: string
+	constructor(message: string, upgradeUrl: string, feature: string) {
+		super(message)
+		this.name = 'PaywallError'
+		this.upgradeUrl = upgradeUrl
+		this.feature = feature
+	}
+}
+
+async function parsePaywallResponse(
+	response: Response,
+	defaultFeature: string
+): Promise<PaywallError> {
+	try {
+		const body = (await response.json()) as {
+			error?: string
+			upgrade_url?: string
+			upgrade_required?: boolean
+		}
+		const url = typeof body.upgrade_url === 'string'
+			? body.upgrade_url
+			: `/billing/plans?source=${defaultFeature}_gate`
+		const msg = typeof body.error === 'string'
+			? body.error
+			: 'This feature requires a Growth or Max subscription.'
+		return new PaywallError(msg, url, defaultFeature)
+	} catch {
+		return new PaywallError(
+			'This feature requires a Growth or Max subscription.',
+			`/billing/plans?source=${defaultFeature}_gate`,
+			defaultFeature
+		)
+	}
+}
+
 async function callExportEdgeFunction(
 	reportType: string,
 	format: 'csv' | 'xlsx' | 'pdf',
@@ -151,6 +193,9 @@ async function callExportEdgeFunction(
 		headers: { Authorization: `Bearer ${token}` }
 	})
 
+	if (response.status === 402) {
+		throw await parsePaywallResponse(response, 'reports')
+	}
 	if (!response.ok) {
 		throw new Error(`Export failed: ${response.statusText}`)
 	}
@@ -187,6 +232,9 @@ async function callGeneratePdfEdgeFunction(reportType: string, year: number): Pr
 		body: JSON.stringify({ reportType, year, filename }),
 	})
 
+	if (response.status === 402) {
+		throw await parsePaywallResponse(response, 'reports')
+	}
 	if (!response.ok) {
 		const errText = await response.text().catch(() => response.statusText)
 		throw new Error(`PDF generation failed: ${errText}`)

--- a/src/hooks/api/use-report-mutations.ts
+++ b/src/hooks/api/use-report-mutations.ts
@@ -15,7 +15,30 @@ import {
 	handleMutationError,
 	handleMutationSuccess
 } from '#lib/mutation-error-handler'
-import { reportMutations } from './query-keys/report-keys'
+import { PaywallError, reportMutations } from './query-keys/report-keys'
+
+/**
+ * Report download mutation error handler. When the Edge Function returned 402,
+ * surface an "Upgrade" toast CTA that navigates to /billing/plans?source=...
+ * so the Stripe checkout keeps the source attribution for admin analytics
+ * (REQ-45-00 / REQ-46-03). Any other error falls through to the shared
+ * handler so generic network failures still toast the underlying message.
+ */
+function handleReportMutationError(err: unknown, action: string): void {
+	if (err instanceof PaywallError) {
+		toast.error('Upgrade required', {
+			description: err.message,
+			action: {
+				label: 'See plans',
+				onClick: () => {
+					window.location.assign(err.upgradeUrl)
+				}
+			}
+		})
+		return
+	}
+	handleMutationError(err, action)
+}
 
 /**
  * Call the generate-pdf Edge Function with pre-built HTML content.
@@ -60,7 +83,7 @@ export function useDownloadYearEndCsv() {
 	return useMutation({
 		...reportMutations.downloadYearEndCsv(),
 		onSuccess: () => handleMutationSuccess('Download year-end CSV'),
-		onError: (err) => handleMutationError(err, 'Download year-end CSV')
+		onError: (err) => handleReportMutationError(err, 'Download year-end CSV')
 	})
 }
 
@@ -71,7 +94,7 @@ export function useDownload1099Csv() {
 	return useMutation({
 		...reportMutations.download1099Csv(),
 		onSuccess: () => handleMutationSuccess('Download 1099 CSV'),
-		onError: (err) => handleMutationError(err, 'Download 1099 CSV')
+		onError: (err) => handleReportMutationError(err, 'Download 1099 CSV')
 	})
 }
 
@@ -83,7 +106,7 @@ export function useDownloadYearEndPdf() {
 	return useMutation({
 		...reportMutations.downloadYearEndPdf(),
 		onSuccess: () => toast.success('Year-end report downloaded'),
-		onError: (err) => handleMutationError(err, 'Download year-end PDF')
+		onError: (err) => handleReportMutationError(err, 'Download year-end PDF')
 	})
 }
 
@@ -95,6 +118,6 @@ export function useDownloadTaxDocumentPdf() {
 	return useMutation({
 		...reportMutations.downloadTaxDocumentPdf(),
 		onSuccess: () => toast.success('Tax documents downloaded'),
-		onError: (err) => handleMutationError(err, 'Download tax documents PDF')
+		onError: (err) => handleReportMutationError(err, 'Download tax documents PDF')
 	})
 }

--- a/supabase/functions/export-report/index.ts
+++ b/supabase/functions/export-report/index.ts
@@ -9,6 +9,18 @@ import { validateEnv } from '../_shared/env.ts'
 import { errorResponse, captureWebhookError } from '../_shared/errors.ts'
 import { escapeHtml } from '../_shared/escape-html.ts'
 import { createAdminClient } from '../_shared/supabase-client.ts'
+import { checkTierEntitlement, GROWTH_AND_MAX_PLANS } from '../_shared/tier-gate.ts'
+
+// Report types gated behind Growth/Max (REQ-46-02).
+// Free-tier keeps basic reports (maintenance, default revenue trends) so the
+// product is usable without upgrading; tax-prep + year-end reports require paid.
+const PREMIUM_REPORT_TYPES: ReadonlySet<string> = new Set([
+  'year-end',
+  '1099',
+  'financial',
+  'income-statement',
+  'cash-flow',
+])
 
 Deno.serve(async (req: Request) => {
   const optionsResponse = handleCorsOptions(req)
@@ -41,6 +53,18 @@ Deno.serve(async (req: Request) => {
     const reportType = url.searchParams.get('type') ?? 'financial'
     const format = url.searchParams.get('format') ?? 'csv'
     const year = parseInt(url.searchParams.get('year') ?? String(new Date().getFullYear()))
+
+    // REQ-46-01: gate premium report types behind Growth/Max tier.
+    // Returns 402 with upgrade_url on the free tier; records a row in
+    // public.gate_events so admin analytics can attribute conversions.
+    if (PREMIUM_REPORT_TYPES.has(reportType)) {
+      const entitlementBlock = await checkTierEntitlement(req, supabase, user.id, {
+        feature: 'premium_reports',
+        upgrade_source: 'reports_gate',
+        entitled_plans: GROWTH_AND_MAX_PLANS,
+      })
+      if (entitlementBlock) return entitlementBlock
+    }
 
     // Fetch data based on report type
     let rows: Record<string, unknown>[] = []

--- a/supabase/functions/generate-pdf/index.ts
+++ b/supabase/functions/generate-pdf/index.ts
@@ -14,6 +14,20 @@ import { errorResponse, captureWebhookError } from '../_shared/errors.ts'
 import { escapeHtml } from '../_shared/escape-html.ts'
 import { validateEnv } from '../_shared/env.ts'
 import { createAdminClient } from '../_shared/supabase-client.ts'
+import { checkTierEntitlement, GROWTH_AND_MAX_PLANS } from '../_shared/tier-gate.ts'
+
+// Mirror of export-report PREMIUM_REPORT_TYPES. generate-pdf's Mode 1
+// (structured report data via {reportType, year}) bypasses export-report
+// entirely, so the same gate has to live here. Modes 2 (raw HTML) and 3
+// (lease preview) are not gated — those are per-entity operations already
+// bounded by ownership checks.
+const PREMIUM_REPORT_TYPES: ReadonlySet<string> = new Set([
+  'year-end',
+  '1099',
+  'financial',
+  'income-statement',
+  'cash-flow',
+])
 
 type ReportRow = Record<string, string | number | null | undefined>
 
@@ -215,6 +229,17 @@ Deno.serve(async (req: Request) => {
           { status: 400, headers: getJsonHeaders(req) },
         )
       }
+
+      // REQ-46-01: premium report types require Growth/Max tier.
+      if (PREMIUM_REPORT_TYPES.has(body.reportType)) {
+        const entitlementBlock = await checkTierEntitlement(req, supabase, user.id, {
+          feature: 'premium_reports',
+          upgrade_source: 'reports_gate',
+          entitled_plans: GROWTH_AND_MAX_PLANS,
+        })
+        if (entitlementBlock) return entitlementBlock
+      }
+
       const rows = await fetchReportRows(supabase, user.id)
       html = buildReportHtml(body.reportType, body.year, rows)
     }


### PR DESCRIPTION
## Summary

Phase 46 of v2.0 Revenue Gates — paywalls premium tax-prep reports behind Growth/Max tier. Mirrors the Phase 45 DocuSeal gate pattern (#604) using the shared `_shared/tier-gate.ts` helper; no new Edge Functions, no new schema, no new admin surfaces.

### Changes

**Backend** — two Edge Functions now call `checkTierEntitlement` before generating premium reports:

- `supabase/functions/export-report/index.ts` — gate covers reportType `year-end`, `1099`, `financial`, `income-statement`, `cash-flow`. Free-tier users still get `maintenance` and default revenue trends.
- `supabase/functions/generate-pdf/index.ts` — Mode 1 (structured report data via `{reportType, year}`) also gates the same types. Modes 2 (raw HTML) and 3 (lease preview) are not gated — those are per-entity ops already bounded by ownership checks.

402 responses include `upgrade_url: /billing/plans?source=reports_gate` so the Stripe Checkout session carries the attribution metadata the admin conversion analytics already consume (via `metadata.source` on `stripe.subscriptions`).

**Frontend** — typed paywall error plumbing:

- New `PaywallError` class in `src/hooks/api/query-keys/report-keys.ts`. Both `callExportEdgeFunction` and `callGeneratePdfEdgeFunction` parse 402 bodies and throw it with the server-provided `upgrade_url`.
- New `handleReportMutationError` in `use-report-mutations.ts` surfaces a toast with an `action: { label: "See plans", onClick: navigate }` button for `PaywallError`; falls through to the shared mutation error handler for generic failures.
- All four report download mutations (`useDownloadYearEndCsv`, `useDownload1099Csv`, `useDownloadYearEndPdf`, `useDownloadTaxDocumentPdf`) use the new handler.

### What DID NOT change

- No migration. `gate_events` table + `subscription_source` column already shipped with Phase 45 (#604).
- No admin analytics changes. The existing Gate Conversion Stats query already aggregates per-`feature` — it will pick up `premium_reports` rows automatically once the Edge Functions are deployed.
- No changes to pricing copy. Phase 53 (PR #610) already reframed the pricing tiers to list the real included/excluded features.

### Operator action required after merge

Redeploy the two Edge Functions (MCP deploy hit an internal 500 during the shipping session; standard CLI path is fine):

```bash
supabase functions deploy export-report
supabase functions deploy generate-pdf
```

Both are already verified locally (typecheck + lint + 7,292 unit tests clean). The deploy is a pure code push — no env var changes, no schema deltas.

### Battle-proven criterion (from v2.0-ROADMAP.md)

≥10 `stripe.subscriptions` rows with `metadata.source = reports_gate` created in a rolling 14-day window, measured 14+ days after deploy. Admin Gate Conversion Stats page already tracks this.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 7,292 / 7,292 pass
- [ ] Post-deploy manual: log in as a free-tier owner, click "Download year-end CSV", confirm toast surfaces with "See plans" CTA that navigates to `/billing/plans?source=reports_gate`
- [ ] Post-deploy manual: log in as a Growth-tier owner, confirm the same download succeeds with a CSV file
- [ ] Post-deploy SQL: `select * from gate_events where feature = 'premium_reports' order by hit_at desc limit 5` returns rows after free-tier click

[hudsor01]
