### PR TITLE
feat(v2.5/phase-63): vault date-range + multi-select category filters

### DIFF
--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -8,12 +8,16 @@ import { documentSearchQueries } from '#hooks/api/query-keys/document-keys'
 const mockUseQuery = vi.fn()
 const mockSetQueryParam = vi.fn()
 const mockSetEntityParam = vi.fn()
-const mockSetCategoryParam = vi.fn()
+const mockSetCategoriesParam = vi.fn()
+const mockSetFromParam = vi.fn()
+const mockSetToParam = vi.fn()
 const mockSetPageParam = vi.fn()
 
 let queryParamValue = ''
 let entityParamValue = '__any__'
-let categoryParamValue = '__any__'
+let categoriesParamValue: string[] = []
+let fromParamValue = ''
+let toParamValue = ''
 let pageParamValue = 0
 
 vi.mock('@tanstack/react-query', async () => {
@@ -25,7 +29,8 @@ vi.mock('@tanstack/react-query', async () => {
 
 // nuqs hooks call into Next's router; mock to a controllable shape so the
 // component renders deterministically in unit tests without a routing
-// provider.
+// provider. Phase 63 widened the filter set: ?categories=… is now an
+// array, ?from / ?to are ISO date strings.
 vi.mock('nuqs', async () => {
 	const actual = await vi.importActual<typeof import('nuqs')>('nuqs')
 	return {
@@ -33,7 +38,10 @@ vi.mock('nuqs', async () => {
 		useQueryState: (key: string) => {
 			if (key === 'q') return [queryParamValue, mockSetQueryParam]
 			if (key === 'entity') return [entityParamValue, mockSetEntityParam]
-			if (key === 'category') return [categoryParamValue, mockSetCategoryParam]
+			if (key === 'categories')
+				return [categoriesParamValue, mockSetCategoriesParam]
+			if (key === 'from') return [fromParamValue, mockSetFromParam]
+			if (key === 'to') return [toParamValue, mockSetToParam]
 			if (key === 'page') return [pageParamValue, mockSetPageParam]
 			return ['', vi.fn()]
 		}
@@ -57,7 +65,9 @@ describe('DocumentsVaultClient', () => {
 		vi.clearAllMocks()
 		queryParamValue = ''
 		entityParamValue = '__any__'
-		categoryParamValue = '__any__'
+		categoriesParamValue = []
+		fromParamValue = ''
+		toParamValue = ''
 		pageParamValue = 0
 	})
 
@@ -370,7 +380,7 @@ describe('DocumentsVaultClient', () => {
 		}
 	})
 
-	it('renders the category filter (Phase 61)', () => {
+	it('renders the category multi-select filter (Phase 61 + 63)', () => {
 		mockUseQuery.mockReturnValue({
 			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
 			isLoading: false,
@@ -381,8 +391,21 @@ describe('DocumentsVaultClient', () => {
 		expect(screen.getByLabelText(/filter by category/i)).toBeInTheDocument()
 	})
 
-	it('passes valid URL category to documentSearchQueries.list (Phase 61)', () => {
-		categoryParamValue = 'tax_return'
+	it('renders the date-range filter (Phase 63)', () => {
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		renderVault()
+		expect(
+			screen.getByLabelText(/filter by date range/i)
+		).toBeInTheDocument()
+	})
+
+	it('passes valid URL categories to documentSearchQueries.list (Phase 63)', () => {
+		categoriesParamValue = ['tax_return', 'insurance']
 		mockUseQuery.mockReturnValue({
 			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
 			isLoading: false,
@@ -394,18 +417,17 @@ describe('DocumentsVaultClient', () => {
 			renderVault()
 			expect(listSpy).toHaveBeenCalled()
 			const params = listSpy.mock.calls.at(-1)?.[0] as
-				| { category?: unknown }
+				| { categories?: unknown }
 				| undefined
-			expect(params?.category).toBe('tax_return')
+			expect(params?.categories).toEqual(['tax_return', 'insurance'])
 		} finally {
 			listSpy.mockRestore()
 		}
 	})
 
-	it('treats an unknown URL category as "All categories" (Phase 61 H2-style guard)', () => {
-		// Same defense as the entity guard: ?category=banana must NOT flow
-		// into the RPC as a typed DocumentCategory. Falls back to undefined.
-		categoryParamValue = 'banana'
+	it('passes valid URL from/to to documentSearchQueries.list (Phase 63)', () => {
+		fromParamValue = '2026-02-01'
+		toParamValue = '2026-02-28'
 		mockUseQuery.mockReturnValue({
 			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
 			isLoading: false,
@@ -416,14 +438,59 @@ describe('DocumentsVaultClient', () => {
 		try {
 			renderVault()
 			const params = listSpy.mock.calls.at(-1)?.[0] as
-				| { category?: unknown }
+				| { from?: unknown; to?: unknown }
 				| undefined
-			expect(params).toBeDefined()
-			expect(params).not.toHaveProperty('category')
-			// Mirror the entity-guard test's UX assertion: with no real
-			// filter active (the bad value was scrubbed) and no rows,
-			// the empty state should render the "no docs uploaded yet"
-			// copy rather than the "no docs match your search" copy.
+			expect(params?.from).toBe('2026-02-01')
+			expect(params?.to).toBe('2026-02-28')
+		} finally {
+			listSpy.mockRestore()
+		}
+	})
+
+	it('partially rejects URL categories — drops unknown values, keeps known (Phase 63)', () => {
+		// `?categories=lease,banana,insurance` should keep lease + insurance,
+		// drop banana, and scrub the URL to the cleaned set so the address
+		// bar matches what's filtering.
+		categoriesParamValue = ['lease', 'banana', 'insurance']
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		const listSpy = vi.spyOn(documentSearchQueries, 'list')
+		try {
+			renderVault()
+			const params = listSpy.mock.calls.at(-1)?.[0] as
+				| { categories?: unknown }
+				| undefined
+			expect(params?.categories).toEqual(['lease', 'insurance'])
+			// URL scrubbed to the cleaned set.
+			expect(mockSetCategoriesParam).toHaveBeenCalledWith(['lease', 'insurance'])
+		} finally {
+			listSpy.mockRestore()
+		}
+	})
+
+	it('treats an entirely-unknown URL category set as "All categories" (Phase 63 H2 guard)', () => {
+		// `?categories=banana,papaya` filters to nothing valid → no
+		// `categories` param flows into the RPC, AND the URL is scrubbed
+		// (set to null since the cleaned array is empty).
+		categoriesParamValue = ['banana', 'papaya']
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		const listSpy = vi.spyOn(documentSearchQueries, 'list')
+		try {
+			renderVault()
+			const params = listSpy.mock.calls.at(-1)?.[0] as
+				| { categories?: unknown }
+				| undefined
+			expect(params).not.toHaveProperty('categories')
+			expect(mockSetCategoriesParam).toHaveBeenCalledWith(null)
 			expect(
 				screen.getByText(/no documents uploaded yet/i)
 			).toBeInTheDocument()
@@ -432,8 +499,9 @@ describe('DocumentsVaultClient', () => {
 		}
 	})
 
-	it('scrubs an unknown category from the URL when the guard rejects it (cycle-1 P3-5)', () => {
-		categoryParamValue = 'banana'
+	it('scrubs unparseable from/to dates from the URL (Phase 63 H2 guard)', () => {
+		fromParamValue = 'not-a-date'
+		toParamValue = '2026-13-99'
 		mockUseQuery.mockReturnValue({
 			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
 			isLoading: false,
@@ -441,7 +509,8 @@ describe('DocumentsVaultClient', () => {
 			isError: false
 		})
 		renderVault()
-		expect(mockSetCategoryParam).toHaveBeenCalledWith(null)
+		expect(mockSetFromParam).toHaveBeenCalledWith(null)
+		expect(mockSetToParam).toHaveBeenCalledWith(null)
 	})
 
 	it('scrubs an unknown entity from the URL when the guard rejects it (cycle-1 P3-5)', () => {

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { useQueryState, parseAsString, parseAsInteger } from 'nuqs'
+import {
+	useQueryState,
+	parseAsString,
+	parseAsInteger,
+	parseAsArrayOf
+} from 'nuqs'
 import {
 	Card,
 	CardContent,
@@ -19,6 +24,8 @@ import {
 } from '#components/ui/select'
 import { Button } from '#components/ui/button'
 import { Skeleton } from '#components/ui/skeleton'
+import { DateRangePicker } from '#components/shared/date-range-picker'
+import { MultiSelectChips } from '#components/shared/multi-select-chips'
 import {
 	documentSearchQueries,
 	DOCUMENT_ENTITY_TYPES,
@@ -43,22 +50,29 @@ const ENTITY_TYPE_LABELS: Record<DocumentEntityType, string> = {
 }
 
 const ANY_ENTITY = '__any__'
-const ANY_CATEGORY = '__any__'
 
-// Sentinels must not collide with any real taxonomy value, otherwise a
-// URL like `?category=__any__` would silently render as "All categories"
-// instead of a literal category. Module-load assert so adding a new
-// entity/category that happens to be `__any__` fails the import in dev
-// rather than producing a confusing UX in prod.
+// Sentinel must not collide with any real taxonomy value, otherwise a
+// URL like `?entity=__any__` would silently render as "All types"
+// instead of a literal entity. Module-load assert so adding a new entity
+// that happens to be `__any__` fails the import in dev rather than
+// producing a confusing UX in prod.
 if ((DOCUMENT_ENTITY_TYPES as readonly string[]).includes(ANY_ENTITY)) {
 	throw new Error(
 		'ANY_ENTITY sentinel collides with a real DOCUMENT_ENTITY_TYPES value'
 	)
 }
-if ((DOCUMENT_CATEGORIES as readonly string[]).includes(ANY_CATEGORY)) {
-	throw new Error(
-		'ANY_CATEGORY sentinel collides with a real DOCUMENT_CATEGORIES value'
-	)
+
+// Phase 63: category filter is now multi-select via ?categories=lease,insurance.
+// No sentinel needed — empty array is the canonical "no filter" state.
+const CATEGORY_OPTIONS = DOCUMENT_CATEGORIES.map(value => ({
+	value,
+	label: DOCUMENT_CATEGORY_LABELS[value]
+}))
+
+function parseIsoDateOrNull(input: string | null): Date | undefined {
+	if (!input) return undefined
+	const d = new Date(input)
+	return Number.isNaN(d.getTime()) ? undefined : d
 }
 
 export function DocumentsVaultClient() {
@@ -71,9 +85,19 @@ export function DocumentsVaultClient() {
 		'entity',
 		parseAsString.withDefault(ANY_ENTITY)
 	)
-	const [categoryParam, setCategoryParam] = useQueryState(
-		'category',
-		parseAsString.withDefault(ANY_CATEGORY)
+	// Phase 63: multi-select. Default empty array → "no filter".
+	const [categoriesParam, setCategoriesParam] = useQueryState(
+		'categories',
+		parseAsArrayOf(parseAsString, ',').withDefault([])
+	)
+	// Phase 63: ISO date strings (`YYYY-MM-DD` or full ISO timestamps).
+	const [fromParam, setFromParam] = useQueryState(
+		'from',
+		parseAsString.withDefault('')
+	)
+	const [toParam, setToParam] = useQueryState(
+		'to',
+		parseAsString.withDefault('')
 	)
 	const [pageParam, setPageParam] = useQueryState(
 		'page',
@@ -116,40 +140,58 @@ export function DocumentsVaultClient() {
 			: undefined
 	}, [entityParam])
 
-	// Same H2-style guard for category — `?category=banana` must NOT flow
-	// into the RPC as a typed DocumentCategory. Empty string also degrades
-	// to "Any" (the RPC treats null as "no filter").
-	const category = useMemo<DocumentCategory | undefined>(() => {
-		if (categoryParam === ANY_CATEGORY) return undefined
-		return (DOCUMENT_CATEGORIES as readonly string[]).includes(categoryParam)
-			? (categoryParam as DocumentCategory)
-			: undefined
-	}, [categoryParam])
+	// Phase 63: multi-select category. Drop unknown values from the URL
+	// array (partial reject — `?categories=lease,banana` keeps `lease`,
+	// drops `banana`) so a single bad value can't void the user's whole
+	// selection. Memoised + sorted for queryKey stability.
+	const categories = useMemo<DocumentCategory[]>(() => {
+		const valid = (DOCUMENT_CATEGORIES as readonly string[]).filter(c =>
+			categoriesParam.includes(c)
+		) as DocumentCategory[]
+		return valid
+	}, [categoriesParam])
 
-	// When the URL value is rejected by the guard, scrub it from the URL
+	// Phase 63: date-range. Parse to Date or undefined; the RPC sees the
+	// raw ISO string. NaN dates degrade to undefined (silent — the
+	// scrub-effect below also clears them from the URL).
+	const fromDate = useMemo(() => parseIsoDateOrNull(fromParam), [fromParam])
+	const toDate = useMemo(() => parseIsoDateOrNull(toParam), [toParam])
+
+	// When the URL value is rejected by a guard, scrub it from the URL
 	// so the address bar matches what the UI is actually filtering by.
-	// Without this, `?entity=banana` lingers in the URL while the page
-	// shows "All types" — confusing on share/bookmark. Single effect for
-	// both filters so adding a third URL-synced filter (e.g. ?page=…)
-	// stays a one-line change.
+	// Single effect for all four filters so adding a fifth stays a
+	// one-line change.
 	const entityRejected = entityParam !== ANY_ENTITY && entityType === undefined
-	const categoryRejected =
-		categoryParam !== ANY_CATEGORY && category === undefined
+	const categoriesNeedScrub =
+		categoriesParam.length > 0 && categories.length !== categoriesParam.length
+	const fromRejected = fromParam !== '' && fromDate === undefined
+	const toRejected = toParam !== '' && toDate === undefined
 	useEffect(() => {
 		if (entityRejected) void setEntityParam(null)
-		if (categoryRejected) void setCategoryParam(null)
+		if (categoriesNeedScrub) {
+			void setCategoriesParam(categories.length > 0 ? categories : null)
+		}
+		if (fromRejected) void setFromParam(null)
+		if (toRejected) void setToParam(null)
 	}, [
 		entityRejected,
-		categoryRejected,
+		categoriesNeedScrub,
+		categories,
+		fromRejected,
+		toRejected,
 		setEntityParam,
-		setCategoryParam
+		setCategoriesParam,
+		setFromParam,
+		setToParam
 	])
 
 	const { data, isLoading, isFetching, isError, refetch } = useQuery(
 		documentSearchQueries.list({
 			...(queryParam ? { query: queryParam } : {}),
 			...(entityType ? { entityType } : {}),
-			...(category ? { category } : {}),
+			...(categories.length > 0 ? { categories } : {}),
+			...(fromParam ? { from: fromParam } : {}),
+			...(toParam ? { to: toParam } : {}),
 			page: pageParam
 		})
 	)
@@ -198,7 +240,7 @@ export function DocumentsVaultClient() {
 					<CardTitle className="text-base">Search & filter</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-4">
-					<div className="grid gap-3 md:grid-cols-[1fr_180px_180px]">
+					<div className="grid gap-3 md:grid-cols-[1fr_160px_180px_220px]">
 						<div className="relative">
 							<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
 							<Input
@@ -229,25 +271,30 @@ export function DocumentsVaultClient() {
 								))}
 							</SelectContent>
 						</Select>
-						<Select
-							value={categoryParam}
-							onValueChange={value => {
-								void setCategoryParam(value === ANY_CATEGORY ? null : value)
+						<MultiSelectChips<DocumentCategory>
+							options={CATEGORY_OPTIONS}
+							value={categories}
+							onChange={next => {
+								void setCategoriesParam(next.length > 0 ? next : null)
 								void setPageParam(null)
 							}}
-						>
-							<SelectTrigger aria-label="Filter by category">
-								<SelectValue placeholder="All categories" />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value={ANY_CATEGORY}>All categories</SelectItem>
-								{DOCUMENT_CATEGORIES.map(value => (
-									<SelectItem key={value} value={value}>
-										{DOCUMENT_CATEGORY_LABELS[value]}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
+							placeholder="All categories"
+							aria-label="Filter by category"
+						/>
+						<DateRangePicker
+							value={{ from: fromDate, to: toDate }}
+							onChange={range => {
+								void setFromParam(
+									range.from ? range.from.toISOString().slice(0, 10) : null
+								)
+								void setToParam(
+									range.to ? range.to.toISOString().slice(0, 10) : null
+								)
+								void setPageParam(null)
+							}}
+							placeholder="Any date"
+							aria-label="Filter by date range"
+						/>
 					</div>
 				</CardContent>
 			</Card>
@@ -292,12 +339,12 @@ export function DocumentsVaultClient() {
 						<EmptyState
 							icon={<FolderArchive className="size-8 opacity-50" />}
 							title={
-								queryParam || entityType || category
+								queryParam || entityType || categories.length > 0 || fromParam || toParam
 									? 'No documents match your search.'
 									: 'No documents uploaded yet.'
 							}
 							subtitle={
-								queryParam || entityType || category
+								queryParam || entityType || categories.length > 0 || fromParam || toParam
 									? 'Try a different keyword or filter.'
 									: 'Open a property, lease, tenant, maintenance request, or inspection to upload your first document.'
 							}

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -69,10 +69,32 @@ const CATEGORY_OPTIONS = DOCUMENT_CATEGORIES.map(value => ({
 	label: DOCUMENT_CATEGORY_LABELS[value]
 }))
 
-function parseIsoDateOrNull(input: string | null): Date | undefined {
+// Parse a YYYY-MM-DD URL value into a local-zone Date (midnight local).
+// Returns undefined on malformed input. Critically uses local-component
+// construction — NOT `new Date('2026-04-30')` which produces UTC midnight
+// and silently shifts the picker by one day for users east of UTC.
+// Round-trips through getFullYear/getMonth/getDate to reject overflow
+// inputs like `2026-13-99` (which JS otherwise wraps to April 9, 2027).
+function parseLocalYmd(input: string | null): Date | undefined {
 	if (!input) return undefined
-	const d = new Date(input)
-	return Number.isNaN(d.getTime()) ? undefined : d
+	const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(input)
+	if (!m) return undefined
+	const y = Number(m[1])
+	const mo = Number(m[2])
+	const day = Number(m[3])
+	const d = new Date(y, mo - 1, day)
+	if (Number.isNaN(d.getTime())) return undefined
+	if (d.getFullYear() !== y || d.getMonth() !== mo - 1 || d.getDate() !== day) {
+		return undefined
+	}
+	return d
+}
+
+// Format a Date as local-zone YYYY-MM-DD. Pairs with parseLocalYmd for
+// round-trip stability across timezones.
+function formatLocalYmd(d: Date): string {
+	const pad = (n: number) => String(n).padStart(2, '0')
+	return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate())
 }
 
 export function DocumentsVaultClient() {
@@ -151,11 +173,11 @@ export function DocumentsVaultClient() {
 		return valid
 	}, [categoriesParam])
 
-	// Phase 63: date-range. Parse to Date or undefined; the RPC sees the
-	// raw ISO string. NaN dates degrade to undefined (silent — the
-	// scrub-effect below also clears them from the URL).
-	const fromDate = useMemo(() => parseIsoDateOrNull(fromParam), [fromParam])
-	const toDate = useMemo(() => parseIsoDateOrNull(toParam), [toParam])
+	// Phase 63: date-range. Parse the URL YYYY-MM-DD into a local-zone
+	// Date for the picker. The factory expands these to local-zone
+	// start/end-of-day ISO timestamps when calling the RPC.
+	const fromDate = useMemo(() => parseLocalYmd(fromParam), [fromParam])
+	const toDate = useMemo(() => parseLocalYmd(toParam), [toParam])
 
 	// When the URL value is rejected by a guard, scrub it from the URL
 	// so the address bar matches what the UI is actually filtering by.
@@ -285,10 +307,10 @@ export function DocumentsVaultClient() {
 							value={{ from: fromDate, to: toDate }}
 							onChange={range => {
 								void setFromParam(
-									range.from ? range.from.toISOString().slice(0, 10) : null
+									range.from ? formatLocalYmd(range.from) : null
 								)
 								void setToParam(
-									range.to ? range.to.toISOString().slice(0, 10) : null
+									range.to ? formatLocalYmd(range.to) : null
 								)
 								void setPageParam(null)
 							}}

--- a/src/components/shared/date-range-picker.tsx
+++ b/src/components/shared/date-range-picker.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+import { CalendarIcon, X } from 'lucide-react'
+import type { DateRange } from 'react-day-picker'
+import { Button } from '#components/ui/button'
+import { Calendar } from '#components/ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from '#components/ui/popover'
+import { cn } from '#lib/utils'
+
+export interface DateRangePickerProps {
+	value: { from: Date | undefined; to: Date | undefined }
+	onChange: (range: { from: Date | undefined; to: Date | undefined }) => void
+	placeholder?: string
+	'aria-label'?: string
+	className?: string
+}
+
+function formatDate(d: Date): string {
+	return d.toLocaleDateString(undefined, {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	})
+}
+
+export function DateRangePicker({
+	value,
+	onChange,
+	placeholder = 'Pick a date range',
+	'aria-label': ariaLabel = 'Filter by date range',
+	className
+}: DateRangePickerProps) {
+	const [open, setOpen] = useState(false)
+	const hasRange = value.from !== undefined || value.to !== undefined
+
+	const label = (() => {
+		if (value.from && value.to) {
+			return `${formatDate(value.from)} – ${formatDate(value.to)}`
+		}
+		if (value.from) return `From ${formatDate(value.from)}`
+		if (value.to) return `Until ${formatDate(value.to)}`
+		return placeholder
+	})()
+
+	return (
+		<div className={cn('flex items-center gap-1', className)}>
+			<Popover open={open} onOpenChange={setOpen}>
+				<PopoverTrigger asChild>
+					<Button
+						variant="outline"
+						size="sm"
+						className={cn(
+							'flex-1 justify-start text-left font-normal',
+							!hasRange && 'text-muted-foreground'
+						)}
+						aria-label={ariaLabel}
+					>
+						<CalendarIcon className="mr-2 size-4 shrink-0" aria-hidden="true" />
+						<span className="truncate">{label}</span>
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent className="w-auto p-0" align="start">
+					<Calendar
+						mode="range"
+						selected={value as DateRange | undefined}
+						onSelect={range => {
+							onChange({
+								from: range?.from,
+								to: range?.to
+							})
+						}}
+						numberOfMonths={2}
+					/>
+				</PopoverContent>
+			</Popover>
+			{hasRange && (
+				<Button
+					variant="ghost"
+					size="sm"
+					className="size-9 p-0"
+					onClick={() => onChange({ from: undefined, to: undefined })}
+					aria-label="Clear date range"
+				>
+					<X className="size-4" aria-hidden="true" />
+				</Button>
+			)}
+		</div>
+	)
+}

--- a/src/components/shared/multi-select-chips.tsx
+++ b/src/components/shared/multi-select-chips.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useState } from 'react'
+import { Check, ChevronDown, X } from 'lucide-react'
+import { Button } from '#components/ui/button'
+import { Checkbox } from '#components/ui/checkbox'
+import { Popover, PopoverContent, PopoverTrigger } from '#components/ui/popover'
+import { cn } from '#lib/utils'
+
+export interface MultiSelectOption<T extends string> {
+	value: T
+	label: string
+}
+
+export interface MultiSelectChipsProps<T extends string> {
+	options: ReadonlyArray<MultiSelectOption<T>>
+	value: ReadonlyArray<T>
+	onChange: (next: T[]) => void
+	placeholder?: string
+	'aria-label'?: string
+	className?: string
+}
+
+/**
+ * Minimal multi-select control: button trigger summarizes selection,
+ * popover lists every option with a checkbox. Toggling a checkbox adds
+ * or removes that value from the array. Used by the documents vault for
+ * the multi-select category filter (Phase 63).
+ *
+ * Generic over the value type so callers preserve their own union (e.g.
+ * `DocumentCategory`) instead of widening to `string`.
+ */
+export function MultiSelectChips<T extends string>({
+	options,
+	value,
+	onChange,
+	placeholder = 'Any',
+	'aria-label': ariaLabel,
+	className
+}: MultiSelectChipsProps<T>) {
+	const [open, setOpen] = useState(false)
+	const selected = new Set(value)
+
+	const summary = (() => {
+		if (selected.size === 0) return placeholder
+		if (selected.size === 1) {
+			const only = options.find(o => o.value === [...selected][0])
+			return only?.label ?? placeholder
+		}
+		return `${selected.size} selected`
+	})()
+
+	function toggle(v: T) {
+		if (selected.has(v)) {
+			onChange([...selected].filter(x => x !== v) as T[])
+		} else {
+			onChange([...selected, v] as T[])
+		}
+	}
+
+	return (
+		<div className={cn('flex items-center gap-1', className)}>
+			<Popover open={open} onOpenChange={setOpen}>
+				<PopoverTrigger asChild>
+					<Button
+						variant="outline"
+						size="sm"
+						className={cn(
+							'flex-1 justify-between font-normal',
+							selected.size === 0 && 'text-muted-foreground'
+						)}
+						aria-label={ariaLabel}
+					>
+						<span className="truncate">{summary}</span>
+						<ChevronDown className="ml-2 size-4 shrink-0 opacity-50" aria-hidden="true" />
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent className="w-56 p-1" align="start">
+					<ul role="listbox" aria-multiselectable="true" className="space-y-0.5">
+						{options.map(opt => {
+							const checked = selected.has(opt.value)
+							return (
+								<li key={opt.value}>
+									<button
+										type="button"
+										role="option"
+										aria-selected={checked}
+										onClick={() => toggle(opt.value)}
+										className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent focus:bg-accent focus:outline-none"
+									>
+										<Checkbox
+											checked={checked}
+											tabIndex={-1}
+											aria-hidden="true"
+										/>
+										<span className="flex-1 text-left">{opt.label}</span>
+										{checked && <Check className="size-4 text-primary" aria-hidden="true" />}
+									</button>
+								</li>
+							)
+						})}
+					</ul>
+				</PopoverContent>
+			</Popover>
+			{selected.size > 0 && (
+				<Button
+					variant="ghost"
+					size="sm"
+					className="size-9 p-0"
+					onClick={() => onChange([])}
+					aria-label="Clear selection"
+				>
+					<X className="size-4" aria-hidden="true" />
+				</Button>
+			)}
+		</div>
+	)
+}

--- a/src/hooks/api/query-keys/document-search-keys.test.ts
+++ b/src/hooks/api/query-keys/document-search-keys.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the date-boundary helper introduced in PR #640
+ * cycle-1 (Phase 63 I-1). The cycle-1 reviewer flagged that the
+ * naive `range.from.toISOString().slice(0, 10)` pattern silently
+ * misclassifies documents on the chosen end day for any user east
+ * of UTC. The helper expands a YYYY-MM-DD URL value to a local-
+ * zone start-of-day or end-of-day ISO timestamp so the RPC sees
+ * the user's INTENDED day boundary regardless of where the
+ * browser runs.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { expandDateBoundary } from './document-search-keys'
+
+describe('expandDateBoundary', () => {
+	it('returns null for missing input', () => {
+		expect(expandDateBoundary(undefined, false)).toBeNull()
+		expect(expandDateBoundary('', false)).toBeNull()
+	})
+
+	it('returns null for malformed YYYY-MM-DD input', () => {
+		expect(expandDateBoundary('not-a-date', false)).toBeNull()
+		expect(expandDateBoundary('2026-13-99', false)).toBeNull()
+		expect(expandDateBoundary('2026/04/30', false)).toBeNull()
+		expect(expandDateBoundary('26-04-30', false)).toBeNull()
+	})
+
+	it('expands valid YYYY-MM-DD to a parseable ISO timestamp at LOCAL day boundary', () => {
+		const start = expandDateBoundary('2026-04-30', false)
+		const end = expandDateBoundary('2026-04-30', true)
+		expect(start).not.toBeNull()
+		expect(end).not.toBeNull()
+		// Round-trip: parsing the output should yield the right local day.
+		const startDate = new Date(start!)
+		const endDate = new Date(end!)
+		expect(startDate.getFullYear()).toBe(2026)
+		expect(startDate.getMonth()).toBe(3) // April = 3 (0-indexed)
+		expect(startDate.getDate()).toBe(30)
+		expect(startDate.getHours()).toBe(0)
+		expect(startDate.getMinutes()).toBe(0)
+		expect(endDate.getFullYear()).toBe(2026)
+		expect(endDate.getMonth()).toBe(3)
+		expect(endDate.getDate()).toBe(30)
+		expect(endDate.getHours()).toBe(23)
+		expect(endDate.getMinutes()).toBe(59)
+		expect(endDate.getSeconds()).toBe(59)
+		// Crucially: end-of-day comes AFTER start-of-day on the same day.
+		// A naive UTC slice would have made `to` < `from` for a US user
+		// who picked a single-day range.
+		expect(endDate.getTime()).toBeGreaterThan(startDate.getTime())
+	})
+
+	it('produces an end timestamp ~24h after the start timestamp for the same day', () => {
+		const start = expandDateBoundary('2026-06-15', false)!
+		const end = expandDateBoundary('2026-06-15', true)!
+		const diff = new Date(end).getTime() - new Date(start).getTime()
+		// 23h59m59s.999 = 86_399_999 ms
+		expect(diff).toBe(86_399_999)
+	})
+})

--- a/src/hooks/api/query-keys/document-search-keys.ts
+++ b/src/hooks/api/query-keys/document-search-keys.ts
@@ -33,10 +33,48 @@ export interface DocumentSearchParams {
 	entityType?: DocumentEntityType
 	/** Phase 63: multi-select. Empty array is treated as "no filter" by the RPC. */
 	categories?: DocumentCategory[]
-	/** Phase 63: ISO timestamps. The RPC raises if from > to. */
+	/**
+	 * Phase 63: date-range bounds in `YYYY-MM-DD` form (URL shape). The
+	 * factory expands these to local-zone start-of-day / end-of-day ISO
+	 * timestamps at the RPC boundary so a US-Pacific user picking "Apr 30"
+	 * gets documents through 23:59 PT on Apr 30, not 16:59 PT (which is
+	 * what naive UTC slicing would produce). The RPC raises if from > to.
+	 */
 	from?: string
 	to?: string
 	page?: number
+}
+
+/**
+ * Expand a `YYYY-MM-DD` URL date to an ISO timestamp at the boundary of
+ * the user's LOCAL day. Returns null on malformed input — the caller's
+ * H2-style URL guard scrubs the invalid value separately.
+ */
+export function expandDateBoundary(
+	ymd: string | undefined,
+	end: boolean
+): string | null {
+	if (!ymd) return null
+	const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd)
+	if (!m) return null
+	const y = Number(m[1])
+	const mo = Number(m[2])
+	const d = Number(m[3])
+	const local = end
+		? new Date(y, mo - 1, d, 23, 59, 59, 999)
+		: new Date(y, mo - 1, d, 0, 0, 0, 0)
+	if (Number.isNaN(local.getTime())) return null
+	// JS Date silently wraps overflow (e.g. 2026-13-99 → April 9, 2027).
+	// Reject the parse if the constructed Date doesn't match the input
+	// components — otherwise the URL guard hides the bug from the user.
+	if (
+		local.getFullYear() !== y ||
+		local.getMonth() !== mo - 1 ||
+		local.getDate() !== d
+	) {
+		return null
+	}
+	return local.toISOString()
 }
 
 export interface DocumentSearchResult {
@@ -77,8 +115,10 @@ export const documentSearchQueries = {
 					p_query: params.query?.trim() || null,
 					p_entity_type: params.entityType ?? null,
 					p_categories: sortedCategories,
-					p_from: params.from ?? null,
-					p_to: params.to ?? null,
+					// Expand YYYY-MM-DD to local-zone start/end-of-day ISO so
+					// the user's chosen end day is INCLUDED in results.
+					p_from: expandDateBoundary(params.from, false),
+					p_to: expandDateBoundary(params.to, true),
 					p_limit: SEARCH_PAGE_SIZE,
 					p_offset: page * SEARCH_PAGE_SIZE
 				})

--- a/src/hooks/api/query-keys/document-search-keys.ts
+++ b/src/hooks/api/query-keys/document-search-keys.ts
@@ -1,10 +1,13 @@
 /**
- * Global /documents/vault search query factory (v2.4 Phase 60).
+ * Global /documents/vault search query factory (v2.4 Phase 60 + v2.5 Phase 63).
  *
  * Wraps the search_documents RPC. Returns the same DocumentRow shape as
  * the per-entity list factory in `document-keys.ts`, so consumers can
- * reuse <DocumentRow> rendering. Split out of `document-keys.ts` to keep
- * each file under the 300-line cap.
+ * reuse <DocumentRow> rendering.
+ *
+ * Phase 60 shipped query/entity/category/limit/offset filters.
+ * Phase 63 widened category from scalar to array (multi-select) and
+ * added p_from / p_to timestamptz date-range bounds.
  */
 
 import { queryOptions } from '@tanstack/react-query'
@@ -28,7 +31,11 @@ export const SEARCH_PAGE_SIZE = 50
 export interface DocumentSearchParams {
 	query?: string
 	entityType?: DocumentEntityType
-	category?: DocumentCategory
+	/** Phase 63: multi-select. Empty array is treated as "no filter" by the RPC. */
+	categories?: DocumentCategory[]
+	/** Phase 63: ISO timestamps. The RPC raises if from > to. */
+	from?: string
+	to?: string
 	page?: number
 }
 
@@ -42,13 +49,24 @@ export interface DocumentSearchResult {
 export const documentSearchQueries = {
 	all: () => [...documentQueries.all(), 'search'] as const,
 
-	list: (params: DocumentSearchParams) =>
-		queryOptions({
+	list: (params: DocumentSearchParams) => {
+		// Normalize once so both queryKey and queryFn agree on the shape.
+		// Empty array → null so the RPC treats it as "no filter" (matches
+		// the array_length null branch in the RPC body) and the queryKey
+		// stays canonical: same set in different orders shouldn't
+		// fragment the cache.
+		const sortedCategories =
+			params.categories && params.categories.length > 0
+				? [...params.categories].sort()
+				: null
+		return queryOptions({
 			queryKey: [
 				...documentSearchQueries.all(),
 				params.query ?? '',
 				params.entityType ?? null,
-				params.category ?? null,
+				sortedCategories,
+				params.from ?? null,
+				params.to ?? null,
 				params.page ?? 0
 			] as const,
 			queryFn: async (): Promise<DocumentSearchResult> => {
@@ -58,7 +76,9 @@ export const documentSearchQueries = {
 				const { data, error } = await supabase.rpc('search_documents', {
 					p_query: params.query?.trim() || null,
 					p_entity_type: params.entityType ?? null,
-					p_category: params.category ?? null,
+					p_categories: sortedCategories,
+					p_from: params.from ?? null,
+					p_to: params.to ?? null,
 					p_limit: SEARCH_PAGE_SIZE,
 					p_offset: page * SEARCH_PAGE_SIZE
 				})
@@ -126,4 +146,5 @@ export const documentSearchQueries = {
 			staleTime: LIST_STALE_TIME_MS,
 			gcTime: LIST_GC_TIME_MS
 		})
+	}
 }

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -2554,11 +2554,13 @@ export type Database = {
       }
       search_documents: {
         Args: {
-          p_category?: string
+          p_categories?: string[]
           p_entity_type?: string
+          p_from?: string
           p_limit?: number
           p_offset?: number
           p_query?: string
+          p_to?: string
         }
         Returns: {
           created_at: string

--- a/supabase/migrations/20260426043911_v25_phase_63_search_documents_filter_extension.sql
+++ b/supabase/migrations/20260426043911_v25_phase_63_search_documents_filter_extension.sql
@@ -1,0 +1,122 @@
+-- v2.5 Phase 63 — extend search_documents RPC with date-range +
+-- multi-category filtering.
+--
+-- Phase 60 shipped the RPC with single-value p_category and no date
+-- predicate. Phase 63 swaps p_category for p_categories text[] (so
+-- owners can filter "leases AND insurance" in one query) and adds
+-- p_from / p_to timestamptz bounds for date-range filtering.
+--
+-- The signature change requires DROP + CREATE — `documentSearchQueries.list`
+-- in src/hooks/api/query-keys/document-search-keys.ts is the sole caller
+-- and is updated in the same PR to send the array form.
+
+begin;
+
+drop function if exists public.search_documents(text, text, text, int, int);
+
+create or replace function public.search_documents(
+  p_query text default null,
+  p_entity_type text default null,
+  p_categories text[] default null,
+  p_from timestamptz default null,
+  p_to timestamptz default null,
+  p_limit int default 50,
+  p_offset int default 0
+)
+returns table (
+  id uuid,
+  entity_type text,
+  entity_id uuid,
+  document_type text,
+  mime_type text,
+  file_path text,
+  storage_url text,
+  file_size int,
+  title text,
+  tags text[],
+  description text,
+  owner_user_id uuid,
+  created_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+stable
+as $$
+declare
+  v_owner_id uuid := auth.uid();
+  v_ts_query tsquery;
+  v_has_query boolean;
+  v_total bigint;
+begin
+  if v_owner_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if p_limit is null or p_limit < 1 or p_limit > 200 then
+    raise exception 'Limit must be between 1 and 200';
+  end if;
+
+  if p_offset is null or p_offset < 0 then
+    raise exception 'Offset must be >= 0';
+  end if;
+
+  -- Date bounds sanity check — caller-supplied from > to is meaningless;
+  -- raise rather than silently returning zero rows so the UI surfaces it.
+  if p_from is not null and p_to is not null and p_from > p_to then
+    raise exception 'p_from must be <= p_to';
+  end if;
+
+  v_has_query := p_query is not null and length(trim(p_query)) > 0;
+  if v_has_query then
+    v_ts_query := plainto_tsquery('english', p_query);
+  end if;
+
+  -- Count the full matching set before applying limit/offset.
+  -- Empty p_categories array is treated as "no category filter" (same
+  -- semantics as null) so the UI can pass [] without surprises.
+  select count(*) into v_total
+  from public.documents d
+  where d.owner_user_id = v_owner_id
+    and (p_entity_type is null or d.entity_type = p_entity_type)
+    and (
+      p_categories is null
+      or array_length(p_categories, 1) is null
+      or d.document_type = any(p_categories)
+    )
+    and (p_from is null or d.created_at >= p_from)
+    and (p_to is null or d.created_at <= p_to)
+    and (not v_has_query or d.search_vector @@ v_ts_query);
+
+  return query
+  select
+    d.id, d.entity_type, d.entity_id, d.document_type, d.mime_type,
+    d.file_path, d.storage_url, d.file_size, d.title, d.tags,
+    d.description, d.owner_user_id, d.created_at, v_total as total_count
+  from public.documents d
+  where d.owner_user_id = v_owner_id
+    and (p_entity_type is null or d.entity_type = p_entity_type)
+    and (
+      p_categories is null
+      or array_length(p_categories, 1) is null
+      or d.document_type = any(p_categories)
+    )
+    and (p_from is null or d.created_at >= p_from)
+    and (p_to is null or d.created_at <= p_to)
+    and (not v_has_query or d.search_vector @@ v_ts_query)
+  order by
+    case when v_has_query then ts_rank(d.search_vector, v_ts_query) else 0 end desc,
+    d.created_at desc
+  limit p_limit
+  offset p_offset;
+end;
+$$;
+
+revoke all on function public.search_documents(text, text, text[], timestamptz, timestamptz, int, int) from public;
+grant execute on function public.search_documents(text, text, text[], timestamptz, timestamptz, int, int) to authenticated;
+
+comment on function public.search_documents is
+  'Owner-scoped document search. Phase 60 shipped query/entity/category/limit/offset; Phase 63 added p_categories text[] (replacing scalar p_category) and p_from/p_to timestamptz date bounds. SECURITY DEFINER, search_path locked to public.';
+
+commit;

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -444,18 +444,21 @@ describe('search_documents RPC', () => {
 	})
 
 	it('Phase 63: p_from / p_to date-range filter restricts on created_at', async () => {
-		// All fixtures were inserted in beforeAll, so they share a near-
-		// identical created_at. A range that ends one second before now
-		// should exclude all of them; a range that starts a year ago
-		// should include all of them.
-		const oneSecondAgo = new Date(Date.now() - 1000).toISOString()
+		// Fixtures are created in beforeAll; their created_at is "now" at
+		// suite start. A `p_to` cut at a clearly-past date (2020-01-01)
+		// must exclude every fixture; a wide range that brackets today
+		// must include them all. Don't use `Date.now() - small_delta`
+		// for the exclusion case — in CI the suite runs many seconds
+		// after beforeAll, so any "n seconds ago" can land AFTER fixture
+		// creation and silently invert the assertion.
+		const distantPast = '2020-01-01T00:00:00Z'
 		const yearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString()
 		const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
 
 		const { data: excluded } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_to: oneSecondAgo,
+			p_to: distantPast,
 			p_limit: 200,
 			p_offset: 0
 		})

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -6,7 +6,8 @@
  *   - p_query null/empty returns the full owner-scoped set.
  *   - p_query free-text matches title / description / tags.
  *   - p_entity_type filter restricts to one of the five branches.
- *   - p_category filter restricts on `document_type`.
+ *   - p_categories (multi-select, Phase 63) restricts on `document_type`.
+ *   - p_from / p_to (Phase 63) restricts on `created_at`.
  *   - LIMIT/OFFSET pagination + total_count surfaced for the UI banner.
  *
  * Mirrors `documents-cross-entity.rls.test.ts` fixture pattern: dual
@@ -183,7 +184,7 @@ describe('search_documents RPC', () => {
 		const { data, error } = await clientB.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 200,
 			p_offset: 0
 		})
@@ -200,7 +201,7 @@ describe('search_documents RPC', () => {
 		const { data, error } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 200,
 			p_offset: 0
 		})
@@ -221,7 +222,7 @@ describe('search_documents RPC', () => {
 		const { data: q1 } = await clientA.rpc('search_documents', {
 			p_query: 'taxreturn2025',
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 50,
 			p_offset: 0
 		})
@@ -232,7 +233,7 @@ describe('search_documents RPC', () => {
 		const { data: q2 } = await clientA.rpc('search_documents', {
 			p_query: 'plumbing',
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 50,
 			p_offset: 0
 		})
@@ -243,7 +244,7 @@ describe('search_documents RPC', () => {
 		const { data: q3 } = await clientA.rpc('search_documents', {
 			p_query: 'inspection',
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 50,
 			p_offset: 0
 		})
@@ -257,7 +258,7 @@ describe('search_documents RPC', () => {
 		const { data } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: 'lease',
-			p_category: null,
+			p_categories: null,
 			p_limit: 50,
 			p_offset: 0
 		})
@@ -267,12 +268,12 @@ describe('search_documents RPC', () => {
 		}
 	})
 
-	it('p_category filter restricts on document_type', async () => {
+	it('p_categories filter restricts on document_type (multi-select, Phase 63)', async () => {
 		// Only fixture 1 has document_type='receipt'.
 		const { data } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_category: 'receipt',
+			p_categories: ['receipt'],
 			p_limit: 50,
 			p_offset: 0
 		})
@@ -286,7 +287,7 @@ describe('search_documents RPC', () => {
 		const { data: page1 } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: 'property',
-			p_category: null,
+			p_categories: null,
 			p_limit: 2,
 			p_offset: 0
 		})
@@ -299,7 +300,7 @@ describe('search_documents RPC', () => {
 		const { data: page2 } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: 'property',
-			p_category: null,
+			p_categories: null,
 			p_limit: 2,
 			p_offset: 2
 		})
@@ -402,11 +403,101 @@ describe('search_documents RPC', () => {
 		if (row) insertedDocIds.push(row.id)
 	})
 
+	it('Phase 63: p_categories array filter is OR (matches any listed category)', async () => {
+		// Fixture 1 has document_type='receipt'; fixture 4 defaults to 'other'.
+		// Filtering on ['receipt', 'other'] should return both.
+		const { data, error } = await clientA.rpc('search_documents', {
+			p_query: null,
+			p_entity_type: null,
+			p_categories: ['receipt', 'other'],
+			p_limit: 50,
+			p_offset: 0
+		})
+		expect(error).toBeNull()
+		const rows = ownedRows((data ?? []) as SearchDocumentRow[])
+		const matching = rows.filter(r => insertedDocIds.includes(r.id))
+		// Fixtures 1 (receipt), 2 (other), 3 (other), 4 (other) — all four
+		// have document_type in {'receipt', 'other'}.
+		expect(matching.length).toBeGreaterThanOrEqual(4)
+		for (const r of matching) {
+			expect(['receipt', 'other']).toContain(r.document_type)
+		}
+	})
+
+	it('Phase 63: empty p_categories array is treated as "no filter"', async () => {
+		// Empty array must NOT exclude every document (the array_length is
+		// null check in the RPC handles this). Should return the full set.
+		const { data, error } = await clientA.rpc('search_documents', {
+			p_query: null,
+			p_entity_type: null,
+			p_categories: [],
+			p_limit: 200,
+			p_offset: 0
+		})
+		expect(error).toBeNull()
+		const rows = ownedRows((data ?? []) as SearchDocumentRow[])
+		// All 4+ inserted fixtures should be returned; same shape as p_categories: null.
+		const ids = new Set(rows.map(r => r.id))
+		for (const id of insertedDocIds) {
+			expect(ids.has(id)).toBe(true)
+		}
+	})
+
+	it('Phase 63: p_from / p_to date-range filter restricts on created_at', async () => {
+		// All fixtures were inserted in beforeAll, so they share a near-
+		// identical created_at. A range that ends one second before now
+		// should exclude all of them; a range that starts a year ago
+		// should include all of them.
+		const oneSecondAgo = new Date(Date.now() - 1000).toISOString()
+		const yearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString()
+		const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+
+		const { data: excluded } = await clientA.rpc('search_documents', {
+			p_query: null,
+			p_entity_type: null,
+			p_to: oneSecondAgo,
+			p_limit: 200,
+			p_offset: 0
+		})
+		const excludedRows = ownedRows((excluded ?? []) as SearchDocumentRow[])
+		for (const id of insertedDocIds) {
+			expect(excludedRows.find(r => r.id === id)).toBeUndefined()
+		}
+
+		const { data: included } = await clientA.rpc('search_documents', {
+			p_query: null,
+			p_entity_type: null,
+			p_from: yearAgo,
+			p_to: tomorrow,
+			p_limit: 200,
+			p_offset: 0
+		})
+		const includedIds = new Set(
+			((included ?? []) as SearchDocumentRow[]).map(r => r.id)
+		)
+		for (const id of insertedDocIds) {
+			expect(includedIds.has(id)).toBe(true)
+		}
+	})
+
+	it('Phase 63: rejects p_from > p_to with a clear message', async () => {
+		const { error } = await clientA.rpc('search_documents', {
+			p_query: null,
+			p_entity_type: null,
+			p_from: '2026-04-01',
+			p_to: '2026-01-01',
+			p_limit: 50,
+			p_offset: 0
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/p_from must be <= p_to/i)
+	})
+
 	it('rejects invalid limit / offset / null limit / over-200 limit', async () => {
 		const { error: e1 } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 0,
 			p_offset: 0
 		})
@@ -416,7 +507,7 @@ describe('search_documents RPC', () => {
 		const { error: e2 } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 50,
 			p_offset: -1
 		})
@@ -428,7 +519,7 @@ describe('search_documents RPC', () => {
 		const { error: e3 } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: 201,
 			p_offset: 0
 		})
@@ -438,7 +529,7 @@ describe('search_documents RPC', () => {
 		const { error: e4 } = await clientA.rpc('search_documents', {
 			p_query: null,
 			p_entity_type: null,
-			p_category: null,
+			p_categories: null,
 			p_limit: null as unknown as number,
 			p_offset: 0
 		})


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mCloses the v2.5 milestone scope. Adds the two filter dimensions owners keep asking for, completing the vault-polish arc started in Phase 62.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m- **Migration `20260426043911`**: extends `search_documents` RPC with `p_categories text[]` (replacing scalar `p_category`) and `p_from`/`p_to` timestamptz date bounds. Empty array = no filter. Raises if `p_from > p_to`. Applied to prod via MCP.[0m
[38;5;8m   5[0m [37m- **`<DateRangePicker>`** shared component (Calendar `mode="range"` + Popover; em-dash range label, clear-X button).[0m
[38;5;8m   6[0m [37m- **`<MultiSelectChips>`** shared component, generic over value type so callers preserve their union (`DocumentCategory`).[0m
[38;5;8m   7[0m [37m- **`DocumentsVaultClient`** rewires the filter row to four URL-synced controls (`q`, `entity`, `categories`, `from`/`to`) with H2-style guards on every dimension. Categories use partial-reject (drop unknown values, keep known); dates silently scrub on parse failure. Empty-state copy considers all four filter dimensions.[0m
[38;5;8m   8[0m [37m- **Tests**: 7 new vault unit tests + 4 new RPC integration tests (multi-category OR-union, empty-array semantics, date-range exclusion/inclusion, `p_from > p_to` rejection).[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37mURL-shape break: `?category=lease` (Phase 61, singular) → `?categories=lease,insurance` (Phase 63, plural). Bookmarks from the past 24h lose their filter — acceptable.[0m
[38;5;8m  11[0m 
[38;5;8m  12[0m [37m## Test plan[0m
[38;5;8m  13[0m [37m- [x] Migration applied to prod via MCP (`20260426043911`)[0m
[38;5;8m  14[0m [37m- [x] 7,501 unit tests passing (+31 from new vault tests + parameterized cascades)[0m
[38;5;8m  15[0m [37m- [x] Typecheck clean[0m
[38;5;8m  16[0m [37m- [x] Lint clean[0m
[38;5;8m  17[0m [37m- [x] Multi-select category integration test (`p_categories: ['receipt', 'other']` returns OR-union)[0m
[38;5;8m  18[0m [37m- [x] Empty-array integration test (treated as no filter)[0m
[38;5;8m  19[0m [37m- [x] Date-range integration test (`p_to: 1s ago` excludes; `p_from: 1y ago, p_to: tomorrow` includes)[0m
[38;5;8m  20[0m [37m- [x] `p_from > p_to` rejection test[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m[hudsor01][0m