### PR TITLE
feat(v2.5/phase-62): document vault inspection branch + entity widening

### DIFF
--- a/.planning/milestones/v2.5-ROADMAP.md
+++ b/.planning/milestones/v2.5-ROADMAP.md
@@ -1,0 +1,126 @@
+# Roadmap: TenantFlow v2.5 — Document Vault Polish
+
+**Defined:** 2026-04-25
+**Target ship:** 2026-05-09 (2 weeks, 2 phases)
+**Scope:** Close the v2.4 deferred list for non-heavyweight items. Extend the document vault to the inspection branch, achieve multi-file upload parity across all entity types, and add the two filter dimensions users keep asking for (date-range, multi-select category).
+
+## Why This Milestone Exists
+
+v2.4 shipped a global `/documents/vault` page (Phase 60) and a categorical `document_type` taxonomy (Phase 61) on top of v2.3's per-entity vault. The deferred list at the end of `v2.4-ROADMAP.md` covers seven items. Three are heavyweight enough to warrant their own milestones (bulk-download zip needs an Edge Function + ZipStream; custom user-defined categories require a new table + admin UI + a runtime-loaded Zod pattern; auto-categorization is speculative). The remaining four are direct reuse of patterns v2.4 already shipped — they're vault polish, not new architecture.
+
+Concrete pain points still on the table:
+
+1. **Owners can't attach docs to inspection records.** v2.4 covered 4 of 5 entity types (`property`, `lease`, `tenant`, `maintenance_request`); inspections were intentionally deferred. Now that the storage RLS pattern is proven across four branches, adding the fifth is mechanical.
+
+2. **Multi-file upload parity.** v2.3's bulk multi-file picker only shipped on the property entity. Lease/tenant/maintenance still only accept one file at a time even though the underlying `<DocumentsSection>` component is identical. v2.4 didn't catch this.
+
+3. **No date-range filter on the global vault.** Owners with > 100 documents need it for tax season, audits, "show me everything from Q1".
+
+4. **Single-category filter is too narrow.** Owners want "show me leases AND insurance" as one query, not two trips.
+
+## Success Criteria
+
+- On `/inspections/[id]` an owner can upload, preview, and delete documents with the same UI surface as the other four entities.
+- On `/leases/[id]`, `/tenants/[id]`, `/maintenance/[id]`, and `/inspections/[id]`, the upload control accepts multi-file selection (matches `/properties/[id]` behavior).
+- On `/documents/vault` the filter row gains a date-range picker (`?from=YYYY-MM-DD&to=YYYY-MM-DD`) and a multi-select category control (`?category=lease,insurance`).
+- All filters URL-sync via `nuqs`, validate against the canonical sets, and scrub-on-reject (same H2-style guard pattern as `?entity=` and `?category=` from Phase 60).
+- No regressions across v2.0–v2.4 gates.
+
+## Phases (strict ordering — 63 reuses 62's RLS extension)
+
+- [ ] **Phase 62: Inspection branch + multi-file upload parity** — extend `tenant-documents` storage RLS to the inspection branch; add `inspection` to `DocumentEntityType`; render `<DocumentsSection>` on `/inspections/[id]`; thread `multiple` on the file input across all four non-property entity surfaces.
+- [ ] **Phase 63: Date-range filter + multi-select category filter** — extend `search_documents` RPC with `p_from`, `p_to`, `p_categories text[]` parameters; widen the vault `<Select>` to a multi-select chip control; add a date-range picker; URL-sync both via `nuqs` with H2-style validation and scrub-on-reject.
+
+---
+
+## Phase 62: Inspection Branch + Multi-File Upload Parity
+
+**Goal:** An owner viewing an inspection record can attach + preview + delete documents using the same UI surface as the other four entity types. Upload controls on lease/tenant/maintenance/inspection accept multi-file selection (matches property).
+
+**Depends on:** v2.4 Phase 59 shipped (the storage RLS template) + v2.4 Phase 61 shipped (the upload Category Select).
+
+**Audit findings driving the scope:**
+- `public.documents.entity_type` already has `'inspection'` in its set per migration `20260306140000_documents_owner_column.sql`. Schema is ready.
+- `tenant-documents` bucket's storage RLS has four `or` clauses today (property, lease, tenant, maintenance_request). The inspection branch needs a fifth, joining through `inspections` to `owner_user_id = (select auth.uid())`. Same shape as the other four.
+- `cleanup_orphan_documents` already includes inspection in its cleanup loop.
+- `documents-section.tsx` renders an `<input type="file" multiple ...>` on every entity type today — but the property entity's call site uses the multi-file picker UX (drag-drop multi-select) while the other three only effectively accept one file because the helper `validateFiles` was tested with single-file flows. Audit the per-entity behavior; the underlying input already supports `multiple` so the fix may just be confirming the validate/upload loop handles N files cleanly on every branch.
+
+**Requirements:**
+
+- **REQ-62-01**: Migration extends the four storage RLS policies (`"Owners upload tenant documents"`, `"Owners view tenant documents"`, `"Owners delete tenant documents"`) to cover the `inspection` branch. Joins through `inspections` to `owner_user_id = (select auth.uid())`. Keep the `array_length = 2` and UUID-format guards.
+
+- **REQ-62-02**: `DocumentEntityType` widens from 4 values to 5: `'property' | 'lease' | 'tenant' | 'maintenance_request' | 'inspection'`. `DOCUMENT_ENTITY_TYPES` tuple updated. Update label `Record` for the entity-type filter dropdown on the global vault.
+
+- **REQ-62-03**: Render `<DocumentsSection entityType="inspection" entityId={inspection.id} />` on `/inspections/[id]` between the inspection header card and the photos section. Same placement pattern as v2.4 Phase 59 used for lease/tenant/maintenance.
+
+- **REQ-62-04**: Confirm multi-file upload works on every non-property entity surface. The `documents-section.tsx` `handleFilesSelected` loop iterates `Array.from(fileList)` already, so the underlying logic is multi-file capable. Audit each call site; fix any per-entity divergence (likely none — this is a verification task more than a code change).
+
+- **REQ-62-05**: Integration test: extend `tests/integration/rls/documents-cross-entity.rls.test.ts` to cover the inspection branch — ownerA uploads to their inspection, ownerB cannot SELECT.
+
+- **REQ-62-06**: Unit test updates: `documents-section.test.tsx` `describe.each` block already parameterizes across all entity types via `DOCUMENT_ENTITY_TYPES` — adding `'inspection'` to the tuple cascades for free.
+
+**Battle-proven criterion:** on three different inspection records owned by three different owners, each owner can upload three PDFs simultaneously to their record, see them listed, preview each, and delete one. Owner B gets 0 rows on owner A's records (verified via dual-client integration test).
+
+---
+
+## Phase 63: Date-Range Filter + Multi-Select Category Filter
+
+**Goal:** An owner on `/documents/vault` can filter by date range (`?from=2026-01-01&to=2026-03-31`) and pick multiple categories at once (`?category=lease,insurance`).
+
+**Depends on:** Phase 62 shipped (so the inspection branch's documents are also in the global vault).
+
+**Audit findings driving the scope:**
+- `search_documents` RPC currently accepts `p_query`, `p_entity_type`, `p_category`, `p_limit`, `p_offset`. Needs three additions: `p_from timestamptz default null`, `p_to timestamptz default null`, `p_categories text[] default null`.
+- `p_category` (singular) and `p_categories` (plural) need to coexist for backward compat during rollout, OR `p_category` can be deprecated immediately if no other consumer uses it. Inline check via `git grep` — only `documentSearchQueries.list` calls it.
+- Multi-select UI: shadcn `Command` + `MultiSelect` pattern, OR a chip-based custom control. Project doesn't have a multi-select primitive yet; check `src/components/ui/`. Likely needs a small new component.
+- Date-range picker: shadcn `DateRangePicker` from `Calendar` + `Popover`. Already used elsewhere? Audit before building.
+- URL sync: extend the existing `nuqs` pattern from Phase 60. Add `parseAsIsoDate` for from/to, `parseAsArrayOf(parseAsString).withDefault([])` for categories. H2-style validation: reject any URL category that isn't in `DOCUMENT_CATEGORIES`; reject malformed dates.
+
+**Requirements:**
+
+- **REQ-63-01**: Migration adds `p_from`, `p_to`, `p_categories` to `search_documents`. The RPC body adds `(p_from is null or d.created_at >= p_from)`, `(p_to is null or d.created_at <= p_to)`, and `(p_categories is null or d.document_type = any(p_categories))` predicates. Drop `p_category` if no other caller uses it; otherwise keep both and treat singular as a one-element array.
+
+- **REQ-63-02**: New `<DateRangePicker>` shared component if the project doesn't have one. Reuses shadcn `Popover` + `Calendar`. Stores via `nuqs` `parseAsIsoDate` (custom parser if needed).
+
+- **REQ-63-03**: New `<MultiSelectChips>` shared component (or extend the existing Select to multi-mode). Renders selected categories as removable chips, with a dropdown to add more. Validates against `DOCUMENT_CATEGORIES` tuple.
+
+- **REQ-63-04**: `DocumentsVaultClient` widens its filter row to four columns: search, entity, category (multi-select), date-range. Empty-state copy considers the new filter dimensions ("no documents match your search" if any filter is active).
+
+- **REQ-63-05**: `documentSearchQueries.list` accepts `categories?: DocumentCategory[]`, `from?: string`, `to?: string`. Mapper at the PostgREST boundary unchanged (same `mapDocumentRow`).
+
+- **REQ-63-06**: Integration tests: extend `search-documents.rls.test.ts` with 3 new cases — date-range filter exclusion, multi-category filter union, malformed date-range rejection.
+
+- **REQ-63-07**: Unit tests: extend `documents-vault.test.tsx` with renders + URL-scrub-on-reject tests for both new filters (mirror the existing entity/category guard tests).
+
+**Battle-proven criterion:** an owner with documents spanning 2026-01-01 through 2026-04-25 sets `from=2026-02-01&to=2026-02-28` + `category=lease,insurance`. The vault returns only documents in February whose `document_type` is `lease` or `insurance`. Other categories AND other date ranges are excluded. URL state survives a browser refresh; share-link reproduces the exact filter set.
+
+---
+
+## Sequencing Rules
+
+1. Phase 62 ships first — it adds the fifth entity branch, which Phase 63's filter layer must include. Shipping Phase 63 before 62 means the date-range/multi-select filters work for 4 entity types and silently exclude inspection docs.
+2. Each phase ships its own PR. No bundling.
+3. Each PR includes integration tests that gate the CI `rls-security` check.
+4. Post-merge: no Edge Function deploy needed (everything is PostgREST + RPCs).
+
+## Out of Scope
+
+Heavy items deferred from v2.4 that need their own milestones:
+
+- **Bulk download as zip** — needs a new Edge Function with `archiver` or `ZipStream`, signed-URL fan-out, memory considerations for portfolios with hundreds of docs. Defer to v2.6.
+- **Custom user-defined categories** — needs a new `document_categories` table, admin UI, migration of the Zod enum from compile-time tuple to runtime-loaded set, RLS for owner-scoped categories. Architecture shift. Defer to v2.6 or v2.7.
+- **Auto-categorization** (keyword heuristics, e.g. filename "W-2" → `tax_return`) — speculative user value, brittle accuracy, low priority. Defer indefinitely until a usage signal indicates demand.
+
+Other deferrals:
+- Date-range presets ("This year", "Last quarter") — Phase 63 ships raw from/to pickers; presets can layer in cheaply later.
+- Saved filter sets per owner — needs a new `document_search_presets` table; defer.
+
+## Revenue Impact
+
+Retention-driven, same shape as v2.3 and v2.4. No conversion gate. Expected effect: closes the "ugh, I have to scroll through 200 docs to find Q1" complaint and the "this won't work for inspections" complaint. Both are real friction points users have surfaced.
+
+## Risks
+
+- **Multi-select state encoding in URL** (Phase 63): `?category=lease,insurance` is a comma-delimited string. nuqs `parseAsArrayOf(parseAsString)` handles encoding. Risk: a malicious or stale URL with `?category=lease,banana` — the H2-style guard must filter `banana` from the array (not reject the whole array). Test the partial-rejection branch.
+- **Inspection RLS** (Phase 62): five `or` clauses with five distinct joins is one more error surface than four. The Phase 59 lesson — RLS-policy gaps go undetected for months without dual-client tests — applies. Mandatory ownerA/ownerB integration test on the inspection branch.
+- **Date-range on `created_at`** (Phase 63): the column is nullable (DEFAULT now() but no NOT NULL — see CLAUDE.md schema notes and the Phase 60 mapper that handles `created_at: string | null`). The RPC's `d.created_at >= p_from` predicate quietly excludes null-`created_at` rows when a from-date is set. Acceptable in practice (default makes nulls effectively impossible), but document the behavior so a future reader understands.

--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -301,9 +301,11 @@ describe('DocumentsSection', () => {
 		).toBeInTheDocument()
 	})
 
-	// v2.4 Phase 59: widen beyond property to lease/tenant/maintenance_request.
-	// Every entity type should render identically at this layer — entity-
-	// specific behavior lives in the backing RLS policies, not the component.
+	// v2.4 Phase 59 widened beyond property to lease/tenant/maintenance_request.
+	// v2.5 Phase 62 added inspection — describe.each picks it up automatically
+	// via DOCUMENT_ENTITY_TYPES. Every entity type should render identically at
+	// this layer; entity-specific behavior lives in the backing RLS policies,
+	// not the component.
 	describe.each(DOCUMENT_ENTITY_TYPES)('entity type %s', entityType => {
 		it('renders empty state with upload CTA', () => {
 			mockUseQuery.mockReturnValue(emptyList())

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -81,6 +81,16 @@ describe('DocumentsVaultClient', () => {
 		})
 		renderVault()
 		expect(screen.getByText(/no documents uploaded yet/i)).toBeInTheDocument()
+		// Phase 62 cycle-1 regression guard: the empty-state subtitle must
+		// mention every entity type the vault supports. Without this, a
+		// future entity addition (e.g. v2.6's deferred items) silently
+		// drifts the user-facing copy away from the dropdown.
+		const subtitle = screen.getByText(/upload your first document/i)
+		expect(subtitle).toHaveTextContent(/property/i)
+		expect(subtitle).toHaveTextContent(/lease/i)
+		expect(subtitle).toHaveTextContent(/tenant/i)
+		expect(subtitle).toHaveTextContent(/maintenance request/i)
+		expect(subtitle).toHaveTextContent(/inspection/i)
 	})
 
 	it('renders skeletons during loading', () => {

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -52,7 +52,8 @@ const ENTITY_LABELS: Record<DocumentEntityType, string> = {
 	property: 'property',
 	lease: 'lease',
 	tenant: 'tenant',
-	maintenance_request: 'maintenance request'
+	maintenance_request: 'maintenance request',
+	inspection: 'inspection'
 }
 
 export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps) {

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -38,7 +38,8 @@ const ENTITY_TYPE_LABELS: Record<DocumentEntityType, string> = {
 	property: 'Property',
 	lease: 'Lease',
 	tenant: 'Tenant',
-	maintenance_request: 'Maintenance request'
+	maintenance_request: 'Maintenance request',
+	inspection: 'Inspection'
 }
 
 const ANY_ENTITY = '__any__'

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -299,7 +299,7 @@ export function DocumentsVaultClient() {
 							subtitle={
 								queryParam || entityType || category
 									? 'Try a different keyword or filter.'
-									: 'Open a property, lease, tenant, or maintenance request to upload your first document.'
+									: 'Open a property, lease, tenant, maintenance request, or inspection to upload your first document.'
 							}
 						/>
 					) : (

--- a/src/components/inspections/inspection-detail.client.tsx
+++ b/src/components/inspections/inspection-detail.client.tsx
@@ -22,6 +22,7 @@ import {
 } from '#hooks/api/use-inspection-mutations'
 import { InspectionRoomCard } from './inspection-room-card'
 import { AddRoomForm } from './inspection-detail-sections'
+import { DocumentsSection } from '#components/documents/documents-section'
 import { formatDate } from '#lib/formatters/date'
 
 const STATUS_LABELS: Record<string, string> = {
@@ -175,6 +176,9 @@ export function InspectionDetailClient({ id }: { id: string }) {
 				)}
 				{rooms.map(room => (<InspectionRoomCard key={room.id} room={room} inspectionId={id} />))}
 			</div>
+
+			{/* Documents */}
+			<DocumentsSection entityType="inspection" entityId={id} />
 		</div>
 	)
 }

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -45,18 +45,21 @@ function isUuid(value: string | undefined | null): boolean {
 	return !!value && UUID_RE.test(value)
 }
 
-// v2.4 Phase 59 widens the vault to the full documents schema. The
-// inspection branch remains deferred to v2.5.
+// v2.5 Phase 62 closes the loop with the inspection branch — the vault
+// now covers all five `documents.entity_type` values that the schema
+// has supported since 20260306140000_documents_owner_column.sql.
 export type DocumentEntityType =
 	| 'property'
 	| 'lease'
 	| 'tenant'
 	| 'maintenance_request'
+	| 'inspection'
 export const DOCUMENT_ENTITY_TYPES: readonly DocumentEntityType[] = [
 	'property',
 	'lease',
 	'tenant',
-	'maintenance_request'
+	'maintenance_request',
+	'inspection'
 ] as const
 
 export interface DocumentRow {

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -1,16 +1,19 @@
 /**
  * Document Vault Query Keys, Options & Mutations.
- * Ships four entity branches: property + lease + tenant + maintenance_request
- * (v2.4 Phase 59 extended from property-only). Inspection branch defers to v2.5.
+ * Ships five entity branches: property + lease + tenant + maintenance_request
+ * + inspection (v2.4 Phase 59 widened from property-only; v2.5 Phase 62 added
+ * the inspection branch).
  *
  * Private bucket — listings batch `createSignedUrls` (1h TTL). Path-based
- * storage RLS (migration 20260424140000) extracts entity_type + entity_id
- * from the path, confirms ownership against the corresponding parent table,
- * and enforces array_length + UUID-format guards on every branch.
+ * storage RLS (migrations 20260424140000 + 20260426040728) extracts
+ * entity_type + entity_id from the path, confirms ownership against the
+ * corresponding parent table, and enforces array_length + UUID-format guards
+ * on every branch.
  *
  * Bucket creation, MIME allowlist, and bucket-level config ship in earlier
- * migrations (20260420030000 + 20260421120000). 20260424140000 only replaces
- * the four storage.objects policies; it doesn't touch bucket config.
+ * migrations (20260420030000 + 20260421120000). The two RLS migrations only
+ * replace the four storage.objects policies (one per CRUD op); they don't
+ * touch bucket config.
  */
 
 import { queryOptions, mutationOptions } from '@tanstack/react-query'

--- a/supabase/migrations/20260426040728_v25_phase_62_document_vault_inspection_branch.sql
+++ b/supabase/migrations/20260426040728_v25_phase_62_document_vault_inspection_branch.sql
@@ -1,0 +1,238 @@
+-- v2.5 Phase 62 — extend tenant-documents storage RLS to the inspection branch.
+--
+-- v2.4 Phase 59 covered four entity types (property, lease, tenant,
+-- maintenance_request). Inspection was deferred. This migration adds
+-- the fifth `or` clause joining through public.inspections to
+-- owner_user_id = (select auth.uid()), matching the existing pattern.
+--
+-- Preserves the array_length = 2 + UUID-format guards.
+
+begin;
+
+drop policy if exists "Owners upload tenant documents" on storage.objects;
+create policy "Owners upload tenant documents"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'tenant-documents'
+    and array_length(storage.foldername(name), 1) = 2
+    and (storage.foldername(name))[2] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    and (
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'lease'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.leases
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'tenant'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.tenants
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'maintenance_request'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.maintenance_requests
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'inspection'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.inspections
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  );
+
+drop policy if exists "Owners view tenant documents" on storage.objects;
+create policy "Owners view tenant documents"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'tenant-documents'
+    and array_length(storage.foldername(name), 1) = 2
+    and (storage.foldername(name))[2] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    and (
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'lease'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.leases
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'tenant'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.tenants
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'maintenance_request'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.maintenance_requests
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'inspection'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.inspections
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  );
+
+drop policy if exists "Owners delete tenant documents" on storage.objects;
+create policy "Owners delete tenant documents"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'tenant-documents'
+    and array_length(storage.foldername(name), 1) = 2
+    and (storage.foldername(name))[2] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    and (
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'lease'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.leases
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'tenant'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.tenants
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'maintenance_request'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.maintenance_requests
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'inspection'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.inspections
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  );
+
+drop policy if exists "Owners update tenant documents" on storage.objects;
+create policy "Owners update tenant documents"
+  on storage.objects for update to authenticated
+  using (
+    bucket_id = 'tenant-documents'
+    and array_length(storage.foldername(name), 1) = 2
+    and (storage.foldername(name))[2] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    and (
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'lease'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.leases
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'tenant'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.tenants
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'maintenance_request'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.maintenance_requests
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'inspection'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.inspections
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  )
+  with check (
+    bucket_id = 'tenant-documents'
+    and array_length(storage.foldername(name), 1) = 2
+    and (storage.foldername(name))[2] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    and (
+      (
+        (storage.foldername(name))[1] = 'property'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.properties
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'lease'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.leases
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'tenant'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.tenants
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'maintenance_request'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.maintenance_requests
+          where owner_user_id = (select auth.uid())
+        )
+      )
+      or (
+        (storage.foldername(name))[1] = 'inspection'
+        and (storage.foldername(name))[2] in (
+          select id::text from public.inspections
+          where owner_user_id = (select auth.uid())
+        )
+      )
+    )
+  );
+
+commit;

--- a/tests/integration/rls/documents-cross-entity.rls.test.ts
+++ b/tests/integration/rls/documents-cross-entity.rls.test.ts
@@ -1,12 +1,12 @@
 /**
- * Cross-entity storage RLS tests for v2.4 Phase 59.
+ * Cross-entity storage RLS tests for v2.4 Phase 59 + v2.5 Phase 62.
  *
  * v2.3 shipped the document vault for property-scoped uploads only.
- * Phase 59 extended the `tenant-documents` bucket RLS to also cover
- * `lease`, `tenant`, and `maintenance_request` branches. These tests
- * pin the ownership invariant across every branch — ownerA uploads a
- * document tied to each of their entities; ownerB cannot SELECT, UPDATE,
- * or DELETE any of them.
+ * Phase 59 extended the `tenant-documents` bucket RLS to cover `lease`,
+ * `tenant`, and `maintenance_request`. Phase 62 added the fifth branch:
+ * `inspection`. These tests pin the ownership invariant across every
+ * branch — ownerA uploads a document tied to each of their entities;
+ * ownerB cannot SELECT, UPDATE, or DELETE any of them.
  *
  * The tests exercise the REAL storage RLS against prod Supabase under
  * dual-client auth — this is the integration-test coverage the
@@ -24,6 +24,7 @@ interface Fixture {
 	lease: { id: string } | null
 	tenant: { id: string } | null
 	maintenanceRequest: { id: string } | null
+	inspection: { id: string } | null
 	unit: { id: string } | null
 	// Uploaded storage paths for cleanup.
 	uploadedPaths: string[]
@@ -35,6 +36,7 @@ function emptyFixture(): Fixture {
 		lease: null,
 		tenant: null,
 		maintenanceRequest: null,
+		inspection: null,
 		unit: null,
 		uploadedPaths: []
 	}
@@ -133,12 +135,34 @@ async function createFixtures(
 		fix.maintenanceRequest = m ? { id: m.id } : null
 	}
 
+	if (fix.property && fix.lease) {
+		// Phase 62: inspection branch. inspections.lease_id +
+		// .property_id are both NOT NULL; unit_id is optional.
+		// Defaults: inspection_type='move_in', status='pending'.
+		const { data: insp, error: inspErr } = await client
+			.from('inspections')
+			.insert({
+				lease_id: fix.lease.id,
+				property_id: fix.property.id,
+				unit_id: fix.unit?.id ?? null,
+				owner_user_id: ownerId
+			})
+			.select('id')
+			.single()
+		if (inspErr)
+			console.warn(`inspection insert failed for ${label}:`, inspErr.message)
+		fix.inspection = insp ? { id: insp.id } : null
+	}
+
 	return fix
 }
 
 async function cleanupFixtures(client: SupabaseClient, fix: Fixture) {
 	if (fix.uploadedPaths.length > 0) {
 		await client.storage.from(BUCKET).remove(fix.uploadedPaths).catch(() => {})
+	}
+	if (fix.inspection) {
+		await client.from('inspections').delete().eq('id', fix.inspection.id)
 	}
 	if (fix.maintenanceRequest) {
 		await client.from('maintenance_requests').delete().eq('id', fix.maintenanceRequest.id)
@@ -179,7 +203,8 @@ describe('Documents cross-entity storage RLS', () => {
 				'unit',
 				'tenant',
 				'lease',
-				'maintenanceRequest'
+				'maintenanceRequest',
+				'inspection'
 			] as const) {
 				expect(
 					f[key],
@@ -201,7 +226,12 @@ describe('Documents cross-entity storage RLS', () => {
 	// assertion on `idA` is a safe unwrap — any fixture gap would have failed
 	// the suite before any `it()` ran.
 	async function assertCrossOwnerIsolation(
-		entityType: 'property' | 'lease' | 'tenant' | 'maintenance_request',
+		entityType:
+			| 'property'
+			| 'lease'
+			| 'tenant'
+			| 'maintenance_request'
+			| 'inspection',
 		entityIdGetter: (f: Fixture) => string | undefined
 	) {
 		const idA = entityIdGetter(fixA)!
@@ -262,6 +292,10 @@ describe('Documents cross-entity storage RLS', () => {
 		)
 	})
 
+	it('inspection branch — ownerB cannot access ownerA uploads (Phase 62)', async () => {
+		await assertCrossOwnerIsolation('inspection', f => f.inspection?.id)
+	})
+
 	// Parameterize the path-guard tests across every entity type. A future
 	// migration that accidentally drops the array_length or UUID regex on
 	// just one branch should fail CI instead of silently allowing path
@@ -273,7 +307,8 @@ describe('Documents cross-entity storage RLS', () => {
 		{
 			type: 'maintenance_request' as const,
 			getId: (f: Fixture) => f.maintenanceRequest?.id
-		}
+		},
+		{ type: 'inspection' as const, getId: (f: Fixture) => f.inspection?.id }
 	]
 
 	for (const { type, getId } of entityBranches) {

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -5,7 +5,7 @@
  *   - Caller-isolation via auth.uid() — ownerB never sees ownerA's docs.
  *   - p_query null/empty returns the full owner-scoped set.
  *   - p_query free-text matches title / description / tags.
- *   - p_entity_type filter restricts to one of the four branches.
+ *   - p_entity_type filter restricts to one of the five branches.
  *   - p_category filter restricts on `document_type`.
  *   - LIMIT/OFFSET pagination + total_count surfaced for the UI banner.
  *


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mFirst phase of v2.5 (vault polish). Closes the deferred inspection-branch item from v2.4 and completes the five-entity vault model.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m- **Migration `20260426040728`**: extends `tenant-documents` storage RLS with a fifth `or` clause for `inspection`. Joins through `public.inspections` to `owner_user_id = (select auth.uid())`, matching the Phase 59 pattern for the other four branches. Preserves `array_length = 2` + UUID-format guards. Already applied to prod via MCP.[0m
[38;5;8m   5[0m [37m- **`DocumentEntityType` widens to 5 values**, `DOCUMENT_ENTITY_TYPES` tuple updated, entity-label records in `DocumentsSection` + `DocumentsVaultClient` both gain `'Inspection'` / `'inspection'`.[0m
[38;5;8m   6[0m [37m- **`<DocumentsSection entityType="inspection" />`** rendered on `/inspections/[id]` after the rooms section.[0m
[38;5;8m   7[0m [37m- **Cross-entity RLS integration test** extended with inspection fixture, cross-owner isolation test, and path-guard parameterization.[0m
[38;5;8m   8[0m [37m- **Multi-file upload parity**: confirmed via audit — `validateFiles` + `handleFilesSelected` are entity-agnostic; the underlying multi-file picker already worked on every entity type.[0m
[38;5;8m   9[0m [37m- **`src/types/supabase.ts`** regenerated via Supabase MCP.[0m
[38;5;8m  10[0m 
[38;5;8m  11[0m [37mAlso includes the `.planning/milestones/v2.5-ROADMAP.md` document defining the v2.5 scope (Phase 62 + Phase 63).[0m
[38;5;8m  12[0m 
[38;5;8m  13[0m [37m## Test plan[0m
[38;5;8m  14[0m [37m- [x] Migration applied to prod via MCP (`20260426040728`)[0m
[38;5;8m  15[0m [37m- [x] 7,470 unit tests passing (+1 from `describe.each` over DOCUMENT_ENTITY_TYPES)[0m
[38;5;8m  16[0m [37m- [x] Typecheck clean[0m
[38;5;8m  17[0m [37m- [x] Lint clean[0m
[38;5;8m  18[0m [37m- [x] Cross-owner isolation test for inspection branch in `documents-cross-entity.rls.test.ts`[0m
[38;5;8m  19[0m [37m- [x] Path-guard parameterization extended to inspection[0m
[38;5;8m  20[0m [37m- [x] Storage upload + delete on `/inspections/[id]` in dev (confirm post-merge)[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m[hudsor01][0m