### PR TITLE
chore(types): regen supabase types after Phase 57 migration

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -110,6 +110,7 @@ export type Database = {
       documents: {
         Row: {
           created_at: string | null
+          description: string | null
           document_type: string
           entity_id: string
           entity_type: string
@@ -118,9 +119,12 @@ export type Database = {
           id: string
           owner_user_id: string | null
           storage_url: string
+          tags: string[] | null
+          title: string | null
         }
         Insert: {
           created_at?: string | null
+          description?: string | null
           document_type: string
           entity_id: string
           entity_type: string
@@ -129,9 +133,12 @@ export type Database = {
           id?: string
           owner_user_id?: string | null
           storage_url: string
+          tags?: string[] | null
+          title?: string | null
         }
         Update: {
           created_at?: string | null
+          description?: string | null
           document_type?: string
           entity_id?: string
           entity_type?: string
@@ -140,6 +147,8 @@ export type Database = {
           id?: string
           owner_user_id?: string | null
           storage_url?: string
+          tags?: string[] | null
+          title?: string | null
         }
         Relationships: []
       }


### PR DESCRIPTION
Migration `20260420030000_document_vault_phase_57` added `title`, `tags`, `description` to `public.documents` (all nullable). This commit syncs `src/types/supabase.ts` so the Insert/Row/Update interfaces include the new columns.

No code changes — existing `.select()` strings already worked because the new fields are nullable. This is purely keeping the generated types aligned with prod schema.

[hudsor01]