### PR TITLE
fix(v2.0): land gate_events rows via EdgeRuntime.waitUntil + REQ-46-04 spec

### DIFF
--- a/supabase/functions/_shared/tier-gate.ts
+++ b/supabase/functions/_shared/tier-gate.ts
@@ -76,9 +76,16 @@ export async function checkTierEntitlement(
 
   if (hasActiveSub && onEntitledPlan) return null
 
-  // Record the gate hit for admin analytics. Non-blocking — if the insert
-  // fails (e.g. RLS mismatch), log it but still return the 402 to the user.
-  supabase
+  // Record the gate hit for admin analytics. We fire-and-forget (don't await)
+  // so the 402 response returns as fast as possible, but the Deno Edge runtime
+  // hibernates the isolate as soon as the response promise resolves — without
+  // `EdgeRuntime.waitUntil(...)` the INSERT promise is dropped and no row
+  // ever lands in public.gate_events. Verified empirically: 0 rows after 24h+
+  // of Phase 45 being live. Same issue would have silently dropped every
+  // Phase 46 gate hit.
+  //
+  // Reference: https://supabase.com/docs/guides/functions/background-tasks
+  const insertPromise = supabase
     .from('gate_events')
     .insert({
       user_id: userId,
@@ -94,6 +101,17 @@ export async function checkTierEntitlement(
         })
       }
     })
+
+  // EdgeRuntime is a Deno Edge runtime global. In the local `deno test`
+  // harness or a non-Edge runtime it may be undefined, so we feature-detect.
+  const edgeRuntime = (globalThis as { EdgeRuntime?: { waitUntil: (p: Promise<unknown>) => void } }).EdgeRuntime
+  if (edgeRuntime?.waitUntil) {
+    edgeRuntime.waitUntil(insertPromise)
+  } else {
+    // Non-Edge runtime fallback: awaiting the insert is safe because the
+    // response latency penalty is irrelevant outside of production traffic.
+    await insertPromise
+  }
 
   return new Response(
     JSON.stringify({

--- a/tests/e2e/tests/owner/esign-gate.spec.ts
+++ b/tests/e2e/tests/owner/esign-gate.spec.ts
@@ -43,15 +43,14 @@ test.describe('v2.0 Phase 45 — DocuSeal paywall wire-up', () => {
 			'No Supabase auth-token in storageState — run the auth setup project first'
 		)
 
-		// The stored value is a base64-encoded JSON `{access_token, ...}`.
-		const decoded = JSON.parse(
-			Buffer.from(
-				(accessTokenEntry!.value.startsWith('base64-')
-					? accessTokenEntry!.value.slice(7)
-					: accessTokenEntry!.value),
-				'base64'
-			).toString('utf8')
-		) as { access_token?: string }
+		// auth-api.setup.ts writes localStorage as plain JSON (unlike the
+		// `base64-`-prefixed cookie payload @supabase/ssr expects). Parse
+		// directly — any base64 decode here would corrupt the JSON and the
+		// test would throw SyntaxError the moment a seeded token actually
+		// exists, instead of reaching its intended 402/skip branches.
+		const decoded = JSON.parse(accessTokenEntry!.value) as {
+			access_token?: string
+		}
 		const accessToken = decoded.access_token
 		test.skip(!accessToken, 'Could not extract access_token from storageState')
 

--- a/tests/e2e/tests/owner/reports-gate.spec.ts
+++ b/tests/e2e/tests/owner/reports-gate.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test'
+import { ROUTES } from '../constants/routes'
+
+/**
+ * v2.0 Phase 46 — Premium reports paywall (REQ-46-04)
+ *
+ * Verifies the wire-up: Free-tier owners hitting export-report with a premium
+ * report type get a 402 with an `upgrade_url` body that deep-links to
+ * `/billing/plans?source=reports_gate`, and the pricing page accepts + forwards
+ * the source tag so Stripe Checkout metadata records the attribution.
+ *
+ * Mirrors esign-gate.spec.ts (Phase 45) — both gates share the same
+ * `_shared/tier-gate.ts` helper, so the tests differ only in endpoint +
+ * expected upgrade_url.
+ *
+ * Uses owner.json storageState. Skips cleanly if the seeded owner is on
+ * Growth or Max (gate returns 200 on paid tier — exercised by the normal
+ * report download flow elsewhere).
+ */
+test.describe('v2.0 Phase 46 — Reports paywall wire-up', () => {
+	test('export-report returns 402 with upgrade_url on Free tier', async ({
+		page,
+		request,
+		baseURL
+	}) => {
+		const storage = await page.context().storageState()
+		const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+		test.skip(
+			!supabaseUrl,
+			'NEXT_PUBLIC_SUPABASE_URL not set — Edge Function URL cannot be resolved'
+		)
+
+		// Extract Supabase session access_token from storageState (set by
+		// auth-api.setup.ts). Matches the pattern in esign-gate.spec.ts.
+		const origin = storage.origins.find(o =>
+			o.origin.startsWith(baseURL ?? 'http://localhost:3050')
+		)
+		const accessTokenEntry = origin?.localStorage?.find(entry =>
+			entry.name.startsWith('sb-') && entry.name.endsWith('-auth-token')
+		)
+		test.skip(
+			!accessTokenEntry,
+			'No Supabase auth-token in storageState — run the auth setup project first'
+		)
+
+		const decoded = JSON.parse(
+			Buffer.from(
+				(accessTokenEntry!.value.startsWith('base64-')
+					? accessTokenEntry!.value.slice(7)
+					: accessTokenEntry!.value),
+				'base64'
+			).toString('utf8')
+		) as { access_token?: string }
+		const accessToken = decoded.access_token
+		test.skip(!accessToken, 'Could not extract access_token from storageState')
+
+		// Hit export-report with `type=year-end` — one of the five gated types
+		// (year-end | 1099 | financial | income-statement | cash-flow). The tier
+		// gate runs BEFORE the RPC is called, so we get either:
+		//   402 → Free tier (what this test proves)
+		//   200 → Growth/Max tier (skip: paywall not reachable)
+		const resp = await request.get(
+			`${supabaseUrl}/functions/v1/export-report?type=year-end&format=csv&year=2026`,
+			{
+				headers: { Authorization: `Bearer ${accessToken}` }
+			}
+		)
+
+		test.skip(
+			resp.status() === 200,
+			'Seeded owner is on Growth/Max — paywall is not reachable. Use a Free-tier fixture to run this spec.'
+		)
+
+		expect(resp.status()).toBe(402)
+
+		const body = (await resp.json()) as {
+			error?: string
+			upgrade_required?: boolean
+			upgrade_url?: string
+			current_plan?: string | null
+		}
+		expect(body.upgrade_required).toBe(true)
+		expect(body.upgrade_url).toBe('/billing/plans?source=reports_gate')
+	})
+
+	test('pricing page preserves ?source=reports_gate query param on load', async ({
+		page
+	}) => {
+		await page.goto(`${ROUTES.HOME}billing/plans?source=reports_gate`)
+
+		// After client-side hydration the source param should still be on the URL
+		// — the checkout hook forwards it into Stripe session metadata so admin
+		// conversion analytics can attribute the upgrade back to this gate.
+		await expect(page).toHaveURL(/source=reports_gate/)
+	})
+})

--- a/tests/e2e/tests/owner/reports-gate.spec.ts
+++ b/tests/e2e/tests/owner/reports-gate.spec.ts
@@ -43,14 +43,12 @@ test.describe('v2.0 Phase 46 — Reports paywall wire-up', () => {
 			'No Supabase auth-token in storageState — run the auth setup project first'
 		)
 
-		const decoded = JSON.parse(
-			Buffer.from(
-				(accessTokenEntry!.value.startsWith('base64-')
-					? accessTokenEntry!.value.slice(7)
-					: accessTokenEntry!.value),
-				'base64'
-			).toString('utf8')
-		) as { access_token?: string }
+		// auth-api.setup.ts writes localStorage as plain JSON (unlike the
+		// `base64-`-prefixed cookie payload @supabase/ssr expects). Parse
+		// directly — any base64 decode here would corrupt the JSON.
+		const decoded = JSON.parse(accessTokenEntry!.value) as {
+			access_token?: string
+		}
 		const accessToken = decoded.access_token
 		test.skip(!accessToken, 'Could not extract access_token from storageState')
 


### PR DESCRIPTION
## Summary

Audit-driven fix-forward for v2.0 Revenue Gates so the Phase 46 Edge Function deploy is a single clean step instead of deploy-then-patch. Covers two gaps the audit surfaced:

### 1. Fire-and-forget `gate_events` insert was dropping every gate hit

**Symptom:** 0 rows in `public.gate_events` after 24h+ of Phase 45 being live in prod, despite observed traffic to `docuseal`.

**Root cause:** `_shared/tier-gate.ts` was `supabase.from(...).insert(...).then(...)` without awaiting. Deno Edge runtime hibernates the isolate as soon as the 402 response promise resolves — any unresolved promise goes with it, so the INSERT silently gets dropped.

**Fix:** wrap the insert in `EdgeRuntime.waitUntil()` (the canonical Supabase pattern for background tasks — [docs](https://supabase.com/docs/guides/functions/background-tasks)). This keeps the isolate alive until the INSERT resolves without blocking the 402 response. Feature-detected so `deno test` (no Edge runtime global) falls back to `await`.

**Applies to:** Phase 45 (DocuSeal) AND Phase 46 (reports). Same helper, one fix.

### 2. REQ-46-04 E2E spec was missing

v2.0-ROADMAP.md promised a Playwright E2E exercising the reports paywall, but Phase 46 shipped without it. New `tests/e2e/tests/owner/reports-gate.spec.ts` mirrors `esign-gate.spec.ts`:

- Free-tier owner hits `/functions/v1/export-report?type=year-end` → expects 402
- Asserts `upgrade_required: true` and `upgrade_url: /billing/plans?source=reports_gate`
- Separate test asserts the pricing page preserves `?source=reports_gate` on load
- Skips cleanly when the seeded owner is on Growth/Max (paywall not reachable)

## Why batch these with the pending deploy

The audit flagged both items as shipping code that was known-broken. Rather than deploy Phase 46 at v77/v70 and immediately redeploy at v78/v71 with the waitUntil fix, this PR lets the operator run one pass covering three functions:

```bash
supabase functions deploy docuseal         # picks up waitUntil for Phase 45
supabase functions deploy export-report    # picks up Phase 46 gate + waitUntil
supabase functions deploy generate-pdf     # picks up Phase 46 gate + waitUntil
```

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 7,292 / 7,292 pass (Edge Function tests are separate)
- [ ] Post-deploy SQL: trigger a Free-tier owner paywall hit, then `select count(*) from gate_events where feature in ('esign', 'premium_reports')` returns ≥ 1
- [ ] Post-deploy: run `pnpm test:e2e -- reports-gate.spec.ts` against a Free-tier seeded owner and confirm 402 assertions pass

[hudsor01]
