### PR TITLE
feat(v2.4/phase-61): document_type categorical taxonomy + filter UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"db:push": "supabase db push && pnpm db:types",
 		"db:pull": "supabase db pull",
 		"db:reset": "supabase db reset && pnpm db:types",
-		"db:types": "supabase gen types typescript --project-id bshjmbshupiibfiewpxb > src/types/supabase.ts.tmp && test -s src/types/supabase.ts.tmp && mv src/types/supabase.ts.tmp src/types/supabase.ts || (rm -f src/types/supabase.ts.tmp && echo 'db:types failed — supabase.ts unchanged. If CLI is Unauthorized, run `supabase login` or regenerate via the Supabase MCP `generate_typescript_types` tool.' >&2 && exit 1)",
+		"db:types": "bash scripts/db-types.sh",
 		"db:seed:smoke": "psql $DATABASE_URL -f supabase/seeds/seed-common.sql -f supabase/seeds/seed-smoke.sql",
 		"db:seed:dev": "psql $DATABASE_URL -f supabase/seeds/seed-common.sql -f supabase/seeds/seed-development.sql",
 		"db:seed:perf": "psql $DATABASE_URL -f supabase/seeds/seed-common.sql -f supabase/seeds/seed-performance.sql",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"db:push": "supabase db push && pnpm db:types",
 		"db:pull": "supabase db pull",
 		"db:reset": "supabase db reset && pnpm db:types",
-		"db:types": "supabase gen types typescript --project-id bshjmbshupiibfiewpxb > src/types/supabase.ts",
+		"db:types": "supabase gen types typescript --project-id bshjmbshupiibfiewpxb > src/types/supabase.ts.tmp && test -s src/types/supabase.ts.tmp && mv src/types/supabase.ts.tmp src/types/supabase.ts || (rm -f src/types/supabase.ts.tmp && echo 'db:types failed — supabase.ts unchanged. If CLI is Unauthorized, run `supabase login` or regenerate via the Supabase MCP `generate_typescript_types` tool.' >&2 && exit 1)",
 		"db:seed:smoke": "psql $DATABASE_URL -f supabase/seeds/seed-common.sql -f supabase/seeds/seed-smoke.sql",
 		"db:seed:dev": "psql $DATABASE_URL -f supabase/seeds/seed-common.sql -f supabase/seeds/seed-development.sql",
 		"db:seed:perf": "psql $DATABASE_URL -f supabase/seeds/seed-common.sql -f supabase/seeds/seed-performance.sql",

--- a/scripts/db-types.sh
+++ b/scripts/db-types.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Regenerate src/types/supabase.ts from the live Supabase project.
+#
+# Atomic by design: writes to a tempfile, validates non-empty, then mv's.
+# A bare `supabase gen types ... > src/types/supabase.ts` redirect (the
+# previous form) would clobber the existing file with an empty result on
+# any CLI failure (e.g. transient `Unauthorized`, missing `supabase
+# login`, or no network).
+#
+# If the CLI fails: the tempfile is removed, src/types/supabase.ts is
+# untouched, and the error message points to the MCP fallback.
+
+set -euo pipefail
+
+readonly PROJECT_ID="bshjmbshupiibfiewpxb"
+readonly DEST="src/types/supabase.ts"
+
+tmp=$(mktemp -t supabase-types.XXXXXX.ts)
+trap 'rm -f "$tmp"' EXIT
+
+if ! supabase gen types typescript --project-id "$PROJECT_ID" >"$tmp" 2>&1; then
+  echo "db:types: supabase CLI failed. Output:" >&2
+  cat "$tmp" >&2
+  echo "" >&2
+  echo "If the failure is 'Unauthorized', run \`supabase login\` or" >&2
+  echo "regenerate via the Supabase MCP \`generate_typescript_types\`" >&2
+  echo "tool. \`$DEST\` was NOT modified." >&2
+  exit 1
+fi
+
+if [ ! -s "$tmp" ]; then
+  echo "db:types: CLI exited 0 but produced an empty file. \`$DEST\`" >&2
+  echo "was NOT modified." >&2
+  exit 1
+fi
+
+mv "$tmp" "$DEST"
+trap - EXIT
+echo "db:types: regenerated $DEST"

--- a/scripts/db-types.sh
+++ b/scripts/db-types.sh
@@ -15,7 +15,12 @@ set -euo pipefail
 readonly PROJECT_ID="bshjmbshupiibfiewpxb"
 readonly DEST="src/types/supabase.ts"
 
-tmp=$(mktemp -t supabase-types.XXXXXX.ts)
+# Tempfile lives next to the destination on the same filesystem so the
+# final `mv` is atomic. macOS BSD `mktemp -t` has a different prefix
+# semantics than GNU `mktemp -t`, and on macOS the system appends a
+# random suffix AFTER the template, breaking the `.ts` extension —
+# avoid `-t` entirely and pass an explicit template path.
+tmp=$(mktemp "$(dirname "$DEST")/.supabase-types.XXXXXX.tmp")
 trap 'rm -f "$tmp"' EXIT
 
 if ! supabase gen types typescript --project-id "$PROJECT_ID" >"$tmp" 2>&1; then

--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -219,6 +219,37 @@ describe('DocumentsSection', () => {
 		expect(mockToastError).not.toHaveBeenCalled()
 	})
 
+	it('renders the category Select for the next upload (Phase 61)', () => {
+		mockUseQuery.mockReturnValue(emptyList())
+		renderSection()
+		expect(
+			screen.getByLabelText(/category for next upload/i)
+		).toBeInTheDocument()
+	})
+
+	it('passes the chosen category through to the upload mutation (Phase 61)', async () => {
+		mockUseQuery.mockReturnValue(emptyList())
+		mockUploadMutate.mockResolvedValue({})
+		renderSection()
+
+		const input = document.querySelector(
+			'input[type="file"]'
+		) as HTMLInputElement
+		const file = new File(['fake pdf'], 'lease.pdf', {
+			type: 'application/pdf'
+		})
+		fireEvent.change(input, { target: { files: [file] } })
+
+		await waitFor(() => {
+			expect(mockUploadMutate).toHaveBeenCalledTimes(1)
+		})
+		// Default category is 'other' — verify it flows through the
+		// mutateAsync call payload alongside file + entity context.
+		expect(mockUploadMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ category: 'other' })
+		)
+	})
+
 	it('renders an error state with Try again button when the query errors', () => {
 		mockUseQuery.mockReturnValue({
 			data: undefined,

--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactElement } from 'react'
 import { DocumentsSection } from '../documents-section'
@@ -227,7 +228,7 @@ describe('DocumentsSection', () => {
 		).toBeInTheDocument()
 	})
 
-	it('passes the chosen category through to the upload mutation (Phase 61)', async () => {
+	it('passes the default category "other" through to the upload mutation (Phase 61)', async () => {
 		mockUseQuery.mockReturnValue(emptyList())
 		mockUploadMutate.mockResolvedValue({})
 		renderSection()
@@ -243,10 +244,44 @@ describe('DocumentsSection', () => {
 		await waitFor(() => {
 			expect(mockUploadMutate).toHaveBeenCalledTimes(1)
 		})
-		// Default category is 'other' — verify it flows through the
-		// mutateAsync call payload alongside file + entity context.
+		// Stricter matcher — pin the full payload shape so a regression
+		// that drops `mimeType` or swaps `entityType` while adding
+		// `category` is caught.
 		expect(mockUploadMutate).toHaveBeenCalledWith(
-			expect.objectContaining({ category: 'other' })
+			expect.objectContaining({
+				category: 'other',
+				mimeType: 'application/pdf',
+				entityType: 'property',
+				entityId: '00000000-0000-0000-0000-000000000001'
+			})
+		)
+	})
+
+	it('passes a non-default category through after the user selects it (cycle-1 P2-1)', async () => {
+		const user = userEvent.setup()
+		mockUseQuery.mockReturnValue(emptyList())
+		mockUploadMutate.mockResolvedValue({})
+		renderSection()
+
+		// Open the Radix Select via its trigger and pick "Lease".
+		const trigger = screen.getByLabelText(/category for next upload/i)
+		await user.click(trigger)
+		const leaseOption = await screen.findByRole('option', { name: /^lease$/i })
+		await user.click(leaseOption)
+
+		const input = document.querySelector(
+			'input[type="file"]'
+		) as HTMLInputElement
+		const file = new File(['fake pdf'], 'addendum.pdf', {
+			type: 'application/pdf'
+		})
+		fireEvent.change(input, { target: { files: [file] } })
+
+		await waitFor(() => {
+			expect(mockUploadMutate).toHaveBeenCalledTimes(1)
+		})
+		expect(mockUploadMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ category: 'lease' })
 		)
 	})
 

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -8,10 +8,12 @@ import { documentSearchQueries } from '#hooks/api/query-keys/document-keys'
 const mockUseQuery = vi.fn()
 const mockSetQueryParam = vi.fn()
 const mockSetEntityParam = vi.fn()
+const mockSetCategoryParam = vi.fn()
 const mockSetPageParam = vi.fn()
 
 let queryParamValue = ''
 let entityParamValue = '__any__'
+let categoryParamValue = '__any__'
 let pageParamValue = 0
 
 vi.mock('@tanstack/react-query', async () => {
@@ -31,6 +33,7 @@ vi.mock('nuqs', async () => {
 		useQueryState: (key: string) => {
 			if (key === 'q') return [queryParamValue, mockSetQueryParam]
 			if (key === 'entity') return [entityParamValue, mockSetEntityParam]
+			if (key === 'category') return [categoryParamValue, mockSetCategoryParam]
 			if (key === 'page') return [pageParamValue, mockSetPageParam]
 			return ['', vi.fn()]
 		}
@@ -54,6 +57,7 @@ describe('DocumentsVaultClient', () => {
 		vi.clearAllMocks()
 		queryParamValue = ''
 		entityParamValue = '__any__'
+		categoryParamValue = '__any__'
 		pageParamValue = 0
 	})
 
@@ -353,6 +357,61 @@ describe('DocumentsVaultClient', () => {
 			expect(mockSetPageParam).toHaveBeenCalledWith(null)
 		} finally {
 			vi.useRealTimers()
+		}
+	})
+
+	it('renders the category filter (Phase 61)', () => {
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		renderVault()
+		expect(screen.getByLabelText(/filter by category/i)).toBeInTheDocument()
+	})
+
+	it('passes valid URL category to documentSearchQueries.list (Phase 61)', () => {
+		categoryParamValue = 'tax_return'
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		const listSpy = vi.spyOn(documentSearchQueries, 'list')
+		try {
+			renderVault()
+			expect(listSpy).toHaveBeenCalled()
+			const params = listSpy.mock.calls.at(-1)?.[0] as
+				| { category?: unknown }
+				| undefined
+			expect(params?.category).toBe('tax_return')
+		} finally {
+			listSpy.mockRestore()
+		}
+	})
+
+	it('treats an unknown URL category as "All categories" (Phase 61 H2-style guard)', () => {
+		// Same defense as the entity guard: ?category=banana must NOT flow
+		// into the RPC as a typed DocumentCategory. Falls back to undefined.
+		categoryParamValue = 'banana'
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		const listSpy = vi.spyOn(documentSearchQueries, 'list')
+		try {
+			renderVault()
+			const params = listSpy.mock.calls.at(-1)?.[0] as
+				| { category?: unknown }
+				| undefined
+			expect(params).toBeDefined()
+			expect(params).not.toHaveProperty('category')
+		} finally {
+			listSpy.mockRestore()
 		}
 	})
 })

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -410,8 +410,39 @@ describe('DocumentsVaultClient', () => {
 				| undefined
 			expect(params).toBeDefined()
 			expect(params).not.toHaveProperty('category')
+			// Mirror the entity-guard test's UX assertion: with no real
+			// filter active (the bad value was scrubbed) and no rows,
+			// the empty state should render the "no docs uploaded yet"
+			// copy rather than the "no docs match your search" copy.
+			expect(
+				screen.getByText(/no documents uploaded yet/i)
+			).toBeInTheDocument()
 		} finally {
 			listSpy.mockRestore()
 		}
+	})
+
+	it('scrubs an unknown category from the URL when the guard rejects it (cycle-1 P3-5)', () => {
+		categoryParamValue = 'banana'
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		renderVault()
+		expect(mockSetCategoryParam).toHaveBeenCalledWith(null)
+	})
+
+	it('scrubs an unknown entity from the URL when the guard rejects it (cycle-1 P3-5)', () => {
+		entityParamValue = 'banana'
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		renderVault()
+		expect(mockSetEntityParam).toHaveBeenCalledWith(null)
 	})
 })

--- a/src/components/documents/document-row.tsx
+++ b/src/components/documents/document-row.tsx
@@ -15,15 +15,15 @@ function isImage(mime: string | null | undefined): boolean {
 	return !!mime && mime.startsWith('image/')
 }
 
-// Pre-migration rows stored browser MIME in document_type; post-migration
-// rows populate mime_type separately. Prefer mime_type but fall through to
-// document_type so legacy rows still render correctly.
-type MimeResolvable = Pick<DocumentRowData, 'mime_type' | 'document_type'>
+// Post-Phase-61 invariant: `document_type` is a categorical enum (lease,
+// receipt, …, other) — never a MIME string. The MIME lives exclusively in
+// `mime_type`. The pre-migration MIME-in-document_type fallback was
+// removed when migration 20260425172604 added the CHECK constraint and
+// coerced any out-of-band rows to 'other'.
+type MimeResolvable = Pick<DocumentRowData, 'mime_type'>
 
 function resolveMime(doc: MimeResolvable): string | null {
-	if (doc.mime_type) return doc.mime_type
-	if (doc.document_type && doc.document_type.includes('/')) return doc.document_type
-	return null
+	return doc.mime_type ?? null
 }
 
 interface DocumentRowProps {

--- a/src/components/documents/document-row.tsx
+++ b/src/components/documents/document-row.tsx
@@ -70,11 +70,13 @@ export function DocumentRow({
 								</p>
 								<p className="truncate text-xs text-muted-foreground">
 									{formatBytes(doc.file_size)} ·{' '}
-									{new Date(doc.created_at).toLocaleDateString('en-US', {
-										month: 'short',
-										day: 'numeric',
-										year: 'numeric'
-									})}
+									{doc.created_at
+										? new Date(doc.created_at).toLocaleDateString('en-US', {
+												month: 'short',
+												day: 'numeric',
+												year: 'numeric'
+											})
+										: '—'}
 								</p>
 							</div>
 						</button>

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -17,7 +17,6 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '#components/ui/select'
-import { Label } from '#components/ui/label'
 import {
 	documentMutations,
 	documentQueries,
@@ -32,7 +31,7 @@ import {
 } from '#lib/validation/documents'
 import { ownerDashboardKeys } from '#hooks/api/use-owner-dashboard'
 import { AlertTriangle, FileText, Loader2, Plus } from 'lucide-react'
-import { useCallback, useId, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DocumentRow } from './document-row'
 import {
@@ -59,12 +58,13 @@ const ENTITY_LABELS: Record<DocumentEntityType, string> = {
 export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps) {
 	const queryClient = useQueryClient()
 	const fileInputRef = useRef<HTMLInputElement>(null)
-	const categorySelectId = useId()
 	const [openId, setOpenId] = useState<string | null>(null)
 	const [deletingIds, setDeletingIds] = useState<Set<string>>(() => new Set())
 	// One category per upload batch. Multi-file uploads share the choice;
 	// per-file categorization would force a dialog roundtrip we want to
-	// avoid. Defaults to 'other' to preserve the v2.3 semantics.
+	// avoid. Defaults to 'other' — matches the column-level default added
+	// in migration 20260425172604 so the per-file flow and any direct
+	// PostgREST insert produce the same row.
 	const [category, setCategory] = useState<DocumentCategory>('other')
 
 	const {
@@ -179,19 +179,12 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 					</CardDescription>
 				</div>
 				<div className="flex items-center gap-2">
-					<Label
-						htmlFor={categorySelectId}
-						className="sr-only"
-					>
-						Category for next upload
-					</Label>
 					<Select
 						value={category}
 						onValueChange={value => setCategory(value as DocumentCategory)}
 						disabled={isUploading}
 					>
 						<SelectTrigger
-							id={categorySelectId}
 							size="sm"
 							className="w-[180px]"
 							aria-label="Category for next upload"
@@ -224,16 +217,16 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 							</>
 						)}
 					</Button>
+					<input
+						ref={fileInputRef}
+						type="file"
+						multiple
+						accept={ACCEPTED_MIME_TYPES.join(',')}
+						onChange={e => handleFilesSelected(e.target.files)}
+						className="sr-only"
+						aria-label={`Upload ${entityLabel} documents`}
+					/>
 				</div>
-				<input
-					ref={fileInputRef}
-					type="file"
-					multiple
-					accept={ACCEPTED_MIME_TYPES.join(',')}
-					onChange={e => handleFilesSelected(e.target.files)}
-					className="sr-only"
-					aria-label={`Upload ${entityLabel} documents`}
-				/>
 			</CardHeader>
 			<CardContent>
 				{isLoading ? (

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -11,15 +11,28 @@ import {
 import { Button } from '#components/ui/button'
 import { Skeleton } from '#components/ui/skeleton'
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '#components/ui/select'
+import { Label } from '#components/ui/label'
+import {
 	documentMutations,
 	documentQueries,
 	LIST_DISPLAY_LIMIT,
 	type DocumentEntityType,
 	type DocumentRow as DocumentRowData
 } from '#hooks/api/query-keys/document-keys'
+import {
+	DOCUMENT_CATEGORIES,
+	DOCUMENT_CATEGORY_LABELS,
+	type DocumentCategory
+} from '#lib/validation/documents'
 import { ownerDashboardKeys } from '#hooks/api/use-owner-dashboard'
 import { AlertTriangle, FileText, Loader2, Plus } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useId, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DocumentRow } from './document-row'
 import {
@@ -46,8 +59,13 @@ const ENTITY_LABELS: Record<DocumentEntityType, string> = {
 export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps) {
 	const queryClient = useQueryClient()
 	const fileInputRef = useRef<HTMLInputElement>(null)
+	const categorySelectId = useId()
 	const [openId, setOpenId] = useState<string | null>(null)
 	const [deletingIds, setDeletingIds] = useState<Set<string>>(() => new Set())
+	// One category per upload batch. Multi-file uploads share the choice;
+	// per-file categorization would force a dialog roundtrip we want to
+	// avoid. Defaults to 'other' to preserve the v2.3 semantics.
+	const [category, setCategory] = useState<DocumentCategory>('other')
 
 	const {
 		data: listResult,
@@ -91,7 +109,8 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 					// Browser-reported MIME. The documents row stores it in
 					// `mime_type`; `document_type` is a categorical column
 					// (defaults to 'other' for owner-uploaded files).
-					mimeType: file.type
+					mimeType: file.type,
+					category
 				})
 				uploaded++
 			} catch (err) {
@@ -159,24 +178,53 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 						Attach PDFs or images you want to keep alongside this {entityLabel}.
 					</CardDescription>
 				</div>
-				<Button
-					size="sm"
-					variant="outline"
-					onClick={() => fileInputRef.current?.click()}
-					disabled={isUploading}
-				>
-					{isUploading ? (
-						<>
-							<Loader2 className="size-4 mr-2 animate-spin" />
-							Uploading...
-						</>
-					) : (
-						<>
-							<Plus className="size-4 mr-2" />
-							Upload
-						</>
-					)}
-				</Button>
+				<div className="flex items-center gap-2">
+					<Label
+						htmlFor={categorySelectId}
+						className="sr-only"
+					>
+						Category for next upload
+					</Label>
+					<Select
+						value={category}
+						onValueChange={value => setCategory(value as DocumentCategory)}
+						disabled={isUploading}
+					>
+						<SelectTrigger
+							id={categorySelectId}
+							size="sm"
+							className="w-[180px]"
+							aria-label="Category for next upload"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{DOCUMENT_CATEGORIES.map(value => (
+								<SelectItem key={value} value={value}>
+									{DOCUMENT_CATEGORY_LABELS[value]}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={() => fileInputRef.current?.click()}
+						disabled={isUploading}
+					>
+						{isUploading ? (
+							<>
+								<Loader2 className="size-4 mr-2 animate-spin" />
+								Uploading...
+							</>
+						) : (
+							<>
+								<Plus className="size-4 mr-2" />
+								Upload
+							</>
+						)}
+					</Button>
+				</div>
 				<input
 					ref={fileInputRef}
 					type="file"

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -26,6 +26,11 @@ import {
 	type DocumentEntityType,
 	type DocumentRow as DocumentRowData
 } from '#hooks/api/query-keys/document-keys'
+import {
+	DOCUMENT_CATEGORIES,
+	DOCUMENT_CATEGORY_LABELS,
+	type DocumentCategory
+} from '#lib/validation/documents'
 import { DocumentRow } from './document-row'
 import { AlertTriangle, FolderArchive, Loader2, Search } from 'lucide-react'
 
@@ -37,6 +42,7 @@ const ENTITY_TYPE_LABELS: Record<DocumentEntityType, string> = {
 }
 
 const ANY_ENTITY = '__any__'
+const ANY_CATEGORY = '__any__'
 
 export function DocumentsVaultClient() {
 	// URL-synced filters via nuqs so a shared link reproduces the search.
@@ -47,6 +53,10 @@ export function DocumentsVaultClient() {
 	const [entityParam, setEntityParam] = useQueryState(
 		'entity',
 		parseAsString.withDefault(ANY_ENTITY)
+	)
+	const [categoryParam, setCategoryParam] = useQueryState(
+		'category',
+		parseAsString.withDefault(ANY_CATEGORY)
 	)
 	const [pageParam, setPageParam] = useQueryState(
 		'page',
@@ -89,10 +99,21 @@ export function DocumentsVaultClient() {
 			: undefined
 	}, [entityParam])
 
+	// Same H2-style guard for category — `?category=banana` must NOT flow
+	// into the RPC as a typed DocumentCategory. Empty string also degrades
+	// to "Any" (the RPC treats null as "no filter").
+	const category = useMemo<DocumentCategory | undefined>(() => {
+		if (categoryParam === ANY_CATEGORY) return undefined
+		return (DOCUMENT_CATEGORIES as readonly string[]).includes(categoryParam)
+			? (categoryParam as DocumentCategory)
+			: undefined
+	}, [categoryParam])
+
 	const { data, isLoading, isFetching, isError, refetch } = useQuery(
 		documentSearchQueries.list({
 			...(queryParam ? { query: queryParam } : {}),
 			...(entityType ? { entityType } : {}),
+			...(category ? { category } : {}),
 			page: pageParam
 		})
 	)
@@ -141,7 +162,7 @@ export function DocumentsVaultClient() {
 					<CardTitle className="text-base">Search & filter</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-4">
-					<div className="grid gap-3 md:grid-cols-[1fr_220px]">
+					<div className="grid gap-3 md:grid-cols-[1fr_180px_180px]">
 						<div className="relative">
 							<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
 							<Input
@@ -168,6 +189,25 @@ export function DocumentsVaultClient() {
 								{DOCUMENT_ENTITY_TYPES.map(type => (
 									<SelectItem key={type} value={type}>
 										{ENTITY_TYPE_LABELS[type]}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<Select
+							value={categoryParam}
+							onValueChange={value => {
+								void setCategoryParam(value === ANY_CATEGORY ? null : value)
+								void setPageParam(null)
+							}}
+						>
+							<SelectTrigger aria-label="Filter by category">
+								<SelectValue placeholder="All categories" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value={ANY_CATEGORY}>All categories</SelectItem>
+								{DOCUMENT_CATEGORIES.map(value => (
+									<SelectItem key={value} value={value}>
+										{DOCUMENT_CATEGORY_LABELS[value]}
 									</SelectItem>
 								))}
 							</SelectContent>
@@ -216,12 +256,12 @@ export function DocumentsVaultClient() {
 						<EmptyState
 							icon={<FolderArchive className="size-8 opacity-50" />}
 							title={
-								queryParam || entityType
+								queryParam || entityType || category
 									? 'No documents match your search.'
 									: 'No documents uploaded yet.'
 							}
 							subtitle={
-								queryParam || entityType
+								queryParam || entityType || category
 									? 'Try a different keyword or filter.'
 									: 'Open a property, lease, tenant, or maintenance request to upload your first document.'
 							}

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -128,16 +128,21 @@ export function DocumentsVaultClient() {
 	// When the URL value is rejected by the guard, scrub it from the URL
 	// so the address bar matches what the UI is actually filtering by.
 	// Without this, `?entity=banana` lingers in the URL while the page
-	// shows "All types" — confusing on share/bookmark.
+	// shows "All types" — confusing on share/bookmark. Single effect for
+	// both filters so adding a third URL-synced filter (e.g. ?page=…)
+	// stays a one-line change.
 	const entityRejected = entityParam !== ANY_ENTITY && entityType === undefined
 	const categoryRejected =
 		categoryParam !== ANY_CATEGORY && category === undefined
 	useEffect(() => {
 		if (entityRejected) void setEntityParam(null)
-	}, [entityRejected, setEntityParam])
-	useEffect(() => {
 		if (categoryRejected) void setCategoryParam(null)
-	}, [categoryRejected, setCategoryParam])
+	}, [
+		entityRejected,
+		categoryRejected,
+		setEntityParam,
+		setCategoryParam
+	])
 
 	const { data, isLoading, isFetching, isError, refetch } = useQuery(
 		documentSearchQueries.list({

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -44,6 +44,22 @@ const ENTITY_TYPE_LABELS: Record<DocumentEntityType, string> = {
 const ANY_ENTITY = '__any__'
 const ANY_CATEGORY = '__any__'
 
+// Sentinels must not collide with any real taxonomy value, otherwise a
+// URL like `?category=__any__` would silently render as "All categories"
+// instead of a literal category. Module-load assert so adding a new
+// entity/category that happens to be `__any__` fails the import in dev
+// rather than producing a confusing UX in prod.
+if ((DOCUMENT_ENTITY_TYPES as readonly string[]).includes(ANY_ENTITY)) {
+	throw new Error(
+		'ANY_ENTITY sentinel collides with a real DOCUMENT_ENTITY_TYPES value'
+	)
+}
+if ((DOCUMENT_CATEGORIES as readonly string[]).includes(ANY_CATEGORY)) {
+	throw new Error(
+		'ANY_CATEGORY sentinel collides with a real DOCUMENT_CATEGORIES value'
+	)
+}
+
 export function DocumentsVaultClient() {
 	// URL-synced filters via nuqs so a shared link reproduces the search.
 	const [queryParam, setQueryParam] = useQueryState(
@@ -108,6 +124,20 @@ export function DocumentsVaultClient() {
 			? (categoryParam as DocumentCategory)
 			: undefined
 	}, [categoryParam])
+
+	// When the URL value is rejected by the guard, scrub it from the URL
+	// so the address bar matches what the UI is actually filtering by.
+	// Without this, `?entity=banana` lingers in the URL while the page
+	// shows "All types" — confusing on share/bookmark.
+	const entityRejected = entityParam !== ANY_ENTITY && entityType === undefined
+	const categoryRejected =
+		categoryParam !== ANY_CATEGORY && category === undefined
+	useEffect(() => {
+		if (entityRejected) void setEntityParam(null)
+	}, [entityRejected, setEntityParam])
+	useEffect(() => {
+		if (categoryRejected) void setCategoryParam(null)
+	}, [categoryRejected, setCategoryParam])
 
 	const { data, isLoading, isFetching, isError, refetch } = useQuery(
 		documentSearchQueries.list({

--- a/src/hooks/api/query-keys/document-keys.test.ts
+++ b/src/hooks/api/query-keys/document-keys.test.ts
@@ -53,17 +53,18 @@ describe('mapDocumentRow', () => {
 		// Drop `id` — a future hand-edited `.select(...)` typo is the
 		// realistic regression scenario this guards against.
 		const { id: _id, ...withoutId } = fullRow
-		void _id
 		expect(() => mapDocumentRow(withoutId)).toThrowError(/'id'/)
 	})
 
 	it('throws on each NOT NULL field independently', () => {
+		// created_at is intentionally NOT in this list — the DB column is
+		// nullable (DEFAULT now() but no NOT NULL) so the mapper accepts
+		// null and lets downstream consumers handle it.
 		for (const field of [
 			'entity_type',
 			'entity_id',
 			'file_path',
-			'storage_url',
-			'created_at'
+			'storage_url'
 		] as const) {
 			const broken = { ...fullRow, [field]: undefined }
 			expect(
@@ -71,6 +72,11 @@ describe('mapDocumentRow', () => {
 				`expected throw when ${field} is missing`
 			).toThrowError(new RegExp(`'${field}'`))
 		}
+	})
+
+	it('treats null created_at as null (DB column is nullable, cycle-4 P3)', () => {
+		const mapped = mapDocumentRow({ ...fullRow, created_at: null })
+		expect(mapped.created_at).toBeNull()
 	})
 
 	it('treats a null mime_type / tags / description / owner_user_id as null', () => {

--- a/src/hooks/api/query-keys/document-keys.test.ts
+++ b/src/hooks/api/query-keys/document-keys.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for `mapDocumentRow` — the typed PostgREST→DocumentRow
+ * boundary mapper introduced in PR #636 cycle-2 (P2-1).
+ *
+ * Pins three behaviours the cycle-3 audit raised:
+ *   (a) Valid taxonomy values pass through unchanged.
+ *   (b) Out-of-band `document_type` degrades to `'other'` rather than
+ *       poisoning downstream Record<DocumentCategory, ...> lookups.
+ *   (c) Missing NOT NULL fields throw with a descriptive message
+ *       rather than silently producing the literal string "undefined".
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mapDocumentRow } from './document-keys'
+
+const fullRow = {
+	id: '00000000-0000-0000-0000-000000000001',
+	entity_type: 'property',
+	entity_id: '00000000-0000-0000-0000-000000000002',
+	document_type: 'lease',
+	mime_type: 'application/pdf',
+	file_path: 'property/p/1.pdf',
+	storage_url: 'property/p/1.pdf',
+	file_size: 1024,
+	title: 'Lease addendum',
+	tags: ['legal'] as string[],
+	description: null,
+	owner_user_id: '00000000-0000-0000-0000-000000000003',
+	created_at: '2026-04-25T00:00:00Z'
+}
+
+describe('mapDocumentRow', () => {
+	it('passes through a row whose document_type is in the taxonomy', () => {
+		const mapped = mapDocumentRow(fullRow)
+		expect(mapped.document_type).toBe('lease')
+		expect(mapped.id).toBe(fullRow.id)
+		expect(mapped.entity_type).toBe('property')
+		expect(mapped.tags).toEqual(['legal'])
+		expect(mapped.description).toBeNull()
+	})
+
+	it('degrades an out-of-band document_type to "other" (cycle-3 boundary defense)', () => {
+		const mapped = mapDocumentRow({ ...fullRow, document_type: 'warranty' })
+		expect(mapped.document_type).toBe('other')
+	})
+
+	it('degrades a null document_type to "other"', () => {
+		const mapped = mapDocumentRow({ ...fullRow, document_type: null })
+		expect(mapped.document_type).toBe('other')
+	})
+
+	it('throws when a NOT NULL field is missing from the PostgREST response (cycle-3 NIT-1)', () => {
+		// Drop `id` — a future hand-edited `.select(...)` typo is the
+		// realistic regression scenario this guards against.
+		const { id: _id, ...withoutId } = fullRow
+		void _id
+		expect(() => mapDocumentRow(withoutId)).toThrowError(/'id'/)
+	})
+
+	it('throws on each NOT NULL field independently', () => {
+		for (const field of [
+			'entity_type',
+			'entity_id',
+			'file_path',
+			'storage_url',
+			'created_at'
+		] as const) {
+			const broken = { ...fullRow, [field]: undefined }
+			expect(
+				() => mapDocumentRow(broken),
+				`expected throw when ${field} is missing`
+			).toThrowError(new RegExp(`'${field}'`))
+		}
+	})
+
+	it('treats a null mime_type / tags / description / owner_user_id as null', () => {
+		const mapped = mapDocumentRow({
+			...fullRow,
+			mime_type: null,
+			tags: null,
+			description: null,
+			owner_user_id: null
+		})
+		expect(mapped.mime_type).toBeNull()
+		expect(mapped.tags).toBeNull()
+		expect(mapped.description).toBeNull()
+		expect(mapped.owner_user_id).toBeNull()
+	})
+})

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -20,7 +20,10 @@ import { handlePostgrestError } from '#lib/postgrest-error-handler'
 import { requireOwnerUserId } from '#lib/require-owner-user-id'
 import { createLogger } from '#lib/frontend-logger'
 import { mutationKeys } from '../mutation-keys'
-import type { DocumentCategory } from '#lib/validation/documents'
+import {
+	documentCategorySchema,
+	type DocumentCategory
+} from '#lib/validation/documents'
 
 const SIGNED_URL_TTL_SECONDS = 3600
 // Refetch the list (and its signed URLs) well before the 1h TTL expires.
@@ -79,6 +82,41 @@ export interface DocumentListResult {
 	totalCount: number
 }
 
+/**
+ * Maps a PostgREST row (untyped at the TS level — Supabase returns
+ * `document_type: string`) into the strictly-typed `DocumentRow`.
+ * `document_type` is validated via the Zod enum so an out-of-band
+ * value (corruption, dropped CHECK constraint, mid-migration replay)
+ * degrades to `'other'` rather than poisoning downstream
+ * `Record<DocumentCategory, ...>` lookups.
+ *
+ * Applies CLAUDE.md's "RPC Return Typing" rule (typed mapper at the
+ * PostgREST boundary, not `as unknown as` casts).
+ */
+export function mapDocumentRow(
+	raw: Record<string, unknown>
+): Omit<DocumentRow, 'signed_url'> {
+	const parsedCategory = documentCategorySchema.safeParse(raw.document_type)
+	const document_type: DocumentCategory = parsedCategory.success
+		? parsedCategory.data
+		: 'other'
+	return {
+		id: String(raw.id),
+		entity_type: String(raw.entity_type),
+		entity_id: String(raw.entity_id),
+		document_type,
+		mime_type: (raw.mime_type as string | null) ?? null,
+		file_path: String(raw.file_path),
+		storage_url: String(raw.storage_url),
+		file_size: (raw.file_size as number | null) ?? null,
+		title: (raw.title as string | null) ?? null,
+		tags: (raw.tags as string[] | null) ?? null,
+		description: (raw.description as string | null) ?? null,
+		owner_user_id: (raw.owner_user_id as string | null) ?? null,
+		created_at: String(raw.created_at)
+	}
+}
+
 export interface DocumentUploadInput {
 	entityType: DocumentEntityType
 	entityId: string
@@ -131,7 +169,9 @@ export const documentQueries = {
 
 				if (error) handlePostgrestError(error, 'documents')
 
-				const rows = (data ?? []) as Omit<DocumentRow, 'signed_url'>[]
+				const rows = ((data ?? []) as Record<string, unknown>[]).map(
+					mapDocumentRow
+				)
 				const totalCount = count ?? rows.length
 				if (rows.length === 0) {
 					return { rows: [], totalCount }

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -20,6 +20,7 @@ import { handlePostgrestError } from '#lib/postgrest-error-handler'
 import { requireOwnerUserId } from '#lib/require-owner-user-id'
 import { createLogger } from '#lib/frontend-logger'
 import { mutationKeys } from '../mutation-keys'
+import type { DocumentCategory } from '#lib/validation/documents'
 
 const SIGNED_URL_TTL_SECONDS = 3600
 // Refetch the list (and its signed URLs) well before the 1h TTL expires.
@@ -59,7 +60,7 @@ export interface DocumentRow {
 	id: string
 	entity_type: string
 	entity_id: string
-	document_type: string
+	document_type: DocumentCategory
 	mime_type: string | null
 	file_path: string
 	storage_url: string
@@ -84,8 +85,8 @@ export interface DocumentUploadInput {
 	file: File
 	/** Browser-reported MIME type stored on the row's mime_type column. */
 	mimeType?: string
-	/** Categorical label (e.g. 'lease', 'receipt'). Defaults to 'other'. */
-	category?: string
+	/** Categorical label. Defaults to 'other' at the DB column level too. */
+	category?: DocumentCategory
 	title?: string
 }
 

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -72,7 +72,10 @@ export interface DocumentRow {
 	tags: string[] | null
 	description: string | null
 	owner_user_id: string | null
-	created_at: string
+	// Nullable in the DB (column has DEFAULT now() but no NOT NULL).
+	// In practice always populated, but typing reflects schema reality so
+	// downstream consumers must handle the null branch defensively.
+	created_at: string | null
 	signed_url: string | null
 }
 
@@ -128,7 +131,8 @@ export function mapDocumentRow(
 		tags: (raw.tags as string[] | null) ?? null,
 		description: (raw.description as string | null) ?? null,
 		owner_user_id: (raw.owner_user_id as string | null) ?? null,
-		created_at: requireString('created_at')
+		// Nullable in DB (DEFAULT now() but no NOT NULL). Don't requireString.
+		created_at: (raw.created_at as string | null) ?? null
 	}
 }
 

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -90,30 +90,45 @@ export interface DocumentListResult {
  * degrades to `'other'` rather than poisoning downstream
  * `Record<DocumentCategory, ...>` lookups.
  *
+ * NOT NULL fields throw if absent — the boundary should surface a
+ * dropped column in `.select(...)` immediately rather than silently
+ * producing the literal string `"undefined"` (which would break
+ * signed-URL generation, date rendering, and React keys downstream).
+ *
  * Applies CLAUDE.md's "RPC Return Typing" rule (typed mapper at the
  * PostgREST boundary, not `as unknown as` casts).
  */
 export function mapDocumentRow(
 	raw: Record<string, unknown>
 ): Omit<DocumentRow, 'signed_url'> {
+	function requireString(field: string): string {
+		const value = raw[field]
+		if (typeof value !== 'string') {
+			throw new Error(
+				`mapDocumentRow: NOT NULL field '${field}' missing or non-string from PostgREST response`
+			)
+		}
+		return value
+	}
+
 	const parsedCategory = documentCategorySchema.safeParse(raw.document_type)
 	const document_type: DocumentCategory = parsedCategory.success
 		? parsedCategory.data
 		: 'other'
 	return {
-		id: String(raw.id),
-		entity_type: String(raw.entity_type),
-		entity_id: String(raw.entity_id),
+		id: requireString('id'),
+		entity_type: requireString('entity_type'),
+		entity_id: requireString('entity_id'),
 		document_type,
 		mime_type: (raw.mime_type as string | null) ?? null,
-		file_path: String(raw.file_path),
-		storage_url: String(raw.storage_url),
+		file_path: requireString('file_path'),
+		storage_url: requireString('storage_url'),
 		file_size: (raw.file_size as number | null) ?? null,
 		title: (raw.title as string | null) ?? null,
 		tags: (raw.tags as string[] | null) ?? null,
 		description: (raw.description as string | null) ?? null,
 		owner_user_id: (raw.owner_user_id as string | null) ?? null,
-		created_at: String(raw.created_at)
+		created_at: requireString('created_at')
 	}
 }
 
@@ -288,7 +303,10 @@ export const documentMutations = {
 					throw new Error('Failed to record document')
 				}
 
-				return { ...(row as Omit<DocumentRow, 'signed_url'>), signed_url: null }
+				return {
+					...mapDocumentRow(row as Record<string, unknown>),
+					signed_url: null
+				}
 			}
 		}),
 

--- a/src/hooks/api/query-keys/document-search-keys.ts
+++ b/src/hooks/api/query-keys/document-search-keys.ts
@@ -72,8 +72,9 @@ export const documentSearchQueries = {
 				// Every row carries the same `total_count` — the RPC computes
 				// the full match count in a separate scalar query before
 				// applying LIMIT/OFFSET, then attaches it to each returned
-				// row. Pull from the first row, then strip it from the shape
-				// so the rest of the pipeline matches the per-entity list.
+				// row. Read the value from the first row; mapDocumentRow
+				// reads only the named DocumentRow fields, so total_count
+				// is naturally dropped when the rows are mapped below.
 				//
 				// Defense order:
 				// 1. Reject null/undefined explicitly. `Number(null) === 0`

--- a/src/hooks/api/query-keys/document-search-keys.ts
+++ b/src/hooks/api/query-keys/document-search-keys.ts
@@ -12,6 +12,7 @@ import { createClient } from '#lib/supabase/client'
 import { handlePostgrestError } from '#lib/postgrest-error-handler'
 import {
 	documentQueries,
+	mapDocumentRow,
 	type DocumentEntityType,
 	type DocumentRow
 } from './document-keys'
@@ -63,10 +64,8 @@ export const documentSearchQueries = {
 				})
 				if (error) handlePostgrestError(error, 'documents')
 
-				const rpcRows = (data ?? []) as Array<
-					Omit<DocumentRow, 'signed_url'> & { total_count: number }
-				>
-				if (rpcRows.length === 0) {
+				const rawRows = (data ?? []) as Array<Record<string, unknown>>
+				if (rawRows.length === 0) {
 					return { rows: [], totalCount: 0, page, pageSize: SEARCH_PAGE_SIZE }
 				}
 
@@ -75,9 +74,10 @@ export const documentSearchQueries = {
 				// applying LIMIT/OFFSET, then attaches it to each returned
 				// row. Pull from the first row, then strip it from the shape
 				// so the rest of the pipeline matches the per-entity list.
-				const totalCount = rpcRows[0]!.total_count
+				const totalCount = Number(rawRows[0]!.total_count)
 
-				const paths = rpcRows.map(r => r.file_path)
+				const mappedRows = rawRows.map(mapDocumentRow)
+				const paths = mappedRows.map(r => r.file_path)
 				const { data: signed } = await supabase.storage
 					.from(STORAGE_BUCKET)
 					.createSignedUrls(paths, SIGNED_URL_TTL_SECONDS)
@@ -90,20 +90,8 @@ export const documentSearchQueries = {
 				}
 
 				return {
-					rows: rpcRows.map(r => ({
-						id: r.id,
-						entity_type: r.entity_type,
-						entity_id: r.entity_id,
-						document_type: r.document_type,
-						mime_type: r.mime_type,
-						file_path: r.file_path,
-						storage_url: r.storage_url,
-						file_size: r.file_size,
-						title: r.title,
-						tags: r.tags,
-						description: r.description,
-						owner_user_id: r.owner_user_id,
-						created_at: r.created_at,
+					rows: mappedRows.map(r => ({
+						...r,
 						signed_url: urlByPath.get(r.file_path) ?? null
 					})),
 					totalCount,

--- a/src/hooks/api/query-keys/document-search-keys.ts
+++ b/src/hooks/api/query-keys/document-search-keys.ts
@@ -74,19 +74,27 @@ export const documentSearchQueries = {
 				// applying LIMIT/OFFSET, then attaches it to each returned
 				// row. Pull from the first row, then strip it from the shape
 				// so the rest of the pipeline matches the per-entity list.
-				// Finite-check guards against an RPC contract regression
-				// where total_count goes missing — without this, NaN would
-				// silently break pagination math (pageEnd < NaN === false,
-				// so the Next button hides and the user can't reach later
-				// pages) with no surfaced error.
+				//
+				// Defense order:
+				// 1. Reject null/undefined explicitly. `Number(null) === 0`
+				//    and `Number.isFinite(0) === true`, so a bare finite-
+				//    check would silently let a missing count through as 0
+				//    — which silently breaks pagination math.
+				// 2. Then numeric coerce + finite-check to catch strings
+				//    that don't parse, NaN, Infinity.
 				const totalCountRaw = rawRows[0]!.total_count
+				if (totalCountRaw === null || totalCountRaw === undefined) {
+					throw new Error(
+						'search_documents RPC contract: total_count is null/undefined'
+					)
+				}
 				const totalCountNumeric =
 					typeof totalCountRaw === 'number'
 						? totalCountRaw
 						: Number(totalCountRaw)
 				if (!Number.isFinite(totalCountNumeric)) {
 					throw new Error(
-						'search_documents RPC contract: total_count missing or non-numeric'
+						'search_documents RPC contract: total_count is not a finite number'
 					)
 				}
 				const totalCount = totalCountNumeric

--- a/src/hooks/api/query-keys/document-search-keys.ts
+++ b/src/hooks/api/query-keys/document-search-keys.ts
@@ -15,6 +15,7 @@ import {
 	type DocumentEntityType,
 	type DocumentRow
 } from './document-keys'
+import type { DocumentCategory } from '#lib/validation/documents'
 
 const SIGNED_URL_TTL_SECONDS = 3600
 const LIST_STALE_TIME_MS = 45 * 60 * 1000
@@ -26,7 +27,7 @@ export const SEARCH_PAGE_SIZE = 50
 export interface DocumentSearchParams {
 	query?: string
 	entityType?: DocumentEntityType
-	category?: string
+	category?: DocumentCategory
 	page?: number
 }
 

--- a/src/hooks/api/query-keys/document-search-keys.ts
+++ b/src/hooks/api/query-keys/document-search-keys.ts
@@ -74,7 +74,22 @@ export const documentSearchQueries = {
 				// applying LIMIT/OFFSET, then attaches it to each returned
 				// row. Pull from the first row, then strip it from the shape
 				// so the rest of the pipeline matches the per-entity list.
-				const totalCount = Number(rawRows[0]!.total_count)
+				// Finite-check guards against an RPC contract regression
+				// where total_count goes missing — without this, NaN would
+				// silently break pagination math (pageEnd < NaN === false,
+				// so the Next button hides and the user can't reach later
+				// pages) with no surfaced error.
+				const totalCountRaw = rawRows[0]!.total_count
+				const totalCountNumeric =
+					typeof totalCountRaw === 'number'
+						? totalCountRaw
+						: Number(totalCountRaw)
+				if (!Number.isFinite(totalCountNumeric)) {
+					throw new Error(
+						'search_documents RPC contract: total_count missing or non-numeric'
+					)
+				}
+				const totalCount = totalCountNumeric
 
 				const mappedRows = rawRows.map(mapDocumentRow)
 				const paths = mappedRows.map(r => r.file_path)

--- a/src/lib/validation/__tests__/documents.test.ts
+++ b/src/lib/validation/__tests__/documents.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import {
+	DOCUMENT_CATEGORIES,
+	DOCUMENT_CATEGORY_LABELS,
+	documentCategorySchema
+} from '../documents'
+
+describe('documentCategorySchema', () => {
+	it('accepts every category in DOCUMENT_CATEGORIES', () => {
+		for (const category of DOCUMENT_CATEGORIES) {
+			expect(documentCategorySchema.safeParse(category).success).toBe(true)
+		}
+	})
+
+	it('rejects values outside the enum', () => {
+		expect(documentCategorySchema.safeParse('warranty').success).toBe(false)
+		expect(documentCategorySchema.safeParse('LEASE').success).toBe(false)
+		expect(documentCategorySchema.safeParse('').success).toBe(false)
+		expect(documentCategorySchema.safeParse(null).success).toBe(false)
+		expect(documentCategorySchema.safeParse(undefined).success).toBe(false)
+	})
+
+	it('exposes a label for every category — keeps Select renders deterministic', () => {
+		for (const category of DOCUMENT_CATEGORIES) {
+			expect(DOCUMENT_CATEGORY_LABELS[category]).toBeTruthy()
+			expect(typeof DOCUMENT_CATEGORY_LABELS[category]).toBe('string')
+		}
+	})
+
+	it('matches the CHECK constraint in migration 20260425172604 exactly', () => {
+		// If you change DOCUMENT_CATEGORIES, ALSO update the migration —
+		// otherwise PostgREST inserts will throw 23514 check_violation.
+		expect([...DOCUMENT_CATEGORIES]).toEqual([
+			'lease',
+			'receipt',
+			'tax_return',
+			'inspection_report',
+			'maintenance_invoice',
+			'insurance',
+			'other'
+		])
+	})
+})

--- a/src/lib/validation/__tests__/documents.test.ts
+++ b/src/lib/validation/__tests__/documents.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 import {
 	DOCUMENT_CATEGORIES,
 	DOCUMENT_CATEGORY_LABELS,
@@ -39,5 +40,26 @@ describe('documentCategorySchema', () => {
 			'insurance',
 			'other'
 		])
+	})
+
+	it('migration source is in lockstep with DOCUMENT_CATEGORIES (NIT cross-check)', () => {
+		// Reads the migration file at runtime and parses the literal CHECK
+		// list. Catches the three-source-of-truth drift: if someone edits
+		// the tuple WITHOUT updating the migration (or vice versa), the
+		// hard-coded array literal above would still match the tuple but
+		// this test fails. The migration is the database's source of
+		// truth; this guard makes the repo's source of truth match it.
+		const migrationSql = readFileSync(
+			'supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql',
+			'utf8'
+		)
+		const checkBlock = migrationSql.match(
+			/check \(document_type in \(([\s\S]*?)\)\)/
+		)?.[1]
+		expect(checkBlock, 'CHECK block not found in migration').toBeDefined()
+		const quoted = (checkBlock!.match(/'([^']+)'/g) ?? []).map(m =>
+			m.replace(/^'|'$/g, '')
+		)
+		expect(quoted.sort()).toEqual([...DOCUMENT_CATEGORIES].sort())
 	})
 })

--- a/src/lib/validation/__tests__/documents.test.ts
+++ b/src/lib/validation/__tests__/documents.test.ts
@@ -53,8 +53,11 @@ describe('documentCategorySchema', () => {
 			'supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql',
 			'utf8'
 		)
+		// Case-insensitive + whitespace-tolerant — a future migration
+		// that uppercases CHECK / IN, or wraps the predicate over
+		// multiple lines with extra whitespace, must still match.
 		const checkBlock = migrationSql.match(
-			/check \(document_type in \(([\s\S]*?)\)\)/
+			/check\s*\(\s*document_type\s+in\s*\(([\s\S]*?)\)\s*\)/i
 		)?.[1]
 		expect(checkBlock, 'CHECK block not found in migration').toBeDefined()
 		const quoted = (checkBlock!.match(/'([^']+)'/g) ?? []).map(m =>

--- a/src/lib/validation/documents.ts
+++ b/src/lib/validation/documents.ts
@@ -1,0 +1,37 @@
+/**
+ * Document Validation Schemas
+ *
+ * Categorical taxonomy for public.documents.document_type. Mirrors the
+ * CHECK constraint added in migration 20260425172604_v24_phase_61_document_type_taxonomy.
+ */
+
+import { z } from 'zod'
+
+// Tuple form for UI iteration (Select options, filter dropdowns).
+// Order matches the Select rendering order — most-common categories
+// for landlord workflows first, 'other' last as the fallback bucket.
+export const DOCUMENT_CATEGORIES = [
+	'lease',
+	'receipt',
+	'tax_return',
+	'inspection_report',
+	'maintenance_invoice',
+	'insurance',
+	'other'
+] as const
+
+export const documentCategorySchema = z.enum(DOCUMENT_CATEGORIES)
+
+export type DocumentCategory = z.infer<typeof documentCategorySchema>
+
+// Human-readable labels for Select options + filter chips. Keep in
+// sync with DOCUMENT_CATEGORIES order so renders are deterministic.
+export const DOCUMENT_CATEGORY_LABELS: Record<DocumentCategory, string> = {
+	lease: 'Lease',
+	receipt: 'Receipt',
+	tax_return: 'Tax return',
+	inspection_report: 'Inspection report',
+	maintenance_invoice: 'Maintenance invoice',
+	insurance: 'Insurance',
+	other: 'Other'
+}

--- a/src/test/unit-setup.ts
+++ b/src/test/unit-setup.ts
@@ -95,6 +95,27 @@ Object.defineProperty(window, 'ResizeObserver', {
 	value: ResizeObserverMock
 })
 
+// Polyfill pointer-capture + scrollIntoView for Radix UI in JSDOM.
+// Radix Select / Dropdown / Popover trigger handlers call
+// `target.hasPointerCapture(...)` on the trigger element; JSDOM has no
+// PointerEvent implementation so the call throws TypeError. The empty
+// implementations below are sufficient for unit tests — we don't need
+// real pointer-capture semantics, just the methods to exist.
+if (!Element.prototype.hasPointerCapture) {
+	Element.prototype.hasPointerCapture = function () {
+		return false
+	}
+}
+if (!Element.prototype.setPointerCapture) {
+	Element.prototype.setPointerCapture = function () {}
+}
+if (!Element.prototype.releasePointerCapture) {
+	Element.prototype.releasePointerCapture = function () {}
+}
+if (!Element.prototype.scrollIntoView) {
+	Element.prototype.scrollIntoView = function () {}
+}
+
 // Mock IntersectionObserver for components that use it (blur-fade, lazy loading, etc.)
 class IntersectionObserverMock implements IntersectionObserver {
 	readonly root: Element | null = null

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -127,7 +127,7 @@ export type Database = {
         Insert: {
           created_at?: string | null
           description?: string | null
-          document_type: string
+          document_type?: string
           entity_id: string
           entity_type: string
           file_path: string
@@ -2829,4 +2829,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -290,7 +290,7 @@ File attachments for entities.
 | `id` | uuid (PK) | |
 | `entity_type` | text | `lease`, `property`, `tenant`, etc. |
 | `entity_id` | uuid | ID of parent entity |
-| `document_type` | text | `contract`, `id`, `proof_of_income`, etc. |
+| `document_type` | text | CHECK-enforced enum: `lease`, `receipt`, `tax_return`, `inspection_report`, `maintenance_invoice`, `insurance`, `other`. Default `'other'`. |
 | `file_path` | text | Storage path |
 | `storage_url` | text | Public/signed URL |
 | `file_size` | integer | Size in bytes |

--- a/supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql
+++ b/supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql
@@ -1,0 +1,51 @@
+-- v2.4 Phase 61 — categorical taxonomy for public.documents.document_type.
+--
+-- Until now `document_type` was a freetext NOT NULL column without a
+-- column-level default. v2.3 cycle-2 audit flagged owners cramming
+-- browser MIME values into it; cycle-4 fixed that by adding a separate
+-- mime_type column, but document_type remained freetext. Phase 61
+-- closes that gap with a CHECK constraint enforcing seven categorical
+-- values that match common landlord workflows (lease, receipt,
+-- tax_return, inspection_report, maintenance_invoice, insurance,
+-- other).
+--
+-- Defensive coercion: any row whose document_type isn't in the new
+-- enum gets rewritten to 'other' BEFORE the constraint is added. Empty
+-- table at migration time, but the UPDATE keeps the migration safe to
+-- replay against any environment.
+
+begin;
+
+update public.documents
+set document_type = 'other'
+where document_type not in (
+  'lease',
+  'receipt',
+  'tax_return',
+  'inspection_report',
+  'maintenance_invoice',
+  'insurance',
+  'other'
+);
+
+alter table public.documents
+  add constraint documents_document_type_check
+  check (document_type in (
+    'lease',
+    'receipt',
+    'tax_return',
+    'inspection_report',
+    'maintenance_invoice',
+    'insurance',
+    'other'
+  ));
+
+-- Make 'other' the column-level default so PostgREST inserts that omit
+-- document_type get a valid taxonomy value (matches the application-
+-- layer fallback in documentMutations.upload).
+alter table public.documents alter column document_type set default 'other';
+
+comment on column public.documents.document_type is
+  'Categorical taxonomy. CHECK-enforced enum: lease | receipt | tax_return | inspection_report | maintenance_invoice | insurance | other. Default ''other''. Distinct from mime_type which stores browser-reported MIME.';
+
+commit;

--- a/supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql
+++ b/supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql
@@ -28,17 +28,27 @@ where document_type not in (
   'other'
 );
 
-alter table public.documents
-  add constraint documents_document_type_check
-  check (document_type in (
-    'lease',
-    'receipt',
-    'tax_return',
-    'inspection_report',
-    'maintenance_invoice',
-    'insurance',
-    'other'
-  ));
+-- Idempotent ADD CONSTRAINT: project convention (see e.g.
+-- 20260306130000_schema_constraints.sql). Bare `add constraint`
+-- raises 42710 on replay, which would tear out a perfectly-good
+-- schema during a `supabase db reset` after the constraint already
+-- exists.
+do $$
+begin
+  alter table public.documents
+    add constraint documents_document_type_check
+    check (document_type in (
+      'lease',
+      'receipt',
+      'tax_return',
+      'inspection_report',
+      'maintenance_invoice',
+      'insurance',
+      'other'
+    ));
+exception when duplicate_object then null;
+end
+$$;
 
 -- Make 'other' the column-level default so PostgREST inserts that omit
 -- document_type get a valid taxonomy value (matches the application-

--- a/supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql
+++ b/supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql
@@ -28,11 +28,15 @@ where document_type not in (
   'other'
 );
 
--- Idempotent ADD CONSTRAINT: project convention (see e.g.
--- 20260306130000_schema_constraints.sql). Bare `add constraint`
--- raises 42710 on replay, which would tear out a perfectly-good
--- schema during a `supabase db reset` after the constraint already
--- exists.
+-- Idempotent ADD CONSTRAINT via PL/pgSQL exception trap — standard
+-- PostgreSQL pattern for `db reset` replay safety. Bare
+-- `add constraint` raises 42710 if the constraint already exists,
+-- which would tear out a perfectly-good schema during a
+-- `supabase db reset` after the constraint was applied.
+-- (Other idempotent-DDL migrations in this repo use information_schema
+-- introspection plus dynamic execute — same intent, different shape;
+-- the exception-trap form is more concise here because we have a
+-- single named constraint to guard.)
 do $$
 begin
   alter table public.documents

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -372,11 +372,12 @@ describe('search_documents RPC', () => {
 		// erroring on NOT NULL.
 		const ts = Date.now() + 1
 		const path = `property/${propertyA!.id}/${ts}-default-type.pdf`
-		await clientA.storage
+		const { error: storageErr } = await clientA.storage
 			.from('tenant-documents')
 			.upload(path, new Blob([PAYLOAD], { type: 'application/pdf' }), {
 				contentType: 'application/pdf'
 			})
+		expect(storageErr).toBeNull()
 		uploadedPaths.push(path)
 
 		const { data: row, error } = await clientA
@@ -398,7 +399,6 @@ describe('search_documents RPC', () => {
 		expect(row?.document_type).toBe('other')
 		if (row) insertedDocIds.push(row.id)
 	})
-
 
 	it('rejects invalid limit / offset / null limit / over-200 limit', async () => {
 		const { error: e1 } = await clientA.rpc('search_documents', {

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -328,6 +328,85 @@ describe('search_documents RPC', () => {
 		}
 	})
 
+	it('Phase 61: CHECK constraint rejects non-taxonomy document_type values', async () => {
+		// Migration 20260425172604 enforces the seven-category enum. Any
+		// other value must be rejected at insert time with 23514.
+		const ts = Date.now()
+		const path = `property/${propertyA!.id}/${ts}-bad-type.pdf`
+		const { error: storageErr } = await clientA.storage
+			.from('tenant-documents')
+			.upload(path, new Blob([PAYLOAD], { type: 'application/pdf' }), {
+				contentType: 'application/pdf'
+			})
+		expect(storageErr).toBeNull()
+
+		const { error: insertErr } = await clientA
+			.from('documents')
+			.insert({
+				entity_type: 'property',
+				entity_id: propertyA!.id,
+				document_type: 'warranty', // not in the taxonomy
+				mime_type: 'application/pdf',
+				file_path: path,
+				storage_url: path,
+				file_size: PAYLOAD.length,
+				title: 'Bad-type fixture',
+				owner_user_id: ownerAId
+			})
+			.select('id')
+			.single()
+
+		expect(insertErr, 'CHECK constraint should reject non-taxonomy value').not
+			.toBeNull()
+		expect(insertErr!.message).toMatch(
+			/documents_document_type_check|check constraint/i
+		)
+
+		// Roll back the orphaned blob so the test doesn't leak storage.
+		await clientA.storage
+			.from('tenant-documents')
+			.remove([path])
+			.catch(() => {})
+	})
+
+	it('Phase 61: omitted document_type defaults to "other"', async () => {
+		// Migration 20260425172604 sets `default 'other'`. PostgREST inserts
+		// that omit document_type should pick up that default rather than
+		// erroring on NOT NULL.
+		const ts = Date.now() + 1
+		const path = `property/${propertyA!.id}/${ts}-default-type.pdf`
+		await clientA.storage
+			.from('tenant-documents')
+			.upload(path, new Blob([PAYLOAD], { type: 'application/pdf' }), {
+				contentType: 'application/pdf'
+			})
+		uploadedPaths.push(path)
+
+		// Cast to satisfy the generated TS type (which still requires
+		// document_type after type regen). The column default makes the DB
+		// happy regardless.
+		const { data: row, error } = await clientA
+			.from('documents')
+			.insert({
+				entity_type: 'property',
+				entity_id: propertyA!.id,
+				mime_type: 'application/pdf',
+				file_path: path,
+				storage_url: path,
+				file_size: PAYLOAD.length,
+				title: 'Default-type fixture',
+				owner_user_id: ownerAId
+			} as Parameters<
+				ReturnType<typeof clientA.from<'documents'>>['insert']
+			>[0])
+			.select('id, document_type')
+			.single()
+
+		expect(error).toBeNull()
+		expect(row?.document_type).toBe('other')
+		if (row) insertedDocIds.push(row.id)
+	})
+
 	it('rejects invalid limit / offset / null limit / over-200 limit', async () => {
 		const { error: e1 } = await clientA.rpc('search_documents', {
 			p_query: null,

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -339,6 +339,9 @@ describe('search_documents RPC', () => {
 				contentType: 'application/pdf'
 			})
 		expect(storageErr).toBeNull()
+		// Push to uploadedPaths immediately so afterAll cleans up the blob
+		// even if any subsequent expect() bails early.
+		uploadedPaths.push(path)
 
 		const { error: insertErr } = await clientA
 			.from('documents')
@@ -361,12 +364,6 @@ describe('search_documents RPC', () => {
 		expect(insertErr!.message).toMatch(
 			/documents_document_type_check|check constraint/i
 		)
-
-		// Roll back the orphaned blob so the test doesn't leak storage.
-		await clientA.storage
-			.from('tenant-documents')
-			.remove([path])
-			.catch(() => {})
 	})
 
 	it('Phase 61: omitted document_type defaults to "other"', async () => {
@@ -382,9 +379,6 @@ describe('search_documents RPC', () => {
 			})
 		uploadedPaths.push(path)
 
-		// Cast to satisfy the generated TS type (which still requires
-		// document_type after type regen). The column default makes the DB
-		// happy regardless.
 		const { data: row, error } = await clientA
 			.from('documents')
 			.insert({
@@ -396,9 +390,7 @@ describe('search_documents RPC', () => {
 				file_size: PAYLOAD.length,
 				title: 'Default-type fixture',
 				owner_user_id: ownerAId
-			} as Parameters<
-				ReturnType<typeof clientA.from<'documents'>>['insert']
-			>[0])
+			})
 			.select('id, document_type')
 			.single()
 
@@ -406,6 +398,7 @@ describe('search_documents RPC', () => {
 		expect(row?.document_type).toBe('other')
 		if (row) insertedDocIds.push(row.id)
 	})
+
 
 	it('rejects invalid limit / offset / null limit / over-200 limit', async () => {
 		const { error: e1 } = await clientA.rpc('search_documents', {

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -33,7 +33,9 @@ interface SearchDocumentRow {
 	tags: string[] | null
 	description: string | null
 	owner_user_id: string | null
-	created_at: string
+	// Mirror DocumentRow.created_at — DB column is nullable (DEFAULT
+	// now() but no NOT NULL); cycle-5 NIT-1.
+	created_at: string | null
 	total_count: number
 }
 


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mCloses the v2.4 roadmap (after Phase 60 shipped via #634).[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m- **Migration `20260425172604`**: CHECK constraint on `documents.document_type IN ('lease', 'receipt', 'tax_return', 'inspection_report', 'maintenance_invoice', 'insurance', 'other')`; column-level default `'other'`; defensive UPDATE before ADD CONSTRAINT. Already applied to prod via MCP.[0m
[38;5;8m   5[0m [37m- **Zod enum** + `DOCUMENT_CATEGORIES` tuple + `DOCUMENT_CATEGORY_LABELS` in `src/lib/validation/documents.ts`. Tuple lock test fails CI if it diverges from the migration list.[0m
[38;5;8m   6[0m [37m- **Upload Select**: `DocumentsSection` (used on `/properties/[id]`, `/leases/[id]`, `/tenants/[id]`, `/maintenance/[id]`) gains a Category Select that defaults to `'other'` and applies to the next upload batch.[0m
[38;5;8m   7[0m [37m- **Vault filter**: `DocumentsVaultClient` gains an `?category=…` URL-synced Select with the same H2-style validation that silently rejects unknown URL values.[0m
[38;5;8m   8[0m [37m- **Bonus fix**: made `pnpm db:types` atomic. The old `> file` redirect clobbered `supabase.ts` on any CLI failure (saw it produce an empty file via "Unauthorized"). New script uses tmp + non-empty check + atomic mv — failures leave the existing file intact.[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37m## Test plan[0m
[38;5;8m  11[0m [37m- [x] Migration applied to prod via MCP (`20260425172604`)[0m
[38;5;8m  12[0m [37m- [x] 7,458 unit tests passing locally (+9 from Phase 61)[0m
[38;5;8m  13[0m [37m- [x] Typecheck clean[0m
[38;5;8m  14[0m [37m- [x] Lint clean[0m
[38;5;8m  15[0m [37m- [x] CHECK constraint enforced — integration test asserts `'warranty'` (out of taxonomy) is rejected with 23514[0m
[38;5;8m  16[0m [37m- [x] Default `'other'` works — integration test asserts omitted `document_type` picks up the column default[0m
[38;5;8m  17[0m [37m- [x] Vault Category Select renders + URL-syncs + spy-verified params shape[0m
[38;5;8m  18[0m [37m- [x] Upload Select default flows through to mutateAsync as `category: 'other'`[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37m[hudsor01][0m