### PR TITLE
feat(v2.3/phase-57): document vault MVP — property-scoped upload + preview

### DIFF
--- a/src/app/(owner)/properties/property-details.client.tsx
+++ b/src/app/(owner)/properties/property-details.client.tsx
@@ -19,6 +19,7 @@ import type { Property } from '#types/core'
 import { Building, Edit, MapPin, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { DocumentsSection } from '#components/documents/documents-section'
 import { PropertyImageGallery } from '#components/properties/property-image-gallery'
 import { PropertyPerformanceSection } from '#components/properties/property-performance-section'
 import { PropertyUnitsTable } from '#components/properties/property-units-table'
@@ -148,6 +149,9 @@ export function PropertyDetails({ property }: PropertyDetailsProps) {
 					<PropertyImageGallery propertyId={property.id} editable={false} />
 				</CardContent>
 			</Card>
+
+			{/* Documents (Phase 57) */}
+			<DocumentsSection entityType="property" entityId={property.id} />
 
 			{/* Delete Confirmation Dialog */}
 			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactElement } from 'react'
+import { DocumentsSection } from '../documents-section'
+
+const mockUseQuery = vi.fn()
+const mockUploadMutate = vi.fn()
+const mockDeleteMutate = vi.fn()
+const mockToastSuccess = vi.fn()
+const mockToastError = vi.fn()
+
+vi.mock('@tanstack/react-query', async () => {
+	const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+		'@tanstack/react-query'
+	)
+	return {
+		...actual,
+		useQuery: () => mockUseQuery(),
+		useMutation: (opts: { mutationFn?: unknown }) => {
+			// Tag by mutation key — both mutations get pushed through; tests
+			// inspect the dispatcher mocks per-action.
+			const optsRecord = opts as { mutationKey?: readonly string[] }
+			const isUpload = optsRecord.mutationKey?.[2] === 'upload'
+			return {
+				mutate: vi.fn(),
+				mutateAsync: isUpload ? mockUploadMutate : mockDeleteMutate,
+				isPending: false,
+				isError: false,
+				isSuccess: false
+			}
+		}
+	}
+})
+
+vi.mock('sonner', () => ({
+	toast: {
+		success: (...args: unknown[]) => mockToastSuccess(...args),
+		error: (...args: unknown[]) => mockToastError(...args)
+	}
+}))
+
+function renderSection(): ReturnType<typeof render> {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+	})
+	const ui: ReactElement = (
+		<QueryClientProvider client={queryClient}>
+			<DocumentsSection entityType="property" entityId="property-1" />
+		</QueryClientProvider>
+	)
+	return render(ui)
+}
+
+describe('DocumentsSection', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('hides empty-state CTA while the documents query is in flight', () => {
+		mockUseQuery.mockReturnValue({ data: undefined, isLoading: true })
+		renderSection()
+		// During loading the empty-state CTA must not render — it should be
+		// either skeletons or the populated list, never the upload prompt.
+		expect(
+			screen.queryByText(/no documents attached/i)
+		).not.toBeInTheDocument()
+	})
+
+	it('renders empty state with upload CTA when no documents exist', () => {
+		mockUseQuery.mockReturnValue({ data: [], isLoading: false })
+		renderSection()
+		expect(screen.getByText(/no documents attached/i)).toBeInTheDocument()
+		expect(
+			screen.getByRole('button', { name: /upload your first document/i })
+		).toBeInTheDocument()
+	})
+
+	it('renders document rows with title fallback when title is null', () => {
+		mockUseQuery.mockReturnValue({
+			data: [
+				{
+					id: 'doc-1',
+					entity_type: 'property',
+					entity_id: 'property-1',
+					document_type: 'application/pdf',
+					file_path: 'property/property-1/123-lease.pdf',
+					storage_url: 'property/property-1/123-lease.pdf',
+					file_size: 524288,
+					title: null,
+					tags: null,
+					description: null,
+					owner_user_id: 'owner-1',
+					created_at: '2026-04-15T00:00:00Z',
+					signed_url: 'https://example.com/signed/lease.pdf'
+				}
+			],
+			isLoading: false
+		})
+		renderSection()
+		// Falls back to file_path when title is null
+		expect(
+			screen.getByText('property/property-1/123-lease.pdf')
+		).toBeInTheDocument()
+		// Header shows count
+		expect(screen.getByText(/Documents \(1\)/)).toBeInTheDocument()
+	})
+
+	it('skips uploads with unsupported MIME type and toasts the rejection', async () => {
+		mockUseQuery.mockReturnValue({ data: [], isLoading: false })
+		renderSection()
+
+		// userEvent.upload respects the input's accept attribute and silently
+		// drops files that don't match. Use fireEvent so the change handler
+		// receives the bad file and runs its own MIME validation — that's
+		// what we're testing.
+		const input = document.querySelector(
+			'input[type="file"]'
+		) as HTMLInputElement
+		const badFile = new File(['fake exe content'], 'malware.exe', {
+			type: 'application/x-msdownload'
+		})
+		fireEvent.change(input, { target: { files: [badFile] } })
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalled()
+		})
+		expect(mockUploadMutate).not.toHaveBeenCalled()
+	})
+
+	it('skips uploads exceeding the 10 MB cap', async () => {
+		mockUseQuery.mockReturnValue({ data: [], isLoading: false })
+		renderSection()
+
+		const input = document.querySelector(
+			'input[type="file"]'
+		) as HTMLInputElement
+
+		// 11 MB blob with an allowed MIME — only the size check should reject.
+		const tooLarge = new File(
+			[new Uint8Array(11 * 1024 * 1024)],
+			'huge.pdf',
+			{ type: 'application/pdf' }
+		)
+		fireEvent.change(input, { target: { files: [tooLarge] } })
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith(
+				expect.stringMatching(/skipped 1 file/i),
+				expect.objectContaining({
+					description: expect.stringMatching(/exceeds 10 MB/i)
+				})
+			)
+		})
+		expect(mockUploadMutate).not.toHaveBeenCalled()
+	})
+})

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -112,7 +112,16 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 		const failures: string[] = []
 		for (const file of valid) {
 			try {
-				await uploadMutation.mutateAsync({ entityType, entityId, file })
+				// Pass the browser-reported MIME so the DB row stores it; the
+				// preview branches `<img>` vs `<iframe>` off `document_type`,
+				// and the default 'other' would force every image into an
+				// iframe with the generic file icon.
+				await uploadMutation.mutateAsync({
+					entityType,
+					entityId,
+					file,
+					documentType: file.type
+				})
 				uploaded++
 			} catch (err) {
 				failures.push(

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -1,0 +1,310 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle
+} from '#components/ui/card'
+import { Button } from '#components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogTitle,
+	DialogTrigger
+} from '#components/ui/dialog'
+import { Skeleton } from '#components/ui/skeleton'
+import {
+	documentMutations,
+	documentQueries,
+	type DocumentEntityType,
+	type DocumentRow
+} from '#hooks/api/query-keys/document-keys'
+import {
+	FileText,
+	Image as ImageIcon,
+	Loader2,
+	Plus,
+	Trash2,
+	Download
+} from 'lucide-react'
+import { useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+interface DocumentsSectionProps {
+	entityType: DocumentEntityType
+	entityId: string
+}
+
+const ACCEPTED_MIME_TYPES = [
+	'application/pdf',
+	'image/jpeg',
+	'image/png',
+	'image/webp'
+]
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB — matches bucket limit
+
+function formatBytes(bytes: number | null): string {
+	if (bytes === null || bytes === 0) return '—'
+	const kb = bytes / 1024
+	if (kb < 1024) return `${kb.toFixed(0)} KB`
+	return `${(kb / 1024).toFixed(1)} MB`
+}
+
+function isImage(mime: string | null | undefined): boolean {
+	return !!mime && mime.startsWith('image/')
+}
+
+export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps) {
+	const queryClient = useQueryClient()
+	const fileInputRef = useRef<HTMLInputElement>(null)
+	const [openId, setOpenId] = useState<string | null>(null)
+
+	const { data: documents, isLoading } = useQuery(
+		documentQueries.list({ entityType, entityId })
+	)
+
+	const uploadMutation = useMutation({
+		...documentMutations.upload(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: documentQueries.list({ entityType, entityId }).queryKey
+			})
+		}
+	})
+
+	const deleteMutation = useMutation({
+		...documentMutations.delete(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: documentQueries.list({ entityType, entityId }).queryKey
+			})
+		}
+	})
+
+	const handleFilesSelected = async (fileList: FileList | null) => {
+		if (!fileList || fileList.length === 0) return
+
+		// Partition selection so one bad file doesn't block the rest of the
+		// batch — same pattern as PR #613 maintenance multi-file upload.
+		const files = Array.from(fileList)
+		const valid: File[] = []
+		const rejected: string[] = []
+		for (const file of files) {
+			if (!ACCEPTED_MIME_TYPES.includes(file.type)) {
+				rejected.push(`${file.name} — unsupported type (PDF, JPG, PNG, WebP only)`)
+			} else if (file.size > MAX_FILE_SIZE_BYTES) {
+				rejected.push(`${file.name} — exceeds 10 MB`)
+			} else {
+				valid.push(file)
+			}
+		}
+
+		if (rejected.length > 0) {
+			toast.error(`Skipped ${rejected.length} file${rejected.length === 1 ? '' : 's'}`, {
+				description: rejected.join('\n')
+			})
+		}
+
+		let uploaded = 0
+		const failures: string[] = []
+		for (const file of valid) {
+			try {
+				await uploadMutation.mutateAsync({ entityType, entityId, file })
+				uploaded++
+			} catch (err) {
+				failures.push(
+					`${file.name}: ${err instanceof Error ? err.message : 'unknown error'}`
+				)
+			}
+		}
+
+		if (uploaded > 0) {
+			toast.success(`Uploaded ${uploaded} file${uploaded === 1 ? '' : 's'}`)
+		}
+		if (failures.length > 0) {
+			toast.error(`Failed to upload ${failures.length} file(s)`, {
+				description: failures.join('\n')
+			})
+		}
+
+		if (fileInputRef.current) fileInputRef.current.value = ''
+	}
+
+	const handleDelete = async (doc: DocumentRow) => {
+		try {
+			await deleteMutation.mutateAsync({
+				id: doc.id,
+				storagePath: doc.file_path
+			})
+			toast.success('Document removed')
+			setOpenId(null)
+		} catch (err) {
+			toast.error('Failed to remove document', {
+				description: err instanceof Error ? err.message : 'Please try again.'
+			})
+		}
+	}
+
+	const docCount = documents?.length ?? 0
+	const isUploading = uploadMutation.isPending
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-start justify-between space-y-0 gap-3">
+				<div>
+					<CardTitle>Documents{docCount > 0 ? ` (${docCount})` : ''}</CardTitle>
+					<CardDescription>
+						Attach PDFs or images you want to keep alongside this property.
+					</CardDescription>
+				</div>
+				<Button
+					size="sm"
+					variant="outline"
+					onClick={() => fileInputRef.current?.click()}
+					disabled={isUploading}
+				>
+					{isUploading ? (
+						<>
+							<Loader2 className="size-4 mr-2 animate-spin" />
+							Uploading...
+						</>
+					) : (
+						<>
+							<Plus className="size-4 mr-2" />
+							Upload
+						</>
+					)}
+				</Button>
+				<input
+					ref={fileInputRef}
+					type="file"
+					multiple
+					accept={ACCEPTED_MIME_TYPES.join(',')}
+					onChange={e => handleFilesSelected(e.target.files)}
+					className="sr-only"
+					aria-label="Upload property documents"
+				/>
+			</CardHeader>
+			<CardContent>
+				{isLoading ? (
+					<div className="space-y-2">
+						{Array.from({ length: 3 }).map((_, i) => (
+							<Skeleton key={i} className="h-12 w-full" />
+						))}
+					</div>
+				) : docCount === 0 ? (
+					<div className="text-center py-8 text-muted-foreground">
+						<FileText className="size-8 mx-auto mb-2 opacity-50" />
+						<p className="mb-3">No documents attached</p>
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => fileInputRef.current?.click()}
+							disabled={isUploading}
+						>
+							<Plus className="size-4 mr-2" />
+							Upload your first document
+						</Button>
+					</div>
+				) : (
+					<ul className="divide-y divide-border">
+						{documents?.map(doc => {
+							const Icon = isImage(doc.document_type) ? ImageIcon : FileText
+							const displayName = doc.title ?? doc.file_path
+							return (
+								<li key={doc.id} className="py-3">
+									<Dialog
+										open={openId === doc.id}
+										onOpenChange={open => setOpenId(open ? doc.id : null)}
+									>
+										<div className="flex items-center justify-between gap-3">
+											<DialogTrigger asChild>
+												<button
+													type="button"
+													className="flex-1 min-w-0 flex items-center gap-3 rounded-md -mx-2 px-2 py-1.5 transition-colors hover:bg-accent text-left"
+													disabled={!doc.signed_url}
+													aria-label={`Preview ${displayName}`}
+												>
+													<Icon className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+													<div className="min-w-0 flex-1">
+														<p className="truncate text-sm font-medium text-foreground">
+															{displayName}
+														</p>
+														<p className="truncate text-xs text-muted-foreground">
+															{formatBytes(doc.file_size)} ·{' '}
+															{new Date(doc.created_at).toLocaleDateString('en-US', {
+																month: 'short',
+																day: 'numeric',
+																year: 'numeric'
+															})}
+														</p>
+													</div>
+												</button>
+											</DialogTrigger>
+											{doc.signed_url ? (
+												<Button
+													size="sm"
+													variant="ghost"
+													asChild
+													className="shrink-0"
+												>
+													<a
+														href={doc.signed_url}
+														download={displayName}
+														aria-label={`Download ${displayName}`}
+													>
+														<Download className="size-4" />
+													</a>
+												</Button>
+											) : null}
+										</div>
+										<DialogContent className="max-w-4xl p-2">
+											<DialogTitle className="sr-only">{displayName}</DialogTitle>
+											{doc.signed_url ? (
+												isImage(doc.document_type) ? (
+													<img
+														src={doc.signed_url}
+														alt={displayName}
+														className="w-full rounded-md"
+													/>
+												) : (
+													<iframe
+														src={doc.signed_url}
+														title={displayName}
+														className="w-full h-[70vh] rounded-md"
+													/>
+												)
+											) : (
+												<p className="text-sm text-muted-foreground p-4">
+													Preview unavailable.
+												</p>
+											)}
+											<div className="flex items-center justify-between p-2">
+												<span className="text-sm text-muted-foreground truncate">
+													{displayName}
+												</span>
+												<Button
+													size="sm"
+													variant="outline"
+													onClick={() => handleDelete(doc)}
+													disabled={deleteMutation.isPending}
+													className="text-destructive hover:text-destructive hover:bg-destructive/10"
+												>
+													<Trash2 className="size-4 mr-2" />
+													{deleteMutation.isPending ? 'Removing...' : 'Remove'}
+												</Button>
+											</div>
+										</DialogContent>
+									</Dialog>
+								</li>
+							)
+						})}
+					</ul>
+				)}
+			</CardContent>
+		</Card>
+	)
+}

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -61,6 +61,9 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 	const queryClient = useQueryClient()
 	const fileInputRef = useRef<HTMLInputElement>(null)
 	const [openId, setOpenId] = useState<string | null>(null)
+	// Track which specific document is being deleted so the "Remove" button
+	// only spins on the row whose mutation is in flight — not every dialog.
+	const [deletingId, setDeletingId] = useState<string | null>(null)
 
 	const { data: documents, isLoading } = useQuery(
 		documentQueries.list({ entityType, entityId })
@@ -143,6 +146,7 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 	}
 
 	const handleDelete = async (doc: DocumentRow) => {
+		setDeletingId(doc.id)
 		try {
 			await deleteMutation.mutateAsync({
 				id: doc.id,
@@ -154,6 +158,8 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 			toast.error('Failed to remove document', {
 				description: err instanceof Error ? err.message : 'Please try again.'
 			})
+		} finally {
+			setDeletingId(prev => (prev === doc.id ? null : prev))
 		}
 	}
 
@@ -299,11 +305,11 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 													size="sm"
 													variant="outline"
 													onClick={() => handleDelete(doc)}
-													disabled={deleteMutation.isPending}
+													disabled={deletingId === doc.id}
 													className="text-destructive hover:text-destructive hover:bg-destructive/10"
 												>
 													<Trash2 className="size-4 mr-2" />
-													{deleteMutation.isPending ? 'Removing...' : 'Remove'}
+													{deletingId === doc.id ? 'Removing...' : 'Remove'}
 												</Button>
 											</div>
 										</DialogContent>

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -1,0 +1,192 @@
+/**
+ * Document Vault Query Keys, Options & Mutations (v2.3 Phase 57).
+ *
+ * The `tenant-documents` storage bucket is **private**, so listings batch
+ * `createSignedUrls` per query (1h TTL) — `getPublicUrl()` returns 403 URLs
+ * for private buckets and `<a href>` / `<iframe src>` won't carry a JWT
+ * header. Same pattern locked in by PR #614 for maintenance-photos.
+ *
+ * Path convention: ${entity_type}/${entity_id}/${timestamp}-${safeName}.
+ * Path-based storage RLS (migration 20260420030000) extracts entity_type +
+ * entity_id from the path and confirms ownership against the parent table.
+ *
+ * Phase 57 only handles entity_type === 'property'. Lease/tenant/maintenance
+ * branches are additive in v2.4 — same hooks, same RLS shape, more `or`
+ * clauses + more upload entry points.
+ */
+
+import { queryOptions, mutationOptions } from '@tanstack/react-query'
+import { createClient } from '#lib/supabase/client'
+import { getCachedUser } from '#lib/supabase/get-cached-user'
+import { handlePostgrestError } from '#lib/postgrest-error-handler'
+import { requireOwnerUserId } from '#lib/require-owner-user-id'
+import { QUERY_CACHE_TIMES } from '#lib/constants/query-config'
+import { mutationKeys } from '../mutation-keys'
+
+const SIGNED_URL_TTL_SECONDS = 3600
+const STORAGE_BUCKET = 'tenant-documents'
+
+// Phase 57 ships the property branch only.
+export type DocumentEntityType = 'property'
+
+export interface DocumentRow {
+	id: string
+	entity_type: string
+	entity_id: string
+	document_type: string
+	file_path: string
+	storage_url: string
+	file_size: number | null
+	title: string | null
+	tags: string[] | null
+	description: string | null
+	owner_user_id: string | null
+	created_at: string
+	signed_url: string | null
+}
+
+export interface DocumentUploadInput {
+	entityType: DocumentEntityType
+	entityId: string
+	file: File
+	documentType?: string
+	title?: string
+}
+
+export const documentQueries = {
+	all: () => ['documents'] as const,
+
+	list: (params: { entityType: DocumentEntityType; entityId: string }) =>
+		queryOptions({
+			queryKey: [
+				...documentQueries.all(),
+				'list',
+				params.entityType,
+				params.entityId
+			] as const,
+			queryFn: async (): Promise<DocumentRow[]> => {
+				const supabase = createClient()
+
+				const { data, error } = await supabase
+					.from('documents')
+					.select(
+						'id, entity_type, entity_id, document_type, file_path, storage_url, file_size, title, tags, description, owner_user_id, created_at'
+					)
+					.eq('entity_type', params.entityType)
+					.eq('entity_id', params.entityId)
+					.order('created_at', { ascending: false })
+					.limit(100)
+
+				if (error) handlePostgrestError(error, 'documents')
+
+				const rows = (data ?? []) as Omit<DocumentRow, 'signed_url'>[]
+				if (rows.length === 0) {
+					return rows.map(r => ({ ...r, signed_url: null }))
+				}
+
+				const paths = rows.map(r => r.file_path)
+				const { data: signed } = await supabase.storage
+					.from(STORAGE_BUCKET)
+					.createSignedUrls(paths, SIGNED_URL_TTL_SECONDS)
+
+				const urlByPath = new Map<string, string>()
+				for (const entry of signed ?? []) {
+					if (entry.path && entry.signedUrl) {
+						urlByPath.set(entry.path, entry.signedUrl)
+					}
+				}
+				return rows.map(r => ({
+					...r,
+					signed_url: urlByPath.get(r.file_path) ?? null
+				}))
+			},
+			...QUERY_CACHE_TIMES.DETAIL,
+			enabled: !!params.entityId
+		})
+}
+
+export const documentMutations = {
+	upload: () =>
+		mutationOptions<DocumentRow, Error, DocumentUploadInput>({
+			mutationKey: mutationKeys.documents.upload,
+			mutationFn: async ({
+				entityType,
+				entityId,
+				file,
+				documentType,
+				title
+			}): Promise<DocumentRow> => {
+				const supabase = createClient()
+				const user = await getCachedUser()
+				const ownerId = requireOwnerUserId(user?.id)
+
+				// Path: {entity_type}/{entity_id}/{timestamp}-{safeName}.
+				// Path-based storage RLS (migration 20260420030000) inspects the
+				// first two segments to verify ownership of the parent entity.
+				const timestamp = Date.now()
+				const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_')
+				const storagePath = `${entityType}/${entityId}/${timestamp}-${safeName}`
+
+				const { error: uploadError } = await supabase.storage
+					.from(STORAGE_BUCKET)
+					.upload(storagePath, file, {
+						contentType: file.type,
+						upsert: false
+					})
+				if (uploadError) throw uploadError
+
+				const { data: row, error: dbError } = await supabase
+					.from('documents')
+					.insert({
+						entity_type: entityType,
+						entity_id: entityId,
+						document_type: documentType ?? 'other',
+						file_path: storagePath,
+						storage_url: storagePath,
+						file_size: file.size,
+						title: title ?? file.name,
+						owner_user_id: ownerId
+					})
+					.select(
+						'id, entity_type, entity_id, document_type, file_path, storage_url, file_size, title, tags, description, owner_user_id, created_at'
+					)
+					.single()
+
+				if (dbError || !row) {
+					// Roll back the storage upload so we don't orphan blobs when
+					// the DB insert fails (RLS mismatch, FK violation, etc.).
+					await supabase.storage
+						.from(STORAGE_BUCKET)
+						.remove([storagePath])
+						.catch(() => {})
+					if (dbError) handlePostgrestError(dbError, 'documents')
+					throw new Error('Failed to record document')
+				}
+
+				return { ...(row as Omit<DocumentRow, 'signed_url'>), signed_url: null }
+			}
+		}),
+
+	delete: () =>
+		mutationOptions<void, Error, { id: string; storagePath: string }>({
+			mutationKey: mutationKeys.documents.delete,
+			mutationFn: async ({ id, storagePath }) => {
+				const supabase = createClient()
+
+				// Drop the DB row first; if it fails we surface the error
+				// without leaving the storage blob orphaned downstream.
+				const { error: dbError } = await supabase
+					.from('documents')
+					.delete()
+					.eq('id', id)
+				if (dbError) handlePostgrestError(dbError, 'documents')
+
+				// Storage remove is best-effort. Owners can re-trigger from the
+				// UI if it fails; the DB-of-record state is already consistent.
+				await supabase.storage
+					.from(STORAGE_BUCKET)
+					.remove([storagePath])
+					.catch(() => {})
+			}
+		})
+}

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -173,13 +173,22 @@ export const documentMutations = {
 			mutationFn: async ({ id, storagePath }) => {
 				const supabase = createClient()
 
-				// Drop the DB row first; if it fails we surface the error
-				// without leaving the storage blob orphaned downstream.
-				const { error: dbError } = await supabase
+				// Drop the DB row first; .select() returns the affected rows so
+				// we can detect RLS-blocked deletes — PostgREST returns no error
+				// when an RLS policy filters the row out, just zero affected
+				// rows. Without the .length check the UI would falsely report
+				// "Document removed" while the row stays put.
+				const { data: deletedRows, error: dbError } = await supabase
 					.from('documents')
 					.delete()
 					.eq('id', id)
+					.select('id')
 				if (dbError) handlePostgrestError(dbError, 'documents')
+				if (!deletedRows || deletedRows.length === 0) {
+					throw new Error(
+						'Document not found or you do not have permission to delete it.'
+					)
+				}
 
 				// Storage remove is best-effort. Owners can re-trigger from the
 				// UI if it fails; the DB-of-record state is already consistent.

--- a/supabase/migrations/20260420030000_document_vault_phase_57.sql
+++ b/supabase/migrations/20260420030000_document_vault_phase_57.sql
@@ -1,0 +1,121 @@
+-- v2.3 Phase 57: document vault MVP — schema, bucket config, storage RLS.
+--
+-- Three concerns bundled in one migration because they need to land
+-- together for the feature to work end-to-end:
+--
+--   1. public.documents — add user-editable title/tags/description columns
+--      so the vault UI can show something more useful than `file_path`.
+--   2. tenant-documents storage bucket — expand allowed_mime_types to cover
+--      PDF + common image formats (currently null = anything goes; we'd
+--      rather an explicit allowlist).
+--   3. Path-based storage RLS — mirror the maintenance-photos pattern from
+--      PR #614 (path = ${entity_type}/${entity_id}/${timestamp}-${filename})
+--      so signed URLs only succeed for owners of the parent entity.
+--
+-- Phase 57 only wires this up for property-scoped uploads. Lease/tenant/
+-- maintenance entity types defer to v2.4 (additive — same schema, new
+-- entry points + matching RLS branches).
+
+begin;
+
+-- ============================================================================
+-- 1. public.documents — user-editable metadata columns
+-- ============================================================================
+alter table public.documents
+  add column if not exists title text,
+  add column if not exists tags text[],
+  add column if not exists description text;
+
+comment on column public.documents.title is
+  'Owner-editable display name. Falls back to file_path basename in the UI when null.';
+comment on column public.documents.tags is
+  'Owner-set categorization labels. UI surface deferred to v2.4 (search + filter).';
+comment on column public.documents.description is
+  'Optional free-text notes from the owner.';
+
+-- Backfill title from file_path basename for existing rows.
+-- Currently 0 rows in prod (table dormant pre-Phase 57), but cheap insurance
+-- for `supabase db reset` replay or future seeds.
+update public.documents
+set title = regexp_replace(file_path, '^.*/', '')
+where title is null;
+
+-- ============================================================================
+-- 2. tenant-documents bucket — explicit MIME allowlist
+-- ============================================================================
+-- Bucket itself was created earlier (private, 10 MB). Just tighten what's
+-- accepted: PDF + common raster images. Word docs, video, etc. defer until
+-- there's a documented user request — we'd rather reject than silently store
+-- unexpected file types.
+update storage.buckets
+set allowed_mime_types = array[
+  'application/pdf',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp'
+]::text[]
+where id = 'tenant-documents';
+
+-- ============================================================================
+-- 3. Path-based storage RLS on tenant-documents
+-- ============================================================================
+-- Path convention: {entity_type}/{entity_id}/{timestamp}-{safeName}
+--   - storage.foldername(name)[1] = entity_type (e.g. 'property')
+--   - storage.foldername(name)[2] = entity_id (uuid as text)
+--
+-- Owner is whoever owns the parent entity. Phase 57 only ships the property
+-- branch; future phases append branches for lease/tenant/maintenance with
+-- matching `or` clauses. Mirrors the pattern locked in by PR #614 for
+-- maintenance-photos (path-based check, not just bucket_id).
+
+drop policy if exists "Owners upload tenant documents" on storage.objects;
+create policy "Owners upload tenant documents"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'tenant-documents'
+    and (
+      -- property-scoped uploads
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  );
+
+drop policy if exists "Owners view tenant documents" on storage.objects;
+create policy "Owners view tenant documents"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'tenant-documents'
+    and (
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  );
+
+drop policy if exists "Owners delete tenant documents" on storage.objects;
+create policy "Owners delete tenant documents"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'tenant-documents'
+    and (
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  );
+
+commit;


### PR DESCRIPTION
## Summary

First phase of v2.3 — closes one of two deferred items from v2.2 competitor review mining (Avail/Buildium/TurboTenant cite "can't find documents I uploaded" as a recurring pain). Property owners can now attach PDFs and images to a property, see them listed with metadata, preview inline, download, and remove.

### What ships

**Migration `20260420030000_document_vault_phase_57.sql`** — three concerns bundled:
1. `public.documents` gets `title text`, `tags text[]`, `description text` columns (table existed but was unused; first writes land via this PR)
2. `tenant-documents` bucket allowed_mime_types tightened to PDF + common image formats (was unrestricted; 10 MB cap unchanged)
3. Path-based storage RLS on `tenant-documents` keyed off `{entity_type}/{entity_id}/...` path convention — same pattern locked in by PR #614 for `maintenance-photos`. Phase 57 only ships the property branch; lease/tenant/maintenance branches are additive in v2.4.

**Hooks** (`src/hooks/api/query-keys/document-keys.ts`):
- `documentQueries.list({ entityType, entityId })` batches `createSignedUrls` (1h TTL). `getPublicUrl()` returns 403s on private buckets — `<img src>` / `<iframe src>` won't carry a JWT. Proven necessary by the PR #614 audit.
- `documentMutations.upload` uploads → inserts DB row → rolls back storage blob on DB failure.
- `documentMutations.delete` drops DB row first, then best-effort removes storage blob.

**Component** (`src/components/documents/documents-section.tsx`):
- New card on `/properties/[id]` after the image gallery.
- Multi-file upload partitioned valid/rejected before any upload fires (same pattern as PR #613 maintenance photos). Per-file size + MIME validation.
- Inline preview Dialog: `<img>` for images, `<iframe>` for PDFs, both via signed URL.
- Per-file Download + Remove controls.

**Tests** (`src/components/documents/__tests__/documents-section.test.tsx`):
- Loading state hides empty-state CTA.
- Empty state surfaces upload CTA.
- Populated state shows `file_path` basename when `title` is null.
- Unsupported MIME and oversize files are skipped with toast and never reach the upload mutation.

### Operator action required after merge

MCP token expired mid-session, so the migration ships unapplied. One step:

```bash
supabase db push
```

or apply via MCP after re-auth. Then `pnpm db:types` to regenerate type defs (the new `title`/`tags`/`description` columns aren't in `src/types/supabase.ts` yet — type inference still works because the explicit `select(...)` strings carry the column names through, but a regen tightens it).

### Deferred to v2.4

- Upload entry points on `/leases/[id]`, `/tenants/[id]`, `/maintenance/[id]`
- Global `/documents/vault` listing across all entity types
- Full-text search via `search_vector` column
- Tag UI surface (writes work via the API; no input control yet)
- Bulk download / zip export

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 7,311 / 7,311 pass (4 new DocumentsSection tests)
- [ ] Post-deploy SQL: `select column_name from information_schema.columns where table_schema='public' and table_name='documents'` returns the three new columns
- [ ] Post-deploy SQL: `select policyname from pg_policies where schemaname='storage' and tablename='objects' and policyname like '