### PR TITLE
chore(deps): override postcss to >=8.5.10 (Dependabot #141)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
 			"brace-expansion": ">=5.0.5",
 			"yaml": ">=2.8.3",
 			"smol-toml": ">=1.6.1",
-			"uuid": ">=14.0.0"
+			"uuid": ">=14.0.0",
+			"postcss": ">=8.5.10"
 		},
 		"peerDependencyRules": {
 			"allowedVersions": {

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
 		"lefthook": "^2.1.2",
 		"msw": "2.12.13",
 		"playwright": "1.58.2",
-		"postcss": "^8.5.8",
+		"postcss": ">=8.5.10",
 		"prettier": "^3.8.1",
 		"prettier-plugin-tailwindcss": "^0.7.2",
 		"schema-dts": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   yaml: '>=2.8.3'
   smol-toml: '>=1.6.1'
   uuid: '>=14.0.0'
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -366,8 +367,8 @@ importers:
         specifier: 1.58.2
         version: 1.58.2
       postcss:
-        specifier: ^8.5.8
-        version: 8.5.8
+        specifier: '>=8.5.10'
+        version: 8.5.10
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -5408,12 +5409,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -8884,7 +8881,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.8
+      postcss: 8.5.10
       tailwindcss: 4.2.2
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.2.2)':
@@ -11278,7 +11275,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -11539,13 +11536,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -11980,7 +11971,7 @@ snapshots:
       node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.8
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
       prompts: 2.4.2
       recast: 0.23.11
@@ -12424,7 +12415,7 @@ snapshots:
     dependencies:
       lightningcss: 1.31.1
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mResolves Dependabot alert #141 — PostCSS < 8.5.10 has an XSS via unescaped `</style>` in its CSS stringify output (medium severity).[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37mThe repo had two postcss versions in the tree before this PR — `8.4.31` (pulled by next 16.2.3) and `8.5.8` (pulled by tailwindcss + shadcn + vite). Both are vulnerable. The `pnpm.overrides` entry coalesces both to `8.5.10`.[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37m## Test plan[0m
[38;5;8m   7[0m [37m- [x] `pnpm typecheck` clean[0m
[38;5;8m   8[0m [37m- [x] `pnpm lint` clean[0m
[38;5;8m   9[0m [37m- [x] `pnpm test:unit` — 7,469 passing[0m
[38;5;8m  10[0m [37m- [x] `pnpm why postcss` shows single resolution `postcss@8.5.10`[0m
[38;5;8m  11[0m [37m- [x] Lockfile diff is targeted (override-only, no incidental drift)[0m
[38;5;8m  12[0m 
[38;5;8m  13[0m [37m[hudsor01][0m