### PR TITLE
docs(gsd): scope v2.3 — Document Vault + Bulk-Import Extension

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -104,7 +104,12 @@ TenantFlow is a multi-tenant property management SaaS platform for property owne
 
 ## Active Milestone
 
-*None.* Next milestone TBD.
+**v2.3 Document Vault + Bulk-Import Extension** — Phases 57–58 (scoped 2026-04-20, target ship 2026-05-04).
+
+- [ ] Phase 57: Document vault MVP (1w) — upload/list/preview/delete for property-scoped documents using signed URLs + path-based storage RLS. Schema migration adds `title`, `tags`, `description` to `documents`; new `documentQueries` + `documentMutations`; upload surfaces on `/properties/[id]`.
+- [ ] Phase 58: CSV importer extension (3d) — extract shared stepper from property-importer into `src/components/bulk-import/`; wire entry points for tenants (`/tenants`), units (`/properties/[id]/units`), leases (`/leases`). Reuses existing Zod validation schemas.
+
+Both phases derived from v2.2 Phase 54 competitor review mining (Avail/Buildium "can't find documents" pain + Buildium/AppFolio switching-cost barrier). See `milestones/v2.3-ROADMAP.md`.
 
 ## Recently Shipped
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,13 +1,13 @@
 ---
 gsd_state_version: 1.0
-milestone: --
-milestone_name: --
-status: idle
-stopped_at: v2.0 Revenue Gates + v2.2 Landlord-First Positioning both shipped 2026-04-20. v2.0 Phase 46 (premium reports gate) + audit fix PR #617 merged; Phase 45 + Phase 46 Edge Functions pending a single operator deploy pass (docuseal/export-report/generate-pdf). No active milestone.
-last_updated: "2026-04-20T16:00:00.000Z"
+milestone: v2.3
+milestone_name: Document Vault + Bulk-Import Extension
+status: active
+stopped_at: v2.3 scoped 2026-04-20. Two phases derived from v2.2's deferred competitor-review backlog — Phase 57 document vault MVP (1 week, property-scoped upload/list/preview/delete with signed URLs + path-based RLS), Phase 58 CSV importer extension to tenants/units/leases (3 days, reuses property importer stepper pattern). No phase started yet.
+last_updated: "2026-04-20T16:15:00.000Z"
 last_activity: 2026-04-20
 progress:
-  total_phases: 0
+  total_phases: 2
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -26,10 +26,10 @@ See: .planning/PROJECT.md (updated 2026-04-13)
 
 ## Current Position
 
-Phase: -- (no active milestone — v2.0 and v2.2 both shipped 2026-04-20)
-Plan: --
-Milestone: --
-Status: v2.0 Revenue Gates fully shipped (Phase 45 DocuSeal gate + Phase 46 premium reports gate). Audit of the milestone (after Phase 46 merged) surfaced three latent issues, all fixed in PR #617: fire-and-forget gate_events insert was dropping rows (fixed with EdgeRuntime.waitUntil), REQ-46-04 E2E spec was missing (added), and both E2E specs had a base64-decode bug on the localStorage auth path (fixed). v2.2 Landlord-First Positioning also fully shipped earlier same day. Operator action remaining: `supabase functions deploy docuseal && supabase functions deploy export-report && supabase functions deploy generate-pdf` — single pass picks up the waitUntil fix across Phase 45 + Phase 46 gates. Next milestone TBD.
+Phase: 57 (pending — document vault MVP)
+Plan: -- (phase not yet started)
+Milestone: v2.3 Document Vault + Bulk-Import Extension — active. See `milestones/v2.3-ROADMAP.md`.
+Status: v2.3 scoped 2026-04-20 after v2.0 Revenue Gates + v2.2 Landlord-First Positioning shipped same day. v2.3 picks up the two deferred items from v2.2's competitor review mining: document vault (Avail/Buildium "can't find documents" pain) + CSV bulk-import extension to tenants/units/leases (Buildium/AppFolio switching-cost barrier). Phase 57 goes first — property-scoped upload/list/preview/delete using the signed-URL + path-based-RLS pattern locked in by PR #614. Operator action still pending on v2.0: `supabase functions deploy docuseal export-report generate-pdf` (single pass; independent of v2.3 work).
 Last activity: 2026-04-20
 
 ## Shipped Milestones
@@ -51,6 +51,7 @@ Last activity: 2026-04-20
 | v2.0 | Revenue Gates | 2 | 0 | Both phases shipped (Phase 45 PR #604, Phase 46 PR #616 + #617 audit fixes); operator deploy of docuseal/export-report/generate-pdf pending |
 | v2.1 | Production Integrity Hardening | 4 | 0 | All 4 phases shipped 2026-04-19/20 (PRs #605, #606, #607) |
 | v2.2 | Landlord-First Positioning | 3 | 0 | All 3 phases shipped 2026-04-20 (PRs #609, #610, #612, #613, #614) |
+| v2.3 | Document Vault + Bulk-Import Extension | 2 | 0 | Phase 57 pending |
 
 ## Accumulated Context
 

--- a/.planning/milestones/v2.3-ROADMAP.md
+++ b/.planning/milestones/v2.3-ROADMAP.md
@@ -1,0 +1,126 @@
+# Roadmap: TenantFlow v2.3 — Document Vault + Bulk-Import Extension
+
+**Defined:** 2026-04-20
+**Target ship:** 2026-05-04 (2 weeks, 2 phases)
+**Scope:** Close the two loudest deferred items from v2.2's competitor review mining — document vault for kept-anywhere-else pain (Avail/Buildium/TurboTenant) and CSV bulk-import extension for switching-cost pain (Buildium/AppFolio refugees).
+
+## Why This Milestone Exists
+
+The competitor review mining during v2.2 Phase 54 surfaced six concrete fixes. Four shipped:
+- Expiring-leases dashboard widget (PR #612)
+- Rent-increase notice generator (PR #612)
+- Per-property performance section (PR #612)
+- Maintenance multi-file upload + work-order PDF (PR #613)
+
+Two were deferred because each needs its own schema migration + greenfield surface, making them bigger than a "quick win" slot in v2.2:
+- **Document vault** — the `documents` table exists with RLS but is empty in prod; no upload surface, no listing UI, no search. Avail/Buildium/TurboTenant reviewers cite "can't find documents I uploaded" as a recurring pain. This is a foundational feature, not just a fix.
+- **Bulk-import extension** — the property CSV importer ships complete (stepper, PapaParse, validation), but tenants/units/leases can only be created one-at-a-time. Buildium/AppFolio refugees hit a wall on day 1 when they have to re-enter 50 tenants by hand. This is the #1 cited switching-cost barrier.
+
+Neither was shippable in v2.2's tight PR cadence. Both are the right-sized work for v2.3.
+
+## Success Criteria
+
+- A property owner can upload a PDF to a specific property on `/properties/[id]`, see it listed below, click it to preview inline, download it, or delete it. All operations enforce path-based storage RLS + DB row RLS on `owner_user_id`.
+- A property owner onboarding from Buildium/AppFolio can import their full portfolio in 4 CSV uploads (properties, units, tenants, leases) instead of hand-entering each. Validation errors surface per-row before the commit step.
+- No regressions across v2.0/v2.1/v2.2 surfaces. `gate_events` + paywall flows untouched.
+
+## Phases (strict ordering — 58 reuses 57's upload/storage patterns)
+
+- [ ] **Phase 57: Document vault MVP** (1 week)
+- [ ] **Phase 58: Bulk-import extension to tenants/units/leases** (3 days)
+
+---
+
+## Phase 57: Document Vault MVP
+
+**Goal:** An owner can upload, find, preview, and delete documents attached to a property. Lease/tenant/maintenance entity types defer to v2.4 (additive — same schema, just different upload entry points).
+
+**Depends on:** nothing. `documents` table + owner_user_id column + RLS + `tenant-documents` storage bucket already ship in prod.
+
+**Audit findings driving the scope:**
+- `documents` schema is: `id, entity_type, entity_id, document_type, file_path, storage_url, file_size, created_at, owner_user_id`. Missing a user-editable `title` — `file_path` is the only identifier, which is ugly. Missing `tags text[]` for the category recon flagged as a gap.
+- RLS already has owner select/insert/update/delete policies (confirmed via pg_policies).
+- `tenant-documents` bucket: private, 10 MB size limit, no MIME allowlist. Fine for MVP; may need MIME tightening post-launch.
+- No documents hooks exist in `src/hooks/api/`. Full query-keys factory needs building.
+- Existing `getPublicUrl` pattern fails silently on private buckets (audit-confirmed on `maintenance-photos` earlier this milestone) — use `createSignedUrls` batched per query, 1-hour TTL. Mirror the pattern locked in by PR #614.
+
+**Requirements:**
+
+- **REQ-57-01**: Migration adds `title text` (nullable, default null), `tags text[]` (nullable), `description text` (nullable) to `public.documents`. Backfill `title` from `file_path` split-on-slash for any existing rows (currently 0 in prod, so a no-op, but cheap insurance for replay).
+
+- **REQ-57-02**: `tenant-documents` bucket MIME allowlist updated via `update storage.buckets` to include `application/pdf`, `image/jpeg`, `image/png`, `image/webp`. Keeps size limit at 10 MB (consistent with inspection-photos). Private.
+
+- **REQ-57-03**: New `src/hooks/api/query-keys/document-keys.ts` — `documentQueries.list({ entityType, entityId? })` returns DB rows with signed URLs batched via `createSignedUrls` (1h TTL). `documentMutations.upload` uploads to `tenant-documents/${entity_type}/${entity_id}/${timestamp}-${safeName}` and inserts the DB row; rolls back storage blob on DB failure (mirror pattern from `maintenanceMutations.uploadPhoto`). `documentMutations.delete` deletes DB row + storage blob.
+
+- **REQ-57-04**: New `src/components/documents/documents-section.tsx` — card component rendered on `/properties/[id]` between `PropertyPerformanceSection` and `PropertyUnitsTable`. Shows title (falls back to `file_path` basename), upload date, size; multi-file upload button; inline PDF preview in a Dialog (iframe using signed URL, same pattern as maintenance photos). Filter + search defer to v2.4.
+
+- **REQ-57-05**: Path-based storage RLS policies on `tenant-documents` bucket, mirroring `maintenance-photos` from PR #614: extract first-segment `entity_type`, second-segment `entity_id` from path, join against the corresponding table's `owner_user_id`. One SELECT + one INSERT + one DELETE policy per entity type (initially just `property`).
+
+- **REQ-57-06**: Unit tests cover `documents-section.tsx` render (loading, empty, populated with mock signed URL, upload click, delete confirm). Per-file validation partitions (same pattern PR #613 landed: invalid ones rejected with toast, valid ones upload).
+
+**Battle-proven criterion:** on `/properties/<id>` a free-tier owner uploads a 3 MB PDF, sees the tile, clicks it and the PDF renders inline via signed URL; deletes it, confirms both the DB row and the storage blob are gone (SQL + storage listing).
+
+**Deferred to v2.4:**
+- Upload entry points on `/leases/[id]`, `/tenants/[id]`, `/maintenance/[id]`
+- Global `/documents/vault` listing (across all entity types)
+- Full-text search (`search_vector` column via `to_tsvector` on title + description + tags)
+- Bulk download / zip export
+- Document categorization UI beyond raw `tags[]` array entry
+
+---
+
+## Phase 58: Bulk-Import Extension to Tenants + Units + Leases
+
+**Goal:** CSV importer covers all four primary entities, not just properties. Owners migrating from Buildium/AppFolio can land their full portfolio in one onboarding session.
+
+**Depends on:** Phase 57 shipped (shared stepper pattern; no direct code dep, but scheduling).
+
+**Audit findings driving the scope:**
+- Property bulk-import complete at `src/components/properties/bulk-import-{stepper,upload,validate,confirm,dialog}-step.tsx` + `csv-utils.ts`. Uses PapaParse, dry-run validation, row-by-row insert.
+- Validation schemas already exist: `src/lib/validation/{tenants,units,leases}.ts` all use Zod v4 `.safeParse()` — reusable as CSV row validators.
+- No bulk-insert RPCs exist. Row-by-row insert is the precedent and keeps RLS simple; acceptable for 100-row caps.
+
+**Requirements:**
+
+- **REQ-58-01**: Extract shared stepper + CSV utils from `src/components/properties/bulk-import-*` into `src/components/bulk-import/` (generic). Property importer becomes the first consumer; tenants/units/leases are parallel consumers with the same stepper shell and entity-specific `{ csvTemplate, rowValidator, insertFn }` bindings.
+
+- **REQ-58-02**: Add tenant CSV importer entry point on `/tenants` via "Import tenants" button next to the existing "Add tenant" button. Columns: `email, first_name, last_name, phone, status`. Uses `tenantCreateSchema` from `src/lib/validation/tenants.ts`.
+
+- **REQ-58-03**: Add unit CSV importer entry point on `/properties/[id]/units` via "Import units" button. Columns: `unit_number, bedrooms, bathrooms, square_feet, rent_amount, status`. Property ID auto-filled from route; uses `unitInputSchema`.
+
+- **REQ-58-04**: Add lease CSV importer entry point on `/leases` via "Import leases" button. Columns: `unit_id, primary_tenant_id, start_date, end_date, rent_amount, payment_day`. Uses `leaseInputSchema`. References to `unit_id` and `primary_tenant_id` must resolve against rows the caller already owns (enforce via RLS on the insert; the UI shows a validation error if the CSV row points at an ID the owner doesn't own).
+
+- **REQ-58-05**: Each importer ships a downloadable template CSV hosted as a static asset under `public/templates/`. Template has the column headers + one row of example data the user replaces.
+
+- **REQ-58-06**: Tests cover shared stepper state machine (upload → validate → confirm → import), validation error surfacing per row, RLS failure handling mid-import (partial success is acceptable; final toast summarizes "imported N, skipped M due to errors").
+
+**Battle-proven criterion:** a property owner with 3 properties / 12 units / 8 tenants / 5 leases in a CSV can complete onboarding in under 10 minutes end-to-end. Validation errors surface before the commit step. Deleting a half-imported batch leaves no orphan rows (test: force an RLS failure mid-import, confirm no partial inserts by checking counts before/after).
+
+**Deferred to v2.4+:**
+- Bulk-insert RPCs for throughput (100 rows × 50ms each = 5s per CSV; acceptable; revisit if a 500-row CSV arrives)
+- Column mapping UI (currently rigid: CSV must match template exactly; mapping UI defers until users ask for it)
+- Column auto-detection from known competitor CSV formats (Buildium export, AppFolio export)
+
+---
+
+## Sequencing Rules
+
+1. Phase 57 ships first. Phase 58 reuses its `createSignedUrls` + storage-RLS pattern and benefits from the lessons.
+2. Each phase ships as its own PR. No bundling.
+3. Post-merge: Edge Function deploy only if new Edge Functions are introduced (likely not — document vault uses PostgREST + storage direct from the client).
+4. Phase 58 delivery depends on Phase 57's DB migration approach being settled — if we end up adding a `search_vector` column, Phase 58 gets to skip that concern entirely.
+
+## Out of Scope
+
+- Full-text search across documents (defer to v2.4 after observing which filter modes owners actually use)
+- Document sharing (public link, tenant-facing view) — tenants are records not users; not on roadmap
+- Document versioning / revision history — nice-to-have, defer
+- Cloud storage integration (Google Drive, Dropbox) — niche, high eng cost
+- Signed storage URLs via Edge Function (current client-side `createSignedUrls` with owner's JWT is fine for the MVP)
+- Document OCR / text extraction for receipts — future premium-tier feature
+
+## Revenue Impact
+
+Unlike v2.0, this milestone is **retention-driven not conversion-driven**. Document vault and bulk-import are both "keep the user" rather than "make them pay" levers. Expected effect: reduce switching-back-out rate for Buildium/AppFolio migrators, extend trial-to-paid conversion by removing friction during the 14-day window.
+
+Measurement defers to a post-v2.3 funnel analysis once we have 20+ trial users — not part of this milestone's ship criteria.


### PR DESCRIPTION
Scopes the next milestone: two phases closing the deferred items from v2.2's competitor review mining.

- **Phase 57 — Document vault MVP** (1w). Property-scoped upload/list/preview/delete using the signed-URL + path-based storage RLS pattern locked in by PR #614. Schema migration adds `title`, `tags`, `description` to `documents` table. Bucket MIME allowlist expanded (PDF + common images). New `documentQueries` + `documentMutations` hooks; upload surface on `/properties/[id]`. Lease/tenant/maintenance entity types deferred to v2.4.
- **Phase 58 — CSV importer extension** (3d). Extract shared stepper from `src/components/properties/bulk-import-*` into generic `src/components/bulk-import/`. Wire entry points for tenants (`/tenants`), units (`/properties/[id]/units`), and leases (`/leases`) using existing Zod schemas from `src/lib/validation/`.

Target ship 2026-05-04.

No code changes — documentation only. STATE.md + ROADMAP.md + new `milestones/v2.3-ROADMAP.md`.

[hudsor01]