### PR TITLE
chore(vault): address PR #640 cycle-1 minors M-2 through M-5

### DIFF
--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -101,27 +101,32 @@ function formatLocalYmd(d: Date): string {
 
 export function DocumentsVaultClient() {
 	// URL-synced filters via nuqs so a shared link reproduces the search.
+	// Filter dimensions (q/entity/categories/from/to) use history: 'replace'
+	// so refining a search doesn't pollute the back-stack — pressing Back
+	// from the vault should leave the page, not walk through every filter
+	// tweak. Page navigation IS a meaningful event and stays push.
+	const FILTER_HISTORY = { history: 'replace' as const }
 	const [queryParam, setQueryParam] = useQueryState(
 		'q',
-		parseAsString.withDefault('')
+		parseAsString.withDefault('').withOptions(FILTER_HISTORY)
 	)
 	const [entityParam, setEntityParam] = useQueryState(
 		'entity',
-		parseAsString.withDefault(ANY_ENTITY)
+		parseAsString.withDefault(ANY_ENTITY).withOptions(FILTER_HISTORY)
 	)
 	// Phase 63: multi-select. Default empty array → "no filter".
 	const [categoriesParam, setCategoriesParam] = useQueryState(
 		'categories',
-		parseAsArrayOf(parseAsString, ',').withDefault([])
+		parseAsArrayOf(parseAsString, ',').withDefault([]).withOptions(FILTER_HISTORY)
 	)
-	// Phase 63: ISO date strings (`YYYY-MM-DD` or full ISO timestamps).
+	// Phase 63: ISO date strings (`YYYY-MM-DD` form).
 	const [fromParam, setFromParam] = useQueryState(
 		'from',
-		parseAsString.withDefault('')
+		parseAsString.withDefault('').withOptions(FILTER_HISTORY)
 	)
 	const [toParam, setToParam] = useQueryState(
 		'to',
-		parseAsString.withDefault('')
+		parseAsString.withDefault('').withOptions(FILTER_HISTORY)
 	)
 	const [pageParam, setPageParam] = useQueryState(
 		'page',
@@ -167,13 +172,20 @@ export function DocumentsVaultClient() {
 	// Phase 63: multi-select category. Drop unknown values from the URL
 	// array (partial reject — `?categories=lease,banana` keeps `lease`,
 	// drops `banana`) so a single bad value can't void the user's whole
-	// selection. Memoised + sorted for queryKey stability.
+	// selection.
+	//
+	// Memoise on a content-derived key (M-5): nuqs' useQueryState returns
+	// a fresh array reference every render even when content is identical,
+	// so `useMemo([categoriesParam])` would re-run the filter on every
+	// render. Joining the array gives a stable string identity — same
+	// content, same key, no wasted work.
+	const categoriesKey = categoriesParam.join(',')
 	const categories = useMemo<DocumentCategory[]>(() => {
-		const valid = (DOCUMENT_CATEGORIES as readonly string[]).filter(c =>
-			categoriesParam.includes(c)
+		const set = new Set(categoriesKey.split(',').filter(Boolean))
+		return (DOCUMENT_CATEGORIES as readonly string[]).filter(c =>
+			set.has(c)
 		) as DocumentCategory[]
-		return valid
-	}, [categoriesParam])
+	}, [categoriesKey])
 
 	// Phase 63: date-range. Parse the URL YYYY-MM-DD into a local-zone
 	// Date for the picker. The factory expands these to local-zone

--- a/src/components/shared/__tests__/multi-select-chips.test.tsx
+++ b/src/components/shared/__tests__/multi-select-chips.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the MultiSelectChips primitive (Phase 63 + cycle-1
+ * follow-up M-3). Pins the trigger summary, popover toggle behaviour,
+ * and the new Clear/Done footer affordances.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MultiSelectChips } from '../multi-select-chips'
+
+const OPTIONS = [
+	{ value: 'lease' as const, label: 'Lease' },
+	{ value: 'receipt' as const, label: 'Receipt' },
+	{ value: 'insurance' as const, label: 'Insurance' }
+]
+
+describe('MultiSelectChips', () => {
+	it('renders the placeholder when nothing is selected', () => {
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={[]}
+				onChange={vi.fn()}
+				placeholder="All categories"
+				aria-label="Filter by category"
+			/>
+		)
+		const trigger = screen.getByLabelText('Filter by category')
+		expect(trigger).toHaveTextContent('All categories')
+	})
+
+	it('renders the single-label summary when exactly one is selected', () => {
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={['receipt']}
+				onChange={vi.fn()}
+				placeholder="All categories"
+				aria-label="Filter by category"
+			/>
+		)
+		expect(screen.getByLabelText('Filter by category')).toHaveTextContent(
+			'Receipt'
+		)
+	})
+
+	it('renders the count summary when multiple are selected', () => {
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={['lease', 'receipt']}
+				onChange={vi.fn()}
+				placeholder="All categories"
+				aria-label="Filter by category"
+			/>
+		)
+		expect(screen.getByLabelText('Filter by category')).toHaveTextContent(
+			'2 selected'
+		)
+	})
+
+	it('toggling an option calls onChange with the new array', async () => {
+		const user = userEvent.setup()
+		const onChange = vi.fn()
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={['lease']}
+				onChange={onChange}
+				aria-label="Filter by category"
+			/>
+		)
+		await user.click(screen.getByLabelText('Filter by category'))
+		await user.click(screen.getByRole('option', { name: /receipt/i }))
+		expect(onChange).toHaveBeenCalledWith(['lease', 'receipt'])
+	})
+
+	it('Clear button (footer) empties the selection (cycle-1 M-3)', async () => {
+		const user = userEvent.setup()
+		const onChange = vi.fn()
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={['lease', 'receipt']}
+				onChange={onChange}
+				aria-label="Filter by category"
+			/>
+		)
+		await user.click(screen.getByLabelText('Filter by category'))
+		await user.click(screen.getByRole('button', { name: /^clear$/i }))
+		expect(onChange).toHaveBeenCalledWith([])
+	})
+
+	it('Clear button is disabled when nothing is selected (M-3)', async () => {
+		const user = userEvent.setup()
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={[]}
+				onChange={vi.fn()}
+				aria-label="Filter by category"
+			/>
+		)
+		await user.click(screen.getByLabelText('Filter by category'))
+		expect(screen.getByRole('button', { name: /^clear$/i })).toBeDisabled()
+	})
+
+	it('Done button (footer) closes the popover without modifying selection (M-3)', async () => {
+		const user = userEvent.setup()
+		const onChange = vi.fn()
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={['lease']}
+				onChange={onChange}
+				aria-label="Filter by category"
+			/>
+		)
+		await user.click(screen.getByLabelText('Filter by category'))
+		// The popover is open: option list visible.
+		expect(
+			screen.getByRole('option', { name: /^lease$/i })
+		).toBeInTheDocument()
+
+		await user.click(screen.getByRole('button', { name: /^done$/i }))
+
+		// onChange must NOT have fired — Done is purely a "close" affordance.
+		expect(onChange).not.toHaveBeenCalled()
+		// Option list is gone (popover closed).
+		expect(
+			screen.queryByRole('option', { name: /^lease$/i })
+		).not.toBeInTheDocument()
+	})
+
+	it('top-right X button (visible when something is selected) clears the selection', async () => {
+		const onChange = vi.fn()
+		render(
+			<MultiSelectChips
+				options={OPTIONS}
+				value={['lease']}
+				onChange={onChange}
+				aria-label="Filter by category"
+			/>
+		)
+		fireEvent.click(screen.getByLabelText(/clear selection/i))
+		expect(onChange).toHaveBeenCalledWith([])
+	})
+})

--- a/src/components/shared/multi-select-chips.tsx
+++ b/src/components/shared/multi-select-chips.tsx
@@ -100,6 +100,30 @@ export function MultiSelectChips<T extends string>({
 							)
 						})}
 					</ul>
+					{/* Footer affordances — popover auto-closes on outside click,
+					    but explicit "Clear" + "Done" make the multi-select pattern
+					    discoverable for keyboard users and screen readers. */}
+					<div className="flex items-center justify-between gap-2 border-t border-border px-1 pt-1 mt-1">
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-7 px-2 text-xs"
+							onClick={() => onChange([])}
+							disabled={selected.size === 0}
+						>
+							Clear
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-7 px-2 text-xs"
+							onClick={() => setOpen(false)}
+						>
+							Done
+						</Button>
+					</div>
 				</PopoverContent>
 			</Popover>
 			{selected.size > 0 && (

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -104,6 +104,15 @@ export interface DocumentListResult {
  * producing the literal string `"undefined"` (which would break
  * signed-URL generation, date rendering, and React keys downstream).
  *
+ * Why we need this mapper instead of trusting `Database['public']
+ * ['Functions']['search_documents']['Returns']` directly: Supabase's
+ * type generator strips `| null` from `RETURNS TABLE` columns even
+ * when the underlying column is nullable. So the generated RPC return
+ * type claims `description: string` while the column is `string |
+ * null`. Callers who bypass this mapper and use the raw RPC return
+ * type will mistype nullable fields as non-null and hit "Invalid Date"
+ * / `text-content of null` runtime bugs. M-2 from PR #640 cycle-1.
+ *
  * Applies CLAUDE.md's "RPC Return Typing" rule (typed mapper at the
  * PostgREST boundary, not `as unknown as` casts).
  */


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mCloses the four pre-existing/out-of-scope minors flagged by PR #640's cycle-1 reviewer.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m- **M-4 (URL pollution)**: all four vault filter dimensions (`q`, `entity`, `categories`, `from`, `to`) now use `withOptions({ history: 'replace' })`. Refining a search no longer adds back-stack entries; pressing Back leaves the page instead of walking through every filter tweak. Page navigation stays push.[0m
[38;5;8m   5[0m [37m- **M-5 (perf)**: memoize `categories` derivation on a content-derived key (`categoriesParam.join(',')`) instead of the array reference. nuqs returns a fresh array every render even when content is identical — the prior `useMemo([categoriesParam])` re-ran the filter on every render.[0m
[38;5;8m   6[0m [37m- **M-3 (UX)**: `MultiSelectChips` gains a `Clear` / `Done` footer for keyboard + screen-reader discoverability. `Done` is purely a close affordance (doesn't modify selection); `Clear` is disabled when nothing is selected. **8 new unit tests** cover the summary states, toggle, footer affordances, and the existing X-button clear.[0m
[38;5;8m   7[0m [37m- **M-2 (docs)**: expand the `mapDocumentRow` docstring to explain WHY the mapper exists instead of trusting the generated `Returns` type. Supabase's type generator strips `| null` from `RETURNS TABLE` columns even when the underlying column is nullable; bypassing the mapper would produce `'Invalid Date'` / `text-content of null` runtime bugs.[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37m## Test plan[0m
[38;5;8m  10[0m [37m- [x] 7,513 unit tests passing (+8 from new `multi-select-chips.test.tsx`)[0m
[38;5;8m  11[0m [37m- [x] Typecheck clean[0m
[38;5;8m  12[0m [37m- [x] Lint clean[0m
[38;5;8m  13[0m [37m- [x] Manual: filter changes don't add back-stack entries; Back leaves the vault page[0m
[38;5;8m  14[0m [37m- [x] Manual: `Done` closes popover without changing selection; `Clear` empties[0m
[38;5;8m  15[0m 
[38;5;8m  16[0m [37m[hudsor01][0m