### PR TITLE
fix(v2.4/phase-59): cycle-3 audit follow-ups (orphan gap + visual regression + silent-skip tests)

### DIFF
--- a/src/app/(owner)/tenants/components/tenant-details.client.tsx
+++ b/src/app/(owner)/tenants/components/tenant-details.client.tsx
@@ -226,12 +226,13 @@ export function TenantDetails({ id }: TenantDetailsProps) {
 						</div>
 					</CardLayout>
 				)}
-			</div>
 
-			{/* Wrap in space-y-6 so the Mark as Moved Out button + documents
-			    section share the same vertical rhythm as the leases/personal-
-			    info sections above. */}
-			<div className="space-y-6">
+				{/* Move the Mark-as-Moved-Out button + documents card INSIDE
+				    the outer space-y-6 wrapper so they share the same
+				    vertical rhythm as the leases/personal-info sections.
+				    Keeping them as fragment siblings of the outer div left
+				    them flush with zero margin (fragments don't apply
+				    spacing). */}
 				<Button variant="outline" onClick={() => setMoveOutDialogOpen(true)}>
 					Mark as Moved Out
 				</Button>

--- a/supabase/migrations/20260424160000_v24_phase_59_audit_followups.sql
+++ b/supabase/migrations/20260424160000_v24_phase_59_audit_followups.sql
@@ -1,0 +1,54 @@
+-- v2.4 Phase 59 post-merge audit follow-up.
+--
+-- cycle-3 audit caught a P1: cleanup_orphan_documents was written in
+-- v2.3 (migration 20260422120000) to cover the four entity_types that
+-- existed THEN — property, lease, maintenance_request, inspection. It
+-- did NOT include `tenant` because tenants couldn't have documents
+-- attached at the time.
+--
+-- Phase 59 shipped tenant-scoped document uploads this morning
+-- (migration 20260424140000). A hard-deleted tenant now leaves orphan
+-- `documents` rows forever unless the cron cleanup covers the branch.
+-- Tenants are soft-deleted in normal flow, but:
+--   - GDPR anonymization (`anonymize_deleted_user`) can null owner_user_id
+--     and eventually hard-delete after the grace period.
+--   - Admin intervention can hard-delete.
+-- This migration extends the cron function to cover the tenant branch.
+
+begin;
+
+create or replace function public.cleanup_orphan_documents()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from public.documents d
+  where (
+    d.entity_type = 'property'
+    and not exists (select 1 from public.properties p where p.id = d.entity_id)
+  )
+  or (
+    d.entity_type = 'lease'
+    and not exists (select 1 from public.leases l where l.id = d.entity_id)
+  )
+  or (
+    d.entity_type = 'tenant'
+    and not exists (select 1 from public.tenants t where t.id = d.entity_id)
+  )
+  or (
+    d.entity_type = 'maintenance_request'
+    and not exists (select 1 from public.maintenance_requests m where m.id = d.entity_id)
+  )
+  or (
+    d.entity_type = 'inspection'
+    and not exists (select 1 from public.inspections i where i.id = d.entity_id)
+  );
+end;
+$$;
+
+comment on function public.cleanup_orphan_documents is
+  'Removes document rows whose parent entity has been hard-deleted. Covers all five entity_types the documents table supports: property + lease + tenant + maintenance_request + inspection. Runs nightly via pg_cron.';
+
+commit;

--- a/tests/integration/rls/documents-cross-entity.rls.test.ts
+++ b/tests/integration/rls/documents-cross-entity.rls.test.ts
@@ -111,19 +111,25 @@ async function createFixtures(
 		fix.lease = l ? { id: l.id } : null
 	}
 
-	if (fix.property) {
-		const { data: m } = await client
+	if (fix.unit && fix.tenant) {
+		// maintenance_requests requires unit_id + tenant_id (both NOT NULL),
+		// not property_id — the table descends from units, not properties.
+		// priority enum: 'low' | 'normal' | 'high' | 'urgent'.
+		const { data: m, error: mErr } = await client
 			.from('maintenance_requests')
 			.insert({
-				property_id: fix.property.id,
+				unit_id: fix.unit.id,
+				tenant_id: fix.tenant.id,
 				title: `Phase-59 ${label} Maintenance`,
 				description: 'Integration test fixture',
 				status: 'open',
-				priority: 'medium',
+				priority: 'normal',
 				owner_user_id: ownerId
 			})
 			.select('id')
 			.single()
+		if (mErr)
+			console.warn(`maintenance_request insert failed for ${label}:`, mErr.message)
 		fix.maintenanceRequest = m ? { id: m.id } : null
 	}
 
@@ -162,6 +168,25 @@ describe('Documents cross-entity storage RLS', () => {
 
 		fixA = await createFixtures(clientA, ownerAId, 'A')
 		fixB = await createFixtures(clientB, ownerBId, 'B')
+
+		// Fail the suite loudly if any fixture failed to create.
+		// Cycle-3 audit caught this: a silent `fix.X = null` previously
+		// made downstream `if (!id) return` branches skip with zero
+		// assertions, which Vitest counted as PASSED.
+		for (const [label, f] of [['A', fixA], ['B', fixB]] as const) {
+			for (const key of [
+				'property',
+				'unit',
+				'tenant',
+				'lease',
+				'maintenanceRequest'
+			] as const) {
+				expect(
+					f[key],
+					`owner ${label} fixture "${key}" failed to create — check prior test data leaks or RLS drift`
+				).not.toBeNull()
+			}
+		}
 	})
 
 	afterAll(async () => {
@@ -198,11 +223,16 @@ describe('Documents cross-entity storage RLS', () => {
 		const { data: listedByB } = await clientB.storage.from(BUCKET).list(prefix)
 		expect(listedByB ?? []).toHaveLength(0)
 
-		// ownerB cannot download/signed-url it
-		const { data: signedB } = await clientB.storage
+		// ownerB cannot download/signed-url it. createSignedUrl is the one
+		// storage API that returns an explicit error on RLS block (list
+		// and remove just return empty arrays), so assert both the null
+		// data AND the non-null error — guards against a future supabase
+		// change that starts returning data with no error on denied paths.
+		const { data: signedB, error: signErr } = await clientB.storage
 			.from(BUCKET)
 			.createSignedUrl(path, 60)
 		expect(signedB).toBeNull()
+		expect(signErr).not.toBeNull()
 
 		// ownerB cannot delete it — if this returned data with non-empty
 		// array it would mean RLS let them through.

--- a/tests/integration/rls/documents-cross-entity.rls.test.ts
+++ b/tests/integration/rls/documents-cross-entity.rls.test.ts
@@ -197,15 +197,14 @@ describe('Documents cross-entity storage RLS', () => {
 	})
 
 	// Helper: upload a document to ownerA's entity, verify ownerB can't access it.
+	// `beforeAll` already asserts every fixture ID is non-null, so the non-null
+	// assertion on `idA` is a safe unwrap — any fixture gap would have failed
+	// the suite before any `it()` ran.
 	async function assertCrossOwnerIsolation(
 		entityType: 'property' | 'lease' | 'tenant' | 'maintenance_request',
 		entityIdGetter: (f: Fixture) => string | undefined
 	) {
-		const idA = entityIdGetter(fixA)
-		if (!idA) {
-			console.warn(`Skipping ${entityType}: fixture not created`)
-			return
-		}
+		const idA = entityIdGetter(fixA)!
 
 		const path = `${entityType}/${idA}/${Date.now()}-test.pdf`
 		// Minimal valid PDF payload — the bucket's MIME allowlist accepts
@@ -279,8 +278,8 @@ describe('Documents cross-entity storage RLS', () => {
 
 	for (const { type, getId } of entityBranches) {
 		it(`${type}: rejects upload with off-convention path segments (3-segment)`, async () => {
-			const id = getId(fixA)
-			if (!id) return
+			// `beforeAll` asserts fixtures; non-null unwrap is safe.
+			const id = getId(fixA)!
 			const badPath = `${type}/${id}/sub/${Date.now()}-evil.pdf`
 			const pdf = new Blob(['%PDF-1.4\n%%EOF'], { type: 'application/pdf' })
 			const { error } = await clientA.storage


### PR DESCRIPTION
## Summary

Post-merge cycle-3 audit on Phase 59 caught 1 P1 + 2 P2 + 1 P3 that cycles 1-2 missed. This PR addresses all of them.

The user called out that "passing CI + one approved review" isn't the merge bar — "perfect PR is the gate". Saved that as project memory (`feedback_perfect_pr_gate.md`). This PR is the immediate consequence: cycle-3 found regressions cycles 1-2 didn't, proving the standard is the right one.

### What the audit caught

| Severity | Finding |
|----------|---------|
| **P1** | `cleanup_orphan_documents` missed the `tenant` branch — hard-deleting a tenant leaves orphan documents rows forever |
| **P2** | Cycle-2 "polish" commit introduced a visual spacing regression on tenant detail page (fragment siblings instead of space-y-6 children) |
| **P2** | Integration tests silently skipped the maintenance_request branch because the fixture had wrong column names — `if (!id) return` let tests pass with zero assertions |
| **P3** | `createSignedUrl` cross-owner assertion only checked `data`, not `error` — strengthened |

### Changes

- New migration `20260424160000_v24_phase_59_audit_followups.sql` extends `cleanup_orphan_documents` to cover all five `documents.entity_type` values. Applied to prod via MCP.
- `tenant-details.client.tsx`: Mark-as-Moved-Out button + DocumentsSection now live INSIDE the outer `space-y-6` wrapper instead of as fragment siblings.
- `documents-cross-entity.rls.test.ts`:
  - `beforeAll` asserts every fixture was created. Fixture failures now fail the suite loudly.
  - Maintenance fixture fixed: uses `unit_id` + `tenant_id` (the correct FK columns), `priority: 'normal'` (valid enum value).
  - `createSignedUrl` assertion strengthened to include explicit error check.

Validation: **All 12 integration tests genuinely pass now** (previously 2 silently skipped the maintenance branch). 7,420 unit tests still green. Migration applied to prod.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit` (7,420 passing)
- [x] `pnpm vitest --run --project integration tests/integration/rls/documents-cross-entity.rls.test.ts` (12/12 genuinely running, all pass)
- [ ] After CI green: run cycle-4 review before merging (no more "merge on first approval" pattern)

[hudsor01]
