### PR TITLE
feat(v2.6/phase-65): document_categories table + dynamic taxonomy read path

### DIFF
--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -101,13 +101,13 @@ function list(rows: unknown[], totalCount = rows.length) {
 }
 
 const SEVEN_DEFAULTS = [
-	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-2', slug: 'receipt', label: 'Receipt', sort_order: 20, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-3', slug: 'tax_return', label: 'Tax return', sort_order: 30, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-4', slug: 'inspection_report', label: 'Inspection report', sort_order: 40, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-5', slug: 'maintenance_invoice', label: 'Maintenance invoice', sort_order: 50, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-6', slug: 'insurance', label: 'Insurance', sort_order: 60, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null }
+	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-2', slug: 'receipt', label: 'Receipt', sort_order: 20, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-3', slug: 'tax_return', label: 'Tax return', sort_order: 30, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-4', slug: 'inspection_report', label: 'Inspection report', sort_order: 40, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-5', slug: 'maintenance_invoice', label: 'Maintenance invoice', sort_order: 50, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-6', slug: 'insurance', label: 'Insurance', sort_order: 60, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' }
 ]
 
 describe('DocumentsSection', () => {

--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -17,6 +17,15 @@ const mockToastSuccess = vi.fn()
 const mockToastError = vi.fn()
 const mockToastWarning = vi.fn()
 
+// Phase 65: mock the per-owner taxonomy hook with the seven seeded
+// defaults so existing assertions on category-related rendering keep
+// matching pre-65 behaviour.
+const mockUseDocumentCategories = vi.fn()
+
+vi.mock('#hooks/api/use-document-categories', () => ({
+	useDocumentCategories: () => mockUseDocumentCategories()
+}))
+
 // Shape used by useMutation mock — lets individual tests override
 // `isPending` to exercise the uploading-state branch.
 let uploadPending = false
@@ -91,10 +100,25 @@ function list(rows: unknown[], totalCount = rows.length) {
 	}
 }
 
+const SEVEN_DEFAULTS = [
+	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-2', slug: 'receipt', label: 'Receipt', sort_order: 20, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-3', slug: 'tax_return', label: 'Tax return', sort_order: 30, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-4', slug: 'inspection_report', label: 'Inspection report', sort_order: 40, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-5', slug: 'maintenance_invoice', label: 'Maintenance invoice', sort_order: 50, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-6', slug: 'insurance', label: 'Insurance', sort_order: 60, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null }
+]
+
 describe('DocumentsSection', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		uploadPending = false
+		mockUseDocumentCategories.mockReturnValue({
+			categories: SEVEN_DEFAULTS,
+			isLoading: false,
+			isError: false
+		})
 	})
 
 	it('hides empty-state CTA while the documents query is in flight', () => {

--- a/src/components/documents/__tests__/documents-section.test.tsx
+++ b/src/components/documents/__tests__/documents-section.test.tsx
@@ -309,6 +309,68 @@ describe('DocumentsSection', () => {
 		)
 	})
 
+	// Phase 65 cycle-3 I-1: error fallback + state re-sync.
+	it('falls back to seven default categories when useDocumentCategories has no rows', async () => {
+		// Empty owned set + not loading → fallback to DEFAULT_CATEGORY_LABELS.
+		// Covers both isError:true and isError:false-with-zero-rows (M-3).
+		mockUseDocumentCategories.mockReturnValue({
+			categories: [],
+			isLoading: false,
+			isError: true
+		})
+		mockUseQuery.mockReturnValue(emptyList())
+		mockUploadMutate.mockResolvedValue({})
+		const user = userEvent.setup()
+		renderSection()
+		// Open the Radix Select; assert all seven default labels rendered.
+		const trigger = screen.getByLabelText(/category for next upload/i)
+		await user.click(trigger)
+		for (const label of [
+			'Lease',
+			'Receipt',
+			'Tax return',
+			'Inspection report',
+			'Maintenance invoice',
+			'Insurance',
+			'Other'
+		]) {
+			expect(
+				await screen.findByRole('option', { name: new RegExp(`^${label}$`, 'i') })
+			).toBeInTheDocument()
+		}
+	})
+
+	it('re-syncs the upload category if the loaded set excludes the current value', async () => {
+		// Initial render: hook returns SEVEN_DEFAULTS (which includes 'other'),
+		// upload submits with 'other'. Then re-render with hook returning a
+		// reduced set that excludes 'other'; useEffect should re-sync to the
+		// first available slug.
+		const reducedSet = SEVEN_DEFAULTS.filter(c => c.slug !== 'other')
+		mockUseDocumentCategories.mockReturnValue({
+			categories: reducedSet,
+			isLoading: false,
+			isError: false
+		})
+		mockUseQuery.mockReturnValue(emptyList())
+		mockUploadMutate.mockResolvedValue({})
+		renderSection()
+
+		const input = document.querySelector(
+			'input[type="file"]'
+		) as HTMLInputElement
+		const file = new File(['fake pdf'], 'resync.pdf', {
+			type: 'application/pdf'
+		})
+		fireEvent.change(input, { target: { files: [file] } })
+		await waitFor(() => {
+			expect(mockUploadMutate).toHaveBeenCalledTimes(1)
+		})
+		// reducedSet's first slug is 'lease' — useEffect re-synced category.
+		expect(mockUploadMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ category: 'lease' })
+		)
+	})
+
 	it('renders an error state with Try again button when the query errors', () => {
 		mockUseQuery.mockReturnValue({
 			data: undefined,

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -34,13 +34,13 @@ vi.mock('#hooks/api/use-document-categories', () => ({
 }))
 
 const SEVEN_DEFAULTS = [
-	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-2', slug: 'receipt', label: 'Receipt', sort_order: 20, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-3', slug: 'tax_return', label: 'Tax return', sort_order: 30, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-4', slug: 'inspection_report', label: 'Inspection report', sort_order: 40, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-5', slug: 'maintenance_invoice', label: 'Maintenance invoice', sort_order: 50, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-6', slug: 'insurance', label: 'Insurance', sort_order: 60, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
-	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null }
+	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-2', slug: 'receipt', label: 'Receipt', sort_order: 20, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-3', slug: 'tax_return', label: 'Tax return', sort_order: 30, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-4', slug: 'inspection_report', label: 'Inspection report', sort_order: 40, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-5', slug: 'maintenance_invoice', label: 'Maintenance invoice', sort_order: 50, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-6', slug: 'insurance', label: 'Insurance', sort_order: 60, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' }
 ]
 
 vi.mock('sonner', () => ({
@@ -570,6 +570,49 @@ describe('DocumentsVaultClient', () => {
 		})
 		renderVault()
 		expect(mockSetEntityParam).toHaveBeenCalledWith(null)
+	})
+
+	// Phase 65 cycle-1 I-3: while the categories hook is loading, the URL
+	// guard MUST NOT scrub `?categories=…` slugs even if they look unknown.
+	// Otherwise a user landing on a deeplink would see their filter cleared
+	// before the per-owner taxonomy resolves.
+	it('does NOT scrub URL category slugs while useDocumentCategories is loading', () => {
+		mockUseDocumentCategories.mockReturnValue({
+			categories: [],
+			isLoading: true,
+			isError: false
+		})
+		categoriesParamValue = ['lease', 'banana_unknown']
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		renderVault()
+		expect(mockSetCategoriesParam).not.toHaveBeenCalled()
+	})
+
+	// Phase 65 cycle-1 I-3 companion: once the hook lands with a known
+	// owned set that DOESN'T include the URL slug, the scrub effect fires.
+	it('scrubs unknown URL category slugs once owned set has loaded', async () => {
+		mockUseDocumentCategories.mockReturnValue({
+			categories: SEVEN_DEFAULTS,
+			isLoading: false,
+			isError: false
+		})
+		categoriesParamValue = ['lease', 'banana_unknown']
+		mockUseQuery.mockReturnValue({
+			data: { rows: [], totalCount: 0, page: 0, pageSize: 50 },
+			isLoading: false,
+			isFetching: false,
+			isError: false
+		})
+		renderVault()
+		// useEffect runs after render; waitFor lets the scrub commit.
+		await waitFor(() => {
+			expect(mockSetCategoriesParam).toHaveBeenCalledWith(['lease'])
+		})
 	})
 
 	// Phase 64: bulk download as zip

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -24,6 +24,25 @@ vi.mock('#lib/supabase/client', () => ({
 	})
 }))
 
+// Phase 65: vault filter Select reads categories from the per-owner
+// taxonomy hook. Mock with the seven seeded defaults so existing
+// assertions on category-related rendering keep matching pre-65
+// behaviour.
+const mockUseDocumentCategories = vi.fn()
+vi.mock('#hooks/api/use-document-categories', () => ({
+	useDocumentCategories: () => mockUseDocumentCategories()
+}))
+
+const SEVEN_DEFAULTS = [
+	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-2', slug: 'receipt', label: 'Receipt', sort_order: 20, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-3', slug: 'tax_return', label: 'Tax return', sort_order: 30, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-4', slug: 'inspection_report', label: 'Inspection report', sort_order: 40, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-5', slug: 'maintenance_invoice', label: 'Maintenance invoice', sort_order: 50, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-6', slug: 'insurance', label: 'Insurance', sort_order: 60, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null },
+	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: null, updated_at: null }
+]
+
 vi.mock('sonner', () => ({
 	toast: {
 		error: (...args: unknown[]) => mockToastError(...args),
@@ -91,6 +110,11 @@ describe('DocumentsVaultClient', () => {
 		pageParamValue = 0
 		mockGetSession.mockResolvedValue({
 			data: { session: { access_token: 'test-token' } }
+		})
+		mockUseDocumentCategories.mockReturnValue({
+			categories: SEVEN_DEFAULTS,
+			isLoading: false,
+			isError: false
 		})
 	})
 

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -24,11 +24,8 @@ import {
 	type DocumentEntityType,
 	type DocumentRow as DocumentRowData
 } from '#hooks/api/query-keys/document-keys'
-import {
-	DOCUMENT_CATEGORIES,
-	DOCUMENT_CATEGORY_LABELS,
-	type DocumentCategory
-} from '#lib/validation/documents'
+import { type DocumentCategory } from '#lib/validation/documents'
+import { useDocumentCategories } from '#hooks/api/use-document-categories'
 import { ownerDashboardKeys } from '#hooks/api/use-owner-dashboard'
 import { AlertTriangle, FileText, Loader2, Plus } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
@@ -63,10 +60,14 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 	const [deletingIds, setDeletingIds] = useState<Set<string>>(() => new Set())
 	// One category per upload batch. Multi-file uploads share the choice;
 	// per-file categorization would force a dialog roundtrip we want to
-	// avoid. Defaults to 'other' — matches the column-level default added
-	// in migration 20260425172604 so the per-file flow and any direct
-	// PostgREST insert produce the same row.
+	// avoid. Defaults to 'other' — every owner is seeded with `other` at
+	// signup (Phase 65 migration) so this is always a valid slug.
 	const [category, setCategory] = useState<DocumentCategory>('other')
+	// Phase 65: Select options come from the per-owner taxonomy.
+	const {
+		categories: ownedCategories,
+		isLoading: categoriesLoading
+	} = useDocumentCategories()
 
 	const {
 		data: listResult,
@@ -183,19 +184,19 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 					<Select
 						value={category}
 						onValueChange={value => setCategory(value as DocumentCategory)}
-						disabled={isUploading}
+						disabled={isUploading || categoriesLoading}
 					>
 						<SelectTrigger
 							size="sm"
 							className="w-[180px]"
 							aria-label="Category for next upload"
 						>
-							<SelectValue />
+							<SelectValue placeholder={categoriesLoading ? 'Loading…' : undefined} />
 						</SelectTrigger>
 						<SelectContent>
-							{DOCUMENT_CATEGORIES.map(value => (
-								<SelectItem key={value} value={value}>
-									{DOCUMENT_CATEGORY_LABELS[value]}
+							{ownedCategories.map(c => (
+								<SelectItem key={c.id} value={c.slug}>
+									{c.label}
 								</SelectItem>
 							))}
 						</SelectContent>

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -24,11 +24,15 @@ import {
 	type DocumentEntityType,
 	type DocumentRow as DocumentRowData
 } from '#hooks/api/query-keys/document-keys'
-import { type DocumentCategory } from '#lib/validation/documents'
+import {
+	DEFAULT_CATEGORY_LABELS,
+	DEFAULT_CATEGORY_SLUGS,
+	type DocumentCategory
+} from '#lib/validation/documents'
 import { useDocumentCategories } from '#hooks/api/use-document-categories'
 import { ownerDashboardKeys } from '#hooks/api/use-owner-dashboard'
 import { AlertTriangle, FileText, Loader2, Plus } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DocumentRow } from './document-row'
 import {
@@ -61,13 +65,43 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 	// One category per upload batch. Multi-file uploads share the choice;
 	// per-file categorization would force a dialog roundtrip we want to
 	// avoid. Defaults to 'other' — every owner is seeded with `other` at
-	// signup (Phase 65 migration) so this is always a valid slug.
+	// signup (Phase 65 migration) so this is always a valid slug at
+	// first render. The effect below re-syncs if the user has somehow
+	// removed `other` from their taxonomy by the time the categories
+	// query lands (Phase 66+ once delete is exposed).
 	const [category, setCategory] = useState<DocumentCategory>('other')
-	// Phase 65: Select options come from the per-owner taxonomy.
+	// Phase 65: Select options come from the per-owner taxonomy. On
+	// query error, fall back to the seven seeded defaults so the upload
+	// flow keeps working — those slugs are the migration-guaranteed
+	// floor of every owner's category set.
 	const {
 		categories: ownedCategories,
-		isLoading: categoriesLoading
+		isLoading: categoriesLoading,
+		isError: categoriesError
 	} = useDocumentCategories()
+	const selectOptions = useMemo(() => {
+		if (categoriesError && ownedCategories.length === 0) {
+			return DEFAULT_CATEGORY_SLUGS.map(slug => ({
+				slug,
+				label: DEFAULT_CATEGORY_LABELS[slug],
+				key: slug
+			}))
+		}
+		return ownedCategories.map(c => ({
+			slug: c.slug,
+			label: c.label,
+			key: c.id
+		}))
+	}, [ownedCategories, categoriesError])
+	// Re-sync `category` if the loaded set doesn't include the current
+	// state value. Prevents the form from submitting an orphaned slug
+	// (which would 23514 at the trigger boundary).
+	useEffect(() => {
+		if (selectOptions.length === 0) return
+		if (selectOptions.some(o => o.slug === category)) return
+		const fallback = selectOptions[0]?.slug
+		if (fallback) setCategory(fallback)
+	}, [selectOptions, category])
 
 	const {
 		data: listResult,
@@ -194,9 +228,9 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 							<SelectValue placeholder={categoriesLoading ? 'Loading…' : undefined} />
 						</SelectTrigger>
 						<SelectContent>
-							{ownedCategories.map(c => (
-								<SelectItem key={c.id} value={c.slug}>
-									{c.label}
+							{selectOptions.map(o => (
+								<SelectItem key={o.key} value={o.slug}>
+									{o.label}
 								</SelectItem>
 							))}
 						</SelectContent>

--- a/src/components/documents/documents-section.tsx
+++ b/src/components/documents/documents-section.tsx
@@ -76,11 +76,17 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 	// floor of every owner's category set.
 	const {
 		categories: ownedCategories,
-		isLoading: categoriesLoading,
-		isError: categoriesError
+		isLoading: categoriesLoading
 	} = useDocumentCategories()
 	const selectOptions = useMemo(() => {
-		if (categoriesError && ownedCategories.length === 0) {
+		// Fall back to the seven seeded defaults whenever the owned set
+		// is empty AND we're not still loading. Covers BOTH the explicit
+		// error case (network failure, 5xx) AND the empty-success edge
+		// case (transient zero-row response, or — once Phase 66 ships —
+		// a user mid-deletion who removed every category). The fallback
+		// keeps the upload Select usable; the trigger will reject any
+		// slug that isn't in the user's actual taxonomy at write time.
+		if (!categoriesLoading && ownedCategories.length === 0) {
 			return DEFAULT_CATEGORY_SLUGS.map(slug => ({
 				slug,
 				label: DEFAULT_CATEGORY_LABELS[slug],
@@ -92,7 +98,7 @@ export function DocumentsSection({ entityType, entityId }: DocumentsSectionProps
 			label: c.label,
 			key: c.id
 		}))
-	}, [ownedCategories, categoriesError])
+	}, [ownedCategories, categoriesLoading])
 	// Re-sync `category` if the loaded set doesn't include the current
 	// state value. Prevents the form from submitting an orphaned slug
 	// (which would 23514 at the trigger boundary).

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -36,11 +36,8 @@ import {
 	expandDateBoundary,
 	SEARCH_PAGE_SIZE
 } from '#hooks/api/query-keys/document-search-keys'
-import {
-	DOCUMENT_CATEGORIES,
-	DOCUMENT_CATEGORY_LABELS,
-	type DocumentCategory
-} from '#lib/validation/documents'
+import { type DocumentCategory } from '#lib/validation/documents'
+import { useDocumentCategories } from '#hooks/api/use-document-categories'
 import { DocumentRow } from './document-row'
 import { createClient } from '#lib/supabase/client'
 import { toast } from 'sonner'
@@ -77,12 +74,10 @@ if ((DOCUMENT_ENTITY_TYPES as readonly string[]).includes(ANY_ENTITY)) {
 	)
 }
 
-// Phase 63: category filter is now multi-select via ?categories=lease,insurance.
-// No sentinel needed — empty array is the canonical "no filter" state.
-const CATEGORY_OPTIONS = DOCUMENT_CATEGORIES.map(value => ({
-	value,
-	label: DOCUMENT_CATEGORY_LABELS[value]
-}))
+// Phase 65: category filter options now come from the per-owner
+// `document_categories` table via `useDocumentCategories`. The static
+// CATEGORY_OPTIONS constant is gone — see the in-component
+// `categoryOptions` derived from the hook's data.
 
 // Parse a YYYY-MM-DD URL value into a local-zone Date (midnight local).
 // Returns undefined on malformed input. Critically uses local-component
@@ -192,13 +187,35 @@ export function DocumentsVaultClient() {
 	// so `useMemo([categoriesParam])` would re-run the filter on every
 	// render. Joining the array gives a stable string identity — same
 	// content, same key, no wasted work.
+	const {
+		categories: ownedCategories,
+		isLoading: categoriesLoading
+	} = useDocumentCategories()
+	const categoryOptions = useMemo(
+		() =>
+			ownedCategories.map(c => ({
+				value: c.slug,
+				label: c.label
+			})),
+		[ownedCategories]
+	)
+	const ownedSlugSet = useMemo(
+		() => new Set(ownedCategories.map(c => c.slug)),
+		[ownedCategories]
+	)
+	const ownedSlugKey = Array.from(ownedSlugSet).sort().join(',')
 	const categoriesKey = categoriesParam.join(',')
 	const categories = useMemo<DocumentCategory[]>(() => {
-		const set = new Set(categoriesKey.split(',').filter(Boolean))
-		return (DOCUMENT_CATEGORIES as readonly string[]).filter(c =>
-			set.has(c)
-		) as DocumentCategory[]
-	}, [categoriesKey])
+		// Don't scrub URL slugs while categories are still loading — we'd
+		// false-reject every value and clear the user's filter on first
+		// render. Treat empty owned-set as "pass through" until the hook
+		// settles.
+		if (ownedSlugKey.length === 0) {
+			return categoriesKey.split(',').filter(Boolean) as DocumentCategory[]
+		}
+		const requested = new Set(categoriesKey.split(',').filter(Boolean))
+		return Array.from(requested).filter(c => ownedSlugSet.has(c))
+	}, [categoriesKey, ownedSlugSet, ownedSlugKey])
 
 	// Phase 63: date-range. Parse the URL YYYY-MM-DD into a local-zone
 	// Date for the picker. The factory expands these to local-zone
@@ -407,14 +424,17 @@ export function DocumentsVaultClient() {
 							</SelectContent>
 						</Select>
 						<MultiSelectChips<DocumentCategory>
-							options={CATEGORY_OPTIONS}
+							options={categoryOptions}
 							value={categories}
 							onChange={next => {
 								void setCategoriesParam(next.length > 0 ? next : null)
 								void setPageParam(null)
 							}}
-							placeholder="All categories"
+							placeholder={
+								categoriesLoading ? 'Loading…' : 'All categories'
+							}
 							aria-label="Filter by category"
+							disabled={categoriesLoading}
 						/>
 						<DateRangePicker
 							value={{ from: fromDate, to: toDate }}

--- a/src/components/shared/multi-select-chips.tsx
+++ b/src/components/shared/multi-select-chips.tsx
@@ -29,8 +29,12 @@ export interface MultiSelectChipsProps<T extends string> {
  * or removes that value from the array. Used by the documents vault for
  * the multi-select category filter (Phase 63).
  *
- * Generic over the value type so callers preserve their own union (e.g.
- * `DocumentCategory`) instead of widening to `string`.
+ * Generic over the value type — `T extends string` lets callers narrow
+ * to their own slug type even when the underlying alias is `string`
+ * (e.g. `DocumentCategory` post-Phase-65 is a structural alias for
+ * `string`, but `MultiSelectChips<DocumentCategory>` still propagates
+ * `T` through `value`/`onChange` so swapping in a different slug type
+ * later catches mismatches at the call site).
  */
 export function MultiSelectChips<T extends string>({
 	options,
@@ -114,7 +118,7 @@ export function MultiSelectChips<T extends string>({
 							size="sm"
 							className="h-7 px-2 text-xs"
 							onClick={() => onChange([])}
-							disabled={selected.size === 0}
+							disabled={disabled || selected.size === 0}
 						>
 							Clear
 						</Button>
@@ -124,6 +128,7 @@ export function MultiSelectChips<T extends string>({
 							size="sm"
 							className="h-7 px-2 text-xs"
 							onClick={() => setOpen(false)}
+							disabled={disabled}
 						>
 							Done
 						</Button>

--- a/src/components/shared/multi-select-chips.tsx
+++ b/src/components/shared/multi-select-chips.tsx
@@ -19,6 +19,8 @@ export interface MultiSelectChipsProps<T extends string> {
 	placeholder?: string
 	'aria-label'?: string
 	className?: string
+	/** Disables the trigger and the clear-x button. Used while option list is loading. */
+	disabled?: boolean
 }
 
 /**
@@ -36,7 +38,8 @@ export function MultiSelectChips<T extends string>({
 	onChange,
 	placeholder = 'Any',
 	'aria-label': ariaLabel,
-	className
+	className,
+	disabled = false
 }: MultiSelectChipsProps<T>) {
 	const [open, setOpen] = useState(false)
 	const selected = new Set(value)
@@ -70,6 +73,7 @@ export function MultiSelectChips<T extends string>({
 							selected.size === 0 && 'text-muted-foreground'
 						)}
 						aria-label={ariaLabel}
+						disabled={disabled}
 					>
 						<span className="truncate">{summary}</span>
 						<ChevronDown className="ml-2 size-4 shrink-0 opacity-50" aria-hidden="true" />
@@ -133,6 +137,7 @@ export function MultiSelectChips<T extends string>({
 					className="size-9 p-0"
 					onClick={() => onChange([])}
 					aria-label="Clear selection"
+					disabled={disabled}
 				>
 					<X className="size-4" aria-hidden="true" />
 				</Button>

--- a/src/hooks/api/query-keys/document-category-keys.test.ts
+++ b/src/hooks/api/query-keys/document-category-keys.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for `mapDocumentCategoryRow` — the typed PostgREST→
+ * DocumentCategoryRow boundary mapper introduced in v2.6 Phase 65.
+ *
+ * Mirrors the shape of `document-keys.test.ts`'s `mapDocumentRow`
+ * tests so a future column drop / type drift in the
+ * `document_categories` SELECT shows up as a loud throw at the
+ * mapper boundary rather than as silent string-"undefined" rendering
+ * downstream.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mapDocumentCategoryRow } from './document-category-keys'
+
+const fullRow = {
+	id: '00000000-0000-0000-0000-000000000001',
+	slug: 'lease',
+	label: 'Lease',
+	sort_order: 10,
+	is_default: true,
+	owner_user_id: '00000000-0000-0000-0000-000000000002',
+	created_at: '2026-04-26T00:00:00Z',
+	updated_at: '2026-04-26T00:00:00Z'
+}
+
+describe('mapDocumentCategoryRow', () => {
+	it('passes a fully-populated row through unchanged', () => {
+		const mapped = mapDocumentCategoryRow(fullRow)
+		expect(mapped).toEqual(fullRow)
+	})
+
+	it('passes custom slugs through (Phase 65: any lowercase-snake_case)', () => {
+		const mapped = mapDocumentCategoryRow({
+			...fullRow,
+			slug: 'home_office_2024',
+			label: 'Home office 2024',
+			is_default: false
+		})
+		expect(mapped.slug).toBe('home_office_2024')
+		expect(mapped.is_default).toBe(false)
+	})
+
+	it('throws when a NOT NULL string field is missing', () => {
+		for (const field of [
+			'id',
+			'slug',
+			'label',
+			'owner_user_id',
+			'created_at',
+			'updated_at'
+		] as const) {
+			const broken = { ...fullRow, [field]: undefined }
+			expect(
+				() => mapDocumentCategoryRow(broken),
+				`expected throw when ${field} is missing`
+			).toThrowError(new RegExp(`'${field}'`))
+		}
+	})
+
+	it('throws when sort_order is missing or non-number', () => {
+		expect(() =>
+			mapDocumentCategoryRow({ ...fullRow, sort_order: undefined })
+		).toThrowError(/'sort_order'/)
+		expect(() =>
+			mapDocumentCategoryRow({ ...fullRow, sort_order: '10' })
+		).toThrowError(/'sort_order'/)
+	})
+
+	it('throws when is_default is missing or non-boolean', () => {
+		expect(() =>
+			mapDocumentCategoryRow({ ...fullRow, is_default: undefined })
+		).toThrowError(/'is_default'/)
+		expect(() =>
+			mapDocumentCategoryRow({ ...fullRow, is_default: 'true' })
+		).toThrowError(/'is_default'/)
+	})
+
+	it('throws when slug fails the format regex (defense-in-depth)', () => {
+		// The DB CHECK constraint on document_categories.slug already
+		// enforces this, but the mapper re-validates so a future schema
+		// drift (CHECK relaxed, regex broadened) doesn't silently pass
+		// malformed values through to React keys / URL state.
+		for (const slug of [
+			'UPPERCASE',
+			'has space',
+			'has-dash',
+			'',
+			'a'.repeat(51)
+		]) {
+			expect(
+				() => mapDocumentCategoryRow({ ...fullRow, slug }),
+				`expected throw when slug='${slug}'`
+			).toThrowError(/malformed slug/)
+		}
+	})
+})

--- a/src/hooks/api/query-keys/document-category-keys.ts
+++ b/src/hooks/api/query-keys/document-category-keys.ts
@@ -1,0 +1,113 @@
+/**
+ * Document Categories Query Keys (v2.6 Phase 65).
+ *
+ * Wraps the `document_categories` table — per-owner taxonomy that
+ * replaced the compile-time DOCUMENT_CATEGORIES tuple. Existing
+ * users were seeded with the seven v2.5 defaults at migration time;
+ * new users get them via the `seed_default_categories_on_user_insert`
+ * trigger.
+ *
+ * Categories change rarely (only when an owner adds/renames/deletes
+ * via Phase 66's settings UI), so a 5-minute staleTime is plenty.
+ */
+
+import { queryOptions } from '@tanstack/react-query'
+import { createClient } from '#lib/supabase/client'
+import { handlePostgrestError } from '#lib/postgrest-error-handler'
+import { documentCategorySlugSchema } from '#lib/validation/documents'
+
+const LIST_STALE_TIME_MS = 5 * 60 * 1000 // 5 min — categories change rarely
+const LIST_GC_TIME_MS = 30 * 60 * 1000
+
+export interface DocumentCategoryRow {
+	id: string
+	slug: string
+	label: string
+	sort_order: number
+	is_default: boolean
+	owner_user_id: string
+	created_at: string | null
+	updated_at: string | null
+}
+
+/**
+ * Maps a PostgREST row into the strictly-typed `DocumentCategoryRow`.
+ * Rejects rows whose slug doesn't match the format constraint (a
+ * defense against future schema drift; the DB already enforces this
+ * at the CHECK constraint level). NOT NULL fields throw if absent.
+ */
+export function mapDocumentCategoryRow(
+	raw: Record<string, unknown>
+): DocumentCategoryRow {
+	function requireString(field: string): string {
+		const value = raw[field]
+		if (typeof value !== 'string') {
+			throw new Error(
+				`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-string from PostgREST response`
+			)
+		}
+		return value
+	}
+	function requireBool(field: string): boolean {
+		const value = raw[field]
+		if (typeof value !== 'boolean') {
+			throw new Error(
+				`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-boolean from PostgREST response`
+			)
+		}
+		return value
+	}
+	function requireNumber(field: string): number {
+		const value = raw[field]
+		if (typeof value !== 'number') {
+			throw new Error(
+				`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-number from PostgREST response`
+			)
+		}
+		return value
+	}
+	const slug = requireString('slug')
+	const slugCheck = documentCategorySlugSchema.safeParse(slug)
+	if (!slugCheck.success) {
+		throw new Error(
+			`mapDocumentCategoryRow: row '${requireString('id')}' has malformed slug '${slug}'`
+		)
+	}
+	return {
+		id: requireString('id'),
+		slug,
+		label: requireString('label'),
+		sort_order: requireNumber('sort_order'),
+		is_default: requireBool('is_default'),
+		owner_user_id: requireString('owner_user_id'),
+		created_at: (raw.created_at as string | null) ?? null,
+		updated_at: (raw.updated_at as string | null) ?? null
+	}
+}
+
+export const documentCategoryQueries = {
+	all: () =>
+		queryOptions({
+			queryKey: ['documentCategories'] as const
+		}),
+	list: () =>
+		queryOptions({
+			queryKey: ['documentCategories', 'list'] as const,
+			queryFn: async (): Promise<DocumentCategoryRow[]> => {
+				const supabase = createClient()
+				const { data, error } = await supabase
+					.from('document_categories')
+					.select(
+						'id, slug, label, sort_order, is_default, owner_user_id, created_at, updated_at'
+					)
+					.order('sort_order', { ascending: true })
+					.order('label', { ascending: true })
+				if (error) handlePostgrestError(error, 'document categories list')
+				return ((data ?? []) as Record<string, unknown>[]).map(
+					mapDocumentCategoryRow
+				)
+			},
+			staleTime: LIST_STALE_TIME_MS,
+			gcTime: LIST_GC_TIME_MS
+		})
+} as const

--- a/src/hooks/api/query-keys/document-category-keys.ts
+++ b/src/hooks/api/query-keys/document-category-keys.ts
@@ -94,10 +94,11 @@ export function mapDocumentCategoryRow(
 }
 
 export const documentCategoryQueries = {
-	all: () =>
-		queryOptions({
-			queryKey: ['documentCategories'] as const
-		}),
+	// Bare-tuple shape matches sibling factories (propertyQueries.all,
+	// tenantQueries.all, etc.) so consumers can do
+	// `invalidateQueries({ queryKey: documentCategoryQueries.all() })`
+	// without unwrapping `.queryKey`.
+	all: () => ['documentCategories'] as const,
 	list: () =>
 		queryOptions({
 			queryKey: ['documentCategories', 'list'] as const,

--- a/src/hooks/api/query-keys/document-category-keys.ts
+++ b/src/hooks/api/query-keys/document-category-keys.ts
@@ -26,8 +26,43 @@ export interface DocumentCategoryRow {
 	sort_order: number
 	is_default: boolean
 	owner_user_id: string
-	created_at: string | null
-	updated_at: string | null
+	// Both timestamps are NOT NULL (DEFAULT now() + set_updated_at trigger).
+	// Typed as string here to surface schema drift if a future migration
+	// makes them legitimately nullable.
+	created_at: string
+	updated_at: string
+}
+
+// Module-level helpers — hoisted so they're not recreated per call.
+function requireString(
+	raw: Record<string, unknown>,
+	field: string
+): string {
+	const value = raw[field]
+	if (typeof value !== 'string') {
+		throw new Error(
+			`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-string from PostgREST response`
+		)
+	}
+	return value
+}
+function requireBool(raw: Record<string, unknown>, field: string): boolean {
+	const value = raw[field]
+	if (typeof value !== 'boolean') {
+		throw new Error(
+			`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-boolean from PostgREST response`
+		)
+	}
+	return value
+}
+function requireNumber(raw: Record<string, unknown>, field: string): number {
+	const value = raw[field]
+	if (typeof value !== 'number') {
+		throw new Error(
+			`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-number from PostgREST response`
+		)
+	}
+	return value
 }
 
 /**
@@ -39,49 +74,22 @@ export interface DocumentCategoryRow {
 export function mapDocumentCategoryRow(
 	raw: Record<string, unknown>
 ): DocumentCategoryRow {
-	function requireString(field: string): string {
-		const value = raw[field]
-		if (typeof value !== 'string') {
-			throw new Error(
-				`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-string from PostgREST response`
-			)
-		}
-		return value
-	}
-	function requireBool(field: string): boolean {
-		const value = raw[field]
-		if (typeof value !== 'boolean') {
-			throw new Error(
-				`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-boolean from PostgREST response`
-			)
-		}
-		return value
-	}
-	function requireNumber(field: string): number {
-		const value = raw[field]
-		if (typeof value !== 'number') {
-			throw new Error(
-				`mapDocumentCategoryRow: NOT NULL field '${field}' missing or non-number from PostgREST response`
-			)
-		}
-		return value
-	}
-	const slug = requireString('slug')
+	const slug = requireString(raw, 'slug')
 	const slugCheck = documentCategorySlugSchema.safeParse(slug)
 	if (!slugCheck.success) {
 		throw new Error(
-			`mapDocumentCategoryRow: row '${requireString('id')}' has malformed slug '${slug}'`
+			`mapDocumentCategoryRow: row '${requireString(raw, 'id')}' has malformed slug '${slug}'`
 		)
 	}
 	return {
-		id: requireString('id'),
+		id: requireString(raw, 'id'),
 		slug,
-		label: requireString('label'),
-		sort_order: requireNumber('sort_order'),
-		is_default: requireBool('is_default'),
-		owner_user_id: requireString('owner_user_id'),
-		created_at: (raw.created_at as string | null) ?? null,
-		updated_at: (raw.updated_at as string | null) ?? null
+		label: requireString(raw, 'label'),
+		sort_order: requireNumber(raw, 'sort_order'),
+		is_default: requireBool(raw, 'is_default'),
+		owner_user_id: requireString(raw, 'owner_user_id'),
+		created_at: requireString(raw, 'created_at'),
+		updated_at: requireString(raw, 'updated_at')
 	}
 }
 

--- a/src/hooks/api/query-keys/document-keys.test.ts
+++ b/src/hooks/api/query-keys/document-keys.test.ts
@@ -1,11 +1,15 @@
 /**
  * Unit tests for `mapDocumentRow` — the typed PostgREST→DocumentRow
- * boundary mapper introduced in PR #636 cycle-2 (P2-1).
+ * boundary mapper.
  *
- * Pins three behaviours the cycle-3 audit raised:
- *   (a) Valid taxonomy values pass through unchanged.
- *   (b) Out-of-band `document_type` degrades to `'other'` rather than
- *       poisoning downstream Record<DocumentCategory, ...> lookups.
+ * v2.6 Phase 65 changed `document_type` from a CHECK-enum column to a
+ * soft FK against `document_categories.slug`. The mapper no longer
+ * clamps to a closed enum — it trusts whatever slug the DB returns
+ * (the BEFORE-INSERT trigger already validated it at write time).
+ *
+ * Pins:
+ *   (a) Valid slugs pass through unchanged.
+ *   (b) Custom slugs (Phase 65: arbitrary lowercase-snake_case) pass through.
  *   (c) Missing NOT NULL fields throw with a descriptive message
  *       rather than silently producing the literal string "undefined".
  */
@@ -39,17 +43,22 @@ describe('mapDocumentRow', () => {
 		expect(mapped.description).toBeNull()
 	})
 
-	it('degrades an out-of-band document_type to "other" (cycle-3 boundary defense)', () => {
+	it('passes through custom slugs (Phase 65: any lowercase-snake_case)', () => {
+		// Pre-Phase-65 this would have degraded to 'other'. Now slugs are
+		// per-owner via the document_categories table; the trigger gates
+		// at write time, so any slug coming OUT of PostgREST is by
+		// definition one the owner has in their taxonomy.
 		const mapped = mapDocumentRow({ ...fullRow, document_type: 'warranty' })
-		expect(mapped.document_type).toBe('other')
+		expect(mapped.document_type).toBe('warranty')
 	})
 
-	it('degrades a null document_type to "other"', () => {
-		const mapped = mapDocumentRow({ ...fullRow, document_type: null })
-		expect(mapped.document_type).toBe('other')
+	it('throws when document_type is null (column is NOT NULL since Phase 61)', () => {
+		expect(() => mapDocumentRow({ ...fullRow, document_type: null })).toThrowError(
+			/'document_type'/
+		)
 	})
 
-	it('throws when a NOT NULL field is missing from the PostgREST response (cycle-3 NIT-1)', () => {
+	it('throws when a NOT NULL field is missing from the PostgREST response', () => {
 		// Drop `id` — a future hand-edited `.select(...)` typo is the
 		// realistic regression scenario this guards against.
 		const { id: _id, ...withoutId } = fullRow
@@ -63,6 +72,7 @@ describe('mapDocumentRow', () => {
 		for (const field of [
 			'entity_type',
 			'entity_id',
+			'document_type',
 			'file_path',
 			'storage_url'
 		] as const) {

--- a/src/hooks/api/query-keys/document-keys.ts
+++ b/src/hooks/api/query-keys/document-keys.ts
@@ -23,10 +23,7 @@ import { handlePostgrestError } from '#lib/postgrest-error-handler'
 import { requireOwnerUserId } from '#lib/require-owner-user-id'
 import { createLogger } from '#lib/frontend-logger'
 import { mutationKeys } from '../mutation-keys'
-import {
-	documentCategorySchema,
-	type DocumentCategory
-} from '#lib/validation/documents'
+import { type DocumentCategory } from '#lib/validation/documents'
 
 const SIGNED_URL_TTL_SECONDS = 3600
 // Refetch the list (and its signed URLs) well before the 1h TTL expires.
@@ -94,10 +91,14 @@ export interface DocumentListResult {
 /**
  * Maps a PostgREST row (untyped at the TS level — Supabase returns
  * `document_type: string`) into the strictly-typed `DocumentRow`.
- * `document_type` is validated via the Zod enum so an out-of-band
- * value (corruption, dropped CHECK constraint, mid-migration replay)
- * degrades to `'other'` rather than poisoning downstream
- * `Record<DocumentCategory, ...>` lookups.
+ *
+ * Phase 65 changed `document_type` from a CHECK-enum column to a soft
+ * FK against `document_categories.slug`. Validation now lives in a
+ * BEFORE-INSERT/UPDATE trigger (`validate_document_category`), not at
+ * the application boundary. This mapper trusts whatever slug the DB
+ * returns — there's no compile-time enum to clamp against, and the
+ * trigger guarantees the slug existed in the owner's category set at
+ * write time.
  *
  * NOT NULL fields throw if absent — the boundary should surface a
  * dropped column in `.select(...)` immediately rather than silently
@@ -129,10 +130,7 @@ export function mapDocumentRow(
 		return value
 	}
 
-	const parsedCategory = documentCategorySchema.safeParse(raw.document_type)
-	const document_type: DocumentCategory = parsedCategory.success
-		? parsedCategory.data
-		: 'other'
+	const document_type: DocumentCategory = requireString('document_type')
 	return {
 		id: requireString('id'),
 		entity_type: requireString('entity_type'),

--- a/src/hooks/api/use-document-categories.ts
+++ b/src/hooks/api/use-document-categories.ts
@@ -1,0 +1,29 @@
+/**
+ * v2.6 Phase 65: per-owner document taxonomy hook.
+ *
+ * Reads from the `document_categories` table (RLS-scoped to the
+ * current authenticated user). Returns the seven defaults seeded at
+ * signup plus any custom categories the owner adds via Phase 66's
+ * settings UI. 5-min staleTime — categories change rarely.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import {
+	documentCategoryQueries,
+	type DocumentCategoryRow
+} from '#hooks/api/query-keys/document-category-keys'
+
+export function useDocumentCategories(): {
+	categories: DocumentCategoryRow[]
+	isLoading: boolean
+	isError: boolean
+} {
+	const { data, isLoading, isError } = useQuery(
+		documentCategoryQueries.list()
+	)
+	return {
+		categories: data ?? [],
+		isLoading,
+		isError
+	}
+}

--- a/src/lib/validation/__tests__/documents.test.ts
+++ b/src/lib/validation/__tests__/documents.test.ts
@@ -1,37 +1,45 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import {
-	DOCUMENT_CATEGORIES,
-	DOCUMENT_CATEGORY_LABELS,
-	documentCategorySchema
+	DEFAULT_CATEGORY_SLUGS,
+	DEFAULT_CATEGORY_LABELS,
+	documentCategorySlugSchema,
+	makeCategorySchema
 } from '../documents'
 
-describe('documentCategorySchema', () => {
-	it('accepts every category in DOCUMENT_CATEGORIES', () => {
-		for (const category of DOCUMENT_CATEGORIES) {
-			expect(documentCategorySchema.safeParse(category).success).toBe(true)
+describe('documentCategorySlugSchema', () => {
+	it('accepts every default slug', () => {
+		for (const slug of DEFAULT_CATEGORY_SLUGS) {
+			expect(documentCategorySlugSchema.safeParse(slug).success).toBe(true)
 		}
 	})
 
-	it('rejects values outside the enum', () => {
-		expect(documentCategorySchema.safeParse('warranty').success).toBe(false)
-		expect(documentCategorySchema.safeParse('LEASE').success).toBe(false)
-		expect(documentCategorySchema.safeParse('').success).toBe(false)
-		expect(documentCategorySchema.safeParse(null).success).toBe(false)
-		expect(documentCategorySchema.safeParse(undefined).success).toBe(false)
+	it('accepts arbitrary lowercase-snake_case slugs (Phase 65: any-slug shape)', () => {
+		expect(documentCategorySlugSchema.safeParse('warranty').success).toBe(true)
+		expect(documentCategorySlugSchema.safeParse('home_office_2024').success).toBe(true)
 	})
 
-	it('exposes a label for every category — keeps Select renders deterministic', () => {
-		for (const category of DOCUMENT_CATEGORIES) {
-			expect(DOCUMENT_CATEGORY_LABELS[category]).toBeTruthy()
-			expect(typeof DOCUMENT_CATEGORY_LABELS[category]).toBe('string')
+	it('rejects malformed slugs', () => {
+		expect(documentCategorySlugSchema.safeParse('LEASE').success).toBe(false)
+		expect(documentCategorySlugSchema.safeParse('lease 1').success).toBe(false)
+		expect(documentCategorySlugSchema.safeParse('lease-1').success).toBe(false)
+		expect(documentCategorySlugSchema.safeParse('').success).toBe(false)
+		expect(documentCategorySlugSchema.safeParse('a'.repeat(51)).success).toBe(false)
+		expect(documentCategorySlugSchema.safeParse(null).success).toBe(false)
+		expect(documentCategorySlugSchema.safeParse(undefined).success).toBe(false)
+	})
+
+	it('exposes a label for every default slug', () => {
+		for (const slug of DEFAULT_CATEGORY_SLUGS) {
+			expect(DEFAULT_CATEGORY_LABELS[slug]).toBeTruthy()
+			expect(typeof DEFAULT_CATEGORY_LABELS[slug]).toBe('string')
 		}
 	})
 
-	it('matches the CHECK constraint in migration 20260425172604 exactly', () => {
-		// If you change DOCUMENT_CATEGORIES, ALSO update the migration —
-		// otherwise PostgREST inserts will throw 23514 check_violation.
-		expect([...DOCUMENT_CATEGORIES]).toEqual([
+	it('default slug list matches the seed function in migration 20260427023101', () => {
+		// If you change DEFAULT_CATEGORY_SLUGS, ALSO update the seed function —
+		// otherwise new owners get the wrong starter set.
+		expect([...DEFAULT_CATEGORY_SLUGS]).toEqual([
 			'lease',
 			'receipt',
 			'tax_return',
@@ -42,27 +50,47 @@ describe('documentCategorySchema', () => {
 		])
 	})
 
-	it('migration source is in lockstep with DOCUMENT_CATEGORIES (NIT cross-check)', () => {
-		// Reads the migration file at runtime and parses the literal CHECK
-		// list. Catches the three-source-of-truth drift: if someone edits
-		// the tuple WITHOUT updating the migration (or vice versa), the
-		// hard-coded array literal above would still match the tuple but
-		// this test fails. The migration is the database's source of
-		// truth; this guard makes the repo's source of truth match it.
+	it('migration seed function is in lockstep with DEFAULT_CATEGORY_SLUGS', () => {
+		// The seed function in the Phase 65 migration inserts the seven
+		// defaults via VALUES tuples. This regex pulls those slug literals
+		// and asserts they match DEFAULT_CATEGORY_SLUGS — closes the
+		// three-source-of-truth gap (table seed, default labels constant,
+		// new-user trigger).
 		const migrationSql = readFileSync(
-			'supabase/migrations/20260425172604_v24_phase_61_document_type_taxonomy.sql',
+			'supabase/migrations/20260427023101_v26_phase_65_document_categories_table.sql',
 			'utf8'
 		)
-		// Case-insensitive + whitespace-tolerant — a future migration
-		// that uppercases CHECK / IN, or wraps the predicate over
-		// multiple lines with extra whitespace, must still match.
-		const checkBlock = migrationSql.match(
-			/check\s*\(\s*document_type\s+in\s*\(([\s\S]*?)\)\s*\)/i
-		)?.[1]
-		expect(checkBlock, 'CHECK block not found in migration').toBeDefined()
-		const quoted = (checkBlock!.match(/'([^']+)'/g) ?? []).map(m =>
-			m.replace(/^'|'$/g, '')
-		)
-		expect(quoted.sort()).toEqual([...DOCUMENT_CATEGORIES].sort())
+		const seedFn = migrationSql.match(
+			/seed_default_document_categories[\s\S]*?on conflict/i
+		)?.[0]
+		expect(seedFn, 'seed function block not found').toBeDefined()
+		const quoted = (seedFn!.match(/'([a-z_]+)'/g) ?? [])
+			.map(m => m.replace(/^'|'$/g, ''))
+			// The VALUES tuples include label literals too; filter to slug shape.
+			.filter(s => /^[a-z_]+$/.test(s))
+		const slugSet = new Set(quoted)
+		for (const slug of DEFAULT_CATEGORY_SLUGS) {
+			expect(slugSet.has(slug), `slug '${slug}' missing from seed function`).toBe(true)
+		}
+	})
+})
+
+describe('makeCategorySchema', () => {
+	it('returns a runtime enum gating against the allowed set', () => {
+		const schema = makeCategorySchema(['lease', 'insurance'])
+		expect(schema.safeParse('lease').success).toBe(true)
+		expect(schema.safeParse('insurance').success).toBe(true)
+		expect(schema.safeParse('warranty').success).toBe(false)
+	})
+
+	it('falls through to the any-slug shape when the allowed list is empty', () => {
+		// Loading-state callers shouldn't false-reject every value while
+		// the categories query is still in flight.
+		const schema = makeCategorySchema([])
+		expect(schema.safeParse('lease').success).toBe(true)
+		expect(schema.safeParse('warranty').success).toBe(true)
+		// But malformed slugs still fail through documentCategorySlugSchema.
+		expect(schema.safeParse('LEASE').success).toBe(false)
+		expect(schema.safeParse('').success).toBe(false)
 	})
 })

--- a/src/lib/validation/__tests__/documents.test.ts
+++ b/src/lib/validation/__tests__/documents.test.ts
@@ -64,11 +64,9 @@ describe('documentCategorySlugSchema', () => {
 			/seed_default_document_categories[\s\S]*?on conflict/i
 		)?.[0]
 		expect(seedFn, 'seed function block not found').toBeDefined()
-		const quoted = (seedFn!.match(/'([a-z_]+)'/g) ?? [])
-			.map(m => m.replace(/^'|'$/g, ''))
-			// The VALUES tuples include label literals too; filter to slug shape.
-			.filter(s => /^[a-z_]+$/.test(s))
-		const slugSet = new Set(quoted)
+		const slugSet = new Set(
+			Array.from(seedFn!.matchAll(/'([a-z_]+)'/g)).map(m => m[1] as string)
+		)
 		for (const slug of DEFAULT_CATEGORY_SLUGS) {
 			expect(slugSet.has(slug), `slug '${slug}' missing from seed function`).toBe(true)
 		}

--- a/src/lib/validation/documents.ts
+++ b/src/lib/validation/documents.ts
@@ -1,16 +1,33 @@
 /**
  * Document Validation Schemas
  *
- * Categorical taxonomy for public.documents.document_type. Mirrors the
- * CHECK constraint added in migration 20260425172604_v24_phase_61_document_type_taxonomy.
+ * v2.6 Phase 65: replaces the compile-time DOCUMENT_CATEGORIES tuple
+ * with a runtime taxonomy lookup. Categories now live in the
+ * `document_categories` table (per-owner) and the slug set is loaded
+ * via `useDocumentCategories()` rather than imported as a constant.
+ *
+ * What stays here: the seven default slugs/labels that every owner is
+ * seeded with on signup (used as fallback when the categories query
+ * hasn't loaded yet, and as the source of truth for the seed function
+ * in migration 20260427023101). Migration↔code lockstep is enforced
+ * by the integration test in `tests/integration/rls/document-categories.rls.test.ts`.
+ *
+ * What moves out: the Zod enum is no longer a static `z.enum(tuple)`.
+ * Use `makeCategorySchema(allowedSlugs)` when you need runtime
+ * validation against a known slug set (e.g. the URL guard reading
+ * `?categories=lease,insurance` against the user's own categories).
  */
 
 import { z } from 'zod'
 
-// Tuple form for UI iteration (Select options, filter dropdowns).
-// Order matches the Select rendering order — most-common categories
-// for landlord workflows first, 'other' last as the fallback bucket.
-export const DOCUMENT_CATEGORIES = [
+/**
+ * Slugs of the seven categories every owner is seeded with on signup.
+ * KEEP IN LOCKSTEP with the seed function in
+ * `supabase/migrations/20260427023101_v26_phase_65_document_categories_table.sql`.
+ * The lockstep test in `tests/integration/rls/document-categories.rls.test.ts`
+ * verifies this list matches the seeded rows.
+ */
+export const DEFAULT_CATEGORY_SLUGS = [
 	'lease',
 	'receipt',
 	'tax_return',
@@ -20,13 +37,14 @@ export const DOCUMENT_CATEGORIES = [
 	'other'
 ] as const
 
-export const documentCategorySchema = z.enum(DOCUMENT_CATEGORIES)
+export type DefaultCategorySlug = (typeof DEFAULT_CATEGORY_SLUGS)[number]
 
-export type DocumentCategory = z.infer<typeof documentCategorySchema>
-
-// Human-readable labels for Select options + filter chips. Keep in
-// sync with DOCUMENT_CATEGORIES order so renders are deterministic.
-export const DOCUMENT_CATEGORY_LABELS: Record<DocumentCategory, string> = {
+/**
+ * Human-readable labels for the seven default slugs. Used as the
+ * fallback when a custom slug appears that the user-loaded categories
+ * map doesn't know about (e.g. mid-deletion races, optimistic UI).
+ */
+export const DEFAULT_CATEGORY_LABELS: Record<DefaultCategorySlug, string> = {
 	lease: 'Lease',
 	receipt: 'Receipt',
 	tax_return: 'Tax return',
@@ -34,4 +52,40 @@ export const DOCUMENT_CATEGORY_LABELS: Record<DocumentCategory, string> = {
 	maintenance_invoice: 'Maintenance invoice',
 	insurance: 'Insurance',
 	other: 'Other'
+}
+
+/**
+ * Slug shape — any non-empty lowercase-snake_case string up to 50 chars.
+ * Mirrors the CHECK constraint on `document_categories.slug`.
+ */
+export const documentCategorySlugSchema = z
+	.string()
+	.regex(/^[a-z0-9_]+$/)
+	.min(1)
+	.max(50)
+
+export type DocumentCategorySlug = z.infer<typeof documentCategorySlugSchema>
+
+/**
+ * Document category slugs are now arbitrary strings, validated at
+ * runtime against the user's actual category set. Callers that need
+ * to gate on the user's allowed set should use `makeCategorySchema`
+ * below; callers that just need to pass the slug through (RPC
+ * params, mapper boundaries) can use the slug type directly.
+ */
+export type DocumentCategory = DocumentCategorySlug
+
+/**
+ * Build a runtime Zod enum from the user's actual category slug set.
+ * Use this where the static `z.enum(tuple)` was used pre-Phase-65 —
+ * e.g. URL filter guards that need to scrub unknown slugs.
+ *
+ * Returns `documentCategorySlugSchema` (any-slug) when the allowed
+ * list is empty so loading-state callers don't trip false negatives.
+ */
+export function makeCategorySchema(
+	allowedSlugs: readonly string[]
+): z.ZodType<string> {
+	if (allowedSlugs.length === 0) return documentCategorySlugSchema
+	return z.enum(allowedSlugs as [string, ...string[]])
 }

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -107,6 +107,47 @@ export type Database = {
         }
         Relationships: []
       }
+      document_categories: {
+        Row: {
+          created_at: string
+          id: string
+          is_default: boolean
+          label: string
+          owner_user_id: string
+          slug: string
+          sort_order: number
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          is_default?: boolean
+          label: string
+          owner_user_id: string
+          slug: string
+          sort_order?: number
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_default?: boolean
+          label?: string
+          owner_user_id?: string
+          slug?: string
+          sort_order?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "document_categories_owner_user_id_fkey"
+            columns: ["owner_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       documents: {
         Row: {
           created_at: string | null
@@ -2589,6 +2630,10 @@ export type Database = {
           rank: number
           state: string
         }[]
+      }
+      seed_default_document_categories: {
+        Args: { p_owner_user_id: string }
+        Returns: undefined
       }
       sign_lease_and_check_activation:
         | {

--- a/supabase/migrations/20260427023101_v26_phase_65_document_categories_table.sql
+++ b/supabase/migrations/20260427023101_v26_phase_65_document_categories_table.sql
@@ -1,0 +1,140 @@
+-- v2.6 Phase 65: Custom Categories — Schema + Read Path
+--
+-- Replaces the compile-time DOCUMENT_CATEGORIES tuple (Phase 61 CHECK
+-- constraint) with a per-owner `document_categories` table. Existing
+-- users get the seven v2.5 categories seeded as is_default=true so
+-- the read path stays a no-op for landlords who never customize.
+-- documents.document_type becomes a soft FK (text column referencing
+-- document_categories.slug, owner-scoped) validated by a BEFORE
+-- INSERT/UPDATE trigger that replaces the dropped CHECK.
+
+-- 1. Table + constraints
+create table public.document_categories (
+    id uuid primary key default gen_random_uuid(),
+    owner_user_id uuid not null references public.users(id) on delete cascade,
+    slug text not null,
+    label text not null,
+    sort_order integer not null default 0,
+    is_default boolean not null default false,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    constraint document_categories_owner_slug_key unique (owner_user_id, slug),
+    constraint document_categories_slug_format check (slug ~ '^[a-z0-9_]+$' and length(slug) between 1 and 50),
+    constraint document_categories_label_length check (length(trim(label)) between 1 and 80)
+);
+
+create index document_categories_owner_idx on public.document_categories (owner_user_id, sort_order);
+
+-- 2. RLS — owner-scoped, one policy per operation
+alter table public.document_categories enable row level security;
+
+create policy "owners select own categories"
+    on public.document_categories for select to authenticated
+    using (owner_user_id = (select auth.uid()));
+
+create policy "owners insert own categories"
+    on public.document_categories for insert to authenticated
+    with check (owner_user_id = (select auth.uid()));
+
+create policy "owners update own categories"
+    on public.document_categories for update to authenticated
+    using (owner_user_id = (select auth.uid()))
+    with check (owner_user_id = (select auth.uid()));
+
+create policy "owners delete own categories"
+    on public.document_categories for delete to authenticated
+    using (owner_user_id = (select auth.uid()));
+
+-- 3. updated_at trigger (canonical helper from earlier consolidation migration)
+create trigger set_updated_at_document_categories
+    before update on public.document_categories
+    for each row execute function public.set_updated_at();
+
+-- 4. Idempotent seed function — ON CONFLICT DO NOTHING preserves any user-edited
+-- labels for an owner who's already been seeded once.
+create or replace function public.seed_default_document_categories(p_owner_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    insert into public.document_categories (owner_user_id, slug, label, sort_order, is_default)
+    values
+        (p_owner_user_id, 'lease', 'Lease', 10, true),
+        (p_owner_user_id, 'receipt', 'Receipt', 20, true),
+        (p_owner_user_id, 'tax_return', 'Tax return', 30, true),
+        (p_owner_user_id, 'inspection_report', 'Inspection report', 40, true),
+        (p_owner_user_id, 'maintenance_invoice', 'Maintenance invoice', 50, true),
+        (p_owner_user_id, 'insurance', 'Insurance', 60, true),
+        (p_owner_user_id, 'other', 'Other', 70, true)
+    on conflict (owner_user_id, slug) do nothing;
+end;
+$$;
+
+revoke all on function public.seed_default_document_categories(uuid) from public, anon, authenticated;
+
+-- 5. Backfill every existing user so the read path returns the seven defaults
+-- on Day 1, BEFORE the CHECK constraint drop below loses the DB-level guard.
+do $$
+declare
+    u record;
+begin
+    for u in select id from public.users loop
+        perform public.seed_default_document_categories(u.id);
+    end loop;
+end;
+$$;
+
+-- 6. Auto-seed for new users created via the existing auth/users sync trigger.
+create or replace function public.handle_new_user_seed_categories()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    perform public.seed_default_document_categories(NEW.id);
+    return NEW;
+end;
+$$;
+
+create trigger seed_default_categories_on_user_insert
+    after insert on public.users
+    for each row execute function public.handle_new_user_seed_categories();
+
+-- 7. Slug validation trigger — replaces the dropped CHECK constraint with a
+-- per-owner taxonomy lookup. Validates BEFORE INSERT and BEFORE UPDATE of
+-- the slug-bearing columns. SECURITY DEFINER so the lookup isn't blocked
+-- by document_categories' RLS on cross-owner edge cases (admin tooling).
+create or replace function public.validate_document_category()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if NEW.document_type is null then
+        return NEW;
+    end if;
+    if not exists (
+        select 1 from public.document_categories
+        where owner_user_id = NEW.owner_user_id
+          and slug = NEW.document_type
+    ) then
+        raise exception 'document_type % is not a valid category for owner %', NEW.document_type, NEW.owner_user_id
+            using errcode = '23514';
+    end if;
+    return NEW;
+end;
+$$;
+
+create trigger documents_validate_document_category
+    before insert or update of document_type, owner_user_id on public.documents
+    for each row execute function public.validate_document_category();
+
+-- 8. Drop the old CHECK constraint — superseded by the validation trigger.
+alter table public.documents drop constraint if exists documents_document_type_check;
+
+comment on table public.document_categories is
+    'Per-owner document taxonomy. Phase 65 replaces the compile-time DOCUMENT_CATEGORIES tuple with this table; documents.document_type is a soft FK (slug lookup, validated by trigger).';

--- a/supabase/migrations/20260427031807_v26_phase_65_followups.sql
+++ b/supabase/migrations/20260427031807_v26_phase_65_followups.sql
@@ -10,8 +10,6 @@
 --      triggers so client code can't call them anyway, but the asymmetry
 --      stood out in review.
 
-begin;
-
 create or replace function public.validate_document_category()
 returns trigger
 language plpgsql
@@ -36,5 +34,3 @@ $$;
 
 revoke all on function public.validate_document_category() from public, anon, authenticated;
 revoke all on function public.handle_new_user_seed_categories() from public, anon, authenticated;
-
-commit;

--- a/supabase/migrations/20260427031807_v26_phase_65_followups.sql
+++ b/supabase/migrations/20260427031807_v26_phase_65_followups.sql
@@ -1,0 +1,40 @@
+-- v2.6 Phase 65 Followups (cycle-1 review fixes)
+--
+-- C-1: validate_document_category() trigger raised 23514 on every UPDATE
+--      that nulled owner_user_id (e.g. an `ON DELETE SET NULL` cascade
+--      from auth.users). The slug lookup `where owner_user_id = NULL`
+--      always returned no rows, blocking the cascade. Short-circuit on
+--      NULL owner_user_id so cascades pass through.
+-- M-3: revoke EXECUTE on the remaining SECURITY DEFINER trigger funcs for
+--      parity with `seed_default_document_categories` — they're attached as
+--      triggers so client code can't call them anyway, but the asymmetry
+--      stood out in review.
+
+begin;
+
+create or replace function public.validate_document_category()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if NEW.document_type is null or NEW.owner_user_id is null then
+        return NEW;
+    end if;
+    if not exists (
+        select 1 from public.document_categories
+        where owner_user_id = NEW.owner_user_id
+          and slug = NEW.document_type
+    ) then
+        raise exception 'document_type % is not a valid category for owner %', NEW.document_type, NEW.owner_user_id
+            using errcode = '23514';
+    end if;
+    return NEW;
+end;
+$$;
+
+revoke all on function public.validate_document_category() from public, anon, authenticated;
+revoke all on function public.handle_new_user_seed_categories() from public, anon, authenticated;
+
+commit;

--- a/supabase/migrations/20260427035652_v26_phase_65_followup_2_trigger_error_hint.sql
+++ b/supabase/migrations/20260427035652_v26_phase_65_followup_2_trigger_error_hint.sql
@@ -1,0 +1,34 @@
+-- v2.6 Phase 65 Followup 2 (cycle-3 review M-2)
+--
+-- validate_document_category()'s error message previously surfaced
+-- only "is not a valid category for owner X" when the slug lookup
+-- failed. That's accurate but unhelpful when the caller passed a
+-- malformed slug ('TAX' or 'has-dash') — the slug regex on
+-- document_categories.slug means a malformed value can NEVER appear
+-- there, so the lookup ALWAYS returns no rows. Surface a format hint
+-- via DETAIL so the user knows whether to fix the slug shape vs add
+-- a custom category to their taxonomy.
+
+create or replace function public.validate_document_category()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if NEW.document_type is null or NEW.owner_user_id is null then
+        return NEW;
+    end if;
+    if not exists (
+        select 1 from public.document_categories
+        where owner_user_id = NEW.owner_user_id
+          and slug = NEW.document_type
+    ) then
+        raise exception 'document_type % is not a valid category for owner %', NEW.document_type, NEW.owner_user_id
+            using
+                errcode = '23514',
+                detail = 'Slugs must be lowercase-snake_case (matching ^[a-z0-9_]+$, 1-50 chars) AND exist in document_categories for this owner. Add the category via Phase-66 settings, or use one of the seven seeded defaults.';
+    end if;
+    return NEW;
+end;
+$$;

--- a/tests/integration/rls/document-categories.rls.test.ts
+++ b/tests/integration/rls/document-categories.rls.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Integration tests for `public.document_categories` (v2.6 Phase 65).
+ *
+ * Pins the contract:
+ *   - Owner-scoped RLS (ownerB never sees ownerA's categories).
+ *   - Every owner is seeded with the seven v2.5 default slugs.
+ *   - The `validate_document_category` BEFORE-INSERT trigger replaces
+ *     the dropped Phase-61 CHECK constraint: a docs INSERT with a
+ *     non-existent slug raises 23514 / 'is not a valid category'.
+ *   - Owner-scoped slug isolation: ownerA can use slug 'lease' (their
+ *     own seeded row), but a docs INSERT under ownerA referencing a
+ *     slug that ONLY exists in ownerB's category set still fails.
+ *   - Lockstep with `src/lib/validation/documents.ts` DEFAULT_CATEGORY_SLUGS.
+ */
+
+import {
+	DEFAULT_CATEGORY_SLUGS
+} from '../../../src/lib/validation/documents'
+import { createTestClient, getTestCredentials } from '../setup/supabase-client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const PAYLOAD = '%PDF-1.4\n%%EOF'
+
+describe('document_categories — owner isolation + slug validation', () => {
+	let clientA: SupabaseClient
+	let clientB: SupabaseClient
+	let ownerAId: string
+	let propertyA: { id: string } | null = null
+	const insertedDocIds: string[] = []
+	const uploadedPaths: string[] = []
+	const insertedCategoryIds: string[] = []
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials()
+		clientA = await createTestClient(ownerA.email, ownerA.password)
+		clientB = await createTestClient(ownerB.email, ownerB.password)
+		const {
+			data: { user: uA }
+		} = await clientA.auth.getUser()
+		ownerAId = uA!.id
+
+		const { data: p } = await clientA
+			.from('properties')
+			.insert({
+				name: 'Phase-65 Categories Property',
+				address_line1: '1 Categories St',
+				city: 'Testville',
+				state: 'CA',
+				postal_code: '94105',
+				country: 'US',
+				property_type: 'APARTMENT',
+				owner_user_id: ownerAId
+			})
+			.select('id')
+			.single()
+		propertyA = p ? { id: p.id } : null
+		expect(propertyA, 'property fixture failed').not.toBeNull()
+	})
+
+	afterAll(async () => {
+		if (uploadedPaths.length > 0) {
+			await clientA.storage
+				.from('tenant-documents')
+				.remove(uploadedPaths)
+				.catch(() => {})
+		}
+		for (const id of insertedDocIds) {
+			await clientA.from('documents').delete().eq('id', id)
+		}
+		// Custom categories created by these tests must be cleared so the
+		// suite is idempotent across reruns. Default seeded categories are
+		// owned by the user and live for the user's lifetime — don't touch.
+		for (const id of insertedCategoryIds) {
+			await clientA.from('document_categories').delete().eq('id', id)
+		}
+		if (propertyA) await clientA.from('properties').delete().eq('id', propertyA.id)
+		await clientA.auth.signOut()
+		await clientB.auth.signOut()
+	})
+
+	it('seeds the seven default slugs for every owner (lockstep with DEFAULT_CATEGORY_SLUGS)', async () => {
+		const { data, error } = await clientA
+			.from('document_categories')
+			.select('slug, is_default')
+			.eq('is_default', true)
+			.order('sort_order', { ascending: true })
+		expect(error).toBeNull()
+		const seededSlugs = (data ?? []).map(r => r.slug as string)
+		// Every default slug from the constant must be present (the seed
+		// function may have inserted more if Phase 66 ever extends the
+		// defaults, so check subset rather than equality).
+		for (const slug of DEFAULT_CATEGORY_SLUGS) {
+			expect(seededSlugs).toContain(slug)
+		}
+	})
+
+	it('owner-isolation: ownerB cannot see ownerA categories', async () => {
+		// Seed a custom category under ownerA so we have a row that ownerB
+		// definitely can't have.
+		const { data: row, error: insErr } = await clientA
+			.from('document_categories')
+			.insert({
+				owner_user_id: ownerAId,
+				slug: 'phase65_isolation_probe',
+				label: 'Isolation probe',
+				sort_order: 999,
+				is_default: false
+			})
+			.select('id')
+			.single()
+		expect(insErr).toBeNull()
+		if (row) insertedCategoryIds.push(row.id)
+
+		const { data: bRows, error: bErr } = await clientB
+			.from('document_categories')
+			.select('id, slug')
+			.eq('slug', 'phase65_isolation_probe')
+		expect(bErr).toBeNull()
+		expect(bRows ?? []).toHaveLength(0)
+	})
+
+	it('docs INSERT with an unknown slug is rejected by the validation trigger', async () => {
+		const ts = Date.now()
+		const path = `property/${propertyA!.id}/${ts}-bad-slug.pdf`
+		const { error: storageErr } = await clientA.storage
+			.from('tenant-documents')
+			.upload(path, new Blob([PAYLOAD], { type: 'application/pdf' }), {
+				contentType: 'application/pdf'
+			})
+		expect(storageErr).toBeNull()
+		uploadedPaths.push(path)
+
+		const { error: insertErr } = await clientA
+			.from('documents')
+			.insert({
+				entity_type: 'property',
+				entity_id: propertyA!.id,
+				document_type: 'totally_unknown_slug',
+				mime_type: 'application/pdf',
+				file_path: path,
+				storage_url: path,
+				file_size: PAYLOAD.length,
+				title: 'Bad-slug fixture',
+				owner_user_id: ownerAId
+			})
+			.select('id')
+			.single()
+		expect(insertErr, 'trigger should reject unknown slug').not.toBeNull()
+		expect(insertErr!.message).toMatch(/is not a valid category/i)
+	})
+
+	it('docs INSERT with a known default slug succeeds', async () => {
+		const ts = Date.now() + 1
+		const path = `property/${propertyA!.id}/${ts}-good-slug.pdf`
+		const { error: storageErr } = await clientA.storage
+			.from('tenant-documents')
+			.upload(path, new Blob([PAYLOAD], { type: 'application/pdf' }), {
+				contentType: 'application/pdf'
+			})
+		expect(storageErr).toBeNull()
+		uploadedPaths.push(path)
+
+		const { data: row, error } = await clientA
+			.from('documents')
+			.insert({
+				entity_type: 'property',
+				entity_id: propertyA!.id,
+				document_type: 'lease',
+				mime_type: 'application/pdf',
+				file_path: path,
+				storage_url: path,
+				file_size: PAYLOAD.length,
+				title: 'Default-slug fixture',
+				owner_user_id: ownerAId
+			})
+			.select('id, document_type')
+			.single()
+		expect(error).toBeNull()
+		expect(row?.document_type).toBe('lease')
+		if (row) insertedDocIds.push(row.id)
+	})
+
+	it('label CHECK constraint rejects empty labels and >80-char labels', async () => {
+		// CHECK constraint: length(trim(label)) between 1 and 80.
+		const { error: emptyErr } = await clientA
+			.from('document_categories')
+			.insert({
+				owner_user_id: ownerAId,
+				slug: 'phase65_empty_label_probe',
+				label: '   ', // trims to empty
+				sort_order: 998,
+				is_default: false
+			})
+			.select('id')
+			.single()
+		expect(emptyErr).not.toBeNull()
+		expect(emptyErr!.message).toMatch(/check|label/i)
+
+		const { error: longErr } = await clientA
+			.from('document_categories')
+			.insert({
+				owner_user_id: ownerAId,
+				slug: 'phase65_long_label_probe',
+				label: 'x'.repeat(81),
+				sort_order: 998,
+				is_default: false
+			})
+			.select('id')
+			.single()
+		expect(longErr).not.toBeNull()
+		expect(longErr!.message).toMatch(/check|label/i)
+	})
+
+	it('slug CHECK constraint rejects malformed slugs (uppercase, spaces, > 50 chars)', async () => {
+		const cases = [
+			{ slug: 'UPPERCASE_BAD', what: 'uppercase' },
+			{ slug: 'has space', what: 'whitespace' },
+			{ slug: 'has-dash', what: 'dash' },
+			{ slug: 'a'.repeat(51), what: 'over 50 chars' }
+		]
+		for (const c of cases) {
+			const { error } = await clientA
+				.from('document_categories')
+				.insert({
+					owner_user_id: ownerAId,
+					slug: c.slug,
+					label: 'Probe',
+					sort_order: 997,
+					is_default: false
+				})
+				.select('id')
+				.single()
+			expect(error, `slug case '${c.what}' should be rejected`).not.toBeNull()
+			expect(error!.message).toMatch(/check|slug/i)
+		}
+	})
+
+	it('UNIQUE(owner_user_id, slug) blocks duplicate slug per owner', async () => {
+		// Seed a custom slug under ownerA, then try to insert it again.
+		const { data: first, error: firstErr } = await clientA
+			.from('document_categories')
+			.insert({
+				owner_user_id: ownerAId,
+				slug: 'phase65_unique_probe',
+				label: 'Unique probe',
+				sort_order: 996,
+				is_default: false
+			})
+			.select('id')
+			.single()
+		expect(firstErr).toBeNull()
+		if (first) insertedCategoryIds.push(first.id)
+
+		const { error: dupErr } = await clientA
+			.from('document_categories')
+			.insert({
+				owner_user_id: ownerAId,
+				slug: 'phase65_unique_probe',
+				label: 'Duplicate',
+				sort_order: 995,
+				is_default: false
+			})
+			.select('id')
+			.single()
+		expect(dupErr).not.toBeNull()
+		expect(dupErr!.message).toMatch(/duplicate|unique/i)
+	})
+})

--- a/tests/integration/rls/search-documents.rls.test.ts
+++ b/tests/integration/rls/search-documents.rls.test.ts
@@ -331,9 +331,13 @@ describe('search_documents RPC', () => {
 		}
 	})
 
-	it('Phase 61: CHECK constraint rejects non-taxonomy document_type values', async () => {
-		// Migration 20260425172604 enforces the seven-category enum. Any
-		// other value must be rejected at insert time with 23514.
+	it('Phase 61/65: trigger rejects non-taxonomy document_type values', async () => {
+		// Phase 61 (migration 20260425172604) added a CHECK constraint
+		// enforcing the seven-category enum. Phase 65 replaced that CHECK
+		// with a per-owner soft FK validated by a BEFORE-INSERT trigger
+		// (`validate_document_category`). The error code is still 23514
+		// but the message wording changed from PostgreSQL's CHECK violation
+		// to the trigger's RAISE EXCEPTION text.
 		const ts = Date.now()
 		const path = `property/${propertyA!.id}/${ts}-bad-type.pdf`
 		const { error: storageErr } = await clientA.storage
@@ -362,11 +366,8 @@ describe('search_documents RPC', () => {
 			.select('id')
 			.single()
 
-		expect(insertErr, 'CHECK constraint should reject non-taxonomy value').not
-			.toBeNull()
-		expect(insertErr!.message).toMatch(
-			/documents_document_type_check|check constraint/i
-		)
+		expect(insertErr, 'trigger should reject non-taxonomy value').not.toBeNull()
+		expect(insertErr!.message).toMatch(/is not a valid category/i)
 	})
 
 	it('Phase 61: omitted document_type defaults to "other"', async () => {


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37m- Replaces compile-time DOCUMENT_CATEGORIES tuple with per-owner document_categories table[0m
[38;5;8m   4[0m [37m- Frontend reads taxonomy via useDocumentCategories hook (5min staleTime)[0m
[38;5;8m   5[0m [37m- documents.document_type validated by BEFORE INSERT/UPDATE trigger (replaces dropped CHECK)[0m
[38;5;8m   6[0m [37m- Existing users backfilled with seven default slugs; new users seeded via trigger[0m
[38;5;8m   7[0m 
[38;5;8m   8[0m [37m## Migration[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37m`20260427023101_v26_phase_65_document_categories_table.sql` already applied to prod via MCP. Ships with:[0m
[38;5;8m  11[0m [37m- Owner-scoped RLS (one policy per CRUD op)[0m
[38;5;8m  12[0m [37m- Idempotent seed function + backfill DO block[0m
[38;5;8m  13[0m [37m- New-user trigger on public.users[0m
[38;5;8m  14[0m [37m- Validation trigger on documents[0m
[38;5;8m  15[0m [37m- Slug CHECK (lowercase-snake_case, 1-50 chars), label CHECK (1-80 chars), UNIQUE(owner_user_id, slug)[0m
[38;5;8m  16[0m 
[38;5;8m  17[0m [37m## Test plan[0m
[38;5;8m  18[0m 
[38;5;8m  19[0m [37m- [x] 7,523 unit tests pass (vault + section parameterized over mocked categories)[0m
[38;5;8m  20[0m [37m- [x] typecheck + lint clean[0m
[38;5;8m  21[0m [37m- [x] tests/integration/rls/document-categories.rls.test.ts covers: seed lockstep with DEFAULT_CATEGORY_SLUGS, owner isolation (ownerB can't see ownerA), validation-trigger rejection, CHECK constraints (slug + label), UNIQUE constraint[0m
[38;5;8m  22[0m [37m- [ ] CI rls-security run validates the integration tests against prod[0m
[38;5;8m  23[0m [37m- [ ] Code review per perfect-PR gate (two consecutive zero-finding cycles)[0m
[38;5;8m  24[0m 
[38;5;8m  25[0m [37m[hudsor01][0m