### PR TITLE
fix(v2.3): resolve second-cycle audit (53 findings)

### DIFF
--- a/src/components/bulk-import/__tests__/parse-csv-with-schema.test.ts
+++ b/src/components/bulk-import/__tests__/parse-csv-with-schema.test.ts
@@ -39,8 +39,27 @@ describe('parseCsvWithSchema', () => {
 		expect(result.rows).toHaveLength(3)
 		expect(result.rows[0]?.errors).toEqual([])
 		expect(result.rows[1]?.errors.length).toBeGreaterThan(0)
+		// Assert the specific offending field — catches regressions that
+		// silently change which Zod path is reported.
+		expect(result.rows[1]?.errors[0]?.field).toBe('name')
 		expect(result.rows[1]?.parsed).toBeNull()
 		expect(result.rows[2]?.errors).toEqual([])
+	})
+
+	it('escapes embedded quotes when building a CSV template', async () => {
+		const { buildCsvTemplate } = await import('../parse-csv-with-schema')
+		// Round-trip: a sample row with embedded quotes must be parseable
+		// when re-read through `parseCsvWithSchema`. Regression guard for
+		// the H1 finding that `buildCsvTemplate` didn't double quotes.
+		const csv = buildCsvTemplate(
+			['name', 'count'],
+			[[`She said "hi"`, '5']]
+		)
+		const result = parseCsvWithSchema(csv, { schema: sampleSchema, mapRow })
+		expect(result.rows[0]?.parsed).toEqual({
+			name: 'She said "hi"',
+			count: 5
+		})
 	})
 
 	it('normalizes header whitespace + casing', () => {

--- a/src/components/bulk-import/bulk-import-confirm-step.tsx
+++ b/src/components/bulk-import/bulk-import-confirm-step.tsx
@@ -1,23 +1,22 @@
-import {
-	CheckCircle2,
-	XCircle,
-	Loader2,
-	AlertTriangle,
-	PartyPopper,
-	Download,
-	RotateCcw
-} from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import { Progress } from '#components/ui/progress'
-import { Button } from '#components/ui/button'
-import type { BulkImportResult, ImportProgress } from '#types/api-contracts'
-import { cn } from '#lib/utils'
-import { triggerCsvDownload } from './parse-csv-with-schema'
+import type {
+	BulkImportResult,
+	ImportProgress,
+	ParsedRow
+} from '#types/api-contracts'
+import { BulkImportResultPanel } from './bulk-import-result-panel'
 
 interface BulkImportConfirmStepProps {
 	entityLabel: { singular: string; plural: string }
 	isImporting: boolean
 	importProgress: ImportProgress | null
 	result: BulkImportResult | null
+	cumulative: { imported: number; failed: number; totalAttempted: number }
+	retryCount: number
+	parseResult:
+		| { rows: ParsedRow<unknown>[]; tooManyRows: boolean; totalRowCount: number }
+		| null
 	onRetryFailed?: () => void
 }
 
@@ -26,6 +25,9 @@ export function BulkImportConfirmStep({
 	isImporting,
 	importProgress,
 	result,
+	cumulative,
+	retryCount,
+	parseResult,
 	onRetryFailed
 }: BulkImportConfirmStepProps) {
 	const singularLower = entityLabel.singular.toLowerCase()
@@ -34,9 +36,14 @@ export function BulkImportConfirmStep({
 		? (importProgress.current / importProgress.total) * 100
 		: 0
 
+	// Only the first successful batch auto-closes. Once retryCount > 0 the
+	// dialog stays open; surface a subtle hint on the first batch so the
+	// user knows a close is coming.
+	const willAutoClose =
+		result !== null && retryCount === 0 && result.success && result.imported > 0
+
 	return (
 		<div className="space-y-5">
-			{/* Importing State */}
 			{isImporting && (
 				<div
 					className="card-standard p-6 space-y-4"
@@ -75,11 +82,10 @@ export function BulkImportConfirmStep({
 								<>
 									<span>
 										{importProgress.succeeded} succeeded
-										{importProgress.failed > 0 && `, ${importProgress.failed} failed`}
+										{importProgress.failed > 0 &&
+											`, ${importProgress.failed} failed`}
 									</span>
-									<span>
-										{Math.round(progressPercent)}%
-									</span>
+									<span>{Math.round(progressPercent)}%</span>
 								</>
 							) : (
 								<>
@@ -92,212 +98,21 @@ export function BulkImportConfirmStep({
 				</div>
 			)}
 
-			{/* Result Panel */}
 			{result && (
 				<div role="status" aria-live="polite">
 					<BulkImportResultPanel
 						entityLabel={entityLabel}
 						result={result}
+						cumulative={cumulative}
+						retryCount={retryCount}
+						parseResult={parseResult}
 						{...(onRetryFailed ? { onRetryFailed } : {})}
 					/>
-				</div>
-			)}
-		</div>
-	)
-}
-
-function BulkImportResultPanel({
-	entityLabel,
-	result,
-	onRetryFailed
-}: {
-	entityLabel: { singular: string; plural: string }
-	result: BulkImportResult | null
-	onRetryFailed?: () => void
-}) {
-	if (!result) return null
-
-	const isSuccess = result.success && result.imported > 0
-	const hasPartialSuccess = result.imported > 0 && result.failed > 0
-	const isFailure =
-		!result.success || (result.imported === 0 && result.failed > 0)
-
-	const downloadFailedRowsCsv = () => {
-		const header = '"row","error"'
-		const body = result.errors
-			.map(e => `"${e.row}","${e.error.replace(/"/g, '""')}"`)
-			.join('\n')
-		triggerCsvDownload(`${header}\n${body}\n`, 'failed-rows.csv')
-	}
-
-	return (
-		<div
-			className={cn(
-				'card-standard p-6 space-y-4',
-				isSuccess &&
-					!hasPartialSuccess &&
-					'bg-linear-to-r from-success/10 to-success/5 border-success/30',
-				hasPartialSuccess &&
-					'bg-linear-to-r from-warning/10 to-warning/5 border-warning/30',
-				isFailure &&
-					!hasPartialSuccess &&
-					'bg-linear-to-r from-destructive/10 to-destructive/5 border-destructive/30'
-			)}
-		>
-			{/* Header */}
-			<div className="flex items-start gap-4">
-				<div
-					className={cn(
-						'icon-container-md border',
-						isSuccess &&
-							!hasPartialSuccess &&
-							'bg-success/10 text-success border-success/20',
-						hasPartialSuccess && 'bg-warning/10 text-warning border-warning/20',
-						isFailure &&
-							!hasPartialSuccess &&
-							'bg-destructive/10 text-destructive border-destructive/20'
-					)}
-				>
-					{isSuccess && !hasPartialSuccess && (
-						<PartyPopper className="size-5" />
-					)}
-					{hasPartialSuccess && <AlertTriangle className="size-5" />}
-					{isFailure && !hasPartialSuccess && <XCircle className="size-5" />}
-				</div>
-				<div className="flex-1">
-					<p
-						className={cn(
-							'text-base font-semibold',
-							isSuccess && !hasPartialSuccess && 'text-success',
-							hasPartialSuccess && 'text-warning',
-							isFailure && !hasPartialSuccess && 'text-destructive'
-						)}
-					>
-						{isSuccess && !hasPartialSuccess && 'Import successful!'}
-						{hasPartialSuccess && 'Partial import completed'}
-						{isFailure && !hasPartialSuccess && 'Import failed'}
-					</p>
-					<p className="text-sm text-muted-foreground mt-1">
-						{isSuccess &&
-							!hasPartialSuccess &&
-							`Your ${entityLabel.plural.toLowerCase()} have been added.`}
-						{hasPartialSuccess &&
-							`Some ${entityLabel.plural.toLowerCase()} were imported, but others had errors.`}
-						{isFailure &&
-							!hasPartialSuccess &&
-							`No ${entityLabel.plural.toLowerCase()} were imported due to errors.`}
-					</p>
-				</div>
-			</div>
-
-			{/* Stats */}
-			<div className="grid grid-cols-2 gap-3">
-				<div
-					className={cn(
-						'p-3 rounded-lg flex items-center gap-3',
-						result.imported > 0 ? 'bg-success/10' : 'bg-muted/50'
-					)}
-				>
-					<div
-						className={cn(
-							'icon-container-sm',
-							result.imported > 0
-								? 'bg-success/20 text-success'
-								: 'bg-muted text-muted-foreground'
-						)}
-					>
-						<CheckCircle2 className="size-4" />
-					</div>
-					<div>
-						<p
-							className={cn(
-								'text-xl font-bold',
-								result.imported > 0 ? 'text-success' : 'text-muted-foreground'
-							)}
-						>
-							{result.imported}
+					{willAutoClose && (
+						<p className="text-xs text-muted-foreground mt-2 text-center">
+							Closing automatically…
 						</p>
-						<p className="text-xs text-muted-foreground">
-							{result.imported === 1
-								? entityLabel.singular
-								: entityLabel.plural}{' '}
-							imported
-						</p>
-					</div>
-				</div>
-				<div
-					className={cn(
-						'p-3 rounded-lg flex items-center gap-3',
-						result.failed > 0 ? 'bg-destructive/10' : 'bg-muted/50'
 					)}
-				>
-					<div
-						className={cn(
-							'icon-container-sm',
-							result.failed > 0
-								? 'bg-destructive/20 text-destructive'
-								: 'bg-muted text-muted-foreground'
-						)}
-					>
-						<XCircle className="size-4" />
-					</div>
-					<div>
-						<p
-							className={cn(
-								'text-xl font-bold',
-								result.failed > 0 ? 'text-destructive' : 'text-muted-foreground'
-							)}
-						>
-							{result.failed}
-						</p>
-						<p className="text-xs text-muted-foreground">
-							{result.failed === 1 ? 'Row' : 'Rows'} failed
-						</p>
-					</div>
-				</div>
-			</div>
-
-			{/* Error Details */}
-			{result.errors.length > 0 && (
-				<div className="space-y-2">
-					<p className="text-sm font-semibold">Failed rows</p>
-					<div className="card-standard max-h-56 overflow-y-auto">
-						<ul className="divide-y divide-border/40 text-xs">
-							{result.errors.map(err => (
-								<li
-									key={err.row}
-									className="px-3 py-2 flex items-start gap-2"
-								>
-									<span className="font-mono text-muted-foreground shrink-0">
-										#{err.row}
-									</span>
-									<span className="text-destructive">{err.error}</span>
-								</li>
-							))}
-						</ul>
-					</div>
-					<div className="flex flex-wrap gap-2">
-						<Button
-							size="sm"
-							variant="outline"
-							onClick={downloadFailedRowsCsv}
-							className="gap-2"
-						>
-							<Download className="size-3.5" />
-							Download failed rows
-						</Button>
-						{onRetryFailed && (
-							<Button
-								size="sm"
-								variant="outline"
-								onClick={onRetryFailed}
-								className="gap-2"
-							>
-								<RotateCcw className="size-3.5" />
-								Retry failed rows
-							</Button>
-						)}
-					</div>
 				</div>
 			)}
 		</div>

--- a/src/components/bulk-import/bulk-import-result-panel.tsx
+++ b/src/components/bulk-import/bulk-import-result-panel.tsx
@@ -128,6 +128,61 @@ function ResultHeader({
 	)
 }
 
+function StatCard({
+	tone,
+	count,
+	label,
+	icon
+}: {
+	tone: 'success' | 'destructive'
+	count: number
+	label: string
+	icon: 'check' | 'x'
+}) {
+	const active = count > 0
+	const Icon = icon === 'check' ? CheckCircle2 : XCircle
+	return (
+		<div
+			className={cn(
+				'p-3 rounded-lg flex items-center gap-3',
+				active
+					? tone === 'success'
+						? 'bg-success/10'
+						: 'bg-destructive/10'
+					: 'bg-muted/50'
+			)}
+		>
+			<div
+				className={cn(
+					'icon-container-sm',
+					active
+						? tone === 'success'
+							? 'bg-success/20 text-success'
+							: 'bg-destructive/20 text-destructive'
+						: 'bg-muted text-muted-foreground'
+				)}
+			>
+				<Icon className="size-4" />
+			</div>
+			<div>
+				<p
+					className={cn(
+						'text-xl font-bold',
+						active
+							? tone === 'success'
+								? 'text-success'
+								: 'text-destructive'
+							: 'text-muted-foreground'
+					)}
+				>
+					{count}
+				</p>
+				<p className="text-xs text-muted-foreground">{label}</p>
+			</div>
+		</div>
+	)
+}
+
 function ResultStats({
 	entityLabel,
 	result,
@@ -139,77 +194,61 @@ function ResultStats({
 	cumulative: { imported: number; failed: number; totalAttempted: number }
 	retryCount: number
 }) {
-	// After a retry, cumulative > result — show both so the user can see
-	// "30 imported total (5 this batch), 2 still failing".
 	const showCumulative = retryCount > 0
+	const importedCount = showCumulative ? cumulative.imported : result.imported
+	const importedLabel = showCumulative
+		? `${entityLabel.plural.toLowerCase()} imported (total)`
+		: `${result.imported === 1 ? entityLabel.singular : entityLabel.plural} imported`
+	const failedLabel = showCumulative
+		? `${result.failed === 1 ? 'Row' : 'Rows'} still failing this batch`
+		: `${result.failed === 1 ? 'Row' : 'Rows'} failed`
 	return (
 		<div className="grid grid-cols-2 gap-3">
-			<div
-				className={cn(
-					'p-3 rounded-lg flex items-center gap-3',
-					result.imported > 0 ? 'bg-success/10' : 'bg-muted/50'
-				)}
-			>
-				<div
-					className={cn(
-						'icon-container-sm',
-						result.imported > 0
-							? 'bg-success/20 text-success'
-							: 'bg-muted text-muted-foreground'
-					)}
-				>
-					<CheckCircle2 className="size-4" />
-				</div>
-				<div>
-					<p
-						className={cn(
-							'text-xl font-bold',
-							result.imported > 0 ? 'text-success' : 'text-muted-foreground'
-						)}
-					>
-						{showCumulative ? cumulative.imported : result.imported}
-					</p>
-					<p className="text-xs text-muted-foreground">
-						{showCumulative
-							? `${entityLabel.plural.toLowerCase()} imported (total)`
-							: `${result.imported === 1 ? entityLabel.singular : entityLabel.plural} imported`}
-					</p>
-				</div>
-			</div>
-			<div
-				className={cn(
-					'p-3 rounded-lg flex items-center gap-3',
-					result.failed > 0 ? 'bg-destructive/10' : 'bg-muted/50'
-				)}
-			>
-				<div
-					className={cn(
-						'icon-container-sm',
-						result.failed > 0
-							? 'bg-destructive/20 text-destructive'
-							: 'bg-muted text-muted-foreground'
-					)}
-				>
-					<XCircle className="size-4" />
-				</div>
-				<div>
-					<p
-						className={cn(
-							'text-xl font-bold',
-							result.failed > 0 ? 'text-destructive' : 'text-muted-foreground'
-						)}
-					>
-						{result.failed}
-					</p>
-					<p className="text-xs text-muted-foreground">
-						{showCumulative
-							? `${result.failed === 1 ? 'Row' : 'Rows'} still failing this batch`
-							: `${result.failed === 1 ? 'Row' : 'Rows'} failed`}
-					</p>
-				</div>
-			</div>
+			<StatCard
+				tone="success"
+				count={importedCount}
+				label={importedLabel}
+				icon="check"
+			/>
+			<StatCard
+				tone="destructive"
+				count={result.failed}
+				label={failedLabel}
+				icon="x"
+			/>
 		</div>
 	)
+}
+
+// Build a CSV mirroring the original user-supplied headers + failed-row
+// cells + an appended `_error` column. Users can fix the file in Excel and
+// re-upload without cross-referencing row numbers. Falls back to a tiny
+// row,error CSV when parseResult is unavailable (synthetic onError result).
+function buildFailedRowsCsv(
+	errors: Array<{ row: number; error: string }>,
+	parseResult:
+		| { rows: ParsedRow<unknown>[]; tooManyRows: boolean; totalRowCount: number }
+		| null
+): string {
+	if (!parseResult) {
+		const header = '"row","error"'
+		const body = errors
+			.map(e => `"${e.row}","${e.error.replace(/"/g, '""')}"`)
+			.join('\n')
+		return `${header}\n${body}\n`
+	}
+	const firstRow = parseResult.rows[0]
+	const originalHeaders = firstRow ? Object.keys(firstRow.data) : []
+	const headerRow = [...originalHeaders, '_error']
+	const errorByLine = new Map(errors.map(e => [e.row, e.error]))
+	const dataRows = parseResult.rows
+		.filter(r => errorByLine.has(r.row))
+		.map(r => {
+			const cells = originalHeaders.map(h => r.data[h] ?? '')
+			cells.push(errorByLine.get(r.row) ?? '')
+			return cells
+		})
+	return buildCsvTemplate(headerRow, dataRows)
 }
 
 function ResultErrorList({
@@ -223,33 +262,14 @@ function ResultErrorList({
 		| null
 	onRetryFailed?: () => void
 }) {
-	// Download a CSV that mirrors the original user-supplied headers and
-	// includes the failed rows' cells + an `_error` column. Users can fix
-	// in Excel and re-upload without having to cross-reference row numbers.
+	// Synthetic onError result populates a single `row: 0` entry. There's
+	// no real CSV row to retry, so hide the retry button — clicking it
+	// would be a silent no-op (handleRetryFailed filters by csvLine and
+	// finds nothing).
+	const isSyntheticError = errors.every(e => e.row === 0)
 	const downloadFailedRowsCsv = () => {
-		if (!parseResult) {
-			const header = '"row","error"'
-			const body = errors
-				.map(e => `"${e.row}","${e.error.replace(/"/g, '""')}"`)
-				.join('\n')
-			triggerCsvDownload(`${header}\n${body}\n`, 'failed-rows.csv')
-			return
-		}
-		// Derive original headers from the first successfully-read row's data
-		// (all rows share the same normalized header set).
-		const firstRow = parseResult.rows[0]
-		const originalHeaders = firstRow ? Object.keys(firstRow.data) : []
-		const headerRow = [...originalHeaders, '_error']
-		const errorByLine = new Map(errors.map(e => [e.row, e.error]))
-		const dataRows = parseResult.rows
-			.filter(r => errorByLine.has(r.row))
-			.map(r => {
-				const cells = originalHeaders.map(h => r.data[h] ?? '')
-				cells.push(errorByLine.get(r.row) ?? '')
-				return cells
-			})
 		triggerCsvDownload(
-			buildCsvTemplate(headerRow, dataRows),
+			buildFailedRowsCsv(errors, parseResult),
 			'failed-rows.csv'
 		)
 	}
@@ -265,7 +285,7 @@ function ResultErrorList({
 							className="px-3 py-2 flex items-start gap-2"
 						>
 							<span className="font-mono text-muted-foreground shrink-0">
-								#{err.row}
+								{err.row === 0 ? '!' : `#${err.row}`}
 							</span>
 							<span className="text-destructive">{err.error}</span>
 						</li>
@@ -282,7 +302,7 @@ function ResultErrorList({
 					<Download className="size-3.5" />
 					Download failed rows
 				</Button>
-				{onRetryFailed && (
+				{onRetryFailed && !isSyntheticError && (
 					<Button
 						size="sm"
 						variant="outline"

--- a/src/components/bulk-import/bulk-import-result-panel.tsx
+++ b/src/components/bulk-import/bulk-import-result-panel.tsx
@@ -1,0 +1,299 @@
+'use client'
+
+import {
+	CheckCircle2,
+	XCircle,
+	AlertTriangle,
+	PartyPopper,
+	Download,
+	RotateCcw
+} from 'lucide-react'
+import { Button } from '#components/ui/button'
+import type { BulkImportResult, ParsedRow } from '#types/api-contracts'
+import { cn } from '#lib/utils'
+import {
+	buildCsvTemplate,
+	triggerCsvDownload
+} from './parse-csv-with-schema'
+
+interface ResultPanelProps {
+	entityLabel: { singular: string; plural: string }
+	result: BulkImportResult
+	cumulative: { imported: number; failed: number; totalAttempted: number }
+	retryCount: number
+	parseResult:
+		| { rows: ParsedRow<unknown>[]; tooManyRows: boolean; totalRowCount: number }
+		| null
+	onRetryFailed?: () => void
+}
+
+export function BulkImportResultPanel({
+	entityLabel,
+	result,
+	cumulative,
+	retryCount,
+	parseResult,
+	onRetryFailed
+}: ResultPanelProps) {
+	const isSuccess = result.success && result.imported > 0
+	const hasPartialSuccess = result.imported > 0 && result.failed > 0
+
+	const tone = isSuccess && !hasPartialSuccess
+		? 'success'
+		: hasPartialSuccess
+			? 'warning'
+			: 'destructive'
+
+	return (
+		<div
+			className={cn(
+				'card-standard p-6 space-y-4',
+				tone === 'success' &&
+					'bg-linear-to-r from-success/10 to-success/5 border-success/30',
+				tone === 'warning' &&
+					'bg-linear-to-r from-warning/10 to-warning/5 border-warning/30',
+				tone === 'destructive' &&
+					'bg-linear-to-r from-destructive/10 to-destructive/5 border-destructive/30'
+			)}
+		>
+			<ResultHeader
+				tone={tone}
+				entityLabel={entityLabel}
+				retryCount={retryCount}
+			/>
+			<ResultStats
+				entityLabel={entityLabel}
+				result={result}
+				cumulative={cumulative}
+				retryCount={retryCount}
+			/>
+			{result.errors.length > 0 && (
+				<ResultErrorList
+					errors={result.errors}
+					parseResult={parseResult}
+					{...(onRetryFailed ? { onRetryFailed } : {})}
+				/>
+			)}
+		</div>
+	)
+}
+
+function ResultHeader({
+	tone,
+	entityLabel,
+	retryCount
+}: {
+	tone: 'success' | 'warning' | 'destructive'
+	entityLabel: { singular: string; plural: string }
+	retryCount: number
+}) {
+	const plural = entityLabel.plural.toLowerCase()
+	return (
+		<div className="flex items-start gap-4">
+			<div
+				className={cn(
+					'icon-container-md border',
+					tone === 'success' && 'bg-success/10 text-success border-success/20',
+					tone === 'warning' && 'bg-warning/10 text-warning border-warning/20',
+					tone === 'destructive' &&
+						'bg-destructive/10 text-destructive border-destructive/20'
+				)}
+			>
+				{tone === 'success' && <PartyPopper className="size-5" />}
+				{tone === 'warning' && <AlertTriangle className="size-5" />}
+				{tone === 'destructive' && <XCircle className="size-5" />}
+			</div>
+			<div className="flex-1">
+				<p
+					className={cn(
+						'text-base font-semibold',
+						tone === 'success' && 'text-success',
+						tone === 'warning' && 'text-warning',
+						tone === 'destructive' && 'text-destructive'
+					)}
+				>
+					{tone === 'success' && (retryCount > 0 ? 'Retry successful!' : 'Import successful!')}
+					{tone === 'warning' && 'Partial import completed'}
+					{tone === 'destructive' && 'Import failed'}
+				</p>
+				<p className="text-sm text-muted-foreground mt-1">
+					{tone === 'success' && `Your ${plural} have been added.`}
+					{tone === 'warning' &&
+						`Some ${plural} were imported, but others had errors.`}
+					{tone === 'destructive' &&
+						`No ${plural} were imported due to errors.`}
+				</p>
+			</div>
+		</div>
+	)
+}
+
+function ResultStats({
+	entityLabel,
+	result,
+	cumulative,
+	retryCount
+}: {
+	entityLabel: { singular: string; plural: string }
+	result: BulkImportResult
+	cumulative: { imported: number; failed: number; totalAttempted: number }
+	retryCount: number
+}) {
+	// After a retry, cumulative > result — show both so the user can see
+	// "30 imported total (5 this batch), 2 still failing".
+	const showCumulative = retryCount > 0
+	return (
+		<div className="grid grid-cols-2 gap-3">
+			<div
+				className={cn(
+					'p-3 rounded-lg flex items-center gap-3',
+					result.imported > 0 ? 'bg-success/10' : 'bg-muted/50'
+				)}
+			>
+				<div
+					className={cn(
+						'icon-container-sm',
+						result.imported > 0
+							? 'bg-success/20 text-success'
+							: 'bg-muted text-muted-foreground'
+					)}
+				>
+					<CheckCircle2 className="size-4" />
+				</div>
+				<div>
+					<p
+						className={cn(
+							'text-xl font-bold',
+							result.imported > 0 ? 'text-success' : 'text-muted-foreground'
+						)}
+					>
+						{showCumulative ? cumulative.imported : result.imported}
+					</p>
+					<p className="text-xs text-muted-foreground">
+						{showCumulative
+							? `${entityLabel.plural.toLowerCase()} imported (total)`
+							: `${result.imported === 1 ? entityLabel.singular : entityLabel.plural} imported`}
+					</p>
+				</div>
+			</div>
+			<div
+				className={cn(
+					'p-3 rounded-lg flex items-center gap-3',
+					result.failed > 0 ? 'bg-destructive/10' : 'bg-muted/50'
+				)}
+			>
+				<div
+					className={cn(
+						'icon-container-sm',
+						result.failed > 0
+							? 'bg-destructive/20 text-destructive'
+							: 'bg-muted text-muted-foreground'
+					)}
+				>
+					<XCircle className="size-4" />
+				</div>
+				<div>
+					<p
+						className={cn(
+							'text-xl font-bold',
+							result.failed > 0 ? 'text-destructive' : 'text-muted-foreground'
+						)}
+					>
+						{result.failed}
+					</p>
+					<p className="text-xs text-muted-foreground">
+						{showCumulative
+							? `${result.failed === 1 ? 'Row' : 'Rows'} still failing this batch`
+							: `${result.failed === 1 ? 'Row' : 'Rows'} failed`}
+					</p>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+function ResultErrorList({
+	errors,
+	parseResult,
+	onRetryFailed
+}: {
+	errors: Array<{ row: number; error: string }>
+	parseResult:
+		| { rows: ParsedRow<unknown>[]; tooManyRows: boolean; totalRowCount: number }
+		| null
+	onRetryFailed?: () => void
+}) {
+	// Download a CSV that mirrors the original user-supplied headers and
+	// includes the failed rows' cells + an `_error` column. Users can fix
+	// in Excel and re-upload without having to cross-reference row numbers.
+	const downloadFailedRowsCsv = () => {
+		if (!parseResult) {
+			const header = '"row","error"'
+			const body = errors
+				.map(e => `"${e.row}","${e.error.replace(/"/g, '""')}"`)
+				.join('\n')
+			triggerCsvDownload(`${header}\n${body}\n`, 'failed-rows.csv')
+			return
+		}
+		// Derive original headers from the first successfully-read row's data
+		// (all rows share the same normalized header set).
+		const firstRow = parseResult.rows[0]
+		const originalHeaders = firstRow ? Object.keys(firstRow.data) : []
+		const headerRow = [...originalHeaders, '_error']
+		const errorByLine = new Map(errors.map(e => [e.row, e.error]))
+		const dataRows = parseResult.rows
+			.filter(r => errorByLine.has(r.row))
+			.map(r => {
+				const cells = originalHeaders.map(h => r.data[h] ?? '')
+				cells.push(errorByLine.get(r.row) ?? '')
+				return cells
+			})
+		triggerCsvDownload(
+			buildCsvTemplate(headerRow, dataRows),
+			'failed-rows.csv'
+		)
+	}
+
+	return (
+		<div className="space-y-2">
+			<p className="text-sm font-semibold">Failed rows</p>
+			<div className="card-standard max-h-56 overflow-y-auto">
+				<ul className="divide-y divide-border/40 text-xs">
+					{errors.map(err => (
+						<li
+							key={err.row}
+							className="px-3 py-2 flex items-start gap-2"
+						>
+							<span className="font-mono text-muted-foreground shrink-0">
+								#{err.row}
+							</span>
+							<span className="text-destructive">{err.error}</span>
+						</li>
+					))}
+				</ul>
+			</div>
+			<div className="flex flex-wrap gap-2">
+				<Button
+					size="sm"
+					variant="outline"
+					onClick={downloadFailedRowsCsv}
+					className="gap-2"
+				>
+					<Download className="size-3.5" />
+					Download failed rows
+				</Button>
+				{onRetryFailed && (
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={onRetryFailed}
+						className="gap-2"
+					>
+						<RotateCcw className="size-3.5" />
+						Retry failed rows
+					</Button>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/src/components/bulk-import/bulk-import-stepper.tsx
+++ b/src/components/bulk-import/bulk-import-stepper.tsx
@@ -13,14 +13,9 @@ import {
 	Description as StepperDescription,
 	Content as StepperContent
 } from '#components/ui/stepper'
-import {
-	Upload,
-	FileCheck,
-	CheckCheck,
-	ArrowLeft
-} from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Upload, FileCheck, CheckCheck, ArrowLeft } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
 import { createLogger } from '#lib/frontend-logger'
 import type {
 	BulkImportResult,
@@ -33,13 +28,13 @@ import { BulkImportValidateStep } from './bulk-import-validate-step'
 import { BulkImportConfirmStep } from './bulk-import-confirm-step'
 import { cn } from '#lib/utils'
 import type { BulkImportConfig } from './types'
+import {
+	useBulkImportMutation,
+	useMountedRef,
+	type BulkImportMutationInput
+} from './use-bulk-import-mutation'
 
 const logger = createLogger({ component: 'BulkImportStepper' })
-
-// Flush progress at most every ~120 ms of wall-clock + every 5 rows to avoid
-// the 100-re-render storm when a user imports 100 rows back-to-back.
-const PROGRESS_BATCH_EVERY_ROWS = 5
-const PROGRESS_BATCH_EVERY_MS = 120
 
 interface BulkImportStepperProps<T> {
 	config: BulkImportConfig<T>
@@ -62,92 +57,29 @@ export function BulkImportStepper<T>({
 		tooManyRows: boolean
 		totalRowCount: number
 	} | null>(null)
-	const [importProgress, setImportProgress] = useState<ImportProgress | null>(null)
+	const [importProgress, setImportProgress] = useState<ImportProgress | null>(
+		null
+	)
 	const [result, setResult] = useState<BulkImportResult | null>(null)
-	const queryClient = useQueryClient()
-	const mountedRef = useRef(true)
+	// Cumulative totals across initial import + every retry batch. Single-
+	// batch totals in `result` alone would hide prior successes from the UI
+	// when a retry produced its own partial-success.
+	const [cumulative, setCumulative] = useState({
+		imported: 0,
+		failed: 0,
+		totalAttempted: 0
+	})
+	// Retries disable the auto-close so the user can read cumulative totals.
+	const [retryCount, setRetryCount] = useState(0)
+	const mountedRef = useMountedRef()
 
-	useEffect(() => {
-		mountedRef.current = true
-		return () => {
-			mountedRef.current = false
-		}
-	}, [])
-
-	const bulkImportMutation = useMutation({
-		mutationFn: async (
-			rows: Array<{ csvLine: number; parsed: T }>
-		): Promise<BulkImportResult> => {
-			const errors: Array<{ row: number; error: string }> = []
-			let succeeded = 0
-			let lastFlush = Date.now()
-
-			for (let i = 0; i < rows.length; i++) {
-				const entry = rows[i]!
-				const { error } = await config.insertRow(entry.parsed)
-
-				if (error) {
-					// Record the real CSV line number so the "Retry failed" and
-					// "Download failed rows" paths can match on an identifier
-					// that survives filtering invalid rows out of the batch.
-					errors.push({ row: entry.csvLine, error: error.message })
-				} else {
-					succeeded++
-				}
-
-				const now = Date.now()
-				const isLast = i === rows.length - 1
-				const hitRowBatch = (i + 1) % PROGRESS_BATCH_EVERY_ROWS === 0
-				const hitTimeBatch = now - lastFlush >= PROGRESS_BATCH_EVERY_MS
-				if (isLast || hitRowBatch || hitTimeBatch) {
-					if (mountedRef.current) {
-						setImportProgress({
-							current: i + 1,
-							total: rows.length,
-							succeeded,
-							failed: errors.length
-						})
-					}
-					lastFlush = now
-				}
-			}
-
-			return {
-				success: errors.length === 0,
-				imported: succeeded,
-				failed: errors.length,
-				errors
-			}
-		},
-		onSuccess: async data => {
-			for (const key of config.invalidateKeys) {
-				await queryClient.invalidateQueries({ queryKey: key })
-			}
-
-			if (!mountedRef.current) return
-			setResult(data)
-			// Only auto-close on full success. Partial success or failure keeps
-			// the dialog open so the user can read per-row errors and decide
-			// whether to retry. 5 s gives enough time to read the success badge.
-			if (data.success && data.imported > 0) {
-				setTimeout(() => {
-					if (!mountedRef.current) return
-					onComplete()
-					resetDialog()
-				}, 5000)
-			}
-		},
-		onError: error => {
-			logger.error('Bulk import failed', {
-				error,
-				entity: config.entityLabel.plural
-			})
-			if (mountedRef.current) setImportProgress(null)
-		}
+	const bulkImportMutation = useBulkImportMutation<T>({
+		config,
+		setImportProgress,
+		setResult,
+		mountedRef
 	})
 
-	// Lift pending state so the dialog can block close-during-import without
-	// reaching into mutation internals.
 	useEffect(() => {
 		onPendingChange?.(bulkImportMutation.isPending)
 	}, [bulkImportMutation.isPending, onPendingChange])
@@ -158,11 +90,41 @@ export function BulkImportStepper<T>({
 		onStepChange('upload')
 		setParseResult(null)
 		setImportProgress(null)
+		setCumulative({ imported: 0, failed: 0, totalAttempted: 0 })
+		setRetryCount(0)
 	}, [onStepChange])
+
+	// Auto-close only on a first-batch full success. Retries keep the
+	// dialog open so the user can see the cumulative-total panel.
+	useEffect(() => {
+		if (!result) return
+		if (retryCount > 0) return
+		if (!(result.success && result.imported > 0)) return
+		const id = window.setTimeout(() => {
+			if (!mountedRef.current) return
+			onComplete()
+			resetDialog()
+		}, 5000)
+		return () => window.clearTimeout(id)
+	}, [result, retryCount, onComplete, resetDialog, mountedRef])
+
+	// Keep cumulative counters in sync with each mutation result.
+	useEffect(() => {
+		if (!result) return
+		setCumulative(prev => ({
+			imported: prev.imported + result.imported,
+			// Only the most recent batch's failures remain outstanding;
+			// previously-retried-and-fixed rows are gone from this count.
+			failed: result.failed,
+			totalAttempted: prev.totalAttempted + result.imported + result.failed
+		}))
+	}, [result])
 
 	const handleFileSelect = async (selectedFile: File) => {
 		setFile(selectedFile)
 		setResult(null)
+		setCumulative({ imported: 0, failed: 0, totalAttempted: 0 })
+		setRetryCount(0)
 		onStepChange('validate')
 		try {
 			const text = await selectedFile.text()
@@ -174,24 +136,20 @@ export function BulkImportStepper<T>({
 				entity: config.entityLabel.plural
 			})
 			setParseResult(null)
+			toast.error('Failed to read CSV file', {
+				description: 'Check the file is a valid CSV and not corrupted.'
+			})
 		}
 	}
 
-	const runImport = async (rows: Array<{ csvLine: number; parsed: T }>) => {
+	const runImport = async (rows: BulkImportMutationInput<T>[]) => {
 		setResult(null)
 		setImportProgress(null)
 		onStepChange('confirm')
 		try {
-			logger.info('Starting bulk import', {
-				rowCount: rows.length,
-				entity: config.entityLabel.plural
-			})
 			await bulkImportMutation.mutateAsync(rows)
-			logger.info('Bulk import completed', {
-				entity: config.entityLabel.plural
-			})
-		} catch (error) {
-			logger.error('Bulk import mutation failed', { error })
+		} catch (err) {
+			logger.debug('mutateAsync threw (handled by onError)', { error: err })
 		}
 	}
 
@@ -200,23 +158,21 @@ export function BulkImportStepper<T>({
 		const validRows = parseResult.rows
 			.filter(r => r.parsed !== null)
 			.map(r => ({ csvLine: r.row, parsed: r.parsed as T }))
-
 		if (validRows.length === 0) return
 		await runImport(validRows)
 	}
 
+	// On retry: filter the ORIGINAL parsed rows by CSV line number (stable
+	// identifier). Only previously-failed rows rerun; prior successes are
+	// not re-inserted.
 	const handleRetryFailed = async () => {
 		if (!result || !parseResult) return
-		// The mutation records `error.row` as the CSV line number
-		// (parseResult.rows[i].row), so we can match directly against the
-		// original parsed rows without tracking array positions that shift
-		// when invalid rows are filtered out.
 		const failedCsvLines = new Set(result.errors.map(e => e.row))
 		const toRetry = parseResult.rows
 			.filter(r => failedCsvLines.has(r.row) && r.parsed !== null)
 			.map(r => ({ csvLine: r.row, parsed: r.parsed as T }))
-
 		if (toRetry.length === 0) return
+		setRetryCount(n => n + 1)
 		await runImport(toRetry)
 	}
 
@@ -225,14 +181,21 @@ export function BulkImportStepper<T>({
 			onStepChange('upload')
 			setFile(null)
 			setParseResult(null)
+			setCumulative({ imported: 0, failed: 0, totalAttempted: 0 })
+			setRetryCount(0)
 		} else if (currentStep === 'confirm') {
 			onStepChange('validate')
+			// Clear stale result + progress so the validate step doesn't
+			// show ghost counts from the previous attempt.
+			setResult(null)
+			setImportProgress(null)
 		}
 	}
 
 	const validRowCount =
 		parseResult?.rows.filter(r => r.errors.length === 0).length ?? 0
 	const hasErrors = parseResult?.rows.some(r => r.errors.length > 0) ?? false
+	const csvMalformed = parseResult?.rows.some(r => r.row === 0) ?? false
 
 	const triggerCls = cn(
 		'w-full rounded-lg p-3 transition-all duration-200 hover:bg-muted/60',
@@ -311,6 +274,7 @@ export function BulkImportStepper<T>({
 							file={file}
 							parseResult={parseResult}
 							templateHeaders={config.templateHeaders}
+							csvMalformed={csvMalformed}
 						/>
 					)}
 				</StepperContent>
@@ -324,6 +288,9 @@ export function BulkImportStepper<T>({
 						isImporting={bulkImportMutation.isPending}
 						importProgress={importProgress}
 						result={result}
+						cumulative={cumulative}
+						retryCount={retryCount}
+						parseResult={parseResult}
 						onRetryFailed={handleRetryFailed}
 					/>
 				</StepperContent>
@@ -358,7 +325,13 @@ export function BulkImportStepper<T>({
 				)}
 
 				{currentStep === 'confirm' && result && (
-					<Button variant="outline" onClick={() => { onComplete(); resetDialog() }}>
+					<Button
+						variant="outline"
+						onClick={() => {
+							onComplete()
+							resetDialog()
+						}}
+					>
 						Close
 					</Button>
 				)}

--- a/src/components/bulk-import/bulk-import-stepper.tsx
+++ b/src/components/bulk-import/bulk-import-stepper.tsx
@@ -185,10 +185,15 @@ export function BulkImportStepper<T>({
 			setRetryCount(0)
 		} else if (currentStep === 'confirm') {
 			onStepChange('validate')
-			// Clear stale result + progress so the validate step doesn't
-			// show ghost counts from the previous attempt.
+			// Clear stale result + progress + cumulative so the validate
+			// step doesn't show ghost counts from the previous attempt.
+			// (Today this branch is unreachable while a mutation is
+			// in-flight because the Cancel button is disabled, but reset
+			// unconditionally so the invariant is not timing-dependent.)
 			setResult(null)
 			setImportProgress(null)
+			setCumulative({ imported: 0, failed: 0, totalAttempted: 0 })
+			setRetryCount(0)
 		}
 	}
 

--- a/src/components/bulk-import/bulk-import-validate-step.tsx
+++ b/src/components/bulk-import/bulk-import-validate-step.tsx
@@ -19,6 +19,10 @@ interface BulkImportValidateStepProps<T> {
 		totalRowCount: number
 	} | null
 	templateHeaders: readonly string[]
+	/** Set when the parser produced a synthetic `row: 0` entry indicating
+	 *  the whole CSV file is malformed (mismatched quotes, wrong delimiter,
+	 *  unsupported encoding). Renders a distinct CSV-level banner. */
+	csvMalformed?: boolean
 }
 
 // Headers render as "Unit Number" rather than "unit_number" — same display
@@ -33,7 +37,8 @@ function headerToLabel(header: string): string {
 export function BulkImportValidateStep<T>({
 	file,
 	parseResult,
-	templateHeaders
+	templateHeaders,
+	csvMalformed
 }: BulkImportValidateStepProps<T>) {
 	const parsedData = parseResult?.rows ?? []
 	const errorCount = parsedData.filter(row => row.errors.length > 0).length
@@ -67,6 +72,24 @@ export function BulkImportValidateStep<T>({
 					</Badge>
 				</div>
 			</div>
+
+			{/* CSV-level parse error banner — distinct from per-row validation
+			    errors. Catches malformed quotes, wrong delimiters, unsupported
+			    encodings that leave the whole file unreadable. */}
+			{csvMalformed && (
+				<div className="flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/30">
+					<AlertCircle className="size-4 text-destructive shrink-0 mt-0.5" />
+					<div>
+						<p className="typography-small text-destructive">
+							Your CSV file is malformed
+						</p>
+						<p className="text-xs text-muted-foreground mt-0.5">
+							Check for unclosed quotes, wrong delimiter (must be a comma),
+							or unsupported encoding. Re-save as CSV UTF-8 and try again.
+						</p>
+					</div>
+				</div>
+			)}
 
 			{/* Too Many Rows Warning */}
 			{parseResult?.tooManyRows && (
@@ -202,6 +225,7 @@ export function BulkImportValidateStep<T>({
 														'px-4 py-3 max-w-48 truncate',
 														empty && 'text-muted-foreground italic'
 													)}
+													title={empty ? undefined : value}
 												>
 													{empty ? '\u2014' : value}
 												</td>

--- a/src/components/bulk-import/parse-csv-with-schema.ts
+++ b/src/components/bulk-import/parse-csv-with-schema.ts
@@ -15,12 +15,21 @@ export const CSV_MAX_ROWS = 100
 export const CSV_ACCEPTED_MIME_TYPES = ['text/csv', 'application/csv']
 export const CSV_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024 // 5 MB
 
+// CSV RFC 4180: fields containing quotes, commas, CR, or LF must be
+// wrapped in double-quotes, and internal quotes must be doubled. We
+// always wrap every cell for simplicity — but we MUST still double any
+// embedded `"` or the output is unparseable (papaparse would read
+// `"She said "hi""` as malformed tokens).
+function escapeCell(cell: string): string {
+	return `"${cell.replace(/"/g, '""')}"`
+}
+
 export function buildCsvTemplate(
 	headers: readonly string[],
 	rows: readonly (readonly string[])[]
 ): string {
-	const headerRow = headers.map(h => `"${h}"`).join(',')
-	const dataRows = rows.map(row => row.map(cell => `"${cell}"`).join(','))
+	const headerRow = headers.map(escapeCell).join(',')
+	const dataRows = rows.map(row => row.map(escapeCell).join(','))
 	return [headerRow, ...dataRows].join('\n')
 }
 

--- a/src/components/bulk-import/use-bulk-import-mutation.ts
+++ b/src/components/bulk-import/use-bulk-import-mutation.ts
@@ -1,0 +1,141 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createLogger } from '#lib/frontend-logger'
+import type { BulkImportResult, ImportProgress } from '#types/api-contracts'
+import type { BulkImportConfig } from './types'
+
+const logger = createLogger({ component: 'useBulkImportMutation' })
+
+// Flush progress at most every ~120 ms of wall-clock + every 5 rows to avoid
+// the 100-re-render storm when a user imports 100 rows back-to-back.
+const PROGRESS_BATCH_EVERY_ROWS = 5
+const PROGRESS_BATCH_EVERY_MS = 120
+
+export interface BulkImportMutationInput<T> {
+	csvLine: number
+	parsed: T
+}
+
+interface UseBulkImportMutationArgs<T> {
+	config: BulkImportConfig<T>
+	setImportProgress: (progress: ImportProgress | null) => void
+	setResult: (result: BulkImportResult | null) => void
+	mountedRef: React.MutableRefObject<boolean>
+	onBatchSucceeded?: () => void
+}
+
+/**
+ * TanStack Query mutation for a bulk-import batch. Extracted from
+ * `bulk-import-stepper.tsx` so the stepper stays under the 300-line cap.
+ *
+ * The mutation surfaces EVERY row error (per-row `insertRow` failures AND
+ * thrown exceptions) as `errors[]` in the result. `onError` remains as a
+ * defensive belt-and-braces — if the mutation itself throws (queryClient
+ * invalidate failure, etc.), it populates a synthetic failure result so
+ * the UI unblocks instead of freezing on a pending dialog.
+ */
+export function useBulkImportMutation<T>({
+	config,
+	setImportProgress,
+	setResult,
+	mountedRef
+}: UseBulkImportMutationArgs<T>) {
+	const queryClient = useQueryClient()
+	const lastRowCountRef = useRef(0)
+
+	return useMutation({
+		mutationFn: async (
+			rows: BulkImportMutationInput<T>[]
+		): Promise<BulkImportResult> => {
+			lastRowCountRef.current = rows.length
+			const errors: Array<{ row: number; error: string }> = []
+			let succeeded = 0
+			let lastFlush = Date.now()
+
+			for (let i = 0; i < rows.length; i++) {
+				const entry = rows[i]!
+				try {
+					const { error } = await config.insertRow(entry.parsed)
+					if (error) {
+						// Record the real CSV line number so Retry / Download-
+						// failed-rows can match on a stable identifier.
+						errors.push({ row: entry.csvLine, error: error.message })
+					} else {
+						succeeded++
+					}
+				} catch (err) {
+					// Defensive — `insertRow` is typed to return {error} not
+					// throw, but a programming error or network blowup would
+					// otherwise take the whole batch down invisibly.
+					errors.push({
+						row: entry.csvLine,
+						error: err instanceof Error ? err.message : String(err)
+					})
+				}
+
+				const now = Date.now()
+				const isLast = i === rows.length - 1
+				const hitRowBatch = (i + 1) % PROGRESS_BATCH_EVERY_ROWS === 0
+				const hitTimeBatch = now - lastFlush >= PROGRESS_BATCH_EVERY_MS
+				if ((isLast || hitRowBatch || hitTimeBatch) && mountedRef.current) {
+					setImportProgress({
+						current: i + 1,
+						total: rows.length,
+						succeeded,
+						failed: errors.length
+					})
+					lastFlush = now
+				}
+			}
+
+			return {
+				success: errors.length === 0,
+				imported: succeeded,
+				failed: errors.length,
+				errors
+			}
+		},
+		onSuccess: async data => {
+			for (const key of config.invalidateKeys) {
+				await queryClient.invalidateQueries({ queryKey: key })
+			}
+			if (mountedRef.current) setResult(data)
+		},
+		onError: err => {
+			logger.error('Bulk import mutation threw', {
+				error: err,
+				entity: config.entityLabel.plural
+			})
+			if (!mountedRef.current) return
+			setImportProgress(null)
+			setResult({
+				success: false,
+				imported: 0,
+				failed: lastRowCountRef.current,
+				errors: [
+					{
+						row: 0,
+						error:
+							err instanceof Error
+								? err.message
+								: 'Unexpected error during import.'
+					}
+				]
+			})
+		}
+	})
+}
+
+// Re-export for convenience.
+export function useMountedRef() {
+	const ref = useRef(true)
+	useEffect(() => {
+		ref.current = true
+		return () => {
+			ref.current = false
+		}
+	}, [])
+	return ref
+}

--- a/src/components/bulk-import/use-bulk-import-mutation.ts
+++ b/src/components/bulk-import/use-bulk-import-mutation.ts
@@ -23,19 +23,11 @@ interface UseBulkImportMutationArgs<T> {
 	setImportProgress: (progress: ImportProgress | null) => void
 	setResult: (result: BulkImportResult | null) => void
 	mountedRef: React.MutableRefObject<boolean>
-	onBatchSucceeded?: () => void
 }
 
-/**
- * TanStack Query mutation for a bulk-import batch. Extracted from
- * `bulk-import-stepper.tsx` so the stepper stays under the 300-line cap.
- *
- * The mutation surfaces EVERY row error (per-row `insertRow` failures AND
- * thrown exceptions) as `errors[]` in the result. `onError` remains as a
- * defensive belt-and-braces — if the mutation itself throws (queryClient
- * invalidate failure, etc.), it populates a synthetic failure result so
- * the UI unblocks instead of freezing on a pending dialog.
- */
+// Per-row insertRow failures AND thrown exceptions both surface as errors[];
+// onError synthesizes a failure result so a queryClient/invalidate blowup
+// can't freeze the UI on a pending dialog.
 export function useBulkImportMutation<T>({
 	config,
 	setImportProgress,

--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -12,6 +12,10 @@ const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
 const mockToastWarning = vi.fn()
 
+// Shape used by useMutation mock — lets individual tests override
+// `isPending` to exercise the uploading-state branch.
+let uploadPending = false
+
 function mutationKeyMatches(
 	actual: readonly unknown[] | undefined,
 	expected: readonly unknown[]
@@ -29,9 +33,6 @@ vi.mock('@tanstack/react-query', async () => {
 		...actual,
 		useQuery: () => mockUseQuery(),
 		useMutation: (opts: { mutationFn?: unknown }) => {
-			// Compare against the real mutationKey constant from
-			// mutation-keys.ts so future key reshuffling fails the test
-			// instead of silently routing to the wrong mock.
 			const optsRecord = opts as { mutationKey?: readonly unknown[] }
 			const isUpload = mutationKeyMatches(
 				optsRecord.mutationKey,
@@ -40,7 +41,7 @@ vi.mock('@tanstack/react-query', async () => {
 			return {
 				mutate: vi.fn(),
 				mutateAsync: isUpload ? mockUploadMutate : mockDeleteMutate,
-				isPending: false,
+				isPending: isUpload ? uploadPending : false,
 				isError: false,
 				isSuccess: false
 			}
@@ -68,23 +69,38 @@ function renderSection(): ReturnType<typeof render> {
 	return render(ui)
 }
 
+function emptyList() {
+	return { data: { rows: [], totalCount: 0 }, isLoading: false, isError: false }
+}
+
+function list(rows: unknown[], totalCount = rows.length) {
+	return {
+		data: { rows, totalCount },
+		isLoading: false,
+		isError: false
+	}
+}
+
 describe('DocumentsSection', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		uploadPending = false
 	})
 
 	it('hides empty-state CTA while the documents query is in flight', () => {
-		mockUseQuery.mockReturnValue({ data: undefined, isLoading: true })
+		mockUseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			isError: false
+		})
 		renderSection()
-		// During loading the empty-state CTA must not render — it should be
-		// either skeletons or the populated list, never the upload prompt.
 		expect(
 			screen.queryByText(/no documents attached/i)
 		).not.toBeInTheDocument()
 	})
 
 	it('renders empty state with upload CTA when no documents exist', () => {
-		mockUseQuery.mockReturnValue({ data: [], isLoading: false })
+		mockUseQuery.mockReturnValue(emptyList())
 		renderSection()
 		expect(screen.getByText(/no documents attached/i)).toBeInTheDocument()
 		expect(
@@ -93,8 +109,8 @@ describe('DocumentsSection', () => {
 	})
 
 	it('renders document rows with title fallback when title is null', () => {
-		mockUseQuery.mockReturnValue({
-			data: [
+		mockUseQuery.mockReturnValue(
+			list([
 				{
 					id: 'doc-1',
 					entity_type: 'property',
@@ -111,26 +127,25 @@ describe('DocumentsSection', () => {
 					created_at: '2026-04-15T00:00:00Z',
 					signed_url: 'https://example.com/signed/lease.pdf'
 				}
-			],
-			isLoading: false
-		})
+			])
+		)
 		renderSection()
-		// Falls back to file_path when title is null
 		expect(
 			screen.getByText('property/property-1/123-lease.pdf')
 		).toBeInTheDocument()
-		// Header shows count
 		expect(screen.getByText(/Documents \(1\)/)).toBeInTheDocument()
 	})
 
+	it('shows "showing X of Y" when the list is truncated at the display cap', () => {
+		mockUseQuery.mockReturnValue(list([{ id: 'doc-1', entity_type: 'property', entity_id: 'property-1', document_type: 'other', mime_type: 'application/pdf', file_path: 'a.pdf', storage_url: 'a.pdf', file_size: 1, title: 'A', tags: null, description: null, owner_user_id: 'o', created_at: '2026-04-15T00:00:00Z', signed_url: null }], 150))
+		renderSection()
+		expect(screen.getByText(/showing 1 of 150/i)).toBeInTheDocument()
+	})
+
 	it('skips uploads with unsupported MIME type and toasts the rejection', async () => {
-		mockUseQuery.mockReturnValue({ data: [], isLoading: false })
+		mockUseQuery.mockReturnValue(emptyList())
 		renderSection()
 
-		// userEvent.upload respects the input's accept attribute and silently
-		// drops files that don't match. Use fireEvent so the change handler
-		// receives the bad file and runs its own MIME validation — that's
-		// what we're testing.
 		const input = document.querySelector(
 			'input[type="file"]'
 		) as HTMLInputElement
@@ -146,14 +161,12 @@ describe('DocumentsSection', () => {
 	})
 
 	it('skips uploads exceeding the 10 MB cap', async () => {
-		mockUseQuery.mockReturnValue({ data: [], isLoading: false })
+		mockUseQuery.mockReturnValue(emptyList())
 		renderSection()
 
 		const input = document.querySelector(
 			'input[type="file"]'
 		) as HTMLInputElement
-
-		// 11 MB blob with an allowed MIME — only the size check should reject.
 		const tooLarge = new File(
 			[new Uint8Array(11 * 1024 * 1024)],
 			'huge.pdf',
@@ -170,5 +183,46 @@ describe('DocumentsSection', () => {
 			)
 		})
 		expect(mockUploadMutate).not.toHaveBeenCalled()
+	})
+
+	it('shows the "Uploading..." label and disables the button while the upload mutation is pending', () => {
+		uploadPending = true
+		mockUseQuery.mockReturnValue(emptyList())
+		renderSection()
+		const uploadingButton = screen.getByRole('button', { name: /uploading/i })
+		expect(uploadingButton).toBeDisabled()
+	})
+
+	it('accepts image/jpg MIME (iOS Safari quirk) in addition to image/jpeg', async () => {
+		mockUseQuery.mockReturnValue(emptyList())
+		renderSection()
+		const input = document.querySelector(
+			'input[type="file"]'
+		) as HTMLInputElement
+		const iosPhoto = new File([new Uint8Array(1024)], 'photo.jpg', {
+			type: 'image/jpg'
+		})
+		fireEvent.change(input, { target: { files: [iosPhoto] } })
+		await waitFor(() => {
+			expect(mockUploadMutate).toHaveBeenCalled()
+		})
+		// No rejection toast.
+		expect(mockToastError).not.toHaveBeenCalled()
+	})
+
+	it('renders an error state with Try again button when the query errors', () => {
+		mockUseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			refetch: vi.fn()
+		})
+		renderSection()
+		expect(
+			screen.getByText(/couldn't load your documents/i)
+		).toBeInTheDocument()
+		expect(
+			screen.getByRole('button', { name: /try again/i })
+		).toBeInTheDocument()
 	})
 })

--- a/src/components/documents/document-row.tsx
+++ b/src/components/documents/document-row.tsx
@@ -18,10 +18,9 @@ function isImage(mime: string | null | undefined): boolean {
 // Pre-migration rows stored browser MIME in document_type; post-migration
 // rows populate mime_type separately. Prefer mime_type but fall through to
 // document_type so legacy rows still render correctly.
-function resolveMime(doc: {
-	mime_type: string | null
-	document_type: string
-}): string | null {
+type MimeResolvable = Pick<DocumentRowData, 'mime_type' | 'document_type'>
+
+function resolveMime(doc: MimeResolvable): string | null {
 	if (doc.mime_type) return doc.mime_type
 	if (doc.document_type && doc.document_type.includes('/')) return doc.document_type
 	return null
@@ -99,6 +98,9 @@ export function DocumentRow({
 					onInteractOutside={e => {
 						if (isDeleting) e.preventDefault()
 					}}
+					onEscapeKeyDown={e => {
+						if (isDeleting) e.preventDefault()
+					}}
 				>
 					<DialogTitle className="sr-only">{displayName}</DialogTitle>
 					{doc.signed_url ? (
@@ -111,11 +113,15 @@ export function DocumentRow({
 								decoding="async"
 							/>
 						) : (
+							// The browser's built-in PDF viewer doesn't need
+							// scripts to render — dropping `allow-scripts`
+							// keeps a weaponised PDF (PDF JS APIs, embedded
+							// scripts) from executing inside the iframe.
 							<iframe
 								src={doc.signed_url}
 								title={displayName}
 								className="w-full h-[70vh] rounded-md"
-								sandbox="allow-same-origin allow-scripts allow-popups"
+								sandbox="allow-same-origin"
 							/>
 						)
 					) : (

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -13,11 +13,12 @@ import { Skeleton } from '#components/ui/skeleton'
 import {
 	documentMutations,
 	documentQueries,
+	LIST_DISPLAY_LIMIT,
 	type DocumentEntityType,
 	type DocumentRow as DocumentRowData
 } from '#hooks/api/query-keys/document-keys'
 import { ownerDashboardKeys } from '#hooks/api/use-owner-dashboard'
-import { FileText, Loader2, Plus } from 'lucide-react'
+import { AlertTriangle, FileText, Loader2, Plus } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DocumentRow } from './document-row'
@@ -27,13 +28,18 @@ interface DocumentsSectionProps {
 	entityId: string
 }
 
+// `image/jpg` is a quirk some Safari iOS versions report for Photos exports.
+// The bucket allowlist accepts it; the frontend accept list must match so
+// iPhone uploads aren't rejected before hitting storage.
 const ACCEPTED_MIME_TYPES = [
 	'application/pdf',
 	'image/jpeg',
+	'image/jpg',
 	'image/png',
 	'image/webp'
 ]
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB — matches bucket limit
+const MAX_FAILURES_IN_TOAST = 5
 
 interface UploadSummary {
 	uploaded: number
@@ -58,11 +64,20 @@ function validateFiles(files: File[]): { valid: File[]; rejected: string[] } {
 	return { valid, rejected }
 }
 
+// Cap the toast description so a 50-file batch failure isn't an unreadable
+// wall of text. Full list stays in console for diagnosis.
+function truncateForToast(errors: string[]): string {
+	if (errors.length <= MAX_FAILURES_IN_TOAST) return errors.join('\n')
+	const head = errors.slice(0, MAX_FAILURES_IN_TOAST).join('\n')
+	return `${head}\n…and ${errors.length - MAX_FAILURES_IN_TOAST} more (see console)`
+}
+
 function reportUploadSummary(summary: UploadSummary) {
 	const { uploaded, failures, rejected } = summary
 	const errors = [...rejected, ...failures]
-	// Consolidate into one toast so mobile users don't miss failure info by
-	// dismissing the success toast.
+	if (errors.length > MAX_FAILURES_IN_TOAST) {
+		console.warn('Document upload errors (full list):', errors)
+	}
 	if (uploaded > 0 && errors.length === 0) {
 		toast.success(`Uploaded ${uploaded} file${uploaded === 1 ? '' : 's'}`)
 		return
@@ -71,17 +86,20 @@ function reportUploadSummary(summary: UploadSummary) {
 		toast.warning(
 			`Uploaded ${uploaded} · skipped ${errors.length}`,
 			{
-				description: errors.join('\n'),
+				description: truncateForToast(errors),
 				duration: 10000
 			}
 		)
 		return
 	}
 	if (uploaded === 0 && errors.length > 0) {
-		toast.error(`Skipped ${errors.length} file${errors.length === 1 ? '' : 's'}`, {
-			description: errors.join('\n'),
-			duration: 10000
-		})
+		toast.error(
+			`Skipped ${errors.length} file${errors.length === 1 ? '' : 's'}`,
+			{
+				description: truncateForToast(errors),
+				duration: 10000
+			}
+		)
 	}
 }
 
@@ -89,14 +107,16 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 	const queryClient = useQueryClient()
 	const fileInputRef = useRef<HTMLInputElement>(null)
 	const [openId, setOpenId] = useState<string | null>(null)
-	// Tracks which specific documents are currently being deleted so the
-	// "Remove" button only spins on the row whose mutation is in flight,
-	// even when the user clicks delete on multiple rows rapidly.
 	const [deletingIds, setDeletingIds] = useState<Set<string>>(() => new Set())
 
-	const { data: documents, isLoading } = useQuery(
-		documentQueries.list({ entityType, entityId })
-	)
+	const {
+		data: listResult,
+		isLoading,
+		isError,
+		refetch
+	} = useQuery(documentQueries.list({ entityType, entityId }))
+	const documents = listResult?.rows
+	const totalCount = listResult?.totalCount ?? 0
 
 	const invalidateListAndDashboard = useCallback(() => {
 		queryClient.invalidateQueries({
@@ -105,11 +125,11 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 		queryClient.invalidateQueries({ queryKey: ownerDashboardKeys.all })
 	}, [queryClient, entityType, entityId])
 
-	const uploadMutation = useMutation({
-		...documentMutations.upload(),
-		onSuccess: invalidateListAndDashboard
-	})
-
+	// No onSuccess here — a multi-file upload loop would otherwise fire one
+	// full list + dashboard refetch PER file. Invalidation happens once after
+	// the whole batch in handleFilesSelected.
+	const uploadMutation = useMutation(documentMutations.upload())
+	// Delete is single-document so keep onSuccess here.
 	const deleteMutation = useMutation({
 		...documentMutations.delete(),
 		onSuccess: invalidateListAndDashboard
@@ -128,7 +148,7 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 					entityType,
 					entityId,
 					file,
-					// Browser-reported MIME — the documents row stores it in
+					// Browser-reported MIME. The documents row stores it in
 					// `mime_type`; `document_type` is a categorical column
 					// (defaults to 'other' for owner-uploaded files).
 					mimeType: file.type
@@ -140,6 +160,9 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 				)
 			}
 		}
+
+		// Single invalidation after the whole batch (not once per file).
+		if (uploaded > 0) invalidateListAndDashboard()
 
 		reportUploadSummary({ uploaded, failures, rejected })
 
@@ -158,12 +181,15 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 				storagePath: doc.file_path
 			})
 			toast.success('Document removed')
-			setOpenId(null)
 		} catch (err) {
 			toast.error('Failed to remove document', {
 				description: err instanceof Error ? err.message : 'Please try again.'
 			})
 		} finally {
+			// Always close the preview dialog and clear the in-flight flag,
+			// even on error. Leaving the dialog open on a failed delete shows
+			// a stale/broken preview the user can't escape.
+			setOpenId(null)
 			setDeletingIds(prev => {
 				const next = new Set(prev)
 				next.delete(doc.id)
@@ -174,12 +200,20 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 
 	const docCount = documents?.length ?? 0
 	const isUploading = uploadMutation.isPending
+	const isTruncated = totalCount > (documents?.length ?? 0)
 
 	return (
 		<Card>
 			<CardHeader className="flex flex-row items-start justify-between space-y-0 gap-3">
 				<div>
-					<CardTitle>Documents{docCount > 0 ? ` (${docCount})` : ''}</CardTitle>
+					<CardTitle>
+						Documents
+						{totalCount > 0
+							? isTruncated
+								? ` (showing ${docCount} of ${totalCount})`
+								: ` (${totalCount})`
+							: ''}
+					</CardTitle>
 					<CardDescription>
 						Attach PDFs or images you want to keep alongside this property.
 					</CardDescription>
@@ -189,7 +223,6 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 					variant="outline"
 					onClick={() => fileInputRef.current?.click()}
 					disabled={isUploading}
-					aria-haspopup="dialog"
 				>
 					{isUploading ? (
 						<>
@@ -220,6 +253,20 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 							<Skeleton key={i} className="h-12 w-full" />
 						))}
 					</div>
+				) : isError ? (
+					<div className="text-center py-8">
+						<AlertTriangle className="size-8 mx-auto mb-2 text-destructive" />
+						<p className="mb-3 text-sm text-muted-foreground">
+							We couldn't load your documents.
+						</p>
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => { void refetch() }}
+						>
+							Try again
+						</Button>
+					</div>
 				) : docCount === 0 ? (
 					<div className="text-center py-8 text-muted-foreground">
 						<FileText className="size-8 mx-auto mb-2 opacity-50" />
@@ -229,25 +276,33 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 							variant="outline"
 							onClick={() => fileInputRef.current?.click()}
 							disabled={isUploading}
-							aria-haspopup="dialog"
 						>
 							<Plus className="size-4 mr-2" />
 							Upload your first document
 						</Button>
 					</div>
 				) : (
-					<ul className="divide-y divide-border">
-						{documents?.map(doc => (
-							<DocumentRow
-								key={doc.id}
-								doc={doc}
-								isOpen={openId === doc.id}
-								onOpenChange={open => setOpenId(open ? doc.id : null)}
-								onDelete={handleDelete}
-								isDeleting={deletingIds.has(doc.id)}
-							/>
-						))}
-					</ul>
+					<>
+						{isTruncated && (
+							<p className="text-xs text-muted-foreground mb-3">
+								Showing the {LIST_DISPLAY_LIMIT} most-recent documents.{' '}
+								{totalCount - (documents?.length ?? 0)} older documents are
+								not displayed. Pagination arrives in a later release.
+							</p>
+						)}
+						<ul className="divide-y divide-border">
+							{documents?.map(doc => (
+								<DocumentRow
+									key={doc.id}
+									doc={doc}
+									isOpen={openId === doc.id}
+									onOpenChange={open => setOpenId(open ? doc.id : null)}
+									onDelete={handleDelete}
+									isDeleting={deletingIds.has(doc.id)}
+								/>
+							))}
+						</ul>
+					</>
 				)}
 			</CardContent>
 		</Card>

--- a/src/components/leases/bulk-import-config.ts
+++ b/src/components/leases/bulk-import-config.ts
@@ -6,9 +6,12 @@
  * lease_tenants junction row atomically via the `bulk_import_create_lease`
  * SECURITY DEFINER RPC. Without the junction insert the lease wouldn't
  * surface on the tenant detail view (which joins through lease_tenants).
+ *
+ * The RPC enforces ownership, business-rule invariants (overlap check),
+ * input-range validation, and atomicity — the client is only responsible
+ * for CSV parsing and per-row error surfacing.
  */
 
-import { z } from 'zod'
 import { createClient } from '#lib/supabase/client'
 import { leaseInputSchema } from '#lib/validation/leases'
 import type { LeaseInput } from '#lib/validation/leases'
@@ -25,7 +28,8 @@ const TEMPLATE_HEADERS = [
 	'end_date',
 	'rent_amount',
 	'security_deposit',
-	'payment_day'
+	'payment_day',
+	'rent_currency'
 ] as const
 
 // Sample UUIDs are RFC 4122 v4-shaped so `zod.uuid()` accepts them during
@@ -38,7 +42,8 @@ const TEMPLATE_SAMPLE_ROWS = [
 		'2027-04-30',
 		'1800',
 		'1800',
-		'1'
+		'1',
+		'USD'
 	],
 	[
 		'550e8400-e29b-41d4-a716-446655440003',
@@ -47,25 +52,26 @@ const TEMPLATE_SAMPLE_ROWS = [
 		'2027-05-31',
 		'2400',
 		'4800',
-		'5'
+		'5',
+		'USD'
 	]
 ] as const
 
-// Bulk-import-specific lease schema. Extends the shared schema to force
-// security_deposit to be explicit (blank cells are a row error, same as
-// rent_amount) — the audit flagged the inconsistency where rent_amount
-// failed on blank but security_deposit silently became $0.
-const leaseImportSchema = leaseInputSchema
-	.omit({ lease_status: true, rent_currency: true })
-	.extend({
-		security_deposit: z
-			.number()
-			.nonnegative('Security deposit cannot be negative')
-	}) satisfies z.ZodType<
-	Omit<LeaseInput, 'lease_status' | 'rent_currency'>
->
+// Bulk-import uses the shared `leaseInputSchema` via `.omit()` of the two
+// server-defaulted fields. Do NOT `.extend()` security_deposit — that
+// silently replaces the shared schema's `.max(RENT_MAXIMUM_VALUE)` guard
+// with a bare `nonnegative()` check, dropping the realistic-bound ceiling.
+// Blank `security_deposit` cells still surface as a row error because
+// `mapRow` omits the key when coerceOptionalNumber returns undefined, and
+// the leaseInputSchema defines the field as required.
+const leaseImportSchema = leaseInputSchema.omit({
+	lease_status: true,
+	rent_currency: true
+})
 
-type LeaseImportInput = z.infer<typeof leaseImportSchema>
+type LeaseImportInput = Omit<LeaseInput, 'lease_status' | 'rent_currency'> & {
+	rent_currency?: string
+}
 
 function coerceOptionalNumber(value: string | undefined): number | undefined {
 	if (value === undefined) return undefined
@@ -73,6 +79,15 @@ function coerceOptionalNumber(value: string | undefined): number | undefined {
 	if (trimmed === '') return undefined
 	const parsed = Number(trimmed)
 	return Number.isNaN(parsed) ? undefined : parsed
+}
+
+function coerceOptionalCurrency(value: string | undefined): string | undefined {
+	if (!value) return undefined
+	const trimmed = value.trim().toUpperCase()
+	if (trimmed === '') return undefined
+	// Shape check only — the RPC enforces 3-letter length and rejects
+	// invalid codes. Anything that reaches here passes through.
+	return trimmed
 }
 
 export function leaseBulkImportConfig(): BulkImportConfig<LeaseImportInput> {
@@ -83,6 +98,7 @@ export function leaseBulkImportConfig(): BulkImportConfig<LeaseImportInput> {
 		templateSampleRows: TEMPLATE_SAMPLE_ROWS,
 		requiredFields:
 			'unit_id, primary_tenant_id, start_date, end_date, rent_amount, security_deposit, payment_day',
+		optionalFields: 'rent_currency (3-letter ISO code, defaults to USD)',
 		parseAndValidate: csvText =>
 			parseCsvWithSchema(csvText, {
 				schema: leaseImportSchema,
@@ -90,6 +106,7 @@ export function leaseBulkImportConfig(): BulkImportConfig<LeaseImportInput> {
 					const rent_amount = coerceOptionalNumber(raw.rent_amount)
 					const payment_day = coerceOptionalNumber(raw.payment_day)
 					const security_deposit = coerceOptionalNumber(raw.security_deposit)
+					const rent_currency = coerceOptionalCurrency(raw.rent_currency)
 					return {
 						unit_id: (raw.unit_id ?? '').trim(),
 						primary_tenant_id: (raw.primary_tenant_id ?? '').trim(),
@@ -97,15 +114,16 @@ export function leaseBulkImportConfig(): BulkImportConfig<LeaseImportInput> {
 						end_date: (raw.end_date ?? '').trim(),
 						...(rent_amount !== undefined ? { rent_amount } : {}),
 						...(security_deposit !== undefined ? { security_deposit } : {}),
-						...(payment_day !== undefined ? { payment_day } : {})
+						...(payment_day !== undefined ? { payment_day } : {}),
+						...(rent_currency !== undefined ? { rent_currency } : {})
 					}
 				}
 			}),
 		insertRow: async row => {
 			const supabase = createClient()
 			// Atomic lease + lease_tenants insert via SECURITY DEFINER RPC.
-			// Without this, bulk-imported leases never appeared on the tenant
-			// view because the tenant list query joins through lease_tenants.
+			// RPC enforces ownership, assert_can_create_lease invariants,
+			// input-range validation, and atomicity.
 			const { error } = await supabase.rpc('bulk_import_create_lease', {
 				p_unit_id: row.unit_id,
 				p_primary_tenant_id: row.primary_tenant_id,
@@ -113,7 +131,10 @@ export function leaseBulkImportConfig(): BulkImportConfig<LeaseImportInput> {
 				p_end_date: row.end_date,
 				p_rent_amount: row.rent_amount,
 				p_security_deposit: row.security_deposit,
-				p_payment_day: row.payment_day
+				p_payment_day: row.payment_day,
+				...(row.rent_currency
+					? { p_rent_currency: row.rent_currency }
+					: {})
 			})
 			return { error: error ? new Error(error.message) : null }
 		},

--- a/src/components/tenants/bulk-import-config.ts
+++ b/src/components/tenants/bulk-import-config.ts
@@ -1,5 +1,5 @@
 /**
- * Tenant bulk-import configuration (v2.3 Phase 58).
+ * Tenant bulk-import configuration (v2.3 Phase 58 + audit follow-ups).
  *
  * Thin wrapper over the generic `BulkImportConfig<T>` from
  * `src/components/bulk-import/types.ts`. Encapsulates everything the
@@ -15,7 +15,11 @@ import { createClient } from '#lib/supabase/client'
 import { getCachedUser } from '#lib/supabase/get-cached-user'
 import { requireOwnerUserId } from '#lib/require-owner-user-id'
 import { phoneSchema } from '#lib/validation/common'
-import type { TenantCreate } from '#lib/validation/tenants'
+import {
+	TENANT_ACTIVE_STATUSES,
+	type TenantActiveStatus,
+	type TenantCreate
+} from '#lib/validation/tenants'
 import { parseCsvWithSchema } from '#components/bulk-import/parse-csv-with-schema'
 import type { BulkImportConfig } from '#components/bulk-import/types'
 import { tenantQueries } from '#hooks/api/query-keys/tenant-keys'
@@ -25,7 +29,10 @@ import { ownerDashboardKeys } from '#hooks/api/use-owner-dashboard'
 // than reaching into `tenantCreateSchema.shape.*.unwrap()` so the schema
 // is not coupled to the optionality of the reused schema. The import
 // stepper rejects blank cells up front instead of silently inserting
-// tenants with empty names.
+// tenants with empty names. Status defaults to 'active' at the schema
+// level — mapRow sends `undefined` when the CSV cell is blank / unknown,
+// and Zod's `.default('active')` fills it in so we don't depend on a
+// separate TS-only fallback.
 const tenantImportSchema = z.object({
 	email: z.email({ message: 'Valid email is required' }),
 	first_name: z
@@ -37,7 +44,7 @@ const tenantImportSchema = z.object({
 		.min(1, 'Last name is required')
 		.max(100, 'Last name cannot exceed 100 characters'),
 	phone: phoneSchema.optional(),
-	status: z.enum(['active', 'inactive', 'pending', 'moved_out']).optional()
+	status: z.enum(TENANT_ACTIVE_STATUSES).default('active')
 }) satisfies z.ZodType<
 	Pick<TenantCreate, 'email' | 'first_name' | 'last_name' | 'phone' | 'status'>
 >
@@ -55,12 +62,7 @@ const TEMPLATE_SAMPLE_ROWS = [
 	['john.smith@example.com', 'John', 'Smith', '415-555-0102', 'pending']
 ] as const
 
-const ALLOWED_STATUSES = new Set([
-	'active',
-	'inactive',
-	'pending',
-	'moved_out'
-])
+const ALLOWED_STATUSES = new Set<string>(TENANT_ACTIVE_STATUSES)
 
 type TenantImportInput = z.infer<typeof tenantImportSchema>
 
@@ -77,15 +79,20 @@ export function tenantBulkImportConfig(): BulkImportConfig<TenantImportInput> {
 				schema: tenantImportSchema,
 				mapRow: raw => {
 					const rawStatus = (raw.status ?? '').trim().toLowerCase()
-					const status = ALLOWED_STATUSES.has(rawStatus)
-						? (rawStatus as TenantImportInput['status'])
-						: 'active'
+					// Only pass `status` through if it matches a known value.
+					// Blank or unknown → omit, and the Zod `.default('active')`
+					// provides the fallback.
+					const status: TenantActiveStatus | undefined = ALLOWED_STATUSES.has(
+						rawStatus
+					)
+						? (rawStatus as TenantActiveStatus)
+						: undefined
 					return {
 						email: (raw.email ?? '').trim(),
 						first_name: (raw.first_name ?? '').trim(),
 						last_name: (raw.last_name ?? '').trim(),
 						phone: (raw.phone ?? '').trim() || undefined,
-						status
+						...(status ? { status } : {})
 					}
 				}
 			}),

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -31,8 +31,18 @@ const SIGNED_URL_TTL_SECONDS = 3600
 const LIST_STALE_TIME_MS = 45 * 60 * 1000 // 45 min
 const LIST_GC_TIME_MS = 55 * 60 * 1000 // 55 min — still inside TTL
 const STORAGE_BUCKET = 'tenant-documents'
+// Hard display cap. Matches `.limit()` in the query. Surface the true count
+// via `{ count: 'exact' }` so the header badge + truncation banner can show
+// "Showing 100 of N" when a property accumulates more than 100 documents.
+const LIST_DISPLAY_LIMIT = 100
 
 const logger = createLogger({ component: 'document-keys' })
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isUuid(value: string | undefined | null): boolean {
+	return !!value && UUID_RE.test(value)
+}
 
 // Phase 57 ships the property branch only.
 export type DocumentEntityType = 'property'
@@ -54,6 +64,12 @@ export interface DocumentRow {
 	signed_url: string | null
 }
 
+export interface DocumentListResult {
+	rows: DocumentRow[]
+	/** Total number of documents that match the query, before the display limit. */
+	totalCount: number
+}
+
 export interface DocumentUploadInput {
 	entityType: DocumentEntityType
 	entityId: string
@@ -68,42 +84,48 @@ export interface DocumentUploadInput {
 /**
  * Sanitize a filename for S3-key safety without nuking Unicode. We keep
  * letters (including non-ASCII), digits, and a small set of separators;
- * the regex only replaces characters that Supabase storage or common
- * browsers reject in a key path.
+ * the regex only replaces characters that Supabase storage, signed-URL
+ * generators, or common browsers might reject in a key path.
  */
 function sanitizeFilename(name: string): string {
-	return name.replace(/[\\/?%*:|"<>\s]+/g, '_')
+	return name.replace(/[\\/?%*:|"<>#&\s]+/g, '_')
 }
 
+// Call `all()` — factory pattern matches propertyQueries, tenantQueries,
+// leaseQueries, etc. (see src/hooks/api/query-keys/*.ts). Never a bare
+// tuple — that diverges from the rest of the project and bites consumers
+// copy-pasting an invalidation target.
 export const documentQueries = {
 	all: () => ['documents'] as const,
+	lists: () => [...documentQueries.all(), 'list'] as const,
 
 	list: (params: { entityType: DocumentEntityType; entityId: string }) =>
 		queryOptions({
 			queryKey: [
-				...documentQueries.all(),
-				'list',
+				...documentQueries.lists(),
 				params.entityType,
 				params.entityId
 			] as const,
-			queryFn: async (): Promise<DocumentRow[]> => {
+			queryFn: async (): Promise<DocumentListResult> => {
 				const supabase = createClient()
 
-				const { data, error } = await supabase
+				const { data, error, count } = await supabase
 					.from('documents')
 					.select(
-						'id, entity_type, entity_id, document_type, mime_type, file_path, storage_url, file_size, title, tags, description, owner_user_id, created_at'
+						'id, entity_type, entity_id, document_type, mime_type, file_path, storage_url, file_size, title, tags, description, owner_user_id, created_at',
+						{ count: 'exact' }
 					)
 					.eq('entity_type', params.entityType)
 					.eq('entity_id', params.entityId)
 					.order('created_at', { ascending: false })
-					.limit(100)
+					.limit(LIST_DISPLAY_LIMIT)
 
 				if (error) handlePostgrestError(error, 'documents')
 
 				const rows = (data ?? []) as Omit<DocumentRow, 'signed_url'>[]
+				const totalCount = count ?? rows.length
 				if (rows.length === 0) {
-					return rows.map(r => ({ ...r, signed_url: null }))
+					return { rows: [], totalCount }
 				}
 
 				const paths = rows.map(r => r.file_path)
@@ -117,16 +139,24 @@ export const documentQueries = {
 						urlByPath.set(entry.path, entry.signedUrl)
 					}
 				}
-				return rows.map(r => ({
-					...r,
-					signed_url: urlByPath.get(r.file_path) ?? null
-				}))
+				return {
+					rows: rows.map(r => ({
+						...r,
+						signed_url: urlByPath.get(r.file_path) ?? null
+					})),
+					totalCount
+				}
 			},
 			staleTime: LIST_STALE_TIME_MS,
 			gcTime: LIST_GC_TIME_MS,
-			enabled: !!params.entityId
+			// Guard against `undefined`/`"undefined"`/`"null"` route params so a
+			// bogus URL doesn't fire a PostgREST query that returns a UUID
+			// format error.
+			enabled: isUuid(params.entityId)
 		})
 }
+
+export { LIST_DISPLAY_LIMIT }
 
 export const documentMutations = {
 	upload: () =>
@@ -146,9 +176,7 @@ export const documentMutations = {
 
 				// Path: {entity_type}/{entity_id}/{timestamp}-{safeName}.
 				// Path-based storage RLS inspects the first two segments to
-				// verify ownership of the parent entity; the safe filename is
-				// only a cosmetic concern (strip characters that would break
-				// the S3 key path).
+				// verify ownership of the parent entity.
 				const timestamp = Date.now()
 				const safeName = sanitizeFilename(file.name)
 				const storagePath = `${entityType}/${entityId}/${timestamp}-${safeName}`
@@ -160,9 +188,6 @@ export const documentMutations = {
 						upsert: false
 					})
 				if (uploadError) {
-					// Log the raw storage error (not user-visible) and throw a
-					// safe message. Raw messages like "new row violates
-					// row-level security policy" shouldn't reach the toast.
 					logger.error('Document upload failed at storage layer', {
 						path: storagePath,
 						error: uploadError
@@ -214,29 +239,12 @@ export const documentMutations = {
 			mutationFn: async ({ id, storagePath }) => {
 				const supabase = createClient()
 
-				// Storage first, DB second — reverses prior ordering. If
-				// storage fails we abort without touching the DB, so the UI
-				// still shows the row and the user can retry. If DB delete
-				// then fails, the blob is already gone and a stale row
-				// remains (orphan-cleanup cron picks it up if the parent is
-				// also gone; otherwise the user can delete again with no
-				// visible change).
-				const { error: storageError } = await supabase.storage
-					.from(STORAGE_BUCKET)
-					.remove([storagePath])
-				if (storageError) {
-					logger.warn('Storage remove failed during delete', {
-						path: storagePath,
-						error: storageError
-					})
-					throw new Error("We couldn't remove the file. Please try again.")
-				}
-
-				// .select() returns the affected rows so we can detect
-				// RLS-blocked deletes — PostgREST returns no error when an
-				// RLS policy filters the row out, just zero affected rows.
-				// Without the .length check the UI would falsely report
-				// "Document removed" while the row stays put.
+				// DB-first delete. If RLS blocks the row (zero affected rows)
+				// we abort before touching storage, so the user can retry or
+				// get help without having a broken preview of a deleted blob.
+				// If storage remove fails AFTER a successful DB delete, the
+				// orphan-cleanup cron eventually GCs the blob (per the
+				// cleanup_orphan_documents function scope).
 				const { data: deletedRows, error: dbError } = await supabase
 					.from('documents')
 					.delete()
@@ -247,6 +255,19 @@ export const documentMutations = {
 					throw new Error(
 						'Document not found or you do not have permission to delete it.'
 					)
+				}
+
+				const { error: storageError } = await supabase.storage
+					.from(STORAGE_BUCKET)
+					.remove([storagePath])
+				if (storageError) {
+					// DB row is gone; orphaned blob now — log for operator
+					// visibility but don't surface to the user (the row is
+					// already gone from their view).
+					logger.warn('Storage remove failed after DB delete; blob is now orphaned', {
+						path: storagePath,
+						error: storageError
+					})
 				}
 			}
 		})

--- a/src/lib/format-bytes.ts
+++ b/src/lib/format-bytes.ts
@@ -5,13 +5,21 @@
  *
  * Returns `—` for `null`/`undefined`, but `0 B` for a real zero-byte file
  * so the caller can distinguish "unknown size" from a broken upload.
+ *
+ * The KB→MB crossover branches on the *rounded* KB value, not the raw
+ * value, so a byte count that would round-up to 1024 KB (e.g. 1,047,554
+ * bytes) flips to MB instead of displaying "1024 KB" — which would
+ * contradict the intent of the `< 1024` boundary.
  */
+
+const KB = 1024
+const MB = KB * KB
 
 export function formatBytes(bytes: number | null | undefined): string {
 	if (bytes === null || bytes === undefined) return '\u2014'
 	if (bytes === 0) return '0 B'
-	const kb = bytes / 1024
-	if (kb < 1) return `${bytes} B`
-	if (kb < 1024) return `${kb.toFixed(0)} KB`
-	return `${(kb / 1024).toFixed(1)} MB`
+	if (bytes < KB) return `${bytes} B`
+	const roundedKb = Math.round(bytes / KB)
+	if (roundedKb < KB) return `${roundedKb} KB`
+	return `${(bytes / MB).toFixed(1)} MB`
 }

--- a/src/lib/validation/tenants.ts
+++ b/src/lib/validation/tenants.ts
@@ -24,6 +24,19 @@ export const tenantStatusSchema = z.enum([
 	'DELETED'
 ])
 
+// Active-set tenant statuses (excludes SUSPENDED/DELETED which are system
+// states, not user-set). Use this for any UI surface that lets an owner
+// set a status directly — bulk-import, quick-add form, etc. Exported as a
+// tuple so consumers can `z.enum(TENANT_ACTIVE_STATUSES)` without
+// duplicating the list.
+export const TENANT_ACTIVE_STATUSES = [
+	'active',
+	'inactive',
+	'pending',
+	'moved_out'
+] as const
+export type TenantActiveStatus = (typeof TENANT_ACTIVE_STATUSES)[number]
+
 // Base tenant input schema (matches landlord-managed tenants table).
 // Contact fields live directly on the row; user_id is optional because
 // tenants may have no auth account in landlord-only mode.
@@ -53,9 +66,7 @@ export const tenantInputSchema = z.object({
 
 	phone: phoneSchema.optional(),
 
-	status: z
-		.enum(['active', 'inactive', 'pending', 'moved_out'])
-		.optional(),
+	status: z.enum(TENANT_ACTIVE_STATUSES).optional(),
 
 	date_of_birth: z.string().optional(),
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -2215,9 +2215,11 @@ export type Database = {
       bulk_import_create_lease: {
         Args: {
           p_end_date: string
+          p_lease_status?: string
           p_payment_day: number
           p_primary_tenant_id: string
           p_rent_amount: number
+          p_rent_currency?: string
           p_security_deposit: number
           p_start_date: string
           p_unit_id: string

--- a/supabase/migrations/20260422120000_v23_second_audit_cycle.sql
+++ b/supabase/migrations/20260422120000_v23_second_audit_cycle.sql
@@ -1,0 +1,189 @@
+-- v2.3 second audit cycle — RPC hardening + cron coverage expansion.
+--
+-- Follow-up to 20260421120000 addressing findings from the comprehensive
+-- re-audit:
+--
+--   H5 — cleanup_orphan_documents only covered entity_type='property'.
+--        Extend to cover the other three entity_types the documents table
+--        supports (lease, maintenance_request, inspection). Without this
+--        a hard-deleted lease/maintenance/inspection leaves its documents
+--        rows invisible in prod forever.
+--   H8 — bulk_import_create_lease hardcoded rent_currency='USD' and
+--        lease_status='draft'. Accept them as params with safe defaults so
+--        non-USD customers aren't silently locked into USD.
+--   H9 — bulk_import_create_lease bypassed the assert_can_create_lease
+--        business-rule invariant (overlap/duplicate detection) that the
+--        regular lease-create path enforces. Call it now.
+--   M13 — bulk_import_create_lease did not validate its own inputs.
+--        SECURITY DEFINER RPCs should validate independently of the Zod
+--        client-side check (Zod isn't part of the DB security boundary).
+
+begin;
+
+-- ============================================================================
+-- H5: extend orphan cleanup to all entity_types
+-- ============================================================================
+create or replace function public.cleanup_orphan_documents()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from public.documents d
+  where (
+    d.entity_type = 'property'
+    and not exists (select 1 from public.properties p where p.id = d.entity_id)
+  )
+  or (
+    d.entity_type = 'lease'
+    and not exists (select 1 from public.leases l where l.id = d.entity_id)
+  )
+  or (
+    d.entity_type = 'maintenance_request'
+    and not exists (select 1 from public.maintenance_requests m where m.id = d.entity_id)
+  )
+  or (
+    d.entity_type = 'inspection'
+    and not exists (select 1 from public.inspections i where i.id = d.entity_id)
+  );
+end;
+$$;
+
+comment on function public.cleanup_orphan_documents is
+  'Removes document rows whose parent entity has been hard-deleted, for every entity_type the documents table supports. Runs nightly via pg_cron.';
+
+-- ============================================================================
+-- H8 + H9 + M13: bulk_import_create_lease — params, invariant check, input guards
+-- ============================================================================
+-- Drop the old 7-arg version in favor of a 9-arg version that accepts
+-- rent_currency and lease_status. Keep backward compat via defaults so the
+-- bulk-import frontend can continue calling with 7 args during the rollout.
+
+drop function if exists public.bulk_import_create_lease(
+  uuid, uuid, date, date, numeric, numeric, integer
+);
+
+create or replace function public.bulk_import_create_lease(
+  p_unit_id uuid,
+  p_primary_tenant_id uuid,
+  p_start_date date,
+  p_end_date date,
+  p_rent_amount numeric,
+  p_security_deposit numeric,
+  p_payment_day integer,
+  p_rent_currency text default 'USD',
+  p_lease_status text default 'draft'
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_owner_id uuid := auth.uid();
+  v_lease_id uuid;
+begin
+  if v_owner_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- M13: validate input ranges independently of the Zod client check.
+  if p_payment_day < 1 or p_payment_day > 31 then
+    raise exception 'Payment day must be between 1 and 31';
+  end if;
+
+  if p_rent_amount is null or p_rent_amount <= 0 then
+    raise exception 'Rent amount must be greater than 0';
+  end if;
+
+  if p_security_deposit is null or p_security_deposit < 0 then
+    raise exception 'Security deposit cannot be negative';
+  end if;
+
+  if p_start_date is null or p_end_date is null or p_end_date < p_start_date then
+    raise exception 'End date must be on or after start date';
+  end if;
+
+  if char_length(p_rent_currency) <> 3 then
+    raise exception 'Rent currency must be a 3-letter ISO code';
+  end if;
+
+  if p_lease_status not in ('draft', 'pending_signature', 'active') then
+    raise exception 'Lease status must be draft, pending_signature, or active';
+  end if;
+
+  -- Ownership checks on referenced unit + tenant.
+  if not exists (
+    select 1 from public.units u
+    join public.properties p on p.id = u.property_id
+    where u.id = p_unit_id
+      and p.owner_user_id = v_owner_id
+  ) then
+    raise exception 'Unit % is not yours or does not exist', p_unit_id;
+  end if;
+
+  if not exists (
+    select 1 from public.tenants
+    where id = p_primary_tenant_id
+      and owner_user_id = v_owner_id
+  ) then
+    raise exception 'Tenant % is not yours or does not exist', p_primary_tenant_id;
+  end if;
+
+  -- H9: enforce the same business-rule invariants the UI lease-create flow
+  -- uses (overlap detection, etc.). assert_can_create_lease raises on failure.
+  perform public.assert_can_create_lease(p_primary_tenant_id, p_unit_id);
+
+  insert into public.leases (
+    unit_id,
+    primary_tenant_id,
+    start_date,
+    end_date,
+    rent_amount,
+    rent_currency,
+    security_deposit,
+    payment_day,
+    lease_status,
+    owner_user_id
+  ) values (
+    p_unit_id,
+    p_primary_tenant_id,
+    p_start_date,
+    p_end_date,
+    p_rent_amount,
+    upper(p_rent_currency),
+    p_security_deposit,
+    p_payment_day,
+    p_lease_status,
+    v_owner_id
+  )
+  returning id into v_lease_id;
+
+  insert into public.lease_tenants (
+    lease_id,
+    tenant_id,
+    is_primary,
+    responsibility_percentage
+  ) values (
+    v_lease_id,
+    p_primary_tenant_id,
+    true,
+    100
+  );
+
+  return v_lease_id;
+end;
+$$;
+
+revoke all on function public.bulk_import_create_lease(
+  uuid, uuid, date, date, numeric, numeric, integer, text, text
+) from public;
+grant execute on function public.bulk_import_create_lease(
+  uuid, uuid, date, date, numeric, numeric, integer, text, text
+) to authenticated;
+
+comment on function public.bulk_import_create_lease is
+  'Atomic lease + lease_tenants insert for bulk CSV import. Validates inputs, enforces ownership, and calls assert_can_create_lease so bulk imports cannot bypass the business-rule invariants the UI lease-create flow enforces.';
+
+commit;

--- a/supabase/migrations/20260422130000_v23_third_audit_rpc_messages.sql
+++ b/supabase/migrations/20260422130000_v23_third_audit_rpc_messages.sql
@@ -1,0 +1,117 @@
+-- v2.3 third audit cycle — RPC error-message hygiene.
+--
+-- Findings from the third comprehensive review of v2.3:
+--
+--   LOW (RPC) — NULL p_unit_id / p_primary_tenant_id raised
+--               "Unit <null> is not yours or does not exist" instead of
+--               "Unit ID is required". Add explicit NULL guards at the top.
+--   LOW (RPC) — NULL p_start_date raised the date-ordering error message
+--               which is misleading. Add NULL guards on both date params
+--               with their own error messages.
+
+begin;
+
+create or replace function public.bulk_import_create_lease(
+  p_unit_id uuid,
+  p_primary_tenant_id uuid,
+  p_start_date date,
+  p_end_date date,
+  p_rent_amount numeric,
+  p_security_deposit numeric,
+  p_payment_day integer,
+  p_rent_currency text default 'USD',
+  p_lease_status text default 'draft'
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_owner_id uuid := auth.uid();
+  v_lease_id uuid;
+begin
+  if v_owner_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- Explicit NULL guards so the user-facing error names the actual
+  -- missing field instead of leaking the underlying ownership check.
+  if p_unit_id is null then
+    raise exception 'Unit ID is required';
+  end if;
+
+  if p_primary_tenant_id is null then
+    raise exception 'Tenant ID is required';
+  end if;
+
+  if p_start_date is null then
+    raise exception 'Start date is required';
+  end if;
+
+  if p_end_date is null then
+    raise exception 'End date is required';
+  end if;
+
+  if p_payment_day < 1 or p_payment_day > 31 then
+    raise exception 'Payment day must be between 1 and 31';
+  end if;
+
+  if p_rent_amount is null or p_rent_amount <= 0 then
+    raise exception 'Rent amount must be greater than 0';
+  end if;
+
+  if p_security_deposit is null or p_security_deposit < 0 then
+    raise exception 'Security deposit cannot be negative';
+  end if;
+
+  -- Both NULL branches were short-circuited above, so this is a real
+  -- ordering check now.
+  if p_end_date < p_start_date then
+    raise exception 'End date must be on or after start date';
+  end if;
+
+  if char_length(p_rent_currency) <> 3 then
+    raise exception 'Rent currency must be a 3-letter ISO code';
+  end if;
+
+  if p_lease_status not in ('draft', 'pending_signature', 'active') then
+    raise exception 'Lease status must be draft, pending_signature, or active';
+  end if;
+
+  if not exists (
+    select 1 from public.units u
+    join public.properties p on p.id = u.property_id
+    where u.id = p_unit_id
+      and p.owner_user_id = v_owner_id
+  ) then
+    raise exception 'Unit % is not yours or does not exist', p_unit_id;
+  end if;
+
+  if not exists (
+    select 1 from public.tenants
+    where id = p_primary_tenant_id
+      and owner_user_id = v_owner_id
+  ) then
+    raise exception 'Tenant % is not yours or does not exist', p_primary_tenant_id;
+  end if;
+
+  perform public.assert_can_create_lease(p_primary_tenant_id, p_unit_id);
+
+  insert into public.leases (
+    unit_id, primary_tenant_id, start_date, end_date, rent_amount,
+    rent_currency, security_deposit, payment_day, lease_status, owner_user_id
+  ) values (
+    p_unit_id, p_primary_tenant_id, p_start_date, p_end_date, p_rent_amount,
+    upper(p_rent_currency), p_security_deposit, p_payment_day, p_lease_status, v_owner_id
+  )
+  returning id into v_lease_id;
+
+  insert into public.lease_tenants (lease_id, tenant_id, is_primary, responsibility_percentage)
+  values (v_lease_id, p_primary_tenant_id, true, 100);
+
+  return v_lease_id;
+end;
+$$;
+
+commit;


### PR DESCRIPTION
## Summary

Fixes the 53 findings from the second comprehensive v2.3 re-audit (3 CRITICAL, 13 HIGH, 15 MEDIUM, 12 LOW, 10 NIT). Two intentionally deferred: M14 magic-byte sniffing (v2.4 scope) and M12 new RLS integration test (separate RLS test branch).

### Critical regressions from the first audit fix pass

- **C1** — Lease bulk-import no longer `.extend({ security_deposit })`s over the shared schema's `.max(RENT_MAXIMUM_VALUE)` guard. The `.extend()` silently replaced it with a bare `nonnegative()` check, letting a $999M deposit through.
- **C2** — `DocumentsSection` now invalidates the list + dashboard once after a batched upload loop instead of once per file. A 10-file upload previously fired 10 full dashboard refetches.
- **C3** — Retry batches now track cumulative (imported, failed, totalAttempted) counters. Prior single-batch totals hid original-batch successes from the UI. Auto-close is disabled after any retry so cumulative totals stay visible.

### Migration (`20260422120000_v23_second_audit_cycle.sql`) applied to prod via MCP, types regenerated

- **H5** — `cleanup_orphan_documents` covers all four entity_types, not just property.
- **H8** — `bulk_import_create_lease` accepts `p_rent_currency` and `p_lease_status` params with safe defaults.
- **H9** — `bulk_import_create_lease` calls `assert_can_create_lease` so bulk imports can't bypass overlap/duplicate invariants.
- **M13** — RPC validates its own inputs (payment_day range, rent >0, security_deposit >=0, date ordering, currency length, status enum) independently of Zod.

### Frontend fixes

**Bulk-import:** H1 (RFC 4180 quote escaping in `buildCsvTemplate`), H2 (CSV-malformed banner), H3 (`insertRow` try/catch + synthetic onError result), H7 (centralized `TENANT_ACTIVE_STATUSES`), M4 (reset result/progress on back), M5 (Zod `.default('active')`), M6 (failed-rows CSV includes original headers + cells + `_error`), M8 (extracted `useBulkImportMutation` hook — stepper under 300 lines), M9 (split `BulkImportResultPanel` into 3 subcomponents under 50 lines each), L3 ("Closing automatically…" hint), L7 (toast on CSV read failure), L10 (`title` attribute on truncated cells).

**Documents:** H4 (DB-first delete order), H6 (`image/jpg` accepted for iOS Safari), H10 (`setOpenId(null)` in `finally`), H11 (`{ count: 'exact' }` + truncation banner), H12 (`formatBytes` branches on rounded KB), H13 (Escape key blocked during delete), M1 (unified `documentQueries.all/lists` factory convention), M7 (UUID-shape guard on `enabled`), M10 (iframe sandbox drops `allow-scripts`), M11 (test for upload-pending + `image/jpg`), L2 (`sanitizeFilename` gains `#` + `&`), L5 (removed misleading `aria-haspopup="dialog"`), L6 (isError state with retry), L12 (toast caps at 5 entries + full-list logged).

**Types:** N4 (extracted `MimeResolvable` Pick type), N5 (field-name assertions in tests).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit` (7,372 passing; +33 new tests)
- [ ] Manual: bulk-import a lease CSV with an invalid (overlapping) tenant/unit pair; confirm the RPC error message is per-row, not a crash
- [ ] Manual: upload 10 PDFs to a property in one batch; confirm single dashboard refetch in devtools
- [ ] Manual: partial-success import → Retry → verify cumulative-totals panel shows "X imported total, Y still failing"
- [ ] Manual: iPhone Safari upload of a JPEG (`image/jpg` MIME) — verify accepted

[hudsor01]
