### PR TITLE
chore: drop document-keys.ts re-export (closes ZTR #2 violation)

### DIFF
--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactElement } from 'react'
 import { DocumentsVaultClient } from '../documents-vault.client'
-import { documentSearchQueries } from '#hooks/api/query-keys/document-keys'
+import { documentSearchQueries } from '#hooks/api/query-keys/document-search-keys'
 
 const mockUseQuery = vi.fn()
 const mockSetQueryParam = vi.fn()

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -27,12 +27,14 @@ import { Skeleton } from '#components/ui/skeleton'
 import { DateRangePicker } from '#components/shared/date-range-picker'
 import { MultiSelectChips } from '#components/shared/multi-select-chips'
 import {
-	documentSearchQueries,
 	DOCUMENT_ENTITY_TYPES,
-	SEARCH_PAGE_SIZE,
 	type DocumentEntityType,
 	type DocumentRow as DocumentRowData
 } from '#hooks/api/query-keys/document-keys'
+import {
+	documentSearchQueries,
+	SEARCH_PAGE_SIZE
+} from '#hooks/api/query-keys/document-search-keys'
 import {
 	DOCUMENT_CATEGORIES,
 	DOCUMENT_CATEGORY_LABELS,

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -232,15 +232,10 @@ export const documentQueries = {
 
 export { LIST_DISPLAY_LIMIT }
 
-// Global vault search lives in `document-search-keys.ts` to keep this
-// file under the 300-line cap. Re-exported so existing import sites
-// (`#hooks/api/query-keys/document-keys`) keep working.
-export {
-	SEARCH_PAGE_SIZE,
-	documentSearchQueries,
-	type DocumentSearchParams,
-	type DocumentSearchResult
-} from './document-search-keys'
+// Global vault search lives in `document-search-keys.ts` (split out to
+// keep this file under the 300-line cap). Import the search symbols
+// directly from there — no re-export here per the project's "no barrel
+// files / no re-exports" Zero Tolerance Rule.
 
 export const documentMutations = {
 	upload: () =>


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mCloses a long-standing ZTR violation (Zero Tolerance Rule #2: no barrel files / no re-exports) flagged by the PR #640 cycle-1 reviewer (M-6) and hiding since Phase 60.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37mWhen Phase 60 split `documentSearchQueries` / `SEARCH_PAGE_SIZE` / `DocumentSearchParams` / `DocumentSearchResult` into `document-search-keys.ts` (to keep `document-keys.ts` under the 300-line cap), the search symbols were re-exported from `document-keys.ts` so existing import sites kept working. That re-export violated the ZTR.[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37mFix:[0m
[38;5;8m   7[0m [37m- `documents-vault.client.tsx` splits imports into two statements: `document-keys` for the per-entity types (`DocumentEntityType`, `DocumentRow`, `DOCUMENT_ENTITY_TYPES`), `document-search-keys` for the search symbols[0m
[38;5;8m   8[0m [37m- `documents-vault.test.tsx` imports `documentSearchQueries` directly from `document-search-keys`[0m
[38;5;8m   9[0m [37m- `document-keys.ts` drops the re-export block + the explanatory comment that justified it[0m
[38;5;8m  10[0m 
[38;5;8m  11[0m [37mNo behavior change; the `vi.spyOn(documentSearchQueries, 'list')` pattern still works because the spy target is the same symbol either way (re-exported or not, the module identity is the same).[0m
[38;5;8m  12[0m 
[38;5;8m  13[0m [37m## Test plan[0m
[38;5;8m  14[0m [37m- [x] 7,505 unit tests still pass[0m
[38;5;8m  15[0m [37m- [x] Typecheck clean[0m
[38;5;8m  16[0m [37m- [x] Lint clean[0m
[38;5;8m  17[0m [37m- [x] Only 4 files in repo touch the search symbols; all updated to import directly from the defining file[0m
[38;5;8m  18[0m 
[38;5;8m  19[0m [37m[hudsor01][0m