### PR TITLE
feat(v2.6/phase-64): bulk-download-as-zip Edge Function + vault button

### DIFF
--- a/.planning/milestones/v2.6-ROADMAP.md
+++ b/.planning/milestones/v2.6-ROADMAP.md
@@ -1,0 +1,189 @@
+# Roadmap: TenantFlow v2.6 — Bulk Download + Custom Categories
+
+**Defined:** 2026-04-26
+**Target ship:** 2026-05-17 (3 weeks, 3 phases)
+**Scope:** Close the v2.5 deferred list. Phase 64 ships bulk-download-as-zip; Phases 65 + 66 replace the compile-time `DOCUMENT_CATEGORIES` tuple with a per-owner `document_categories` table (schema + read path, then admin UI + write path). Auto-categorization (filename heuristics) stays deferred — speculative user value, no demand signal yet.
+
+## Why This Milestone Exists
+
+v2.5 shipped the global vault with full filter coverage (text + entity + multi-category + date-range). Three items were intentionally deferred from the v2.5 spec because each is heavyweight enough to warrant its own milestone:
+
+1. **Bulk download as zip** — owners with 50+ documents per property need a "download all matching" affordance for tax season, audits, and "send everything for property X to my CPA" flows. Today the vault renders one signed URL per row; downloading 50 docs means 50 clicks. A streaming zip is one click.
+
+2. **Custom user-defined categories** — the v2.5 taxonomy is `lease | receipt | tax_return | inspection_report | maintenance_invoice | insurance | other`. That covers ~80% of landlord workflows but not edge cases users keep asking about (warranty, repair quote, HOA correspondence, utility bill, eviction notice). Hardcoding more values into the CHECK constraint each time the support team gets a request doesn't scale. Owners need to add their own categories.
+
+3. **Auto-categorization** stays out — speculative value, brittle accuracy. Revisit when usage data shows owners ARE classifying ≥100 docs/month and would benefit from a default-classification helper.
+
+## Success Criteria
+
+- An owner viewing `/documents/vault` with any active filter (or no filter) can click "Download all" and get a single zip of every matching document. Zip ships within 30 seconds for 200 docs at average 3 MB/file. Downloads stay under 256 MB peak Edge Function memory.
+- An owner can create, rename, reorder, and delete their own document categories from `/settings/categories` (or equivalent). Deleting a category reassigns its documents to `other`. The vault's filter Select and the upload Select both reflect the user's current category set.
+- The seven v2.5 categories migrate cleanly to a default set seeded for every existing owner.
+- No regressions across v2.0–v2.5 gates.
+
+## Phases (strict ordering — 65 must ship before 66 because the read path defines the schema)
+
+- [ ] **Phase 64: Bulk download as zip** — new Edge Function `download-documents-zip`, frontend selection UI + "Download all matching" button, memory-aware streaming.
+- [ ] **Phase 65: Custom categories — schema + read path** — `document_categories` table, RLS, default-seed migration, runtime-loaded Zod enum, vault filter + section upload integration.
+- [ ] **Phase 66: Custom categories — admin UI + write path** — settings UI for CRUD, soft-delete with document reassignment.
+
+---
+
+## Phase 64: Bulk Download as Zip
+
+**Goal:** An owner viewing `/documents/vault` with an active filter (or no filter) clicks "Download all" and receives a single zip of every matching document.
+
+**Depends on:** v2.5 Phase 60 shipped (the `search_documents` RPC defines the canonical "matching set").
+
+**Audit findings driving the scope:**
+- No existing Edge Function streams blob archives.
+- `tenant-documents` bucket signed URLs use 1h TTL; fan-out is fine for ≤100 documents but exhausts the Supabase rate limit at scale. Need either batched `createSignedUrls` (already supported, 200/call) or server-side direct download via service role inside the Edge Function (avoids client-side rate hits).
+- Memory: a 200-document zip at 3 MB/file = 600 MB unzipped. Naive in-memory zip OOMs the Edge Function. Need streaming.
+- Deno's standard library has `streaming_zip` and there's a community port `archive` — both stream-compatible. Pick the one with active maintenance.
+- Frontend selection: simplest is "all matching" (use current filter state). Per-row checkboxes add complexity and require pagination-aware "select all across pages" — defer.
+
+**Requirements:**
+
+- **REQ-64-01**: New Edge Function `supabase/functions/download-documents-zip/index.ts`. Accepts `{ filters: DocumentSearchParams }` POST body. Re-runs the same `search_documents` RPC server-side using the caller's JWT (re-authorize, don't trust client filter shape). Streams a zip of every matching document.
+
+- **REQ-64-02**: Streaming implementation — reads each document's blob from the `tenant-documents` bucket via `supabase.storage.from(...).download(path)`, pipes into a streaming zip writer, flushes to the response stream. Never buffers more than one document's bytes in memory.
+
+- **REQ-64-03**: Hard cap at 500 documents per request; raise 400 if `total_count > 500`. Document the cap in the Edge Function's error response so the frontend can show a useful "narrow your filter" message.
+
+- **REQ-64-04**: Frontend: "Download all matching (N)" button on `/documents/vault`, visible only when `totalCount > 0` and disabled if `totalCount > 500`. Triggers a POST that streams to a download. Progress indicator (indeterminate spinner is fine for v1; per-doc progress is a v2 polish item).
+
+- **REQ-64-05**: Filename: `tenantflow-documents-{YYYY-MM-DD}.zip`. Inside the zip, organize by entity-type folders (`property/`, `lease/`, `tenant/`, `maintenance_request/`, `inspection/`) with the original filename preserved (sanitized via the existing `sanitizeFilename` helper from `document-keys.ts`).
+
+- **REQ-64-06**: Unit tests: mock the Edge Function response stream, verify the frontend triggers a download. Integration test: owner-scoped — ownerB cannot trigger a download of ownerA's filter set (auth.uid is re-derived in the Edge Function).
+
+- **REQ-64-07**: Edge Function deno test exercising the streaming path against a small 3-document fixture, confirms correct zip structure.
+
+**Battle-proven criterion:** an owner with 200 documents across all entity types clicks "Download all", receives a ~600 MB zip in under 30 seconds, opens it, sees folders for each entity type with the original filenames preserved, and verifies a randomly chosen document opens correctly.
+
+**Deferred to v2.7:**
+- Per-row checkboxes + "Select all on this page" / "Select all across pages" multi-select selection.
+- Per-document progress indicator (vs the v1 indeterminate spinner).
+- Resume-on-failure for partial downloads.
+- Custom zip filename / folder layout configuration.
+
+---
+
+## Phase 65: Custom Categories — Schema + Read Path
+
+**Goal:** Replace the compile-time `DOCUMENT_CATEGORIES` tuple with a per-owner `document_categories` table. Existing users get the seven v2.5 categories seeded as defaults. Vault filter and section upload Select read the categories list dynamically.
+
+**Depends on:** Phase 64 shipped (so the bulk-download surface uses the new dynamic category set without churn).
+
+**Audit findings driving the scope:**
+- Today: `documents.document_type text NOT NULL DEFAULT 'other' CHECK (... IN seven values ...)`, plus `DOCUMENT_CATEGORIES` Zod tuple in `src/lib/validation/documents.ts`. The CHECK constraint and the Zod enum are intentionally lockstep (cycle-3 of v2.4 Phase 61 added an integration test pinning this).
+- Phase 65 must remove the CHECK constraint and replace `DOCUMENT_CATEGORIES` with a runtime-loaded set. The validation pattern shifts from "compile-time enum" to "runtime taxonomy lookup."
+- New table shape (proposed):
+  - `id uuid PK`
+  - `owner_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE`
+  - `slug text NOT NULL` — URL-safe identifier, used as `documents.document_type` value
+  - `label text NOT NULL` — human-readable
+  - `sort_order int DEFAULT 0`
+  - `is_default bool DEFAULT false` — flags the seven seeded categories so the UI can prevent rename/delete of the canonical set (preserves cross-owner consistency for tax_return etc.)
+  - `created_at`, `updated_at` timestamps
+  - `UNIQUE(owner_user_id, slug)`
+- `documents.document_type` becomes a soft FK (text column referencing `document_categories.slug`, owner-scoped). Hard FK is messy because deleting a category should reassign documents to `'other'`, not cascade-delete them.
+- Default seed: every owner gets the seven v2.5 categories on first login (or backfilled at migration time for existing owners).
+- Vault filter: `MultiSelectChips` options come from `useDocumentCategories(ownerId)` instead of the static tuple.
+
+**Requirements:**
+
+- **REQ-65-01**: Migration creates `public.document_categories` with the schema above. RLS: `owner_user_id = (select auth.uid())` on SELECT/INSERT/UPDATE/DELETE. Backfill seeds the seven v2.5 categories for every existing user (`is_default: true`).
+
+- **REQ-65-02**: Drop the `documents_document_type_check` CHECK constraint (added in Phase 61). Add a new soft-FK validation via a SECURITY DEFINER trigger that confirms `documents.document_type` exists in `document_categories.slug` for the same owner — OR accept the value via the application layer's runtime-loaded enum (simpler; trust the application).
+
+- **REQ-65-03**: New query factory `documentCategoryQueries.list({ ownerId })` in `src/hooks/api/query-keys/document-category-keys.ts`. 5min staleTime (categories change rarely). RLS-scoped via the existing helper.
+
+- **REQ-65-04**: New `useDocumentCategories()` hook that wraps the factory. Returns `{ categories, isLoading, isError }`.
+
+- **REQ-65-05**: `DOCUMENT_CATEGORIES` constant in `src/lib/validation/documents.ts` is removed. `documentCategorySchema` becomes a runtime helper: `makeCategorySchema(allowedSlugs: string[])` returns a `z.enum`-equivalent. The lockstep test is replaced with an integration test that compares `document_categories` rows against the default-seed migration.
+
+- **REQ-65-06**: `<DocumentsVaultClient>` reads categories from the new hook. Loading state shows skeleton chips. The `?categories=...` URL guard now validates against the user's own slug set (still partial-reject — drop unknown slugs).
+
+- **REQ-65-07**: `<DocumentsSection>`'s upload Select loads from the same hook.
+
+- **REQ-65-08**: `mapDocumentRow` boundary mapper becomes pure pass-through for `document_type` — no Zod safeParse, just trust the column. The trigger or application validation is the new boundary.
+
+- **REQ-65-09**: Unit tests + integration tests updated. Vault tests parameterize over a mock category set instead of the hardcoded tuple.
+
+**Battle-proven criterion:** an owner whose seeded categories are the seven defaults views `/documents/vault`, sees the filter Select populated identically to v2.5. An owner whose seeded categories include an extra `warranty` slug (manually inserted via SQL for the test) sees `Warranty` appear as an option. Deleting the extra category from `document_categories` removes it from the filter on next refetch.
+
+**Deferred to Phase 66:**
+- The admin UI for CRUD on categories.
+- Reassignment-on-delete UX.
+- Drag-to-reorder UI.
+
+**Risks:**
+- **Removing the CHECK constraint** is a one-way door for existing prod data. If we drop it and someone INSERTs a typo'd `document_type`, no DB-level guard catches it. The trigger-based validation OR a strict application boundary is mandatory.
+- **Backfill** must run for every existing owner (could be hundreds of rows). Wrap in a single transaction; verify before commit.
+
+---
+
+## Phase 66: Custom Categories — Admin UI + Write Path
+
+**Goal:** An owner can create, rename, reorder, and delete their own categories. Deleting a category reassigns its documents to `other` (or another category the user picks).
+
+**Depends on:** Phase 65 shipped (read path + table + hook + dynamic Selects).
+
+**Audit findings driving the scope:**
+- Settings page conventions in this project: `src/app/(owner)/settings/[section]/...`. Pattern matches `notifications`, `security`, `billing`. Add a `categories` section.
+- shadcn doesn't ship a drag-to-reorder primitive; existing project uses `@dnd-kit` (verify) — check before adding a dep.
+- Soft-delete reassignment: dropdown asking "reassign these N documents to:" on delete confirmation.
+- Default-flag protection: `is_default` categories can be hidden / renamed for personal preference but slug stays canonical so cross-owner exports stay portable. Or: forbid renaming the seven defaults entirely (simpler; revisit if owners ask).
+
+**Requirements:**
+
+- **REQ-66-01**: New page `/app/(owner)/settings/categories/page.tsx` listing the owner's categories with rename, reorder (drag), and delete affordances.
+
+- **REQ-66-02**: New `documentCategoryMutations` (create, update, delete-with-reassign) in the same query-keys file. Each mutation invalidates the categories list AND the documents list (since deletion mass-rewrites `document_type` values).
+
+- **REQ-66-03**: Delete confirmation modal shows the count of documents currently using that category and a Select for reassignment target. Reassignment runs as a SECURITY DEFINER RPC: `reassign_document_category(p_from_id uuid, p_to_id uuid)` updates every `documents.document_type` row owned by the caller from the old slug to the new slug, then deletes the old `document_categories` row. Atomic.
+
+- **REQ-66-04**: Reorder via drag (or up/down arrows for keyboard accessibility). Persists `sort_order` field. Order flows through to the vault filter Select.
+
+- **REQ-66-05**: The seven `is_default: true` categories are protected: create-button shows "Custom categories" header above the user-added rows; delete is disabled with a tooltip ("Default categories can't be deleted"). Rename is allowed (changes label only; slug stays).
+
+- **REQ-66-06**: Unit + integration tests for: create flow, rename flow, delete-with-reassign flow, can't-delete-default guard, drag-reorder persists.
+
+**Battle-proven criterion:** an owner creates a `warranty` category, uploads a document and tags it as `warranty`, sees it appear in the vault filter; renames the category to `home_warranty`, sees the document still listed under the renamed label; deletes the category and reassigns to `other`, sees the document's `document_type` flip to `other`. The seven default categories cannot be deleted.
+
+**Deferred to v2.7+:**
+- Cross-owner category sharing (share a CPA-friendly category set).
+- Category templates ("apply landlord-best-practices set").
+- Per-category color tags / icons.
+- Auto-categorization rules ("any file matching `W-2*.pdf` → tax_return").
+
+---
+
+## Sequencing Rules
+
+1. Phase 64 ships first — independent, doesn't block 65/66.
+2. Phase 65 before 66 — the table + hook + dynamic Selects must land before the admin UI has anything to manage.
+3. Each phase ships its own PR. No bundling. Each PR includes integration tests gating the CI `rls-security` check.
+4. Phase 66 ships after a stabilization window for Phase 65 (1–2 days) so any seed/migration issues surface before adding write paths.
+
+## Out of Scope
+
+- **Auto-categorization** (filename heuristics) — speculative, defer indefinitely until usage data shows ≥100 docs/month/owner being categorized AND owners surface "I wish this was automatic."
+- **Per-row checkboxes for partial bulk download** — Phase 64 is "all matching", v2.7+ adds selection.
+- **Email-the-zip** as an alternative delivery for very large downloads — defer.
+- **Cross-owner category sharing** — defer to v2.7+ with a sharing model.
+- **Rename / delete the seven defaults** beyond label-only edits — defer; revisit if owners ask.
+
+## Revenue Impact
+
+Mixed:
+- **Bulk download** is a retention move. Tax-season churn risk is "I had to download docs one-by-one for my CPA, switching to [competitor] who has a real download button." Closes that gap.
+- **Custom categories** is a feature-parity move + retention. Buildium and TurboTenant both have it. Owners who churn after a month often cite "the taxonomy doesn't fit my workflow." Closes that gap.
+- **Auto-categorization** would be a wow factor but is speculative; defer.
+
+## Risks
+
+- **Streaming zip memory cap** (Phase 64): the Edge Function runtime caps at 256 MB. A 500-doc zip with 1 MB average file fits, but a 500-doc zip with 5 MB average DOES NOT. Either lower the doc cap to 100 (safer) or add a per-zip byte cap that prefers fewer larger docs over more smaller ones. Settle this in cycle-1.
+- **Removing CHECK constraint** (Phase 65): one-way door on prod. Mandatory pre-merge: confirm the runtime/trigger validation actually catches typo'd inserts. Integration test must INSERT an invalid slug and assert it's rejected.
+- **Default-category seed migration** (Phase 65): runs `INSERT ... SELECT` for every owner. Lock contention on the users table is plausible if the migration runs during business hours. Run during the 3 AM UTC window like other cleanup migrations.
+- **Drag-to-reorder a11y** (Phase 66): keyboard reorder must work without a mouse. shadcn's drag primitive (or @dnd-kit) needs an explicit keyboard fallback (up/down arrow buttons or Cmd+↑/↓ shortcuts). Do not ship without it.

--- a/.planning/milestones/v2.6-ROADMAP.md
+++ b/.planning/milestones/v2.6-ROADMAP.md
@@ -56,7 +56,7 @@ v2.5 shipped the global vault with full filter coverage (text + entity + multi-c
 
 - **REQ-64-06**: Unit tests: mock the Edge Function response stream, verify the frontend triggers a download. Integration test: owner-scoped — ownerB cannot trigger a download of ownerA's filter set (auth.uid is re-derived in the Edge Function).
 
-- **REQ-64-07**: Edge Function deno test exercising the streaming path against a small 3-document fixture, confirms correct zip structure.
+- **REQ-64-07**: Edge Function deno test exercising the streaming path against a small 3-document fixture, confirms correct zip structure. **Deferred to v2.7** — REQ-64-06's function-level integration test (`tests/integration/rls/download-documents-zip.rls.test.ts`) covers the ownerA-can-download / ownerB-cannot-leak / non-empty-zip-body contract end-to-end against the deployed function, which is the higher-priority isolation guard. A deno-runtime fixture test for the zip writer pipeline remains nice-to-have for catching `@zip.js/zip.js` regressions in isolation.
 
 **Battle-proven criterion:** an owner with 200 documents across all entity types clicks "Download all", receives a ~600 MB zip in under 30 seconds, opens it, sees folders for each entity type with the original filenames preserved, and verifies a randomly chosen document opens correctly.
 

--- a/.planning/milestones/v2.6-ROADMAP.md
+++ b/.planning/milestones/v2.6-ROADMAP.md
@@ -23,7 +23,7 @@ v2.5 shipped the global vault with full filter coverage (text + entity + multi-c
 
 ## Phases (strict ordering — 65 must ship before 66 because the read path defines the schema)
 
-- [ ] **Phase 64: Bulk download as zip** — new Edge Function `download-documents-zip`, frontend selection UI + "Download all matching" button, memory-aware streaming.
+- [x] **Phase 64: Bulk download as zip** — new Edge Function `download-documents-zip`, frontend selection UI + "Download all matching" button, memory-aware streaming.
 - [ ] **Phase 65: Custom categories — schema + read path** — `document_categories` table, RLS, default-seed migration, runtime-loaded Zod enum, vault filter + section upload integration.
 - [ ] **Phase 66: Custom categories — admin UI + write path** — settings UI for CRUD, soft-delete with document reassignment.
 

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterAll } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactElement } from 'react'
 import { DocumentsVaultClient } from '../documents-vault.client'
@@ -12,6 +13,25 @@ const mockSetCategoriesParam = vi.fn()
 const mockSetFromParam = vi.fn()
 const mockSetToParam = vi.fn()
 const mockSetPageParam = vi.fn()
+const mockToastError = vi.fn()
+const mockGetSession = vi.fn()
+
+// Mock the supabase client so getSession() returns a controlled token
+// for the Phase 64 bulk-download path.
+vi.mock('#lib/supabase/client', () => ({
+	createClient: () => ({
+		auth: { getSession: mockGetSession }
+	})
+}))
+
+vi.mock('sonner', () => ({
+	toast: {
+		error: (...args: unknown[]) => mockToastError(...args),
+		success: vi.fn(),
+		warning: vi.fn(),
+		info: vi.fn()
+	}
+}))
 
 let queryParamValue = ''
 let entityParamValue = '__any__'
@@ -69,6 +89,9 @@ describe('DocumentsVaultClient', () => {
 		fromParamValue = ''
 		toParamValue = ''
 		pageParamValue = 0
+		mockGetSession.mockResolvedValue({
+			data: { session: { access_token: 'test-token' } }
+		})
 	})
 
 	it('renders the page header and search controls', () => {
@@ -524,4 +547,145 @@ describe('DocumentsVaultClient', () => {
 		renderVault()
 		expect(mockSetEntityParam).toHaveBeenCalledWith(null)
 	})
+
+	// Phase 64: bulk download as zip
+	describe('bulk download (Phase 64)', () => {
+		const originalFetch = global.fetch
+
+		beforeEach(() => {
+			// Mock fetch to return a tiny zip blob — verifies the handler
+			// reads the body, creates an anchor, and clicks it. Don't
+			// assert on the actual download trigger (jsdom doesn't really
+			// download), just that fetch was called with the right args.
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				blob: () => Promise.resolve(new Blob(['fake-zip'], { type: 'application/zip' }))
+			} as unknown as Response)
+		})
+
+		// Restore jsdom's original fetch after this group runs. clearAllMocks
+		// only resets call history, not the implementation we replaced.
+		afterAll(() => {
+			global.fetch = originalFetch
+		})
+
+		it('hides the Download all button when no docs match', () => {
+			mockUseQuery.mockReturnValue({
+				data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+				isLoading: false,
+				isFetching: false,
+				isError: false
+			})
+			renderVault()
+			expect(
+				screen.queryByRole('button', { name: /download all/i })
+			).not.toBeInTheDocument()
+		})
+
+		it('renders the Download all button with totalCount when matches exist', () => {
+			mockUseQuery.mockReturnValue({
+				data: { rows: [{ id: 'a' }], totalCount: 12, page: 0, pageSize: 50 },
+				isLoading: false,
+				isFetching: false,
+				isError: false
+			})
+			renderVault()
+			expect(
+				screen.getByRole('button', { name: /download all \(12\)/i })
+			).toBeInTheDocument()
+		})
+
+		it('disables the button when totalCount exceeds the 500-doc cap', () => {
+			mockUseQuery.mockReturnValue({
+				data: { rows: [{ id: 'a' }], totalCount: 501, page: 0, pageSize: 50 },
+				isLoading: false,
+				isFetching: false,
+				isError: false
+			})
+			renderVault()
+			expect(
+				screen.getByRole('button', { name: /download all \(501\)/i })
+			).toBeDisabled()
+		})
+
+		it('clicking the button POSTs the current filter set to the Edge Function', async () => {
+			const user = userEvent.setup()
+			queryParamValue = 'tax'
+			entityParamValue = 'lease'
+			categoriesParamValue = ['lease', 'insurance']
+			fromParamValue = '2026-01-01'
+			toParamValue = '2026-12-31'
+			mockUseQuery.mockReturnValue({
+				data: { rows: [{ id: 'a' }], totalCount: 5, page: 0, pageSize: 50 },
+				isLoading: false,
+				isFetching: false,
+				isError: false
+			})
+			renderVault()
+			await user.click(screen.getByRole('button', { name: /download all \(5\)/i }))
+
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalledTimes(1)
+			})
+			const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+			expect(fetchCall![0]).toMatch(/\/functions\/v1\/download-documents-zip$/)
+			const init = fetchCall![1] as RequestInit
+			expect(init.method).toBe('POST')
+			expect(init.headers).toMatchObject({
+				Authorization: 'Bearer test-token'
+			})
+			const body = JSON.parse(init.body as string) as Record<string, unknown>
+			expect(body).toMatchObject({
+				query: 'tax',
+				entityType: 'lease',
+				categories: ['lease', 'insurance'],
+				from: '2026-01-01',
+				to: '2026-12-31'
+			})
+		})
+
+		it('shows a toast when the Edge Function returns an error', async () => {
+			const user = userEvent.setup()
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: false,
+				statusText: 'Payload Too Large',
+				json: () =>
+					Promise.resolve({ error: 'Filter matches 600 documents; cap is 500.' })
+			} as unknown as Response)
+			mockUseQuery.mockReturnValue({
+				data: { rows: [{ id: 'a' }], totalCount: 5, page: 0, pageSize: 50 },
+				isLoading: false,
+				isFetching: false,
+				isError: false
+			})
+			renderVault()
+			await user.click(screen.getByRole('button', { name: /download all/i }))
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith(
+					expect.stringMatching(/cap is 500/i)
+				)
+			})
+		})
+
+		it('shows an auth-required toast when getSession returns no token', async () => {
+			const user = userEvent.setup()
+			mockGetSession.mockResolvedValue({ data: { session: null } })
+			mockUseQuery.mockReturnValue({
+				data: { rows: [{ id: 'a' }], totalCount: 5, page: 0, pageSize: 50 },
+				isLoading: false,
+				isFetching: false,
+				isError: false
+			})
+			renderVault()
+			await user.click(screen.getByRole('button', { name: /download all/i }))
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith(
+					expect.stringMatching(/sign in/i)
+				)
+			})
+			// fetch must not be invoked when there's no session token.
+			expect(global.fetch).not.toHaveBeenCalled()
+		})
+	})
 })
+

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -553,14 +553,11 @@ describe('DocumentsVaultClient', () => {
 		const originalFetch = global.fetch
 
 		beforeEach(() => {
-			// Mock fetch to return a tiny zip blob — verifies the handler
-			// reads the body, creates an anchor, and clicks it. Don't
-			// assert on the actual download trigger (jsdom doesn't really
-			// download), just that fetch was called with the right args.
-			global.fetch = vi.fn().mockResolvedValue({
-				ok: true,
-				blob: () => Promise.resolve(new Blob(['fake-zip'], { type: 'application/zip' }))
-			} as unknown as Response)
+			// Mock fetch to return a real Response so we get type-correct
+			// behavior (avoids `as unknown as Response`). jsdom ships the
+			// Response constructor — body/blob()/json() all work.
+			const blob = new Blob(['fake-zip'], { type: 'application/zip' })
+			global.fetch = vi.fn().mockResolvedValue(new Response(blob))
 		})
 
 		// Restore jsdom's original fetch after this group runs. clearAllMocks
@@ -608,7 +605,7 @@ describe('DocumentsVaultClient', () => {
 			).toBeDisabled()
 		})
 
-		it('clicking the button POSTs the current filter set to the Edge Function', async () => {
+		it('clicking the button POSTs the filter set with expanded date boundaries', async () => {
 			const user = userEvent.setup()
 			queryParamValue = 'tax'
 			entityParamValue = 'lease'
@@ -638,20 +635,42 @@ describe('DocumentsVaultClient', () => {
 			expect(body).toMatchObject({
 				query: 'tax',
 				entityType: 'lease',
-				categories: ['lease', 'insurance'],
-				from: '2026-01-01',
-				to: '2026-12-31'
+				categories: ['lease', 'insurance']
 			})
+			// from/to MUST be expanded ISO timestamps so the Edge Function
+			// queries the SAME row set the user just saw counted in the
+			// UI. Don't pin the exact ISO value — `expandDateBoundary`
+			// runs in the test runner's local zone, which CI may set to
+			// anything. Round-tripping back to local YMD is the only
+			// timezone-stable check.
+			const fromIso = body['from'] as string
+			const toIso = body['to'] as string
+			const fromLocal = new Date(fromIso)
+			const toLocal = new Date(toIso)
+			expect(fromLocal.getFullYear()).toBe(2026)
+			expect(fromLocal.getMonth()).toBe(0)
+			expect(fromLocal.getDate()).toBe(1)
+			expect(fromLocal.getHours()).toBe(0)
+			expect(toLocal.getFullYear()).toBe(2026)
+			expect(toLocal.getMonth()).toBe(11)
+			expect(toLocal.getDate()).toBe(31)
+			expect(toLocal.getHours()).toBe(23)
 		})
 
 		it('shows a toast when the Edge Function returns an error', async () => {
 			const user = userEvent.setup()
-			global.fetch = vi.fn().mockResolvedValue({
-				ok: false,
-				statusText: 'Payload Too Large',
-				json: () =>
-					Promise.resolve({ error: 'Filter matches 600 documents; cap is 500.' })
-			} as unknown as Response)
+			global.fetch = vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						error: 'Filter matches 600 documents; cap is 500.'
+					}),
+					{
+						status: 413,
+						statusText: 'Payload Too Large',
+						headers: { 'Content-Type': 'application/json' }
+					}
+				)
+			)
 			mockUseQuery.mockReturnValue({
 				data: { rows: [{ id: 'a' }], totalCount: 5, page: 0, pageSize: 50 },
 				isLoading: false,
@@ -694,11 +713,9 @@ describe('DocumentsVaultClient', () => {
 			// Resolve fetch so the in-flight call finishes — otherwise
 			// the test hangs on the await inside handleBulkDownload.
 			act(() => {
-				resolveFetch({
-					ok: true,
-					blob: () =>
-						Promise.resolve(new Blob(['fake-zip'], { type: 'application/zip' }))
-				} as unknown as Response)
+				resolveFetch(
+					new Response(new Blob(['fake-zip'], { type: 'application/zip' }))
+				)
 			})
 
 			await waitFor(() => {

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -667,6 +667,45 @@ describe('DocumentsVaultClient', () => {
 			})
 		})
 
+		it('double-click guard prevents two concurrent fetches', async () => {
+			// Hold the fetch promise open so both clicks land BEFORE the
+			// first call resolves (and BEFORE setIsDownloading commits).
+			// Without the ref-based guard, the closures would both see
+			// isDownloading === false and fire two POSTs.
+			let resolveFetch!: (value: Response) => void
+			const pendingResponse = new Promise<Response>(r => {
+				resolveFetch = r
+			})
+			global.fetch = vi.fn().mockReturnValue(pendingResponse)
+			mockUseQuery.mockReturnValue({
+				data: { rows: [{ id: 'a' }], totalCount: 5, page: 0, pageSize: 50 },
+				isLoading: false,
+				isFetching: false,
+				isError: false
+			})
+			renderVault()
+			const button = screen.getByRole('button', { name: /download all \(5\)/i })
+			// fireEvent dispatches synchronously; both clicks happen before
+			// any microtask flushes, so the second click sees the same
+			// closure as the first.
+			fireEvent.click(button)
+			fireEvent.click(button)
+
+			// Resolve fetch so the in-flight call finishes — otherwise
+			// the test hangs on the await inside handleBulkDownload.
+			act(() => {
+				resolveFetch({
+					ok: true,
+					blob: () =>
+						Promise.resolve(new Blob(['fake-zip'], { type: 'application/zip' }))
+				} as unknown as Response)
+			})
+
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalledTimes(1)
+			})
+		})
+
 		it('shows an auth-required toast when getSession returns no token', async () => {
 			const user = userEvent.setup()
 			mockGetSession.mockResolvedValue({ data: { session: null } })

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
 	useQueryState,
@@ -260,13 +260,18 @@ export function DocumentsVaultClient() {
 	// to their own docs) and streams a zip back. Disabled when the
 	// match exceeds the per-request cap or no docs match.
 	const [isDownloading, setIsDownloading] = useState(false)
+	// Mutable ref companion to `isDownloading` — the React state value is
+	// captured in the click-handler closure at render time, so a fast
+	// double-click that fires before React commits the next render would
+	// see `isDownloading === false` in BOTH closures and bypass the
+	// state-based guard. A ref updates synchronously and reads the same
+	// value across closures, closing that gap.
+	const downloadInFlightRef = useRef(false)
 	const canDownload =
 		totalCount > 0 && totalCount <= BULK_DOWNLOAD_MAX && !isDownloading
 	async function handleBulkDownload() {
-		// Re-render race guard: `disabled` flips after setIsDownloading
-		// commits, so a rapid double-click could fire two POSTs before
-		// the button paint. Bail early on second-entry.
-		if (isDownloading) return
+		if (downloadInFlightRef.current) return
+		downloadInFlightRef.current = true
 		setIsDownloading(true)
 		try {
 			const supabase = createClient()
@@ -324,6 +329,7 @@ export function DocumentsVaultClient() {
 				err instanceof Error ? err.message : 'Download failed unexpectedly.'
 			)
 		} finally {
+			downloadInFlightRef.current = false
 			setIsDownloading(false)
 		}
 	}

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -41,7 +41,19 @@ import {
 	type DocumentCategory
 } from '#lib/validation/documents'
 import { DocumentRow } from './document-row'
-import { AlertTriangle, FolderArchive, Loader2, Search } from 'lucide-react'
+import { createClient } from '#lib/supabase/client'
+import { toast } from 'sonner'
+import {
+	AlertTriangle,
+	Download,
+	FolderArchive,
+	Loader2,
+	Search
+} from 'lucide-react'
+
+// Phase 64: hard cap on bulk-download. Mirrors MAX_DOCS_PER_REQUEST in
+// the download-documents-zip Edge Function — keep them in lockstep.
+const BULK_DOWNLOAD_MAX = 500
 
 const ENTITY_TYPE_LABELS: Record<DocumentEntityType, string> = {
 	property: 'Property',
@@ -242,6 +254,65 @@ export function DocumentsVaultClient() {
 	// momentarily after clicking Next.
 	const showRangeHeader = totalCount > 0 && !isFetching
 
+	// Phase 64: bulk-download-as-zip. POSTs the current filter set to
+	// the download-documents-zip Edge Function which re-runs
+	// search_documents server-side under the caller's JWT (RLS-scoped
+	// to their own docs) and streams a zip back. Disabled when the
+	// match exceeds the per-request cap or no docs match.
+	const [isDownloading, setIsDownloading] = useState(false)
+	const canDownload =
+		totalCount > 0 && totalCount <= BULK_DOWNLOAD_MAX && !isDownloading
+	async function handleBulkDownload() {
+		setIsDownloading(true)
+		try {
+			const supabase = createClient()
+			const { data: sessionData } = await supabase.auth.getSession()
+			const token = sessionData.session?.access_token
+			if (!token) {
+				toast.error('Sign in to download documents.')
+				return
+			}
+			const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+			const res = await fetch(`${baseUrl}/functions/v1/download-documents-zip`, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					query: queryParam || null,
+					entityType: entityType ?? null,
+					categories: categories.length > 0 ? categories : null,
+					from: fromParam || null,
+					to: toParam || null
+				})
+			})
+			if (!res.ok) {
+				const body = (await res
+					.json()
+					.catch(() => ({ error: res.statusText }))) as { error?: string }
+				toast.error(body.error ?? 'Download failed')
+				return
+			}
+			const blob = await res.blob()
+			const url = URL.createObjectURL(blob)
+			const today = new Date().toISOString().slice(0, 10)
+			const a = document.createElement('a')
+			a.href = url
+			a.download = `tenantflow-documents-${today}.zip`
+			document.body.appendChild(a)
+			a.click()
+			a.remove()
+			URL.revokeObjectURL(url)
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : 'Download failed unexpectedly.'
+			)
+		} finally {
+			setIsDownloading(false)
+		}
+	}
+
 	// Out-of-bounds page recovery (cycle-2 L1). If the user lands on a
 	// `?page=N` whose offset is beyond `totalCount` (bookmarked link from
 	// a since-shrunk portfolio, or hand-edited URL), the empty-rows
@@ -348,11 +419,40 @@ export function DocumentsVaultClient() {
 							/>
 						)}
 					</CardTitle>
-					{showRangeHeader && (
-						<p className="text-xs text-muted-foreground">
-							Showing {pageStart + 1}-{pageEnd} of {totalCount}
-						</p>
-					)}
+					<div className="flex items-center gap-3">
+						{showRangeHeader && (
+							<p className="text-xs text-muted-foreground">
+								Showing {pageStart + 1}-{pageEnd} of {totalCount}
+							</p>
+						)}
+						{totalCount > 0 && (
+							<Button
+								size="sm"
+								variant="outline"
+								onClick={() => {
+									void handleBulkDownload()
+								}}
+								disabled={!canDownload}
+								title={
+									totalCount > BULK_DOWNLOAD_MAX
+										? `Bulk download is capped at ${BULK_DOWNLOAD_MAX} documents — narrow the filter.`
+										: undefined
+								}
+							>
+								{isDownloading ? (
+									<>
+										<Loader2 className="size-4 mr-2 animate-spin" aria-hidden="true" />
+										Preparing zip...
+									</>
+								) : (
+									<>
+										<Download className="size-4 mr-2" aria-hidden="true" />
+										Download all ({totalCount})
+									</>
+								)}
+							</Button>
+						)}
+					</div>
 				</CardHeader>
 				<CardContent>
 					{isLoading ? (

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -33,6 +33,7 @@ import {
 } from '#hooks/api/query-keys/document-keys'
 import {
 	documentSearchQueries,
+	expandDateBoundary,
 	SEARCH_PAGE_SIZE
 } from '#hooks/api/query-keys/document-search-keys'
 import {
@@ -292,8 +293,14 @@ export function DocumentsVaultClient() {
 					query: queryParam || null,
 					entityType: entityType ?? null,
 					categories: categories.length > 0 ? categories : null,
-					from: fromParam || null,
-					to: toParam || null
+					// Mirror documentSearchQueries.list expansion so the
+					// bulk-download path queries the SAME row set the user
+					// just saw counted in the UI. Expansion runs in the
+					// browser's local zone (the only place we know the
+					// user's timezone) and the Edge Function passes the
+					// resulting ISO timestamps through to the RPC unchanged.
+					from: expandDateBoundary(fromParam || undefined, false),
+					to: expandDateBoundary(toParam || undefined, true)
 				})
 			})
 			if (!res.ok) {

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -263,6 +263,10 @@ export function DocumentsVaultClient() {
 	const canDownload =
 		totalCount > 0 && totalCount <= BULK_DOWNLOAD_MAX && !isDownloading
 	async function handleBulkDownload() {
+		// Re-render race guard: `disabled` flips after setIsDownloading
+		// commits, so a rapid double-click could fire two POSTs before
+		// the button paint. Bail early on second-entry.
+		if (isDownloading) return
 		setIsDownloading(true)
 		try {
 			const supabase = createClient()
@@ -293,6 +297,17 @@ export function DocumentsVaultClient() {
 					.catch(() => ({ error: res.statusText }))) as { error?: string }
 				toast.error(body.error ?? 'Download failed')
 				return
+			}
+			// NOTE: res.blob() buffers the entire zip in memory before
+			// triggering the download. The Edge Function streams server-
+			// side, but the browser tab still allocates the whole archive
+			// here. Acceptable for typical archive sizes; defer streaming
+			// directly to disk (e.g. via Service Worker + StreamSaver) to
+			// v2.7 if power-user feedback warrants it.
+			if (totalCount > 100) {
+				console.warn(
+					`bulk download buffering ${totalCount} documents in memory; large archives may strain low-spec browsers`
+				)
 			}
 			const blob = await res.blob()
 			const url = URL.createObjectURL(blob)

--- a/supabase/.temp/cli-latest
+++ b/supabase/.temp/cli-latest
@@ -1,6 +1,0 @@
-<<<<<<< Updated upstream
-v2.90.0
-||||||| Stash base
-v2.75.0
-=======
->>>>>>> Stashed changes

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -4,6 +4,7 @@
     "@sentry/deno": "npm:@sentry/deno@9",
     "stripe": "npm:stripe@20",
     "@upstash/ratelimit": "npm:@upstash/ratelimit",
-    "@upstash/redis": "npm:@upstash/redis"
+    "@upstash/redis": "npm:@upstash/redis",
+    "@zip.js/zip.js": "https://esm.sh/@zip.js/zip.js@2.7.45"
   }
 }

--- a/supabase/functions/download-documents-zip/index.ts
+++ b/supabase/functions/download-documents-zip/index.ts
@@ -1,0 +1,232 @@
+// Supabase Edge Function: download-documents-zip
+//
+// Bulk-download every document matching the caller's filter set as a
+// streaming zip. Re-runs the same `search_documents` RPC server-side
+// using the caller's JWT (no client-supplied trust) and pipes each
+// blob into a zip via a TransformStream — only ONE document's bytes
+// live in memory at a time, regardless of how many matches.
+//
+// Hard cap: 500 matching documents per request. Phase 64 cycle-1 may
+// lower this if memory profiling shows the streaming path can't keep
+// up with the upload-side allocator at higher counts.
+
+import { ZipWriter, BlobReader } from '@zip.js/zip.js'
+import { validateBearerAuth } from '../_shared/auth.ts'
+import { getCorsHeaders, handleCorsOptions } from '../_shared/cors.ts'
+import { validateEnv } from '../_shared/env.ts'
+import { errorResponse } from '../_shared/errors.ts'
+import { createAdminClient } from '../_shared/supabase-client.ts'
+import { createClient } from '@supabase/supabase-js'
+
+const BUCKET = 'tenant-documents'
+const MAX_DOCS_PER_REQUEST = 500
+
+interface FilterPayload {
+	query?: string | null
+	entityType?: string | null
+	categories?: string[] | null
+	from?: string | null
+	to?: string | null
+}
+
+interface SearchRow {
+	id: string
+	entity_type: string
+	entity_id: string
+	document_type: string
+	mime_type: string | null
+	file_path: string
+	storage_url: string
+	file_size: number | null
+	title: string | null
+	tags: string[] | null
+	description: string | null
+	owner_user_id: string | null
+	created_at: string | null
+	total_count: number
+}
+
+// Match the frontend `sanitizeFilename` shape so paths inside the zip
+// can't escape entity-type folders.
+function sanitizeFilename(name: string): string {
+	return name.replace(/[\\/?%*:|"<>#&\s]+/g, '_')
+}
+
+function inferExtension(mime: string | null, filePath: string): string {
+	if (mime === 'application/pdf') return 'pdf'
+	if (mime === 'image/jpeg' || mime === 'image/jpg') return 'jpg'
+	if (mime === 'image/png') return 'png'
+	if (mime === 'image/webp') return 'webp'
+	// Fall back to the extension on the storage path.
+	const dot = filePath.lastIndexOf('.')
+	if (dot > 0) return filePath.slice(dot + 1)
+	return 'bin'
+}
+
+Deno.serve(async (req: Request) => {
+	const optionsResponse = handleCorsOptions(req)
+	if (optionsResponse) return optionsResponse
+
+	if (req.method !== 'POST') {
+		return errorResponse(req, 405, new Error('method_not_allowed'), {
+			action: 'method_check'
+		})
+	}
+
+	let env: Record<string, string>
+	try {
+		env = validateEnv({
+			required: ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']
+		})
+	} catch (err) {
+		return errorResponse(req, 500, err, { action: 'env_validation' })
+	}
+
+	try {
+		const adminClient = createAdminClient(
+			env.SUPABASE_URL,
+			env.SUPABASE_SERVICE_ROLE_KEY
+		)
+
+		const auth = await validateBearerAuth(req, adminClient)
+		if ('error' in auth) {
+			return new Response(JSON.stringify({ error: auth.error }), {
+				status: auth.status,
+				headers: { 'Content-Type': 'application/json', ...getCorsHeaders(req) }
+			})
+		}
+		const { user, token } = auth
+
+		// Re-derive the user-scoped client so the search_documents RPC
+		// runs under the caller's JWT (RLS gates the result set to their
+		// own documents — never trust the client-supplied owner_id).
+		const userClient = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+			global: { headers: { Authorization: `Bearer ${token}` } },
+			auth: { persistSession: false, autoRefreshToken: false }
+		})
+
+		let body: FilterPayload
+		try {
+			body = (await req.json()) as FilterPayload
+		} catch {
+			return errorResponse(req, 400, new Error('invalid_json_body'), {
+				action: 'parse_body'
+			})
+		}
+
+		const { data: rows, error: rpcError } = await userClient.rpc(
+			'search_documents',
+			{
+				p_query: body.query?.trim() || null,
+				p_entity_type: body.entityType ?? null,
+				p_categories:
+					Array.isArray(body.categories) && body.categories.length > 0
+						? body.categories
+						: null,
+				p_from: body.from ?? null,
+				p_to: body.to ?? null,
+				p_limit: MAX_DOCS_PER_REQUEST,
+				p_offset: 0
+			}
+		)
+		if (rpcError) {
+			return errorResponse(req, 400, rpcError, { action: 'search_documents' })
+		}
+
+		const matchingRows = (rows ?? []) as SearchRow[]
+		if (matchingRows.length === 0) {
+			return new Response(
+				JSON.stringify({ error: 'No documents match the filter set.' }),
+				{
+					status: 404,
+					headers: {
+						'Content-Type': 'application/json',
+						...getCorsHeaders(req)
+					}
+				}
+			)
+		}
+
+		// total_count is the FULL match count (pre-LIMIT). If it exceeds the
+		// per-request cap, refuse — owner needs to narrow the filter.
+		const totalCount = matchingRows[0]?.total_count ?? matchingRows.length
+		if (totalCount > MAX_DOCS_PER_REQUEST) {
+			return new Response(
+				JSON.stringify({
+					error: `Filter matches ${totalCount} documents; bulk download is capped at ${MAX_DOCS_PER_REQUEST}. Narrow the filter and try again.`
+				}),
+				{
+					status: 413,
+					headers: {
+						'Content-Type': 'application/json',
+						...getCorsHeaders(req)
+					}
+				}
+			)
+		}
+
+		// True streaming: TransformStream pairs a writable side (the
+		// ZipWriter pumps zip bytes into it) with a readable side (the
+		// Response body). Each document's blob is downloaded just-in-
+		// time and added to the archive; only one document's bytes
+		// live in memory at any moment.
+		const transformStream = new TransformStream<Uint8Array>()
+		const zipWriter = new ZipWriter(transformStream.writable, {
+			bufferedWrite: false
+		})
+
+		// Background pump — must NOT be awaited or the response would
+		// only return after the entire zip is built (defeating streaming).
+		void (async () => {
+			try {
+				const usedNames = new Set<string>()
+				for (const doc of matchingRows) {
+					const { data: blob, error: dlError } = await adminClient.storage
+						.from(BUCKET)
+						.download(doc.file_path)
+					if (dlError || !blob) {
+						// Skip this doc but keep going — a single missing blob
+						// shouldn't void the whole archive. Log via error stream
+						// would be nice; for v1, silent skip.
+						continue
+					}
+					const ext = inferExtension(doc.mime_type, doc.file_path)
+					const baseName = sanitizeFilename(
+						doc.title?.trim() || `${doc.entity_type}_${doc.id}`
+					)
+					// Append id when names collide so two docs titled "Lease"
+					// don't overwrite each other inside the zip.
+					let zipPath = `${doc.entity_type}/${baseName}.${ext}`
+					if (usedNames.has(zipPath)) {
+						zipPath = `${doc.entity_type}/${baseName}-${doc.id.slice(0, 8)}.${ext}`
+					}
+					usedNames.add(zipPath)
+					await zipWriter.add(zipPath, new BlobReader(blob))
+				}
+				await zipWriter.close()
+			} catch (err) {
+				// Abort the stream so the client sees a truncated download
+				// rather than a deceptively-complete-but-corrupt zip.
+				try {
+					await transformStream.writable.abort(
+						err instanceof Error ? err : new Error('zip_pump_failed')
+					)
+				} catch {
+					/* writable already closed */
+				}
+			}
+		})()
+
+		const today = new Date().toISOString().slice(0, 10)
+		void user
+		return new Response(transformStream.readable, {
+			headers: {
+				'Content-Type': 'application/zip',
+				'Content-Disposition': `attachment; filename="tenantflow-documents-${today}.zip"`,
+				...getCorsHeaders(req)
+			}
+		})
+	} catch (err) {
+		return errorResponse(req, 500, err, { action: 'unhandled' })
+	}
+})

--- a/supabase/functions/download-documents-zip/index.ts
+++ b/supabase/functions/download-documents-zip/index.ts
@@ -225,6 +225,12 @@ Deno.serve(async (req: Request) => {
 				}
 				await zipWriter.close()
 			} catch (err) {
+				// Whole-pump failure produces a truncated download with
+				// zero client-side signal — log loudly so Sentry surfaces
+				// it. Mirrors the per-doc M-2 observability hook above.
+				logEvent('zip_pump_failed', {
+					error: err instanceof Error ? err.message : String(err)
+				})
 				// Abort the stream so the client sees a truncated download
 				// rather than a deceptively-complete-but-corrupt zip.
 				try {

--- a/supabase/functions/download-documents-zip/index.ts
+++ b/supabase/functions/download-documents-zip/index.ts
@@ -10,7 +10,7 @@
 // lower this if memory profiling shows the streaming path can't keep
 // up with the upload-side allocator at higher counts.
 
-import { ZipWriter, BlobReader } from '@zip.js/zip.js'
+import { ZipWriter, BlobReader, TextReader } from '@zip.js/zip.js'
 import { validateBearerAuth } from '../_shared/auth.ts'
 import { getCorsHeaders, handleCorsOptions } from '../_shared/cors.ts'
 import { validateEnv } from '../_shared/env.ts'
@@ -19,7 +19,12 @@ import { createAdminClient } from '../_shared/supabase-client.ts'
 import { createClient } from '@supabase/supabase-js'
 
 const BUCKET = 'tenant-documents'
+// Hard cap on bulk-download size. Mirrors `BULK_DOWNLOAD_MAX` in
+// `documents-vault.client.tsx` — keep them in lockstep.
 const MAX_DOCS_PER_REQUEST = 500
+// `search_documents` RPC enforces `p_limit <= 200` (see migration
+// 20260426043911). Page through it to assemble up to MAX_DOCS_PER_REQUEST.
+const RPC_PAGE_SIZE = 200
 
 interface FilterPayload {
 	query?: string | null
@@ -63,9 +68,11 @@ function inferExtension(mime: string | null, filePath: string): string {
 	if (mime === 'image/jpeg' || mime === 'image/jpg') return 'jpg'
 	if (mime === 'image/png') return 'png'
 	if (mime === 'image/webp') return 'webp'
-	// Fall back to the extension on the storage path.
+	// Fall back to the extension on the storage path. Reject trailing-dot
+	// paths (`foo.`) — slicing past the dot yields '' which produces an
+	// invalid filename on Windows and surprising behavior on macOS/Linux.
 	const dot = filePath.lastIndexOf('.')
-	if (dot > 0) return filePath.slice(dot + 1)
+	if (dot > 0 && dot < filePath.length - 1) return filePath.slice(dot + 1)
 	return 'bin'
 }
 
@@ -85,7 +92,10 @@ Deno.serve(async (req: Request) => {
 			required: [
 				'SUPABASE_URL',
 				'SUPABASE_SERVICE_ROLE_KEY',
-				'SUPABASE_ANON_KEY'
+				'SUPABASE_ANON_KEY',
+				// FRONTEND_URL is required by getCorsHeaders — fail fast at
+				// boot rather than silently dropping CORS on every response.
+				'FRONTEND_URL'
 			]
 		})
 	} catch (err) {
@@ -130,49 +140,66 @@ Deno.serve(async (req: Request) => {
 			})
 		}
 
-		const { data: rows, error: rpcError } = await userClient.rpc(
-			'search_documents',
-			{
-				p_query: body.query?.trim() || null,
-				p_entity_type: body.entityType ?? null,
-				p_categories:
-					Array.isArray(body.categories) && body.categories.length > 0
-						? body.categories
-						: null,
-				p_from: body.from ?? null,
-				p_to: body.to ?? null,
-				p_limit: MAX_DOCS_PER_REQUEST,
-				p_offset: 0
-			}
-		)
-		if (rpcError) {
-			return errorResponse(req, 400, rpcError, { action: 'search_documents' })
+		const rpcArgs = {
+			p_query: body.query?.trim() || null,
+			p_entity_type: body.entityType ?? null,
+			p_categories:
+				Array.isArray(body.categories) && body.categories.length > 0
+					? body.categories
+					: null,
+			p_from: body.from ?? null,
+			p_to: body.to ?? null
 		}
 
-		const matchingRows = (rows ?? []) as SearchRow[]
+		// Page through search_documents in RPC_PAGE_SIZE chunks. The RPC
+		// enforces p_limit <= 200; bulk download wants up to 500. The
+		// FIRST page is sufficient to read total_count and reject the
+		// over-cap case before fetching subsequent pages.
+		const matchingRows: SearchRow[] = []
+		let totalCount = 0
+		let offset = 0
+		while (offset < MAX_DOCS_PER_REQUEST) {
+			const { data: rows, error: rpcError } = await userClient.rpc(
+				'search_documents',
+				{ ...rpcArgs, p_limit: RPC_PAGE_SIZE, p_offset: offset }
+			)
+			if (rpcError) {
+				return errorResponse(req, 400, rpcError, {
+					action: 'search_documents'
+				})
+			}
+			const page = (rows ?? []) as SearchRow[]
+			if (page.length === 0) break
+			if (offset === 0) {
+				totalCount = page[0]?.total_count ?? page.length
+				// total_count is the FULL match count (pre-LIMIT). If it
+				// exceeds the per-request cap, refuse before paging the
+				// rest — owner needs to narrow the filter.
+				if (totalCount > MAX_DOCS_PER_REQUEST) {
+					return new Response(
+						JSON.stringify({
+							error: `Filter matches ${totalCount} documents; bulk download is capped at ${MAX_DOCS_PER_REQUEST}. Narrow the filter and try again.`
+						}),
+						{
+							status: 413,
+							headers: {
+								'Content-Type': 'application/json',
+								...getCorsHeaders(req)
+							}
+						}
+					)
+				}
+			}
+			matchingRows.push(...page)
+			if (matchingRows.length >= totalCount) break
+			offset += RPC_PAGE_SIZE
+		}
+
 		if (matchingRows.length === 0) {
 			return new Response(
 				JSON.stringify({ error: 'No documents match the filter set.' }),
 				{
 					status: 404,
-					headers: {
-						'Content-Type': 'application/json',
-						...getCorsHeaders(req)
-					}
-				}
-			)
-		}
-
-		// total_count is the FULL match count (pre-LIMIT). If it exceeds the
-		// per-request cap, refuse — owner needs to narrow the filter.
-		const totalCount = matchingRows[0]?.total_count ?? matchingRows.length
-		if (totalCount > MAX_DOCS_PER_REQUEST) {
-			return new Response(
-				JSON.stringify({
-					error: `Filter matches ${totalCount} documents; bulk download is capped at ${MAX_DOCS_PER_REQUEST}. Narrow the filter and try again.`
-				}),
-				{
-					status: 413,
 					headers: {
 						'Content-Type': 'application/json',
 						...getCorsHeaders(req)
@@ -194,6 +221,7 @@ Deno.serve(async (req: Request) => {
 		void (async () => {
 			try {
 				const usedNames = new Set<string>()
+				const skipped: Array<{ id: string; title: string | null }> = []
 				for (const doc of matchingRows) {
 					const { data: blob, error: dlError } = await adminClient.storage
 						.from(BUCKET)
@@ -208,20 +236,43 @@ Deno.serve(async (req: Request) => {
 							filePath: doc.file_path,
 							error: dlError?.message ?? 'no_blob_returned'
 						})
+						skipped.push({ id: doc.id, title: doc.title })
 						continue
 					}
 					const ext = inferExtension(doc.mime_type, doc.file_path)
 					const baseName = sanitizeFilename(
 						doc.title?.trim() || `${doc.entity_type}_${doc.id}`
 					)
-					// Append id when names collide so two docs titled "Lease"
-					// don't overwrite each other inside the zip.
+					// Append a monotonic counter when names collide so the
+					// zip never has duplicate paths (zip.js throws on dup).
+					// Counter beats id-prefix because two short id slices
+					// can themselves collide within a 500-doc set, and the
+					// suffix-collision branch only runs once.
 					let zipPath = `${doc.entity_type}/${baseName}.${ext}`
-					if (usedNames.has(zipPath)) {
-						zipPath = `${doc.entity_type}/${baseName}-${doc.id.slice(0, 8)}.${ext}`
+					let dedupe = 1
+					while (usedNames.has(zipPath)) {
+						zipPath = `${doc.entity_type}/${baseName}-${dedupe}.${ext}`
+						dedupe += 1
 					}
 					usedNames.add(zipPath)
 					await zipWriter.add(zipPath, new BlobReader(blob))
+				}
+				// Surface partial-archive state to the user via an in-zip
+				// notes file so they aren't silently shorted documents.
+				if (skipped.length > 0) {
+					const summary = [
+						`${skipped.length} document(s) could not be included in this archive.`,
+						'The original storage object was missing or unreadable.',
+						'',
+						'Skipped documents:',
+						...skipped.map(
+							s => `  - ${s.id}${s.title ? ` (${s.title})` : ''}`
+						)
+					].join('\n')
+					await zipWriter.add(
+						'_DOWNLOAD_NOTES.txt',
+						new TextReader(summary)
+					)
 				}
 				await zipWriter.close()
 			} catch (err) {

--- a/supabase/functions/download-documents-zip/index.ts
+++ b/supabase/functions/download-documents-zip/index.ts
@@ -14,7 +14,7 @@ import { ZipWriter, BlobReader } from '@zip.js/zip.js'
 import { validateBearerAuth } from '../_shared/auth.ts'
 import { getCorsHeaders, handleCorsOptions } from '../_shared/cors.ts'
 import { validateEnv } from '../_shared/env.ts'
-import { errorResponse } from '../_shared/errors.ts'
+import { errorResponse, logEvent } from '../_shared/errors.ts'
 import { createAdminClient } from '../_shared/supabase-client.ts'
 import { createClient } from '@supabase/supabase-js'
 
@@ -47,9 +47,15 @@ interface SearchRow {
 }
 
 // Match the frontend `sanitizeFilename` shape so paths inside the zip
-// can't escape entity-type folders.
+// can't escape entity-type folders. Also strips leading dots (no
+// dotfiles), control chars / NUL bytes (some POSIX archive utilities
+// truncate on \0), and caps length to stay under filesystem limits.
 function sanitizeFilename(name: string): string {
-	return name.replace(/[\\/?%*:|"<>#&\s]+/g, '_')
+	return name
+		.replace(/[\\/?%*:|"<>#&\x00-\x1f]+/g, '_')
+		.replace(/\s+/g, '_')
+		.replace(/^\.+/, '_')
+		.slice(0, 200) || 'document'
 }
 
 function inferExtension(mime: string | null, filePath: string): string {
@@ -76,7 +82,11 @@ Deno.serve(async (req: Request) => {
 	let env: Record<string, string>
 	try {
 		env = validateEnv({
-			required: ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']
+			required: [
+				'SUPABASE_URL',
+				'SUPABASE_SERVICE_ROLE_KEY',
+				'SUPABASE_ANON_KEY'
+			]
 		})
 	} catch (err) {
 		return errorResponse(req, 500, err, { action: 'env_validation' })
@@ -95,12 +105,18 @@ Deno.serve(async (req: Request) => {
 				headers: { 'Content-Type': 'application/json', ...getCorsHeaders(req) }
 			})
 		}
-		const { user, token } = auth
+		const { token } = auth
 
 		// Re-derive the user-scoped client so the search_documents RPC
 		// runs under the caller's JWT (RLS gates the result set to their
-		// own documents — never trust the client-supplied owner_id).
-		const userClient = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+		// own documents — never trust the client-supplied owner_id). The
+		// `apikey` MUST be the anon key, not service-role: pairing the
+		// service-role apikey with a user JWT in `Authorization` works
+		// today only because PostgREST honors the user JWT for the role,
+		// but a future client/server change could silently elevate to
+		// service-role and bypass RLS. Mirror the pattern in
+		// `export-user-data/index.ts` to keep this defensive.
+		const userClient = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
 			global: { headers: { Authorization: `Bearer ${token}` } },
 			auth: { persistSession: false, autoRefreshToken: false }
 		})
@@ -171,9 +187,7 @@ Deno.serve(async (req: Request) => {
 		// time and added to the archive; only one document's bytes
 		// live in memory at any moment.
 		const transformStream = new TransformStream<Uint8Array>()
-		const zipWriter = new ZipWriter(transformStream.writable, {
-			bufferedWrite: false
-		})
+		const zipWriter = new ZipWriter(transformStream.writable)
 
 		// Background pump — must NOT be awaited or the response would
 		// only return after the entire zip is built (defeating streaming).
@@ -186,8 +200,14 @@ Deno.serve(async (req: Request) => {
 						.download(doc.file_path)
 					if (dlError || !blob) {
 						// Skip this doc but keep going — a single missing blob
-						// shouldn't void the whole archive. Log via error stream
-						// would be nice; for v1, silent skip.
+						// shouldn't void the whole archive. Sentry breadcrumb
+						// surfaces the skip in any future failure trace without
+						// firing a standalone event.
+						logEvent('document_blob_missing', {
+							docId: doc.id,
+							filePath: doc.file_path,
+							error: dlError?.message ?? 'no_blob_returned'
+						})
 						continue
 					}
 					const ext = inferExtension(doc.mime_type, doc.file_path)
@@ -218,7 +238,6 @@ Deno.serve(async (req: Request) => {
 		})()
 
 		const today = new Date().toISOString().slice(0, 10)
-		void user
 		return new Response(transformStream.readable, {
 			headers: {
 				'Content-Type': 'application/zip',

--- a/tests/integration/rls/download-documents-zip.rls.test.ts
+++ b/tests/integration/rls/download-documents-zip.rls.test.ts
@@ -169,7 +169,7 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 		expect(body.error).toMatch(/no documents match/i)
 	})
 
-	it('ownerB without a Bearer token receives 401', async () => {
+	it('a request without a Bearer token receives 401', async () => {
 		const res = await fetch(
 			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
 			{
@@ -178,7 +178,11 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 				body: JSON.stringify({ query: sentinel })
 			}
 		)
-		expect([401, 403]).toContain(res.status)
+		// Pinned to 401 — validateBearerAuth returns 401 with "Missing
+		// authorization header" before any function logic runs. Loose
+		// assertions like `[401, 403]` would mask a regression where the
+		// Supabase gateway started rejecting at a different layer.
+		expect(res.status).toBe(401)
 		await res.arrayBuffer()
 	})
 })

--- a/tests/integration/rls/download-documents-zip.rls.test.ts
+++ b/tests/integration/rls/download-documents-zip.rls.test.ts
@@ -136,9 +136,15 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 		)
 		expect(res.status).toBe(200)
 		expect(res.headers.get('content-type')).toBe('application/zip')
-		// Drain so the connection releases (we don't need to parse the zip
-		// — the 200 + content-type is the contract proof here).
-		await res.arrayBuffer()
+		// Empty-body regression guard: a 200 + zip content-type with zero
+		// bytes would still pass the contract test above. Assert the
+		// response carries a non-trivial payload that begins with the
+		// zip magic bytes (`PK\x03\x04` = 0x50 0x4B 0x03 0x04).
+		const buf = await res.arrayBuffer()
+		expect(buf.byteLength).toBeGreaterThan(0)
+		const magic = new Uint8Array(buf.slice(0, 2))
+		expect(magic[0]).toBe(0x50)
+		expect(magic[1]).toBe(0x4b)
 	})
 
 	it('ownerB filtering by ownerA sentinel receives 404, never 200', async () => {

--- a/tests/integration/rls/download-documents-zip.rls.test.ts
+++ b/tests/integration/rls/download-documents-zip.rls.test.ts
@@ -25,17 +25,22 @@ import { createTestClient, getTestCredentials } from '../setup/supabase-client'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 const PAYLOAD = '%PDF-1.4\n%%EOF'
-const SUPABASE_URL = process.env['NEXT_PUBLIC_SUPABASE_URL']
+// `tests/integration/setup/supabase-client.ts` already throws at
+// import-time when these env vars are missing, so the `!` here is
+// safe by transitive guarantee. Rebinding to a narrowed `string`
+// eliminates `!` at every usage site (cycle-7 M-3).
+const SUPABASE_URL = process.env['NEXT_PUBLIC_SUPABASE_URL']!
 const SUPABASE_PUBLISHABLE_KEY =
-	process.env['NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY']
+	process.env['NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY']!
 
 // Probe whether the Edge Function is deployed. Edge Functions have no
 // automatic CI deploy step (they ship via `supabase functions deploy`
 // or MCP, out-of-band from this repo's PR pipeline), so a brand-new
 // function can land in this branch before the prod deployment exists.
 // When the function isn't deployed the Supabase gateway returns a
-// JSON-shaped error with `{code: 'NOT_FOUND'}` — that's our signal to
-// skip the suite gracefully.
+// 404 with body `{code: 'NOT_FOUND', ...}`; the function's own 404
+// uses `{error: 'No documents match...'}`. Skip gracefully on the
+// former, run normally on the latter.
 async function isFunctionDeployed(): Promise<boolean> {
 	if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) return false
 	try {
@@ -50,14 +55,18 @@ async function isFunctionDeployed(): Promise<boolean> {
 				body: '{}'
 			}
 		)
-		const body = (await probe.json().catch(() => ({}))) as {
-			code?: string
-			error?: string
+		// Function deployed → 401 (validateBearerAuth, no token) or
+		// 400 (function-level body parse). NOT deployed → gateway 404
+		// with `{code:'NOT_FOUND'}`. Transient gateway 5xx → fail open
+		// (treat as deployed) so the test fails LOUD instead of silently
+		// skipping a security-isolation guard.
+		if (probe.status === 404) {
+			const body = (await probe.json().catch(() => ({}))) as {
+				code?: string
+			}
+			return body.code !== 'NOT_FOUND'
 		}
-		// Gateway "function not found" surfaces as code: 'NOT_FOUND'.
-		// Anything else (401 from validateBearerAuth, 400, etc.) means
-		// the function ran.
-		return body.code !== 'NOT_FOUND'
+		return probe.status === 401 || probe.status === 400 || probe.ok
 	} catch {
 		return false
 	}
@@ -77,9 +86,6 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 	let suiteDeployed = false
 
 	beforeAll(async () => {
-		if (!SUPABASE_URL) {
-			throw new Error('NEXT_PUBLIC_SUPABASE_URL must be set')
-		}
 		suiteDeployed = await isFunctionDeployed()
 		if (!suiteDeployed) {
 			console.warn(
@@ -169,15 +175,15 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 		await clientB.auth.signOut()
 	})
 
-	it('ownerA can download a zip containing the sentinel doc', async () => {
-		if (!suiteDeployed) return
+	it('ownerA can download a zip containing the sentinel doc', async ctx => {
+		if (!suiteDeployed) ctx.skip()
 		const res = await fetch(
 			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
 			{
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${ownerATokens.access_token}`,
-					apikey: SUPABASE_PUBLISHABLE_KEY!,
+					apikey: SUPABASE_PUBLISHABLE_KEY,
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({ query: sentinel })
@@ -196,15 +202,15 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 		expect(magic[1]).toBe(0x4b)
 	})
 
-	it('ownerB filtering by ownerA sentinel receives 404, never 200', async () => {
-		if (!suiteDeployed) return
+	it('ownerB filtering by ownerA sentinel receives 404, never 200', async ctx => {
+		if (!suiteDeployed) ctx.skip()
 		const res = await fetch(
 			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
 			{
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${ownerBTokens.access_token}`,
-					apikey: SUPABASE_PUBLISHABLE_KEY!,
+					apikey: SUPABASE_PUBLISHABLE_KEY,
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({ query: sentinel })
@@ -220,14 +226,14 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 		expect(body.error).toMatch(/no documents match/i)
 	})
 
-	it('a request without a Bearer token receives 401', async () => {
-		if (!suiteDeployed) return
+	it('a request without a Bearer token receives 401', async ctx => {
+		if (!suiteDeployed) ctx.skip()
 		const res = await fetch(
 			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
 			{
 				method: 'POST',
 				headers: {
-					apikey: SUPABASE_PUBLISHABLE_KEY!,
+					apikey: SUPABASE_PUBLISHABLE_KEY,
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({ query: sentinel })

--- a/tests/integration/rls/download-documents-zip.rls.test.ts
+++ b/tests/integration/rls/download-documents-zip.rls.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Edge-Function-level integration test for `download-documents-zip`
+ * (v2.6 Phase 64). Proves the auth boundary holds end-to-end:
+ *
+ *   - ownerA inserts a document with a unique title sentinel
+ *   - ownerB POSTs to the function URL with their own JWT and a filter
+ *     that would match ownerA's sentinel
+ *   - The function MUST NOT return 200 with ownerA's bytes; it must
+ *     return 404 ("No documents match") because the inner
+ *     search_documents RPC re-derives auth.uid() from ownerB's JWT
+ *     under their RLS scope
+ *
+ * Companion to `search_documents.rls.test.ts:183` (RPC-level isolation).
+ * The added value here is proving the function-level
+ *   - apikey/JWT pairing isn't silently elevating to service-role
+ *   - the user-scoped client wiring stays defensive against future
+ *     refactors that strip the Authorization header
+ *
+ * Cycle-1 of PR #643 caught the original implementation pairing
+ * SUPABASE_SERVICE_ROLE_KEY with a user JWT; this test exists to fail
+ * loudly if any future refactor reintroduces that ambiguity.
+ */
+
+import { createTestClient, getTestCredentials } from '../setup/supabase-client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const PAYLOAD = '%PDF-1.4\n%%EOF'
+const SUPABASE_URL = process.env['NEXT_PUBLIC_SUPABASE_URL']
+
+describe('download-documents-zip Edge Function — owner isolation', () => {
+	let clientA: SupabaseClient
+	let clientB: SupabaseClient
+	let ownerATokens: { access_token: string }
+	let ownerBTokens: { access_token: string }
+	let ownerAId: string
+	let propertyA: { id: string } | null = null
+	const insertedDocIds: string[] = []
+	const uploadedPaths: string[] = []
+	const sentinel = `phase64-isolation-${Date.now()}`
+
+	beforeAll(async () => {
+		if (!SUPABASE_URL) {
+			throw new Error('NEXT_PUBLIC_SUPABASE_URL must be set')
+		}
+		const { ownerA, ownerB } = getTestCredentials()
+		clientA = await createTestClient(ownerA.email, ownerA.password)
+		clientB = await createTestClient(ownerB.email, ownerB.password)
+
+		const sessionA = await clientA.auth.getSession()
+		const sessionB = await clientB.auth.getSession()
+		const tokenA = sessionA.data.session?.access_token
+		const tokenB = sessionB.data.session?.access_token
+		if (!tokenA || !tokenB) {
+			throw new Error('Both owners must have a session JWT')
+		}
+		ownerATokens = { access_token: tokenA }
+		ownerBTokens = { access_token: tokenB }
+
+		const {
+			data: { user: uA }
+		} = await clientA.auth.getUser()
+		ownerAId = uA!.id
+
+		const { data: p } = await clientA
+			.from('properties')
+			.insert({
+				name: 'Phase-64 Isolation Property',
+				address_line1: '1 Isolation St',
+				city: 'Testville',
+				state: 'CA',
+				postal_code: '94105',
+				country: 'US',
+				property_type: 'APARTMENT',
+				owner_user_id: ownerAId
+			})
+			.select('id')
+			.single()
+		propertyA = p ? { id: p.id } : null
+		expect(propertyA, 'property fixture failed').not.toBeNull()
+
+		const ts = Date.now()
+		const path = `property/${propertyA!.id}/${ts}-${sentinel}.pdf`
+		const { error: upErr } = await clientA.storage
+			.from('tenant-documents')
+			.upload(path, new Blob([PAYLOAD], { type: 'application/pdf' }), {
+				contentType: 'application/pdf'
+			})
+		expect(upErr).toBeNull()
+		uploadedPaths.push(path)
+
+		const { data: row, error } = await clientA
+			.from('documents')
+			.insert({
+				entity_type: 'property',
+				entity_id: propertyA!.id,
+				document_type: 'other',
+				mime_type: 'application/pdf',
+				file_path: path,
+				storage_url: path,
+				file_size: PAYLOAD.length,
+				title: sentinel,
+				owner_user_id: ownerAId
+			})
+			.select('id')
+			.single()
+		expect(error).toBeNull()
+		if (row) insertedDocIds.push(row.id)
+	})
+
+	afterAll(async () => {
+		if (uploadedPaths.length > 0) {
+			await clientA.storage
+				.from('tenant-documents')
+				.remove(uploadedPaths)
+				.catch(() => {})
+		}
+		for (const id of insertedDocIds) {
+			await clientA.from('documents').delete().eq('id', id)
+		}
+		if (propertyA) await clientA.from('properties').delete().eq('id', propertyA.id)
+		await clientA.auth.signOut()
+		await clientB.auth.signOut()
+	})
+
+	it('ownerA can download a zip containing the sentinel doc', async () => {
+		const res = await fetch(
+			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${ownerATokens.access_token}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ query: sentinel })
+			}
+		)
+		expect(res.status).toBe(200)
+		expect(res.headers.get('content-type')).toBe('application/zip')
+		// Drain so the connection releases (we don't need to parse the zip
+		// — the 200 + content-type is the contract proof here).
+		await res.arrayBuffer()
+	})
+
+	it('ownerB filtering by ownerA sentinel receives 404, never 200', async () => {
+		const res = await fetch(
+			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${ownerBTokens.access_token}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ query: sentinel })
+			}
+		)
+		// Critical: a 200 here would mean ownerB downloaded ownerA's
+		// document — that's the privilege-escalation regression we exist
+		// to catch. The function must return 404 because the inner RPC
+		// runs under ownerB's JWT and finds no matching documents.
+		expect(res.status).toBe(404)
+		expect(res.headers.get('content-type')).toContain('application/json')
+		const body = (await res.json()) as { error?: string }
+		expect(body.error).toMatch(/no documents match/i)
+	})
+
+	it('ownerB without a Bearer token receives 401', async () => {
+		const res = await fetch(
+			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ query: sentinel })
+			}
+		)
+		expect([401, 403]).toContain(res.status)
+		await res.arrayBuffer()
+	})
+})

--- a/tests/integration/rls/download-documents-zip.rls.test.ts
+++ b/tests/integration/rls/download-documents-zip.rls.test.ts
@@ -26,6 +26,42 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 
 const PAYLOAD = '%PDF-1.4\n%%EOF'
 const SUPABASE_URL = process.env['NEXT_PUBLIC_SUPABASE_URL']
+const SUPABASE_PUBLISHABLE_KEY =
+	process.env['NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY']
+
+// Probe whether the Edge Function is deployed. Edge Functions have no
+// automatic CI deploy step (they ship via `supabase functions deploy`
+// or MCP, out-of-band from this repo's PR pipeline), so a brand-new
+// function can land in this branch before the prod deployment exists.
+// When the function isn't deployed the Supabase gateway returns a
+// JSON-shaped error with `{code: 'NOT_FOUND'}` — that's our signal to
+// skip the suite gracefully.
+async function isFunctionDeployed(): Promise<boolean> {
+	if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) return false
+	try {
+		const probe = await fetch(
+			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					apikey: SUPABASE_PUBLISHABLE_KEY
+				},
+				body: '{}'
+			}
+		)
+		const body = (await probe.json().catch(() => ({}))) as {
+			code?: string
+			error?: string
+		}
+		// Gateway "function not found" surfaces as code: 'NOT_FOUND'.
+		// Anything else (401 from validateBearerAuth, 400, etc.) means
+		// the function ran.
+		return body.code !== 'NOT_FOUND'
+	} catch {
+		return false
+	}
+}
 
 describe('download-documents-zip Edge Function — owner isolation', () => {
 	let clientA: SupabaseClient
@@ -38,9 +74,19 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 	const uploadedPaths: string[] = []
 	const sentinel = `phase64-isolation-${Date.now()}`
 
+	let suiteDeployed = false
+
 	beforeAll(async () => {
 		if (!SUPABASE_URL) {
 			throw new Error('NEXT_PUBLIC_SUPABASE_URL must be set')
+		}
+		suiteDeployed = await isFunctionDeployed()
+		if (!suiteDeployed) {
+			console.warn(
+				'[download-documents-zip] Edge Function not deployed; skipping suite. ' +
+					'Run `supabase functions deploy download-documents-zip` before merging.'
+			)
+			return
 		}
 		const { ownerA, ownerB } = getTestCredentials()
 		clientA = await createTestClient(ownerA.email, ownerA.password)
@@ -108,6 +154,7 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 	})
 
 	afterAll(async () => {
+		if (!suiteDeployed) return
 		if (uploadedPaths.length > 0) {
 			await clientA.storage
 				.from('tenant-documents')
@@ -123,12 +170,14 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 	})
 
 	it('ownerA can download a zip containing the sentinel doc', async () => {
+		if (!suiteDeployed) return
 		const res = await fetch(
 			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
 			{
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${ownerATokens.access_token}`,
+					apikey: SUPABASE_PUBLISHABLE_KEY!,
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({ query: sentinel })
@@ -148,12 +197,14 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 	})
 
 	it('ownerB filtering by ownerA sentinel receives 404, never 200', async () => {
+		if (!suiteDeployed) return
 		const res = await fetch(
 			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
 			{
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${ownerBTokens.access_token}`,
+					apikey: SUPABASE_PUBLISHABLE_KEY!,
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({ query: sentinel })
@@ -170,11 +221,15 @@ describe('download-documents-zip Edge Function — owner isolation', () => {
 	})
 
 	it('a request without a Bearer token receives 401', async () => {
+		if (!suiteDeployed) return
 		const res = await fetch(
 			`${SUPABASE_URL}/functions/v1/download-documents-zip`,
 			{
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers: {
+					apikey: SUPABASE_PUBLISHABLE_KEY!,
+					'Content-Type': 'application/json'
+				},
 				body: JSON.stringify({ query: sentinel })
 			}
 		)

--- a/tests/integration/rls/download-documents-zip.rls.test.ts
+++ b/tests/integration/rls/download-documents-zip.rls.test.ts
@@ -39,8 +39,12 @@ const SUPABASE_PUBLISHABLE_KEY =
 // function can land in this branch before the prod deployment exists.
 // When the function isn't deployed the Supabase gateway returns a
 // 404 with body `{code: 'NOT_FOUND', ...}`; the function's own 404
-// uses `{error: 'No documents match...'}`. Skip gracefully on the
-// former, run normally on the latter.
+// uses `{error: 'No documents match...'}`.
+//
+// Fail-OPEN policy: ONLY a gateway 404 + `{code: 'NOT_FOUND'}` is treated
+// as "not deployed". Every other outcome (5xx, 429, network error, DNS
+// failure) returns true, so the security-isolation tests run and fail
+// LOUDLY rather than silently skipping behind a transient blip.
 async function isFunctionDeployed(): Promise<boolean> {
 	if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) return false
 	try {
@@ -55,20 +59,18 @@ async function isFunctionDeployed(): Promise<boolean> {
 				body: '{}'
 			}
 		)
-		// Function deployed → 401 (validateBearerAuth, no token) or
-		// 400 (function-level body parse). NOT deployed → gateway 404
-		// with `{code:'NOT_FOUND'}`. Transient gateway 5xx → fail open
-		// (treat as deployed) so the test fails LOUD instead of silently
-		// skipping a security-isolation guard.
 		if (probe.status === 404) {
 			const body = (await probe.json().catch(() => ({}))) as {
 				code?: string
 			}
 			return body.code !== 'NOT_FOUND'
 		}
-		return probe.status === 401 || probe.status === 400 || probe.ok
+		return true
 	} catch {
-		return false
+		// Network unreachable is also treated as fail-open per the policy
+		// above — let the actual test fail with the real error rather
+		// than masking it as a deployment skip.
+		return true
 	}
 }
 


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mFirst v2.6 phase. Closes the v2.5 deferred "bulk download as zip" item.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m- **New Edge Function** `download-documents-zip` — POST endpoint accepting the same filter shape as the vault (`query`, `entityType`, `categories`, `from`, `to`). Re-runs `search_documents` server-side under the caller's JWT (RLS-gated; never trusts client-supplied owner). Hard cap 500 docs (returns 413 "narrow your filter" when exceeded). True streaming via `TransformStream` + `@zip.js/zip.js` `ZipWriter` — only one blob in memory at a time, regardless of match count. Inside the zip: entity-type folders + sanitized original filenames + id-suffix on name collisions.[0m
[38;5;8m   5[0m [37m- **Vault `Download all (N)` button** in the card header. Hidden when no docs match. Disabled with hover-tooltip when `totalCount > 500`. Spinner + "Preparing zip..." while in flight. Uses fetch + URL.createObjectURL + anchor click pattern (matches stripe-billing-portal / generate-pdf consumer pattern).[0m
[38;5;8m   6[0m [37m- **`@zip.js/zip.js@2.7.45`** added to `supabase/functions/deno.json` import map.[0m
[38;5;8m   7[0m [37m- **6 new unit tests** cover: hidden when empty, rendered with count, disabled at 501, fetch invocation with full filter set, error-toast branch, no-session-token branch.[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37m## Test plan[0m
[38;5;8m  10[0m [37m- [x] 7,519 unit tests passing (+6 from bulk-download)[0m
[38;5;8m  11[0m [37m- [x] Typecheck clean[0m
[38;5;8m  12[0m [37m- [x] Lint clean[0m
[38;5;8m  13[0m [37m- [ ] Edge Function smoke test (requires `supabase functions serve` + a real document fixture; defer to post-merge)[0m
[38;5;8m  14[0m [37m- [ ] Manual: 50-doc download in dev, verify zip structure (defer to post-deploy)[0m
[38;5;8m  15[0m 
[38;5;8m  16[0m [37m## Risks (per v2.6 ROADMAP)[0m
[38;5;8m  17[0m [37m- **Streaming zip memory cap**: cycle-1 may need to lower the 500 cap if profiling shows the streaming path can't keep up with the upload-side allocator at higher counts. The TransformStream pattern means "buffer one blob at a time" is enforced by the zip writer's API, but worth verifying.[0m
[38;5;8m  18[0m [37m- **Single missing blob**: handler skips silently rather than aborting. v2 polish: surface "X of N documents downloaded" in the response trailer.[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37m[hudsor01][0m