### PR TITLE
feat(v2.6/phase-66): custom categories — admin UI + write path

### DIFF
--- a/.planning/milestones/v2.6-ROADMAP.md
+++ b/.planning/milestones/v2.6-ROADMAP.md
@@ -24,8 +24,8 @@ v2.5 shipped the global vault with full filter coverage (text + entity + multi-c
 ## Phases (strict ordering — 65 must ship before 66 because the read path defines the schema)
 
 - [x] **Phase 64: Bulk download as zip** — new Edge Function `download-documents-zip`, frontend selection UI + "Download all matching" button, memory-aware streaming.
-- [ ] **Phase 65: Custom categories — schema + read path** — `document_categories` table, RLS, default-seed migration, runtime-loaded Zod enum, vault filter + section upload integration.
-- [ ] **Phase 66: Custom categories — admin UI + write path** — settings UI for CRUD, soft-delete with document reassignment.
+- [x] **Phase 65: Custom categories — schema + read path** — `document_categories` table, RLS, default-seed migration, runtime-loaded Zod enum, vault filter + section upload integration.
+- [x] **Phase 66: Custom categories — admin UI + write path** — settings UI for CRUD, soft-delete with document reassignment.
 
 ---
 

--- a/src/app/(owner)/settings/page.tsx
+++ b/src/app/(owner)/settings/page.tsx
@@ -3,15 +3,39 @@
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
-import { Bell, Building2, CreditCard, Shield, ChevronRight, Database } from 'lucide-react'
+import {
+	Bell,
+	Building2,
+	CreditCard,
+	Shield,
+	ChevronRight,
+	Database,
+	FolderTree
+} from 'lucide-react'
 import { BlurFade } from '#components/ui/blur-fade'
 import { GeneralSettings } from '#components/settings/general-settings'
 import { NotificationSettings } from '#components/settings/notification-settings'
 import { SecuritySettings } from '#components/settings/security-settings'
 import { BillingSettings } from '#components/settings/billing-settings'
 import { AccountDataSection } from '#components/settings/account-data-section'
+import { CategoriesSettings } from '#components/settings/categories-settings'
 
-type SettingsTab = 'general' | 'notifications' | 'security' | 'billing' | 'data'
+type SettingsTab =
+	| 'general'
+	| 'notifications'
+	| 'security'
+	| 'billing'
+	| 'categories'
+	| 'data'
+
+const TAB_VALUES: readonly SettingsTab[] = [
+	'general',
+	'notifications',
+	'security',
+	'billing',
+	'categories',
+	'data'
+] as const
 
 interface SettingsSection {
 	id: SettingsTab
@@ -46,6 +70,12 @@ const sections: SettingsSection[] = [
 		description: 'Subscription and payment info'
 	},
 	{
+		id: 'categories',
+		label: 'Categories',
+		icon: <FolderTree className="h-4 w-4" />,
+		description: 'Customize the document taxonomy'
+	},
+	{
 		id: 'data',
 		label: 'My Data',
 		icon: <Database className="h-4 w-4" />,
@@ -58,18 +88,14 @@ export default function SettingsPage() {
 	const router = useRouter()
 	const tabParam = searchParams.get('tab') as SettingsTab | null
 	const [activeTab, setActiveTab] = useState<SettingsTab>(
-		tabParam &&
-			['general', 'notifications', 'security', 'billing', 'data'].includes(tabParam)
+		tabParam && (TAB_VALUES as readonly string[]).includes(tabParam)
 			? tabParam
 			: 'general'
 	)
 
 	// Update tab when URL changes
 	useEffect(() => {
-		if (
-			tabParam &&
-			['general', 'notifications', 'security', 'billing', 'data'].includes(tabParam)
-		) {
+		if (tabParam && (TAB_VALUES as readonly string[]).includes(tabParam)) {
 			setActiveTab(tabParam)
 		}
 	}, [tabParam])
@@ -90,6 +116,8 @@ export default function SettingsPage() {
 				return <SecuritySettings />
 			case 'billing':
 				return <BillingSettings />
+			case 'categories':
+				return <CategoriesSettings />
 			case 'data':
 				return <AccountDataSection />
 			default:

--- a/src/app/(owner)/settings/page.tsx
+++ b/src/app/(owner)/settings/page.tsx
@@ -37,6 +37,10 @@ const TAB_VALUES: readonly SettingsTab[] = [
 	'data'
 ] as const
 
+function isSettingsTab(value: string): value is SettingsTab {
+	return (TAB_VALUES as readonly string[]).includes(value)
+}
+
 interface SettingsSection {
 	id: SettingsTab
 	label: string
@@ -88,14 +92,12 @@ export default function SettingsPage() {
 	const router = useRouter()
 	const tabParam = searchParams.get('tab') as SettingsTab | null
 	const [activeTab, setActiveTab] = useState<SettingsTab>(
-		tabParam && (TAB_VALUES as readonly string[]).includes(tabParam)
-			? tabParam
-			: 'general'
+		tabParam && isSettingsTab(tabParam) ? tabParam : 'general'
 	)
 
 	// Update tab when URL changes
 	useEffect(() => {
-		if (tabParam && (TAB_VALUES as readonly string[]).includes(tabParam)) {
+		if (tabParam && isSettingsTab(tabParam)) {
 			setActiveTab(tabParam)
 		}
 	}, [tabParam])

--- a/src/components/settings/__tests__/categories-settings.test.tsx
+++ b/src/components/settings/__tests__/categories-settings.test.tsx
@@ -39,9 +39,9 @@ function mutationKeyMatches(
 
 // Capture the reorder mutation's onMutate/onError handlers so a unit
 // test can drive them directly to exercise the snapshot-rollback path
-// (cycle-1 M-7).
+// (cycle-1 M-7). Cycle-3 M-2: onMutate now takes an `input` arg.
 const reorderHooks: {
-	onMutate?: () => Promise<unknown>
+	onMutate?: (input: unknown) => Promise<unknown>
 	onError?: (err: Error, vars: unknown, ctx: unknown) => void
 } = {}
 
@@ -53,7 +53,7 @@ vi.mock('@tanstack/react-query', async () => {
 		...actual,
 		useMutation: (opts: {
 			mutationKey?: readonly unknown[]
-			onMutate?: () => Promise<unknown>
+			onMutate?: (input: unknown) => Promise<unknown>
 			onError?: (err: Error, vars: unknown, ctx: unknown) => void
 		}) => {
 			const key = opts.mutationKey
@@ -91,6 +91,11 @@ vi.mock('@tanstack/react-query', async () => {
 
 const SEVEN_DEFAULTS = [
 	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-2', slug: 'receipt', label: 'Receipt', sort_order: 20, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-3', slug: 'tax_return', label: 'Tax return', sort_order: 30, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-4', slug: 'inspection_report', label: 'Inspection report', sort_order: 40, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-5', slug: 'maintenance_invoice', label: 'Maintenance invoice', sort_order: 50, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-6', slug: 'insurance', label: 'Insurance', sort_order: 60, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
 	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' }
 ]
 
@@ -296,14 +301,20 @@ describe('CategoriesSettings', () => {
 		const listKey = ['documentCategories', 'list'] as const
 		queryClient.setQueryData(listKey, initial)
 
-		// Snapshot phase — onMutate captures the current cache.
+		// Snapshot phase — onMutate cancels in-flight queries, captures
+		// the current cache, and writes the optimistic order from
+		// `input.next`. Cycle-3 M-2 moved this write inside onMutate so
+		// the snapshot/optimistic ordering is atomic against concurrent
+		// refetches.
 		expect(reorderHooks.onMutate).toBeDefined()
-		const ctx = await reorderHooks.onMutate!()
-
-		// Optimistic mutation — settle a different (incorrect) order in
-		// the cache to simulate the drag.
 		const reordered = [...initial].reverse()
-		queryClient.setQueryData(listKey, reordered)
+		const ctx = await reorderHooks.onMutate!({
+			orders: reordered.map((c, i) => ({
+				id: c.id,
+				sort_order: (i + 1) * 10
+			})),
+			next: reordered
+		})
 		expect(queryClient.getQueryData(listKey)).toEqual(reordered)
 
 		// Failure path — onError should restore the snapshot.

--- a/src/components/settings/__tests__/categories-settings.test.tsx
+++ b/src/components/settings/__tests__/categories-settings.test.tsx
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactElement } from 'react'
+import { CategoriesSettings } from '../categories-settings'
+import { mutationKeys } from '#hooks/api/mutation-keys'
+
+const mockUseDocumentCategories = vi.fn()
+const mockToastError = vi.fn()
+const mockToastSuccess = vi.fn()
+
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+const mockReorder = vi.fn()
+
+vi.mock('#hooks/api/use-document-categories', () => ({
+	useDocumentCategories: () => mockUseDocumentCategories()
+}))
+
+vi.mock('sonner', () => ({
+	toast: {
+		success: (...args: unknown[]) => mockToastSuccess(...args),
+		error: (...args: unknown[]) => mockToastError(...args),
+		warning: vi.fn(),
+		info: vi.fn()
+	}
+}))
+
+function mutationKeyMatches(
+	actual: readonly unknown[] | undefined,
+	expected: readonly unknown[]
+): boolean {
+	if (!actual) return false
+	if (actual.length !== expected.length) return false
+	return actual.every((v, i) => v === expected[i])
+}
+
+vi.mock('@tanstack/react-query', async () => {
+	const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+		'@tanstack/react-query'
+	)
+	return {
+		...actual,
+		useMutation: (opts: { mutationKey?: readonly unknown[] }) => {
+			const key = opts.mutationKey
+			let mutate: ReturnType<typeof vi.fn> = vi.fn()
+			if (mutationKeyMatches(key, mutationKeys.documentCategories.create)) {
+				mutate = mockCreate
+			} else if (
+				mutationKeyMatches(key, mutationKeys.documentCategories.update)
+			) {
+				mutate = mockUpdate
+			} else if (
+				mutationKeyMatches(
+					key,
+					mutationKeys.documentCategories.deleteWithReassign
+				)
+			) {
+				mutate = mockDelete
+			} else if (
+				mutationKeyMatches(key, mutationKeys.documentCategories.reorder)
+			) {
+				mutate = mockReorder
+			}
+			return {
+				mutate,
+				mutateAsync: mutate,
+				isPending: false,
+				isError: false,
+				isSuccess: false
+			}
+		}
+	}
+})
+
+const SEVEN_DEFAULTS = [
+	{ id: 'cat-1', slug: 'lease', label: 'Lease', sort_order: 10, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' },
+	{ id: 'cat-7', slug: 'other', label: 'Other', sort_order: 70, is_default: true, owner_user_id: 'u', created_at: '2026-04-26T00:00:00Z', updated_at: '2026-04-26T00:00:00Z' }
+]
+
+const WITH_CUSTOM = [
+	...SEVEN_DEFAULTS,
+	{ id: 'cat-custom', slug: 'warranty', label: 'Warranty', sort_order: 100, is_default: false, owner_user_id: 'u', created_at: '2026-04-27T00:00:00Z', updated_at: '2026-04-27T00:00:00Z' }
+]
+
+function renderSettings(): ReturnType<typeof render> {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
+	})
+	const ui: ReactElement = (
+		<QueryClientProvider client={queryClient}>
+			<CategoriesSettings />
+		</QueryClientProvider>
+	)
+	return render(ui)
+}
+
+describe('CategoriesSettings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockUseDocumentCategories.mockReturnValue({
+			categories: SEVEN_DEFAULTS,
+			isLoading: false,
+			isError: false
+		})
+	})
+
+	it('renders skeletons while categories are loading', () => {
+		mockUseDocumentCategories.mockReturnValue({
+			categories: [],
+			isLoading: true,
+			isError: false
+		})
+		renderSettings()
+		// Skeletons render with role="status" or class fragment; title still renders.
+		expect(screen.getByText(/document categories/i)).toBeInTheDocument()
+	})
+
+	it('renders every category as a row with slug + label visible', () => {
+		mockUseDocumentCategories.mockReturnValue({
+			categories: WITH_CUSTOM,
+			isLoading: false,
+			isError: false
+		})
+		renderSettings()
+		expect(screen.getByText('Lease')).toBeInTheDocument()
+		expect(screen.getByText('Other')).toBeInTheDocument()
+		expect(screen.getByText('Warranty')).toBeInTheDocument()
+		// Custom category does NOT show the Default badge.
+		const warrantyRow = screen.getByText('Warranty').closest('li')
+		expect(warrantyRow).toBeTruthy()
+		expect(warrantyRow!.textContent).not.toMatch(/Default/)
+	})
+
+	it('disables the delete button on default categories with a tooltip', () => {
+		mockUseDocumentCategories.mockReturnValue({
+			categories: SEVEN_DEFAULTS,
+			isLoading: false,
+			isError: false
+		})
+		renderSettings()
+		// Every default row renders the same aria-label for its disabled
+		// delete button — assert ALL of them are present and disabled.
+		const disabledButtons = screen.getAllByLabelText(
+			"Default categories can't be deleted"
+		)
+		expect(disabledButtons).toHaveLength(SEVEN_DEFAULTS.length)
+		for (const btn of disabledButtons) {
+			expect(btn).toBeDisabled()
+		}
+	})
+
+	it('enables the delete button on custom categories', () => {
+		mockUseDocumentCategories.mockReturnValue({
+			categories: WITH_CUSTOM,
+			isLoading: false,
+			isError: false
+		})
+		renderSettings()
+		expect(
+			screen.getByRole('button', { name: /delete warranty/i })
+		).toBeEnabled()
+	})
+
+	it('opens the create dialog and submits with auto-derived slug', async () => {
+		const user = userEvent.setup()
+		renderSettings()
+		await user.click(screen.getByRole('button', { name: /add category/i }))
+		const labelInput = await screen.findByLabelText('Label')
+		await user.type(labelInput, 'Home Office')
+		// Slug should auto-fill from the label.
+		const slugInput = screen.getByLabelText('Slug') as HTMLInputElement
+		expect(slugInput.value).toBe('home_office')
+		await user.click(screen.getByRole('button', { name: /^create$/i }))
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				slug: 'home_office',
+				label: 'Home Office'
+			})
+		)
+	})
+
+	it('opens the rename dialog and submits the new label', async () => {
+		const user = userEvent.setup()
+		mockUseDocumentCategories.mockReturnValue({
+			categories: WITH_CUSTOM,
+			isLoading: false,
+			isError: false
+		})
+		renderSettings()
+		await user.click(screen.getByRole('button', { name: /rename warranty/i }))
+		const labelInput = await screen.findByLabelText('Label')
+		await user.clear(labelInput)
+		await user.type(labelInput, 'Home Warranty')
+		await user.click(screen.getByRole('button', { name: /^save$/i }))
+		expect(mockUpdate).toHaveBeenCalledWith({
+			id: 'cat-custom',
+			label: 'Home Warranty'
+		})
+	})
+
+	it('opens delete confirmation with reassignment Select and submits both ids', async () => {
+		const user = userEvent.setup()
+		mockUseDocumentCategories.mockReturnValue({
+			categories: WITH_CUSTOM,
+			isLoading: false,
+			isError: false
+		})
+		renderSettings()
+		await user.click(screen.getByRole('button', { name: /delete warranty/i }))
+		// Default reassignment target should be 'other' (the canonical fallback).
+		// The button is enabled because the default is pre-filled.
+		const submitBtn = await screen.findByRole('button', {
+			name: /delete & reassign/i
+		})
+		await user.click(submitBtn)
+		expect(mockDelete).toHaveBeenCalledWith({
+			from_id: 'cat-custom',
+			to_id: 'cat-7' // 'other' fallback
+		})
+	})
+
+	it('disables Save in rename dialog when label is unchanged', async () => {
+		const user = userEvent.setup()
+		mockUseDocumentCategories.mockReturnValue({
+			categories: WITH_CUSTOM,
+			isLoading: false,
+			isError: false
+		})
+		renderSettings()
+		await user.click(screen.getByRole('button', { name: /rename warranty/i }))
+		// Label pre-fills with current value 'Warranty'; Save is disabled until
+		// the user changes it.
+		const saveBtn = await screen.findByRole('button', { name: /^save$/i })
+		expect(saveBtn).toBeDisabled()
+	})
+
+	it('disables Create in new-category dialog when label is empty', async () => {
+		const user = userEvent.setup()
+		renderSettings()
+		await user.click(screen.getByRole('button', { name: /add category/i }))
+		const createBtn = await screen.findByRole('button', { name: /^create$/i })
+		expect(createBtn).toBeDisabled()
+	})
+
+	it('Cancel in delete dialog clears the dialog state without firing the mutation', async () => {
+		const user = userEvent.setup()
+		mockUseDocumentCategories.mockReturnValue({
+			categories: WITH_CUSTOM,
+			isLoading: false,
+			isError: false
+		})
+		renderSettings()
+		await user.click(screen.getByRole('button', { name: /delete warranty/i }))
+		const cancelBtn = await screen.findByRole('button', { name: /^cancel$/i })
+		await user.click(cancelBtn)
+		await waitFor(() => {
+			expect(
+				screen.queryByText(/Delete "Warranty"/)
+			).not.toBeInTheDocument()
+		})
+		expect(mockDelete).not.toHaveBeenCalled()
+	})
+})

--- a/src/components/settings/__tests__/categories-settings.test.tsx
+++ b/src/components/settings/__tests__/categories-settings.test.tsx
@@ -286,6 +286,31 @@ describe('CategoriesSettings', () => {
 		expect(mockDelete).not.toHaveBeenCalled()
 	})
 
+	it('reorder onMutate: skips optimistic write when input.next is omitted (cycle-5 M-4)', async () => {
+		// Pure-RPC callers that don't want UI cache updates can omit
+		// `next` from the mutation input — `onMutate` should still
+		// snapshot but skip the setQueryData write.
+		const initial = WITH_CUSTOM
+		mockUseDocumentCategories.mockReturnValue({
+			categories: initial,
+			isLoading: false,
+			isError: false
+		})
+		delete reorderHooks.onMutate
+		delete reorderHooks.onError
+		const { queryClient } = renderSettings()
+		const listKey = ['documentCategories', 'list'] as const
+		queryClient.setQueryData(listKey, initial)
+
+		expect(reorderHooks.onMutate).toBeDefined()
+		await reorderHooks.onMutate!({
+			orders: [{ id: 'cat-custom', sort_order: 1234 }]
+			// next omitted intentionally
+		})
+		// Cache is unchanged — onMutate snapshotted but didn't write.
+		expect(queryClient.getQueryData(listKey)).toEqual(initial)
+	})
+
 	it('reorder rollback: onError restores the snapshot taken in onMutate (cycle-1 M-7)', async () => {
 		const initial = WITH_CUSTOM
 		mockUseDocumentCategories.mockReturnValue({

--- a/src/components/settings/__tests__/categories-settings.test.tsx
+++ b/src/components/settings/__tests__/categories-settings.test.tsx
@@ -37,13 +37,25 @@ function mutationKeyMatches(
 	return actual.every((v, i) => v === expected[i])
 }
 
+// Capture the reorder mutation's onMutate/onError handlers so a unit
+// test can drive them directly to exercise the snapshot-rollback path
+// (cycle-1 M-7).
+const reorderHooks: {
+	onMutate?: () => Promise<unknown>
+	onError?: (err: Error, vars: unknown, ctx: unknown) => void
+} = {}
+
 vi.mock('@tanstack/react-query', async () => {
 	const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
 		'@tanstack/react-query'
 	)
 	return {
 		...actual,
-		useMutation: (opts: { mutationKey?: readonly unknown[] }) => {
+		useMutation: (opts: {
+			mutationKey?: readonly unknown[]
+			onMutate?: () => Promise<unknown>
+			onError?: (err: Error, vars: unknown, ctx: unknown) => void
+		}) => {
 			const key = opts.mutationKey
 			let mutate: ReturnType<typeof vi.fn> = vi.fn()
 			if (mutationKeyMatches(key, mutationKeys.documentCategories.create)) {
@@ -63,6 +75,8 @@ vi.mock('@tanstack/react-query', async () => {
 				mutationKeyMatches(key, mutationKeys.documentCategories.reorder)
 			) {
 				mutate = mockReorder
+				if (opts.onMutate) reorderHooks.onMutate = opts.onMutate
+				if (opts.onError) reorderHooks.onError = opts.onError
 			}
 			return {
 				mutate,
@@ -85,7 +99,9 @@ const WITH_CUSTOM = [
 	{ id: 'cat-custom', slug: 'warranty', label: 'Warranty', sort_order: 100, is_default: false, owner_user_id: 'u', created_at: '2026-04-27T00:00:00Z', updated_at: '2026-04-27T00:00:00Z' }
 ]
 
-function renderSettings(): ReturnType<typeof render> {
+function renderSettings(): ReturnType<typeof render> & {
+	queryClient: QueryClient
+} {
 	const queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
 	})
@@ -94,7 +110,8 @@ function renderSettings(): ReturnType<typeof render> {
 			<CategoriesSettings />
 		</QueryClientProvider>
 	)
-	return render(ui)
+	const result = render(ui)
+	return { ...result, queryClient }
 }
 
 describe('CategoriesSettings', () => {
@@ -262,5 +279,40 @@ describe('CategoriesSettings', () => {
 			).not.toBeInTheDocument()
 		})
 		expect(mockDelete).not.toHaveBeenCalled()
+	})
+
+	it('reorder rollback: onError restores the snapshot taken in onMutate (cycle-1 M-7)', async () => {
+		const initial = WITH_CUSTOM
+		mockUseDocumentCategories.mockReturnValue({
+			categories: initial,
+			isLoading: false,
+			isError: false
+		})
+		// Reset the captured hooks before mounting so we know the values
+		// we read after render came from THIS render.
+		delete reorderHooks.onMutate
+		delete reorderHooks.onError
+		const { queryClient } = renderSettings()
+		const listKey = ['documentCategories', 'list'] as const
+		queryClient.setQueryData(listKey, initial)
+
+		// Snapshot phase — onMutate captures the current cache.
+		expect(reorderHooks.onMutate).toBeDefined()
+		const ctx = await reorderHooks.onMutate!()
+
+		// Optimistic mutation — settle a different (incorrect) order in
+		// the cache to simulate the drag.
+		const reordered = [...initial].reverse()
+		queryClient.setQueryData(listKey, reordered)
+		expect(queryClient.getQueryData(listKey)).toEqual(reordered)
+
+		// Failure path — onError should restore the snapshot.
+		expect(reorderHooks.onError).toBeDefined()
+		reorderHooks.onError!(new Error('rpc failed'), undefined, ctx)
+
+		expect(queryClient.getQueryData(listKey)).toEqual(initial)
+		expect(mockToastError).toHaveBeenCalledWith(
+			expect.stringContaining('rpc failed')
+		)
 	})
 })

--- a/src/components/settings/categories-settings.tsx
+++ b/src/components/settings/categories-settings.tsx
@@ -229,6 +229,7 @@ export function CategoriesSettings() {
 				onSubmit={input => createMutation.mutate(input)}
 				isPending={createMutation.isPending}
 				defaultSortOrder={nextSortOrder}
+				existingSlugs={categories.map(c => c.slug)}
 			/>
 
 			<CategoryRenameDialog

--- a/src/components/settings/categories-settings.tsx
+++ b/src/components/settings/categories-settings.tsx
@@ -109,10 +109,22 @@ export function CategoriesSettings() {
 	const listKey = documentCategoryQueries.list().queryKey
 	const reorderMutation = useMutation({
 		...documentCategoryMutations.reorder(),
-		onMutate: async () => {
+		// Cycle-3 M-2: write the optimistic order INSIDE onMutate
+		// (after cancelQueries + snapshot), not before mutate(). Doing
+		// the write outside leaves a tiny window where an in-flight
+		// refetch could overwrite the optimistic state, then the
+		// snapshot would capture that already-overwritten state. The
+		// caller passes the pre-computed `next` array via the input.
+		onMutate: async input => {
 			await queryClient.cancelQueries({ queryKey: listKey })
 			const previous =
 				queryClient.getQueryData<DocumentCategoryRow[]>(listKey)
+			if (input.next) {
+				queryClient.setQueryData<DocumentCategoryRow[]>(
+					listKey,
+					() => input.next
+				)
+			}
 			return { previous }
 		},
 		onSuccess: () => invalidateAll(),
@@ -135,16 +147,14 @@ export function CategoriesSettings() {
 			id: c.id,
 			sort_order: (idx + 1) * 10
 		}))
-		// Optimistic UI: write the reordered list to the cache so the
-		// dragged row stays where the user dropped it. onMutate has
-		// already snapshotted the previous order; onError restores it.
-		queryClient.setQueryData<DocumentCategoryRow[]>(listKey, () =>
-			reordered.map((c, idx) => ({
-				...c,
-				sort_order: (idx + 1) * 10
-			}))
-		)
-		reorderMutation.mutate({ orders })
+		const nextRows = reordered.map((c, idx) => ({
+			...c,
+			sort_order: (idx + 1) * 10
+		}))
+		// Pass the pre-computed reordered rows to the mutation so
+		// onMutate can serialize cancelQueries → snapshot → setQueryData
+		// atomically.
+		reorderMutation.mutate({ orders, next: nextRows })
 	}
 
 	// Cycle-1 M-1: append-at-end semantics. Picking max+10 stays

--- a/src/components/settings/categories-settings.tsx
+++ b/src/components/settings/categories-settings.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import {
 	DndContext,
@@ -15,11 +15,9 @@ import {
 	SortableContext,
 	arrayMove,
 	sortableKeyboardCoordinates,
-	useSortable,
 	verticalListSortingStrategy
 } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '#components/ui/button'
 import {
@@ -29,132 +27,18 @@ import {
 	CardHeader,
 	CardTitle
 } from '#components/ui/card'
-import { Input } from '#components/ui/input'
 import { Skeleton } from '#components/ui/skeleton'
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle
-} from '#components/ui/dialog'
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue
-} from '#components/ui/select'
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger
-} from '#components/ui/tooltip'
 import { useDocumentCategories } from '#hooks/api/use-document-categories'
 import {
 	documentCategoryMutations,
 	documentCategoryQueries,
 	type DocumentCategoryRow
 } from '#hooks/api/query-keys/document-category-keys'
-
-const SLUG_INPUT_HINT =
-	'lowercase letters, numbers, and underscores only (1-50 chars)'
-const LABEL_MAX = 80
-
-function asciiSlugify(label: string): string {
-	return label
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, '_')
-		.replace(/^_+|_+$/g, '')
-		.slice(0, 50)
-}
-
-interface SortableRowProps {
-	category: DocumentCategoryRow
-	onEdit: (c: DocumentCategoryRow) => void
-	onDelete: (c: DocumentCategoryRow) => void
-}
-
-function SortableRow({ category, onEdit, onDelete }: SortableRowProps) {
-	const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-		useSortable({ id: category.id })
-	const style = {
-		transform: CSS.Transform.toString(transform),
-		transition,
-		opacity: isDragging ? 0.6 : 1
-	}
-	return (
-		<li
-			ref={setNodeRef}
-			style={style}
-			className="flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2"
-		>
-			<button
-				type="button"
-				className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
-				aria-label={`Drag to reorder ${category.label}`}
-				{...attributes}
-				{...listeners}
-			>
-				<GripVertical className="size-4" aria-hidden="true" />
-			</button>
-			<div className="flex-1 min-w-0">
-				<div className="flex items-center gap-2">
-					<span className="font-medium truncate">{category.label}</span>
-					{category.is_default && (
-						<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-							Default
-						</span>
-					)}
-				</div>
-				<code className="text-xs text-muted-foreground">{category.slug}</code>
-			</div>
-			<Button
-				variant="ghost"
-				size="sm"
-				className="size-9 p-0"
-				onClick={() => onEdit(category)}
-				aria-label={`Rename ${category.label}`}
-			>
-				<Pencil className="size-4" aria-hidden="true" />
-			</Button>
-			{category.is_default ? (
-				<TooltipProvider delayDuration={150}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<span tabIndex={0}>
-								<Button
-									variant="ghost"
-									size="sm"
-									className="size-9 p-0 text-muted-foreground"
-									disabled
-									aria-label="Default categories can't be deleted"
-								>
-									<Trash2 className="size-4" aria-hidden="true" />
-								</Button>
-							</span>
-						</TooltipTrigger>
-						<TooltipContent>
-							Default categories can&rsquo;t be deleted.
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
-			) : (
-				<Button
-					variant="ghost"
-					size="sm"
-					className="size-9 p-0"
-					onClick={() => onDelete(category)}
-					aria-label={`Delete ${category.label}`}
-				>
-					<Trash2 className="size-4" aria-hidden="true" />
-				</Button>
-			)}
-		</li>
-	)
-}
+import { documentQueries } from '#hooks/api/query-keys/document-keys'
+import { CategoryCreateDialog } from './category-create-dialog'
+import { CategoryRenameDialog } from './category-rename-dialog'
+import { CategoryDeleteDialog } from './category-delete-dialog'
+import { CategoryRow } from './category-row'
 
 export function CategoriesSettings() {
 	const { categories, isLoading } = useDocumentCategories()
@@ -166,24 +50,21 @@ export function CategoriesSettings() {
 	)
 
 	const [createOpen, setCreateOpen] = useState(false)
-	const [createLabel, setCreateLabel] = useState('')
-	const [createSlug, setCreateSlug] = useState('')
-	const [slugTouched, setSlugTouched] = useState(false)
-
 	const [renaming, setRenaming] = useState<DocumentCategoryRow | null>(null)
-	const [renameLabel, setRenameLabel] = useState('')
-
 	const [deleting, setDeleting] = useState<DocumentCategoryRow | null>(null)
-	const [reassignTo, setReassignTo] = useState<string>('')
 
 	const invalidateAll = () => {
 		void queryClient.invalidateQueries({
 			queryKey: documentCategoryQueries.all()
 		})
-		// Reassign also rewrites documents.document_type, so the documents
-		// list view is stale too.
-		void queryClient.invalidateQueries({ queryKey: ['documents'] })
-		void queryClient.invalidateQueries({ queryKey: ['documentSearch'] })
+		// Reassign rewrites documents.document_type, so EVERY cached
+		// document-related query is now stale — the per-entity list
+		// AND the global vault search (whose key prefix is `['documents',
+		// 'search', ...]`). `documentQueries.all()` returns
+		// `['documents']`, which TanStack Query expands into a
+		// prefix-match against every key starting with that tuple,
+		// covering both surfaces in one call.
+		void queryClient.invalidateQueries({ queryKey: documentQueries.all() })
 	}
 
 	const createMutation = useMutation({
@@ -191,9 +72,6 @@ export function CategoriesSettings() {
 		onSuccess: () => {
 			invalidateAll()
 			setCreateOpen(false)
-			setCreateLabel('')
-			setCreateSlug('')
-			setSlugTouched(false)
 			toast.success('Category created.')
 		},
 		onError: err => {
@@ -218,7 +96,6 @@ export function CategoriesSettings() {
 		onSuccess: () => {
 			invalidateAll()
 			setDeleting(null)
-			setReassignTo('')
 			toast.success('Category deleted; documents reassigned.')
 		},
 		onError: err => {
@@ -226,22 +103,26 @@ export function CategoriesSettings() {
 		}
 	})
 
+	// Reorder mutation uses TanStack Query's onMutate/onError snapshot
+	// pattern (cycle-1 M-6) so a failed RPC restores the EXACT cached
+	// order the user saw before drag — no full refetch flash.
+	const listKey = documentCategoryQueries.list().queryKey
 	const reorderMutation = useMutation({
 		...documentCategoryMutations.reorder(),
+		onMutate: async () => {
+			await queryClient.cancelQueries({ queryKey: listKey })
+			const previous =
+				queryClient.getQueryData<DocumentCategoryRow[]>(listKey)
+			return { previous }
+		},
 		onSuccess: () => invalidateAll(),
-		onError: err => {
+		onError: (err, _vars, ctx) => {
+			if (ctx?.previous) {
+				queryClient.setQueryData(listKey, ctx.previous)
+			}
 			toast.error(err instanceof Error ? err.message : 'Reorder failed.')
-			// Roll back the optimistic UI by re-fetching authoritative order.
-			void queryClient.invalidateQueries({
-				queryKey: documentCategoryQueries.list().queryKey
-			})
 		}
 	})
-
-	const reassignTargets = useMemo(
-		() => categories.filter(c => c.id !== deleting?.id),
-		[categories, deleting]
-	)
 
 	function handleDragEnd(event: DragEndEvent) {
 		const { active, over } = event
@@ -254,20 +135,24 @@ export function CategoriesSettings() {
 			id: c.id,
 			sort_order: (idx + 1) * 10
 		}))
-		// Optimistic UI: update the cached list immediately so the
-		// dragged row stays where the user dropped it. Server confirms
-		// via invalidateAll on success; the rollback path on error
-		// re-fetches the authoritative order.
-		queryClient.setQueryData<DocumentCategoryRow[]>(
-			documentCategoryQueries.list().queryKey,
-			() =>
-				reordered.map((c, idx) => ({
-					...c,
-					sort_order: (idx + 1) * 10
-				}))
+		// Optimistic UI: write the reordered list to the cache so the
+		// dragged row stays where the user dropped it. onMutate has
+		// already snapshotted the previous order; onError restores it.
+		queryClient.setQueryData<DocumentCategoryRow[]>(listKey, () =>
+			reordered.map((c, idx) => ({
+				...c,
+				sort_order: (idx + 1) * 10
+			}))
 		)
 		reorderMutation.mutate({ orders })
 	}
+
+	// Cycle-1 M-1: append-at-end semantics. Picking max+10 stays
+	// behind the highest sort_order even after a reorder produced gaps.
+	const nextSortOrder =
+		(categories.length === 0
+			? 0
+			: Math.max(...categories.map(c => c.sort_order))) + 10
 
 	if (isLoading) {
 		return (
@@ -316,22 +201,11 @@ export function CategoriesSettings() {
 					>
 						<ul className="space-y-2" aria-label="Document categories">
 							{categories.map(c => (
-								<SortableRow
+								<CategoryRow
 									key={c.id}
 									category={c}
-									onEdit={cat => {
-										setRenaming(cat)
-										setRenameLabel(cat.label)
-									}}
-									onDelete={cat => {
-										setDeleting(cat)
-										// Default to the canonical fallback when present.
-										const fallback =
-											categories.find(
-												x => x.slug === 'other' && x.id !== cat.id
-											) ?? categories.find(x => x.id !== cat.id)
-										setReassignTo(fallback?.id ?? '')
-									}}
+									onEdit={cat => setRenaming(cat)}
+									onDelete={cat => setDeleting(cat)}
 								/>
 							))}
 						</ul>
@@ -339,232 +213,32 @@ export function CategoriesSettings() {
 				</DndContext>
 			</CardContent>
 
-			<Dialog
+			<CategoryCreateDialog
 				open={createOpen}
-				onOpenChange={open => {
-					setCreateOpen(open)
-					if (!open) {
-						setCreateLabel('')
-						setCreateSlug('')
-						setSlugTouched(false)
-					}
-				}}
-			>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>New category</DialogTitle>
-						<DialogDescription>
-							Categories are private to your account. Slugs cannot be
-							changed after creation.
-						</DialogDescription>
-					</DialogHeader>
-					<div className="space-y-4">
-						<div className="space-y-1">
-							<label
-								htmlFor="new-cat-label"
-								className="text-sm font-medium"
-							>
-								Label
-							</label>
-							<Input
-								id="new-cat-label"
-								value={createLabel}
-								maxLength={LABEL_MAX}
-								onChange={e => {
-									setCreateLabel(e.target.value)
-									if (!slugTouched) {
-										setCreateSlug(asciiSlugify(e.target.value))
-									}
-								}}
-								placeholder="Warranty"
-								autoFocus
-							/>
-						</div>
-						<div className="space-y-1">
-							<label htmlFor="new-cat-slug" className="text-sm font-medium">
-								Slug
-							</label>
-							<Input
-								id="new-cat-slug"
-								value={createSlug}
-								onChange={e => {
-									setSlugTouched(true)
-									setCreateSlug(e.target.value)
-								}}
-								placeholder="warranty"
-								aria-describedby="new-cat-slug-hint"
-							/>
-							<p
-								id="new-cat-slug-hint"
-								className="text-xs text-muted-foreground"
-							>
-								{SLUG_INPUT_HINT}
-							</p>
-						</div>
-					</div>
-					<DialogFooter>
-						<Button variant="ghost" onClick={() => setCreateOpen(false)}>
-							Cancel
-						</Button>
-						<Button
-							onClick={() =>
-								createMutation.mutate({
-									slug: createSlug,
-									label: createLabel,
-									sort_order: (categories.length + 1) * 10
-								})
-							}
-							disabled={
-								createMutation.isPending ||
-								createLabel.trim().length === 0 ||
-								createSlug.length === 0
-							}
-						>
-							{createMutation.isPending && (
-								<Loader2
-									className="size-4 mr-2 animate-spin"
-									aria-hidden="true"
-								/>
-							)}
-							Create
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+				onOpenChange={setCreateOpen}
+				onSubmit={input => createMutation.mutate(input)}
+				isPending={createMutation.isPending}
+				defaultSortOrder={nextSortOrder}
+			/>
 
-			<Dialog
-				open={renaming !== null}
+			<CategoryRenameDialog
+				target={renaming}
 				onOpenChange={open => {
-					if (!open) {
-						setRenaming(null)
-					}
+					if (!open) setRenaming(null)
 				}}
-			>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Rename category</DialogTitle>
-						<DialogDescription>
-							Slug stays as <code>{renaming?.slug}</code>. Labels can be
-							edited freely.
-						</DialogDescription>
-					</DialogHeader>
-					<div className="space-y-1">
-						<label htmlFor="rename-label" className="text-sm font-medium">
-							Label
-						</label>
-						<Input
-							id="rename-label"
-							value={renameLabel}
-							maxLength={LABEL_MAX}
-							onChange={e => setRenameLabel(e.target.value)}
-							autoFocus
-						/>
-					</div>
-					<DialogFooter>
-						<Button variant="ghost" onClick={() => setRenaming(null)}>
-							Cancel
-						</Button>
-						<Button
-							onClick={() => {
-								if (!renaming) return
-								updateMutation.mutate({
-									id: renaming.id,
-									label: renameLabel
-								})
-							}}
-							disabled={
-								updateMutation.isPending ||
-								renameLabel.trim().length === 0 ||
-								renameLabel.trim() === renaming?.label
-							}
-						>
-							{updateMutation.isPending && (
-								<Loader2
-									className="size-4 mr-2 animate-spin"
-									aria-hidden="true"
-								/>
-							)}
-							Save
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+				onSubmit={input => updateMutation.mutate(input)}
+				isPending={updateMutation.isPending}
+			/>
 
-			<Dialog
-				open={deleting !== null}
+			<CategoryDeleteDialog
+				target={deleting}
+				candidates={categories}
 				onOpenChange={open => {
-					if (!open) {
-						setDeleting(null)
-						setReassignTo('')
-					}
+					if (!open) setDeleting(null)
 				}}
-			>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>Delete &ldquo;{deleting?.label}&rdquo;</DialogTitle>
-						<DialogDescription>
-							Documents currently tagged with this category will be
-							reassigned to the category you pick below. This change is
-							atomic — every affected document is updated in a single
-							transaction.
-						</DialogDescription>
-					</DialogHeader>
-					<div className="space-y-1">
-						<label htmlFor="reassign-target" className="text-sm font-medium">
-							Reassign documents to
-						</label>
-						<Select value={reassignTo} onValueChange={setReassignTo}>
-							<SelectTrigger
-								id="reassign-target"
-								aria-label="Reassignment target category"
-							>
-								<SelectValue placeholder="Choose a category" />
-							</SelectTrigger>
-							<SelectContent>
-								{reassignTargets.map(c => (
-									<SelectItem key={c.id} value={c.id}>
-										{c.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</div>
-					<DialogFooter>
-						<Button
-							variant="ghost"
-							onClick={() => {
-								setDeleting(null)
-								setReassignTo('')
-							}}
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="destructive"
-							onClick={() => {
-								if (!deleting || !reassignTo) return
-								deleteMutation.mutate({
-									from_id: deleting.id,
-									to_id: reassignTo
-								})
-							}}
-							disabled={
-								deleteMutation.isPending ||
-								!reassignTo ||
-								reassignTo === deleting?.id
-							}
-						>
-							{deleteMutation.isPending && (
-								<Loader2
-									className="size-4 mr-2 animate-spin"
-									aria-hidden="true"
-								/>
-							)}
-							Delete &amp; reassign
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+				onSubmit={input => deleteMutation.mutate(input)}
+				isPending={deleteMutation.isPending}
+			/>
 		</Card>
 	)
 }

--- a/src/components/settings/categories-settings.tsx
+++ b/src/components/settings/categories-settings.tsx
@@ -1,0 +1,570 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+	DndContext,
+	type DragEndEvent,
+	KeyboardSensor,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors
+} from '@dnd-kit/core'
+import {
+	SortableContext,
+	arrayMove,
+	sortableKeyboardCoordinates,
+	useSortable,
+	verticalListSortingStrategy
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical, Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '#components/ui/button'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle
+} from '#components/ui/card'
+import { Input } from '#components/ui/input'
+import { Skeleton } from '#components/ui/skeleton'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '#components/ui/dialog'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '#components/ui/select'
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger
+} from '#components/ui/tooltip'
+import { useDocumentCategories } from '#hooks/api/use-document-categories'
+import {
+	documentCategoryMutations,
+	documentCategoryQueries,
+	type DocumentCategoryRow
+} from '#hooks/api/query-keys/document-category-keys'
+
+const SLUG_INPUT_HINT =
+	'lowercase letters, numbers, and underscores only (1-50 chars)'
+const LABEL_MAX = 80
+
+function asciiSlugify(label: string): string {
+	return label
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.slice(0, 50)
+}
+
+interface SortableRowProps {
+	category: DocumentCategoryRow
+	onEdit: (c: DocumentCategoryRow) => void
+	onDelete: (c: DocumentCategoryRow) => void
+}
+
+function SortableRow({ category, onEdit, onDelete }: SortableRowProps) {
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+		useSortable({ id: category.id })
+	const style = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+		opacity: isDragging ? 0.6 : 1
+	}
+	return (
+		<li
+			ref={setNodeRef}
+			style={style}
+			className="flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2"
+		>
+			<button
+				type="button"
+				className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+				aria-label={`Drag to reorder ${category.label}`}
+				{...attributes}
+				{...listeners}
+			>
+				<GripVertical className="size-4" aria-hidden="true" />
+			</button>
+			<div className="flex-1 min-w-0">
+				<div className="flex items-center gap-2">
+					<span className="font-medium truncate">{category.label}</span>
+					{category.is_default && (
+						<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+							Default
+						</span>
+					)}
+				</div>
+				<code className="text-xs text-muted-foreground">{category.slug}</code>
+			</div>
+			<Button
+				variant="ghost"
+				size="sm"
+				className="size-9 p-0"
+				onClick={() => onEdit(category)}
+				aria-label={`Rename ${category.label}`}
+			>
+				<Pencil className="size-4" aria-hidden="true" />
+			</Button>
+			{category.is_default ? (
+				<TooltipProvider delayDuration={150}>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span tabIndex={0}>
+								<Button
+									variant="ghost"
+									size="sm"
+									className="size-9 p-0 text-muted-foreground"
+									disabled
+									aria-label="Default categories can't be deleted"
+								>
+									<Trash2 className="size-4" aria-hidden="true" />
+								</Button>
+							</span>
+						</TooltipTrigger>
+						<TooltipContent>
+							Default categories can&rsquo;t be deleted.
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			) : (
+				<Button
+					variant="ghost"
+					size="sm"
+					className="size-9 p-0"
+					onClick={() => onDelete(category)}
+					aria-label={`Delete ${category.label}`}
+				>
+					<Trash2 className="size-4" aria-hidden="true" />
+				</Button>
+			)}
+		</li>
+	)
+}
+
+export function CategoriesSettings() {
+	const { categories, isLoading } = useDocumentCategories()
+	const queryClient = useQueryClient()
+
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+	)
+
+	const [createOpen, setCreateOpen] = useState(false)
+	const [createLabel, setCreateLabel] = useState('')
+	const [createSlug, setCreateSlug] = useState('')
+	const [slugTouched, setSlugTouched] = useState(false)
+
+	const [renaming, setRenaming] = useState<DocumentCategoryRow | null>(null)
+	const [renameLabel, setRenameLabel] = useState('')
+
+	const [deleting, setDeleting] = useState<DocumentCategoryRow | null>(null)
+	const [reassignTo, setReassignTo] = useState<string>('')
+
+	const invalidateAll = () => {
+		void queryClient.invalidateQueries({
+			queryKey: documentCategoryQueries.all()
+		})
+		// Reassign also rewrites documents.document_type, so the documents
+		// list view is stale too.
+		void queryClient.invalidateQueries({ queryKey: ['documents'] })
+		void queryClient.invalidateQueries({ queryKey: ['documentSearch'] })
+	}
+
+	const createMutation = useMutation({
+		...documentCategoryMutations.create(),
+		onSuccess: () => {
+			invalidateAll()
+			setCreateOpen(false)
+			setCreateLabel('')
+			setCreateSlug('')
+			setSlugTouched(false)
+			toast.success('Category created.')
+		},
+		onError: err => {
+			toast.error(err instanceof Error ? err.message : 'Create failed.')
+		}
+	})
+
+	const updateMutation = useMutation({
+		...documentCategoryMutations.update(),
+		onSuccess: () => {
+			invalidateAll()
+			setRenaming(null)
+			toast.success('Category renamed.')
+		},
+		onError: err => {
+			toast.error(err instanceof Error ? err.message : 'Rename failed.')
+		}
+	})
+
+	const deleteMutation = useMutation({
+		...documentCategoryMutations.deleteWithReassign(),
+		onSuccess: () => {
+			invalidateAll()
+			setDeleting(null)
+			setReassignTo('')
+			toast.success('Category deleted; documents reassigned.')
+		},
+		onError: err => {
+			toast.error(err instanceof Error ? err.message : 'Delete failed.')
+		}
+	})
+
+	const reorderMutation = useMutation({
+		...documentCategoryMutations.reorder(),
+		onSuccess: () => invalidateAll(),
+		onError: err => {
+			toast.error(err instanceof Error ? err.message : 'Reorder failed.')
+			// Roll back the optimistic UI by re-fetching authoritative order.
+			void queryClient.invalidateQueries({
+				queryKey: documentCategoryQueries.list().queryKey
+			})
+		}
+	})
+
+	const reassignTargets = useMemo(
+		() => categories.filter(c => c.id !== deleting?.id),
+		[categories, deleting]
+	)
+
+	function handleDragEnd(event: DragEndEvent) {
+		const { active, over } = event
+		if (!over || active.id === over.id) return
+		const oldIndex = categories.findIndex(c => c.id === active.id)
+		const newIndex = categories.findIndex(c => c.id === over.id)
+		if (oldIndex < 0 || newIndex < 0) return
+		const reordered = arrayMove(categories, oldIndex, newIndex)
+		const orders = reordered.map((c, idx) => ({
+			id: c.id,
+			sort_order: (idx + 1) * 10
+		}))
+		// Optimistic UI: update the cached list immediately so the
+		// dragged row stays where the user dropped it. Server confirms
+		// via invalidateAll on success; the rollback path on error
+		// re-fetches the authoritative order.
+		queryClient.setQueryData<DocumentCategoryRow[]>(
+			documentCategoryQueries.list().queryKey,
+			() =>
+				reordered.map((c, idx) => ({
+					...c,
+					sort_order: (idx + 1) * 10
+				}))
+		)
+		reorderMutation.mutate({ orders })
+	}
+
+	if (isLoading) {
+		return (
+			<Card>
+				<CardHeader>
+					<CardTitle>Document categories</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-2">
+					{[0, 1, 2, 3].map(i => (
+						<Skeleton key={i} className="h-12 w-full" />
+					))}
+				</CardContent>
+			</Card>
+		)
+	}
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+				<div className="space-y-1">
+					<CardTitle>Document categories</CardTitle>
+					<CardDescription>
+						Customize the taxonomy used when uploading and filtering
+						documents. Default categories can be reordered or renamed but
+						not deleted.
+					</CardDescription>
+				</div>
+				<Button
+					size="sm"
+					onClick={() => setCreateOpen(true)}
+					className="shrink-0"
+				>
+					<Plus className="size-4 mr-1" aria-hidden="true" />
+					Add category
+				</Button>
+			</CardHeader>
+			<CardContent>
+				<DndContext
+					sensors={sensors}
+					collisionDetection={closestCenter}
+					onDragEnd={handleDragEnd}
+				>
+					<SortableContext
+						items={categories.map(c => c.id)}
+						strategy={verticalListSortingStrategy}
+					>
+						<ul className="space-y-2" aria-label="Document categories">
+							{categories.map(c => (
+								<SortableRow
+									key={c.id}
+									category={c}
+									onEdit={cat => {
+										setRenaming(cat)
+										setRenameLabel(cat.label)
+									}}
+									onDelete={cat => {
+										setDeleting(cat)
+										// Default to the canonical fallback when present.
+										const fallback =
+											categories.find(
+												x => x.slug === 'other' && x.id !== cat.id
+											) ?? categories.find(x => x.id !== cat.id)
+										setReassignTo(fallback?.id ?? '')
+									}}
+								/>
+							))}
+						</ul>
+					</SortableContext>
+				</DndContext>
+			</CardContent>
+
+			<Dialog
+				open={createOpen}
+				onOpenChange={open => {
+					setCreateOpen(open)
+					if (!open) {
+						setCreateLabel('')
+						setCreateSlug('')
+						setSlugTouched(false)
+					}
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>New category</DialogTitle>
+						<DialogDescription>
+							Categories are private to your account. Slugs cannot be
+							changed after creation.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-4">
+						<div className="space-y-1">
+							<label
+								htmlFor="new-cat-label"
+								className="text-sm font-medium"
+							>
+								Label
+							</label>
+							<Input
+								id="new-cat-label"
+								value={createLabel}
+								maxLength={LABEL_MAX}
+								onChange={e => {
+									setCreateLabel(e.target.value)
+									if (!slugTouched) {
+										setCreateSlug(asciiSlugify(e.target.value))
+									}
+								}}
+								placeholder="Warranty"
+								autoFocus
+							/>
+						</div>
+						<div className="space-y-1">
+							<label htmlFor="new-cat-slug" className="text-sm font-medium">
+								Slug
+							</label>
+							<Input
+								id="new-cat-slug"
+								value={createSlug}
+								onChange={e => {
+									setSlugTouched(true)
+									setCreateSlug(e.target.value)
+								}}
+								placeholder="warranty"
+								aria-describedby="new-cat-slug-hint"
+							/>
+							<p
+								id="new-cat-slug-hint"
+								className="text-xs text-muted-foreground"
+							>
+								{SLUG_INPUT_HINT}
+							</p>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button variant="ghost" onClick={() => setCreateOpen(false)}>
+							Cancel
+						</Button>
+						<Button
+							onClick={() =>
+								createMutation.mutate({
+									slug: createSlug,
+									label: createLabel,
+									sort_order: (categories.length + 1) * 10
+								})
+							}
+							disabled={
+								createMutation.isPending ||
+								createLabel.trim().length === 0 ||
+								createSlug.length === 0
+							}
+						>
+							{createMutation.isPending && (
+								<Loader2
+									className="size-4 mr-2 animate-spin"
+									aria-hidden="true"
+								/>
+							)}
+							Create
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={renaming !== null}
+				onOpenChange={open => {
+					if (!open) {
+						setRenaming(null)
+					}
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Rename category</DialogTitle>
+						<DialogDescription>
+							Slug stays as <code>{renaming?.slug}</code>. Labels can be
+							edited freely.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-1">
+						<label htmlFor="rename-label" className="text-sm font-medium">
+							Label
+						</label>
+						<Input
+							id="rename-label"
+							value={renameLabel}
+							maxLength={LABEL_MAX}
+							onChange={e => setRenameLabel(e.target.value)}
+							autoFocus
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="ghost" onClick={() => setRenaming(null)}>
+							Cancel
+						</Button>
+						<Button
+							onClick={() => {
+								if (!renaming) return
+								updateMutation.mutate({
+									id: renaming.id,
+									label: renameLabel
+								})
+							}}
+							disabled={
+								updateMutation.isPending ||
+								renameLabel.trim().length === 0 ||
+								renameLabel.trim() === renaming?.label
+							}
+						>
+							{updateMutation.isPending && (
+								<Loader2
+									className="size-4 mr-2 animate-spin"
+									aria-hidden="true"
+								/>
+							)}
+							Save
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={deleting !== null}
+				onOpenChange={open => {
+					if (!open) {
+						setDeleting(null)
+						setReassignTo('')
+					}
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete &ldquo;{deleting?.label}&rdquo;</DialogTitle>
+						<DialogDescription>
+							Documents currently tagged with this category will be
+							reassigned to the category you pick below. This change is
+							atomic — every affected document is updated in a single
+							transaction.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-1">
+						<label htmlFor="reassign-target" className="text-sm font-medium">
+							Reassign documents to
+						</label>
+						<Select value={reassignTo} onValueChange={setReassignTo}>
+							<SelectTrigger
+								id="reassign-target"
+								aria-label="Reassignment target category"
+							>
+								<SelectValue placeholder="Choose a category" />
+							</SelectTrigger>
+							<SelectContent>
+								{reassignTargets.map(c => (
+									<SelectItem key={c.id} value={c.id}>
+										{c.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<DialogFooter>
+						<Button
+							variant="ghost"
+							onClick={() => {
+								setDeleting(null)
+								setReassignTo('')
+							}}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={() => {
+								if (!deleting || !reassignTo) return
+								deleteMutation.mutate({
+									from_id: deleting.id,
+									to_id: reassignTo
+								})
+							}}
+							disabled={
+								deleteMutation.isPending ||
+								!reassignTo ||
+								reassignTo === deleting?.id
+							}
+						>
+							{deleteMutation.isPending && (
+								<Loader2
+									className="size-4 mr-2 animate-spin"
+									aria-hidden="true"
+								/>
+							)}
+							Delete &amp; reassign
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</Card>
+	)
+}

--- a/src/components/settings/category-create-dialog.tsx
+++ b/src/components/settings/category-create-dialog.tsx
@@ -12,18 +12,21 @@ import {
 	DialogTitle
 } from '#components/ui/dialog'
 import { Input } from '#components/ui/input'
+import { cn } from '#lib/utils'
 import type { CreateDocumentCategoryInput } from '#hooks/api/query-keys/document-category-keys'
 
 const SLUG_INPUT_HINT =
 	'lowercase letters, numbers, and underscores only (1-50 chars)'
+const SLUG_FORMAT_RE = /^[a-z0-9_]+$/
 const LABEL_MAX = 80
+const SLUG_MAX = 50
 
 function asciiSlugify(label: string): string {
 	return label
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, '_')
 		.replace(/^_+|_+$/g, '')
-		.slice(0, 50)
+		.slice(0, SLUG_MAX)
 }
 
 interface CategoryCreateDialogProps {
@@ -34,6 +37,10 @@ interface CategoryCreateDialogProps {
 	/** Used to compute the new row's sort_order — defaults to max+10 to
 	 * append at the end of the list. */
 	defaultSortOrder: number
+	/** Existing slugs in the user's taxonomy. Used for client-side
+	 * dedup so the user gets a friendly inline error before the RPC
+	 * round-trip surfaces a raw 23505 from the unique constraint. */
+	existingSlugs: ReadonlyArray<string>
 }
 
 export function CategoryCreateDialog({
@@ -41,7 +48,8 @@ export function CategoryCreateDialog({
 	onOpenChange,
 	onSubmit,
 	isPending,
-	defaultSortOrder
+	defaultSortOrder,
+	existingSlugs
 }: CategoryCreateDialogProps) {
 	const [label, setLabel] = useState('')
 	const [slug, setSlug] = useState('')
@@ -80,8 +88,28 @@ export function CategoryCreateDialog({
 	}
 
 	const trimmedLabel = label.trim()
+	// Client-side validation surfaces issues inline BEFORE the RPC round-
+	// trip, so users don't see a raw "duplicate key value violates
+	// unique constraint" toast for an obvious dupe (cycle-5 M-1) or a
+	// post-submit Zod rejection for a malformed slug (cycle-5 M-2).
+	const slugFormatValid = slug.length === 0 || SLUG_FORMAT_RE.test(slug)
+	const slugTooLong = slug.length > SLUG_MAX
+	const slugDuplicate =
+		slug.length > 0 && existingSlugs.includes(slug)
+	const slugError = !slugFormatValid
+		? `Slug must match ${SLUG_INPUT_HINT}.`
+		: slugTooLong
+			? `Slug must be 1-${SLUG_MAX} characters.`
+			: slugDuplicate
+				? 'A category with this slug already exists.'
+				: null
 	const canSubmit =
-		!isPending && trimmedLabel.length > 0 && slug.length > 0
+		!isPending &&
+		trimmedLabel.length > 0 &&
+		slug.length > 0 &&
+		slugFormatValid &&
+		!slugTooLong &&
+		!slugDuplicate
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -117,12 +145,22 @@ export function CategoryCreateDialog({
 							onChange={e => handleSlugChange(e.target.value)}
 							placeholder="warranty"
 							aria-describedby="new-cat-slug-hint"
+							aria-invalid={slugError !== null}
+							className={cn(
+								slugError !== null &&
+									'border-destructive focus-visible:ring-destructive'
+							)}
 						/>
 						<p
 							id="new-cat-slug-hint"
-							className="text-xs text-muted-foreground"
+							className={cn(
+								'text-xs',
+								slugError !== null
+									? 'text-destructive'
+									: 'text-muted-foreground'
+							)}
 						>
-							{SLUG_INPUT_HINT}
+							{slugError ?? SLUG_INPUT_HINT}
 						</p>
 					</div>
 				</div>

--- a/src/components/settings/category-create-dialog.tsx
+++ b/src/components/settings/category-create-dialog.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '#components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '#components/ui/dialog'
+import { Input } from '#components/ui/input'
+import type { CreateDocumentCategoryInput } from '#hooks/api/query-keys/document-category-keys'
+
+const SLUG_INPUT_HINT =
+	'lowercase letters, numbers, and underscores only (1-50 chars)'
+const LABEL_MAX = 80
+
+function asciiSlugify(label: string): string {
+	return label
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '')
+		.slice(0, 50)
+}
+
+interface CategoryCreateDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	onSubmit: (input: CreateDocumentCategoryInput) => void
+	isPending: boolean
+	/** Used to compute the new row's sort_order — defaults to max+10 to
+	 * append at the end of the list. */
+	defaultSortOrder: number
+}
+
+export function CategoryCreateDialog({
+	open,
+	onOpenChange,
+	onSubmit,
+	isPending,
+	defaultSortOrder
+}: CategoryCreateDialogProps) {
+	const [label, setLabel] = useState('')
+	const [slug, setSlug] = useState('')
+	const [slugTouched, setSlugTouched] = useState(false)
+
+	// Reset form state whenever the dialog closes — single side effect so
+	// the cleanup path lives in one place rather than being duplicated
+	// across onOpenChange + Cancel-button handlers.
+	useEffect(() => {
+		if (!open) {
+			setLabel('')
+			setSlug('')
+			setSlugTouched(false)
+		}
+	}, [open])
+
+	function handleLabelChange(next: string) {
+		setLabel(next)
+		// Auto-derive slug from label until the user explicitly edits it.
+		// If they then clear the slug field, restore the auto-fill so
+		// they're not stuck with stale state (cycle-1 M-10).
+		if (!slugTouched) {
+			setSlug(asciiSlugify(next))
+		}
+	}
+
+	function handleSlugChange(next: string) {
+		if (next.length === 0) {
+			// Reset the touched flag so the auto-fill re-engages on the
+			// next label edit.
+			setSlugTouched(false)
+		} else {
+			setSlugTouched(true)
+		}
+		setSlug(next)
+	}
+
+	const trimmedLabel = label.trim()
+	const canSubmit =
+		!isPending && trimmedLabel.length > 0 && slug.length > 0
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>New category</DialogTitle>
+					<DialogDescription>
+						Categories are private to your account. Slugs cannot be
+						changed after creation.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-4">
+					<div className="space-y-1">
+						<label htmlFor="new-cat-label" className="text-sm font-medium">
+							Label
+						</label>
+						<Input
+							id="new-cat-label"
+							value={label}
+							maxLength={LABEL_MAX}
+							onChange={e => handleLabelChange(e.target.value)}
+							placeholder="Warranty"
+							autoFocus
+						/>
+					</div>
+					<div className="space-y-1">
+						<label htmlFor="new-cat-slug" className="text-sm font-medium">
+							Slug
+						</label>
+						<Input
+							id="new-cat-slug"
+							value={slug}
+							onChange={e => handleSlugChange(e.target.value)}
+							placeholder="warranty"
+							aria-describedby="new-cat-slug-hint"
+						/>
+						<p
+							id="new-cat-slug-hint"
+							className="text-xs text-muted-foreground"
+						>
+							{SLUG_INPUT_HINT}
+						</p>
+					</div>
+				</div>
+				<DialogFooter>
+					<Button variant="ghost" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button
+						onClick={() =>
+							onSubmit({
+								slug,
+								label: trimmedLabel,
+								sort_order: defaultSortOrder
+							})
+						}
+						disabled={!canSubmit}
+					>
+						{isPending && (
+							<Loader2
+								className="size-4 mr-2 animate-spin"
+								aria-hidden="true"
+							/>
+						)}
+						Create
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/settings/category-create-dialog.tsx
+++ b/src/components/settings/category-create-dialog.tsx
@@ -142,6 +142,7 @@ export function CategoryCreateDialog({
 						<Input
 							id="new-cat-slug"
 							value={slug}
+							maxLength={SLUG_MAX}
 							onChange={e => handleSlugChange(e.target.value)}
 							placeholder="warranty"
 							aria-describedby="new-cat-slug-hint"

--- a/src/components/settings/category-delete-dialog.tsx
+++ b/src/components/settings/category-delete-dialog.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '#components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '#components/ui/dialog'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '#components/ui/select'
+import type {
+	DeleteWithReassignInput,
+	DocumentCategoryRow
+} from '#hooks/api/query-keys/document-category-keys'
+
+interface CategoryDeleteDialogProps {
+	target: DocumentCategoryRow | null
+	candidates: DocumentCategoryRow[]
+	onOpenChange: (open: boolean) => void
+	onSubmit: (input: DeleteWithReassignInput) => void
+	isPending: boolean
+}
+
+export function CategoryDeleteDialog({
+	target,
+	candidates,
+	onOpenChange,
+	onSubmit,
+	isPending
+}: CategoryDeleteDialogProps) {
+	const [reassignTo, setReassignTo] = useState('')
+
+	// Default to the canonical 'other' fallback when present (or first
+	// non-self candidate otherwise). Reset on open.
+	useEffect(() => {
+		if (!target) {
+			setReassignTo('')
+			return
+		}
+		const fallback =
+			candidates.find(c => c.slug === 'other' && c.id !== target.id) ??
+			candidates.find(c => c.id !== target.id)
+		setReassignTo(fallback?.id ?? '')
+	}, [target, candidates])
+
+	const canSubmit =
+		!isPending &&
+		!!target &&
+		!!reassignTo &&
+		reassignTo !== target.id
+
+	return (
+		<Dialog open={target !== null} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Delete &ldquo;{target?.label}&rdquo;</DialogTitle>
+					<DialogDescription>
+						Documents currently tagged with this category will be reassigned
+						to the category you pick below. This change is atomic — every
+						affected document is updated in a single transaction.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-1">
+					<label htmlFor="reassign-target" className="text-sm font-medium">
+						Reassign documents to
+					</label>
+					<Select value={reassignTo} onValueChange={setReassignTo}>
+						<SelectTrigger
+							id="reassign-target"
+							aria-label="Reassignment target category"
+						>
+							<SelectValue placeholder="Choose a category" />
+						</SelectTrigger>
+						<SelectContent>
+							{candidates
+								.filter(c => c.id !== target?.id)
+								.map(c => (
+									<SelectItem key={c.id} value={c.id}>
+										{c.label}
+									</SelectItem>
+								))}
+						</SelectContent>
+					</Select>
+				</div>
+				<DialogFooter>
+					<Button variant="ghost" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={() => {
+							if (!target || !reassignTo) return
+							onSubmit({ from_id: target.id, to_id: reassignTo })
+						}}
+						disabled={!canSubmit}
+					>
+						{isPending && (
+							<Loader2
+								className="size-4 mr-2 animate-spin"
+								aria-hidden="true"
+							/>
+						)}
+						Delete &amp; reassign
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/settings/category-delete-dialog.tsx
+++ b/src/components/settings/category-delete-dialog.tsx
@@ -40,18 +40,26 @@ export function CategoryDeleteDialog({
 }: CategoryDeleteDialogProps) {
 	const [reassignTo, setReassignTo] = useState('')
 
-	// Default to the canonical 'other' fallback when present (or first
-	// non-self candidate otherwise). Reset on open.
+	// Default to the canonical 'other' fallback when the dialog opens
+	// against a NEW target. Cycle-3 M-1: only re-run on `target?.id`
+	// change — gating on the full `candidates` array would clobber the
+	// user's chosen reassign target if the categories list refetches
+	// mid-dialog (e.g., refetchOnWindowFocus). The fallback lookup
+	// reaches into the latest `candidates` reference at fire time, so
+	// we don't need it as a dep.
+	const targetId = target?.id
 	useEffect(() => {
-		if (!target) {
+		if (!targetId) {
 			setReassignTo('')
 			return
 		}
 		const fallback =
-			candidates.find(c => c.slug === 'other' && c.id !== target.id) ??
-			candidates.find(c => c.id !== target.id)
+			candidates.find(c => c.slug === 'other' && c.id !== targetId) ??
+			candidates.find(c => c.id !== targetId)
 		setReassignTo(fallback?.id ?? '')
-	}, [target, candidates])
+		// `candidates` intentionally NOT in deps — see comment above.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [targetId])
 
 	const canSubmit =
 		!isPending &&

--- a/src/components/settings/category-rename-dialog.tsx
+++ b/src/components/settings/category-rename-dialog.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '#components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '#components/ui/dialog'
+import { Input } from '#components/ui/input'
+import type {
+	DocumentCategoryRow,
+	UpdateDocumentCategoryInput
+} from '#hooks/api/query-keys/document-category-keys'
+
+const LABEL_MAX = 80
+
+interface CategoryRenameDialogProps {
+	target: DocumentCategoryRow | null
+	onOpenChange: (open: boolean) => void
+	onSubmit: (input: UpdateDocumentCategoryInput) => void
+	isPending: boolean
+}
+
+export function CategoryRenameDialog({
+	target,
+	onOpenChange,
+	onSubmit,
+	isPending
+}: CategoryRenameDialogProps) {
+	const [label, setLabel] = useState('')
+
+	useEffect(() => {
+		setLabel(target?.label ?? '')
+	}, [target])
+
+	const trimmedLabel = label.trim()
+	// Cycle-1 M-2: trim BOTH sides — the DB CHECK only enforces
+	// length(trim(label)), so a stored label could include incidental
+	// whitespace. Comparing trimmed-vs-untrimmed would falsely enable
+	// Save on a no-op rename.
+	const trimmedExisting = target?.label.trim() ?? ''
+	const canSubmit =
+		!isPending &&
+		trimmedLabel.length > 0 &&
+		trimmedLabel !== trimmedExisting
+
+	return (
+		<Dialog open={target !== null} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Rename category</DialogTitle>
+					<DialogDescription>
+						Slug stays as <code>{target?.slug}</code>. Labels can be edited
+						freely.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-1">
+					<label htmlFor="rename-label" className="text-sm font-medium">
+						Label
+					</label>
+					<Input
+						id="rename-label"
+						value={label}
+						maxLength={LABEL_MAX}
+						onChange={e => setLabel(e.target.value)}
+						autoFocus
+					/>
+				</div>
+				<DialogFooter>
+					<Button variant="ghost" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button
+						onClick={() => {
+							if (!target) return
+							onSubmit({ id: target.id, label: trimmedLabel })
+						}}
+						disabled={!canSubmit}
+					>
+						{isPending && (
+							<Loader2
+								className="size-4 mr-2 animate-spin"
+								aria-hidden="true"
+							/>
+						)}
+						Save
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/settings/category-row.tsx
+++ b/src/components/settings/category-row.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical, Pencil, Trash2 } from 'lucide-react'
+import { Button } from '#components/ui/button'
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger
+} from '#components/ui/tooltip'
+import type { DocumentCategoryRow } from '#hooks/api/query-keys/document-category-keys'
+
+interface CategoryRowProps {
+	category: DocumentCategoryRow
+	onEdit: (c: DocumentCategoryRow) => void
+	onDelete: (c: DocumentCategoryRow) => void
+}
+
+/**
+ * Single category row in the settings list. Drag handle + label + slug
+ * + rename + delete. Default categories surface a tooltip-disabled
+ * delete button (the RPC also rejects server-side as defense-in-depth).
+ */
+export function CategoryRow({ category, onEdit, onDelete }: CategoryRowProps) {
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+		useSortable({ id: category.id })
+	const style = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+		opacity: isDragging ? 0.6 : 1
+	}
+	return (
+		<li
+			ref={setNodeRef}
+			style={style}
+			className="flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2"
+		>
+			<button
+				type="button"
+				className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+				aria-label={`Drag to reorder ${category.label}`}
+				{...attributes}
+				{...listeners}
+			>
+				<GripVertical className="size-4" aria-hidden="true" />
+			</button>
+			<div className="flex-1 min-w-0">
+				<div className="flex items-center gap-2">
+					<span className="font-medium truncate">{category.label}</span>
+					{category.is_default && (
+						<span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+							Default
+						</span>
+					)}
+				</div>
+				<code className="text-xs text-muted-foreground">{category.slug}</code>
+			</div>
+			<Button
+				variant="ghost"
+				size="sm"
+				className="size-9 p-0"
+				onClick={() => onEdit(category)}
+				aria-label={`Rename ${category.label}`}
+			>
+				<Pencil className="size-4" aria-hidden="true" />
+			</Button>
+			{category.is_default ? (
+				<TooltipProvider delayDuration={150}>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span tabIndex={0}>
+								<Button
+									variant="ghost"
+									size="sm"
+									className="size-9 p-0 text-muted-foreground"
+									disabled
+									aria-label="Default categories can't be deleted"
+								>
+									<Trash2 className="size-4" aria-hidden="true" />
+								</Button>
+							</span>
+						</TooltipTrigger>
+						<TooltipContent>
+							Default categories can&rsquo;t be deleted.
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			) : (
+				<Button
+					variant="ghost"
+					size="sm"
+					className="size-9 p-0"
+					onClick={() => onDelete(category)}
+					aria-label={`Delete ${category.label}`}
+				>
+					<Trash2 className="size-4" aria-hidden="true" />
+				</Button>
+			)}
+		</li>
+	)
+}

--- a/src/hooks/api/mutation-keys.ts
+++ b/src/hooks/api/mutation-keys.ts
@@ -83,6 +83,18 @@ export const mutationKeys = {
 		generatePdf: ['mutations', 'documents', 'generatePdf'] as const
 	},
 
+	// Document Categories (v2.6 Phase 66)
+	documentCategories: {
+		create: ['mutations', 'documentCategories', 'create'] as const,
+		update: ['mutations', 'documentCategories', 'update'] as const,
+		deleteWithReassign: [
+			'mutations',
+			'documentCategories',
+			'deleteWithReassign'
+		] as const,
+		reorder: ['mutations', 'documentCategories', 'reorder'] as const
+	},
+
 	// Auth
 	auth: {
 		login: ['mutations', 'auth', 'login'] as const,

--- a/src/hooks/api/query-keys/document-category-keys.ts
+++ b/src/hooks/api/query-keys/document-category-keys.ts
@@ -11,10 +11,13 @@
  * via Phase 66's settings UI), so a 5-minute staleTime is plenty.
  */
 
-import { queryOptions } from '@tanstack/react-query'
+import { queryOptions, mutationOptions } from '@tanstack/react-query'
 import { createClient } from '#lib/supabase/client'
 import { handlePostgrestError } from '#lib/postgrest-error-handler'
 import { documentCategorySlugSchema } from '#lib/validation/documents'
+import { requireOwnerUserId } from '#lib/require-owner-user-id'
+import { getCachedUser } from '#lib/supabase/get-cached-user'
+import { mutationKeys } from '../mutation-keys'
 
 const LIST_STALE_TIME_MS = 5 * 60 * 1000 // 5 min — categories change rarely
 const LIST_GC_TIME_MS = 30 * 60 * 1000
@@ -118,5 +121,126 @@ export const documentCategoryQueries = {
 			},
 			staleTime: LIST_STALE_TIME_MS,
 			gcTime: LIST_GC_TIME_MS
+		})
+} as const
+
+// v2.6 Phase 66 — admin UI write path. Each mutation invalidates BOTH
+// `documentCategoryQueries.all()` (the categories list) and the wider
+// document/search queries (since reassign mass-rewrites document_type
+// values). Wiring the invalidations into the mutation options keeps
+// the consumer one-line — `useMutation(documentCategoryMutations.create())`.
+
+export interface CreateDocumentCategoryInput {
+	slug: string
+	label: string
+	sort_order?: number
+}
+
+export interface UpdateDocumentCategoryInput {
+	id: string
+	label: string
+}
+
+export interface DeleteWithReassignInput {
+	from_id: string
+	to_id: string
+}
+
+export interface ReorderInput {
+	orders: Array<{ id: string; sort_order: number }>
+}
+
+export const documentCategoryMutations = {
+	create: () =>
+		mutationOptions<DocumentCategoryRow, Error, CreateDocumentCategoryInput>({
+			mutationKey: mutationKeys.documentCategories.create,
+			mutationFn: async (
+				input: CreateDocumentCategoryInput
+			): Promise<DocumentCategoryRow> => {
+				const supabase = createClient()
+				const user = await getCachedUser()
+				const ownerId = requireOwnerUserId(user?.id)
+				// Slug shape is also enforced by the DB CHECK constraint, but
+				// pre-validating here gives the user an immediate error
+				// without burning a roundtrip.
+				const slugCheck = documentCategorySlugSchema.safeParse(input.slug)
+				if (!slugCheck.success) {
+					throw new Error(
+						'Slug must be lowercase-snake_case (a-z, 0-9, _) and 1-50 chars.'
+					)
+				}
+				const trimmedLabel = input.label.trim()
+				if (trimmedLabel.length < 1 || trimmedLabel.length > 80) {
+					throw new Error('Label must be 1-80 characters.')
+				}
+				const { data, error } = await supabase
+					.from('document_categories')
+					.insert({
+						owner_user_id: ownerId,
+						slug: input.slug,
+						label: trimmedLabel,
+						sort_order: input.sort_order ?? 1000,
+						is_default: false
+					})
+					.select(
+						'id, slug, label, sort_order, is_default, owner_user_id, created_at, updated_at'
+					)
+					.single()
+				if (error) handlePostgrestError(error, 'create document category')
+				return mapDocumentCategoryRow(
+					(data ?? {}) as Record<string, unknown>
+				)
+			}
+		}),
+	update: () =>
+		mutationOptions<DocumentCategoryRow, Error, UpdateDocumentCategoryInput>({
+			mutationKey: mutationKeys.documentCategories.update,
+			mutationFn: async (
+				input: UpdateDocumentCategoryInput
+			): Promise<DocumentCategoryRow> => {
+				const supabase = createClient()
+				const trimmedLabel = input.label.trim()
+				if (trimmedLabel.length < 1 || trimmedLabel.length > 80) {
+					throw new Error('Label must be 1-80 characters.')
+				}
+				// Only `label` is mutable. Slug is canonical (cross-owner export
+				// portability) and `is_default` is set by the seed function. RLS
+				// gates ownership; updating someone else's row returns no rows.
+				const { data, error } = await supabase
+					.from('document_categories')
+					.update({ label: trimmedLabel })
+					.eq('id', input.id)
+					.select(
+						'id, slug, label, sort_order, is_default, owner_user_id, created_at, updated_at'
+					)
+					.single()
+				if (error) handlePostgrestError(error, 'update document category')
+				return mapDocumentCategoryRow(
+					(data ?? {}) as Record<string, unknown>
+				)
+			}
+		}),
+	deleteWithReassign: () =>
+		mutationOptions<void, Error, DeleteWithReassignInput>({
+			mutationKey: mutationKeys.documentCategories.deleteWithReassign,
+			mutationFn: async (input: DeleteWithReassignInput): Promise<void> => {
+				const supabase = createClient()
+				const { error } = await supabase.rpc('reassign_document_category', {
+					p_from_id: input.from_id,
+					p_to_id: input.to_id
+				})
+				if (error) handlePostgrestError(error, 'reassign document category')
+			}
+		}),
+	reorder: () =>
+		mutationOptions<void, Error, ReorderInput>({
+			mutationKey: mutationKeys.documentCategories.reorder,
+			mutationFn: async (input: ReorderInput): Promise<void> => {
+				const supabase = createClient()
+				const { error } = await supabase.rpc('reorder_document_categories', {
+					p_orders: input.orders
+				})
+				if (error) handlePostgrestError(error, 'reorder document categories')
+			}
 		})
 } as const

--- a/src/hooks/api/query-keys/document-category-keys.ts
+++ b/src/hooks/api/query-keys/document-category-keys.ts
@@ -148,6 +148,15 @@ export interface DeleteWithReassignInput {
 
 export interface ReorderInput {
 	orders: Array<{ id: string; sort_order: number }>
+	/**
+	 * Pre-computed reordered list for the optimistic cache write
+	 * inside `onMutate`. Optional — pure RPC callers (without UI
+	 * cache work) can omit it. Cycle-3 M-2 hand-off pattern: the
+	 * caller computes the row order on drag-end and the mutation's
+	 * onMutate hook writes it to the cache after `cancelQueries`,
+	 * keeping snapshot + optimistic write atomically ordered.
+	 */
+	next?: DocumentCategoryRow[]
 }
 
 export const documentCategoryMutations = {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -2587,6 +2587,14 @@ export type Database = {
         Returns: undefined
       }
       queue_lease_reminders: { Args: never; Returns: undefined }
+      reassign_document_category: {
+        Args: { p_from_id: string; p_to_id: string }
+        Returns: undefined
+      }
+      reorder_document_categories: {
+        Args: { p_orders: Json }
+        Returns: undefined
+      }
       request_account_deletion: { Args: never; Returns: undefined }
       require_stripe_schema: { Args: never; Returns: boolean }
       revoke_user_session: {

--- a/supabase/migrations/20260428000019_v26_phase_66_category_mutations_rpcs.sql
+++ b/supabase/migrations/20260428000019_v26_phase_66_category_mutations_rpcs.sql
@@ -1,0 +1,122 @@
+-- v2.6 Phase 66: Custom Categories — Admin UI + Write Path
+--
+-- Adds two SECURITY DEFINER RPCs:
+--   1. reassign_document_category(p_from_id uuid, p_to_id uuid)
+--      Atomically rewrites every documents.document_type owned by the
+--      caller from the source slug to the target slug, then deletes
+--      the source document_categories row. Single transaction so a
+--      half-applied state is impossible.
+--   2. reorder_document_categories(p_orders jsonb)
+--      Bulk-updates sort_order for every category in p_orders. Caller
+--      must own every category referenced. Persisted order flows
+--      through to the vault filter Select.
+--
+-- Both RPCs gate on auth.uid() and re-derive ownership from the caller's
+-- JWT — never trust client-supplied owner_user_id. is_default categories
+-- can be reordered freely (the seven defaults are the user's "starter
+-- set" and ordering is per-owner) but cannot be deleted (UI surfaces a
+-- tooltip; the RPC adds a server-side guard for defense-in-depth).
+
+create or replace function public.reassign_document_category(
+    p_from_id uuid,
+    p_to_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_owner_id uuid := auth.uid();
+    v_from_slug text;
+    v_to_slug text;
+    v_is_default boolean;
+begin
+    if v_owner_id is null then
+        raise exception 'Not authenticated' using errcode = '42501';
+    end if;
+    if p_from_id is null or p_to_id is null then
+        raise exception 'p_from_id and p_to_id are required' using errcode = '22023';
+    end if;
+    if p_from_id = p_to_id then
+        raise exception 'Cannot reassign a category to itself' using errcode = '22023';
+    end if;
+
+    -- Resolve both rows under the caller's ownership. Locks the source
+    -- row so concurrent reassignments serialize cleanly.
+    select slug, is_default into v_from_slug, v_is_default
+    from public.document_categories
+    where id = p_from_id and owner_user_id = v_owner_id
+    for update;
+    if v_from_slug is null then
+        raise exception 'Source category not found or not owned by caller' using errcode = '42501';
+    end if;
+    if v_is_default then
+        raise exception 'Default categories cannot be deleted' using errcode = '42501';
+    end if;
+
+    select slug into v_to_slug
+    from public.document_categories
+    where id = p_to_id and owner_user_id = v_owner_id;
+    if v_to_slug is null then
+        raise exception 'Target category not found or not owned by caller' using errcode = '42501';
+    end if;
+
+    -- Mass-rewrite every document's document_type. The validate_document_category
+    -- trigger fires per row but stays satisfied because v_to_slug exists in the
+    -- caller's taxonomy.
+    update public.documents
+    set document_type = v_to_slug
+    where owner_user_id = v_owner_id
+      and document_type = v_from_slug;
+
+    -- Now safe to delete the source row.
+    delete from public.document_categories
+    where id = p_from_id and owner_user_id = v_owner_id;
+end;
+$$;
+
+revoke all on function public.reassign_document_category(uuid, uuid) from public, anon;
+grant execute on function public.reassign_document_category(uuid, uuid) to authenticated;
+
+
+create or replace function public.reorder_document_categories(
+    p_orders jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_owner_id uuid := auth.uid();
+    v_count int;
+begin
+    if v_owner_id is null then
+        raise exception 'Not authenticated' using errcode = '42501';
+    end if;
+    if p_orders is null or jsonb_typeof(p_orders) <> 'array' then
+        raise exception 'p_orders must be a JSON array of {id, sort_order}' using errcode = '22023';
+    end if;
+
+    -- Verify every referenced category is owned by the caller. Single
+    -- aggregate query → fail-closed if even one row is foreign.
+    select count(*) into v_count
+    from jsonb_array_elements(p_orders) e
+    join public.document_categories c
+      on c.id = (e->>'id')::uuid
+     and c.owner_user_id = v_owner_id;
+    if v_count <> jsonb_array_length(p_orders) then
+        raise exception 'One or more categories not found or not owned by caller' using errcode = '42501';
+    end if;
+
+    -- Atomic bulk-update via a single UPDATE ... FROM jsonb_to_recordset.
+    update public.document_categories c
+    set sort_order = e.sort_order::int
+    from jsonb_to_recordset(p_orders) as e(id uuid, sort_order int)
+    where c.id = e.id and c.owner_user_id = v_owner_id;
+end;
+$$;
+
+revoke all on function public.reorder_document_categories(jsonb) from public, anon;
+grant execute on function public.reorder_document_categories(jsonb) to authenticated;

--- a/supabase/migrations/20260428001737_v26_phase_66_followup_rpc_hardening.sql
+++ b/supabase/migrations/20260428001737_v26_phase_66_followup_rpc_hardening.sql
@@ -1,0 +1,122 @@
+-- v2.6 Phase 66 Followup (cycle-1 review I-3 + I-4)
+--
+-- I-3: reassign_document_category previously selected the target row
+--      without FOR UPDATE. A concurrent transaction could delete the
+--      target between the lookup and the mass-rewrite UPDATE, causing
+--      the validate_document_category trigger to fail per-row with
+--      23514 against a now-missing slug. Lock both source AND target
+--      so the operation is genuinely serializable.
+-- I-4: reorder_document_categories previously only validated owner-
+--      ship via aggregate count — malformed elements (missing id,
+--      missing/non-numeric sort_order) leaked through to the inner
+--      UPDATE and surfaced as generic 500s. Add explicit per-element
+--      shape validation up-front.
+
+create or replace function public.reassign_document_category(
+    p_from_id uuid,
+    p_to_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_owner_id uuid := auth.uid();
+    v_from_slug text;
+    v_to_slug text;
+    v_is_default boolean;
+begin
+    if v_owner_id is null then
+        raise exception 'Not authenticated' using errcode = '42501';
+    end if;
+    if p_from_id is null or p_to_id is null then
+        raise exception 'p_from_id and p_to_id are required' using errcode = '22023';
+    end if;
+    if p_from_id = p_to_id then
+        raise exception 'Cannot reassign a category to itself' using errcode = '22023';
+    end if;
+
+    -- Lock the source row.
+    select slug, is_default into v_from_slug, v_is_default
+    from public.document_categories
+    where id = p_from_id and owner_user_id = v_owner_id
+    for update;
+    if v_from_slug is null then
+        raise exception 'Source category not found or not owned by caller' using errcode = '42501';
+    end if;
+    if v_is_default then
+        raise exception 'Default categories cannot be deleted' using errcode = '42501';
+    end if;
+
+    -- Lock the target too — without this lock a concurrent reassign
+    -- could delete the target between this read and the mass-rewrite
+    -- below, leaving the per-row validate_document_category trigger
+    -- to reject every UPDATE with 23514 against a now-missing slug.
+    select slug into v_to_slug
+    from public.document_categories
+    where id = p_to_id and owner_user_id = v_owner_id
+    for update;
+    if v_to_slug is null then
+        raise exception 'Target category not found or not owned by caller' using errcode = '42501';
+    end if;
+
+    update public.documents
+    set document_type = v_to_slug
+    where owner_user_id = v_owner_id
+      and document_type = v_from_slug;
+
+    delete from public.document_categories
+    where id = p_from_id and owner_user_id = v_owner_id;
+end;
+$$;
+
+create or replace function public.reorder_document_categories(
+    p_orders jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_owner_id uuid := auth.uid();
+    v_count int;
+begin
+    if v_owner_id is null then
+        raise exception 'Not authenticated' using errcode = '42501';
+    end if;
+    if p_orders is null or jsonb_typeof(p_orders) <> 'array' then
+        raise exception 'p_orders must be a JSON array of {id, sort_order}' using errcode = '22023';
+    end if;
+
+    -- Per-element shape validation. Each entry must carry a non-null
+    -- string id (UUID format enforced by the JSONB cast inside the
+    -- ownership join below) AND a numeric sort_order. Catching this
+    -- here surfaces a clear 22023 to callers instead of a generic
+    -- cast/null-violation 500 leaking out of the UPDATE.
+    if exists (
+        select 1
+        from jsonb_array_elements(p_orders) e
+        where (e->>'id') is null
+           or (e->>'sort_order') is null
+           or jsonb_typeof(e->'sort_order') <> 'number'
+    ) then
+        raise exception 'Each entry must have id (uuid) and sort_order (number)' using errcode = '22023';
+    end if;
+
+    select count(*) into v_count
+    from jsonb_array_elements(p_orders) e
+    join public.document_categories c
+      on c.id = (e->>'id')::uuid
+     and c.owner_user_id = v_owner_id;
+    if v_count <> jsonb_array_length(p_orders) then
+        raise exception 'One or more categories not found or not owned by caller' using errcode = '42501';
+    end if;
+
+    update public.document_categories c
+    set sort_order = e.sort_order::int
+    from jsonb_to_recordset(p_orders) as e(id uuid, sort_order int)
+    where c.id = e.id and c.owner_user_id = v_owner_id;
+end;
+$$;

--- a/tests/integration/rls/document-category-mutations.rls.test.ts
+++ b/tests/integration/rls/document-category-mutations.rls.test.ts
@@ -82,7 +82,12 @@ describe('Phase 66 category mutation RPCs', () => {
 		await clientB.auth.signOut()
 	})
 
-	async function seedCategory(slug: string, label: string) {
+	// Append a per-run suffix to slugs so re-runs against the same prod
+	// account don't collide with rows that survived a previous failure
+	// (the cleanup is idempotent but a mid-test crash skips it).
+	const SLUG_SUFFIX = `_${Date.now().toString(36)}`
+	async function seedCategory(baseSlug: string, label: string) {
+		const slug = `${baseSlug}${SLUG_SUFFIX}`.slice(0, 50)
 		const { data, error } = await clientA
 			.from('document_categories')
 			.insert({
@@ -251,7 +256,7 @@ describe('Phase 66 category mutation RPCs', () => {
 			.from('document_categories')
 			.insert({
 				owner_user_id: uB!.id,
-				slug: 'phase66_reorder_foreign',
+				slug: `phase66_reorder_foreign${SLUG_SUFFIX}`.slice(0, 50),
 				label: 'Foreign',
 				sort_order: 999,
 				is_default: false

--- a/tests/integration/rls/document-category-mutations.rls.test.ts
+++ b/tests/integration/rls/document-category-mutations.rls.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Integration tests for the v2.6 Phase 66 admin RPCs:
+ *   - reassign_document_category(p_from_id, p_to_id)
+ *   - reorder_document_categories(p_orders)
+ *
+ * Pins the contract:
+ *   - Owner-scoped: ownerB cannot reassign or reorder ownerA's
+ *     categories even if they hold the source/target ids.
+ *   - Atomicity: reassign rewrites every documents.document_type AND
+ *     deletes the source category in one transaction.
+ *   - Default-protection: reassign refuses to delete an `is_default`
+ *     category server-side (defense-in-depth — UI also disables).
+ *   - Self-reference rejection: from === to → 22023.
+ *   - Reorder fail-closed when any referenced category is foreign.
+ */
+
+import { createTestClient, getTestCredentials } from '../setup/supabase-client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const PAYLOAD = '%PDF-1.4\n%%EOF'
+
+describe('Phase 66 category mutation RPCs', () => {
+	let clientA: SupabaseClient
+	let clientB: SupabaseClient
+	let ownerAId: string
+	let propertyA: { id: string } | null = null
+	const insertedDocIds: string[] = []
+	const uploadedPaths: string[] = []
+	const insertedCategoryIds: string[] = []
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials()
+		clientA = await createTestClient(ownerA.email, ownerA.password)
+		clientB = await createTestClient(ownerB.email, ownerB.password)
+		const {
+			data: { user: uA }
+		} = await clientA.auth.getUser()
+		ownerAId = uA!.id
+
+		const { data: p } = await clientA
+			.from('properties')
+			.insert({
+				name: 'Phase-66 Mutation RPCs Property',
+				address_line1: '1 Mutations St',
+				city: 'Testville',
+				state: 'CA',
+				postal_code: '94105',
+				country: 'US',
+				property_type: 'APARTMENT',
+				owner_user_id: ownerAId
+			})
+			.select('id')
+			.single()
+		propertyA = p ? { id: p.id } : null
+		expect(propertyA).not.toBeNull()
+	})
+
+	afterAll(async () => {
+		if (uploadedPaths.length > 0) {
+			await clientA.storage
+				.from('tenant-documents')
+				.remove(uploadedPaths)
+				.catch(() => {})
+		}
+		for (const id of insertedDocIds) {
+			await clientA.from('documents').delete().eq('id', id)
+		}
+		for (const id of insertedCategoryIds) {
+			await clientA.from('document_categories').delete().eq('id', id)
+		}
+		if (propertyA)
+			await clientA.from('properties').delete().eq('id', propertyA.id)
+		await clientA.auth.signOut()
+		await clientB.auth.signOut()
+	})
+
+	async function seedCategory(slug: string, label: string) {
+		const { data, error } = await clientA
+			.from('document_categories')
+			.insert({
+				owner_user_id: ownerAId,
+				slug,
+				label,
+				sort_order: 999,
+				is_default: false
+			})
+			.select('id, slug')
+			.single()
+		expect(error).toBeNull()
+		if (data) insertedCategoryIds.push(data.id)
+		return data!
+	}
+
+	async function seedDocument(documentType: string) {
+		const ts = Date.now() + Math.floor(Math.random() * 1000)
+		const path = `property/${propertyA!.id}/${ts}-rpc-test.pdf`
+		const { error: storageErr } = await clientA.storage
+			.from('tenant-documents')
+			.upload(path, new Blob([PAYLOAD], { type: 'application/pdf' }), {
+				contentType: 'application/pdf'
+			})
+		expect(storageErr).toBeNull()
+		uploadedPaths.push(path)
+		const { data, error } = await clientA
+			.from('documents')
+			.insert({
+				entity_type: 'property',
+				entity_id: propertyA!.id,
+				document_type: documentType,
+				mime_type: 'application/pdf',
+				file_path: path,
+				storage_url: path,
+				file_size: PAYLOAD.length,
+				title: 'Phase-66 doc fixture',
+				owner_user_id: ownerAId
+			})
+			.select('id')
+			.single()
+		expect(error).toBeNull()
+		if (data) insertedDocIds.push(data.id)
+		return data!
+	}
+
+	it('reassign_document_category: rewrites every matching document AND deletes the source row', async () => {
+		const from = await seedCategory('phase66_reassign_from', 'Reassign From')
+		const to = await seedCategory('phase66_reassign_to', 'Reassign To')
+		const doc1 = await seedDocument(from.slug)
+		const doc2 = await seedDocument(from.slug)
+
+		const { error } = await clientA.rpc('reassign_document_category', {
+			p_from_id: from.id,
+			p_to_id: to.id
+		})
+		expect(error).toBeNull()
+
+		// Documents flipped to the target slug.
+		const { data: updated } = await clientA
+			.from('documents')
+			.select('id, document_type')
+			.in('id', [doc1.id, doc2.id])
+		expect(updated).toHaveLength(2)
+		for (const d of (updated ?? []) as Array<{ document_type: string }>) {
+			expect(d.document_type).toBe(to.slug)
+		}
+
+		// Source category gone.
+		const { data: gone } = await clientA
+			.from('document_categories')
+			.select('id')
+			.eq('id', from.id)
+		expect(gone).toHaveLength(0)
+	})
+
+	it('reassign_document_category: refuses to delete an is_default category', async () => {
+		// Find the seeded `other` default for ownerA.
+		const { data: defaultRow } = await clientA
+			.from('document_categories')
+			.select('id, slug, is_default')
+			.eq('slug', 'other')
+			.single()
+		expect(defaultRow?.is_default).toBe(true)
+
+		const target = await seedCategory(
+			'phase66_default_protect_target',
+			'Default Protect'
+		)
+
+		const { error } = await clientA.rpc('reassign_document_category', {
+			p_from_id: defaultRow!.id,
+			p_to_id: target.id
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/default categories cannot be deleted/i)
+	})
+
+	it('reassign_document_category: rejects self-reference', async () => {
+		const cat = await seedCategory(
+			'phase66_self_ref',
+			'Self Ref'
+		)
+		const { error } = await clientA.rpc('reassign_document_category', {
+			p_from_id: cat.id,
+			p_to_id: cat.id
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/itself/i)
+	})
+
+	it('reassign_document_category: rejects cross-owner source/target', async () => {
+		// ownerB calling with ownerA's category ids should fail.
+		const target = await seedCategory(
+			'phase66_cross_owner_target',
+			'Cross Owner Target'
+		)
+		const source = await seedCategory(
+			'phase66_cross_owner_source',
+			'Cross Owner Source'
+		)
+		const { error } = await clientB.rpc('reassign_document_category', {
+			p_from_id: source.id,
+			p_to_id: target.id
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/not found or not owned by caller/i)
+	})
+
+	it('reorder_document_categories: persists sort_order for every row in the input', async () => {
+		const a = await seedCategory('phase66_reorder_a', 'Reorder A')
+		const b = await seedCategory('phase66_reorder_b', 'Reorder B')
+
+		const { error } = await clientA.rpc('reorder_document_categories', {
+			p_orders: [
+				{ id: a.id, sort_order: 1234 },
+				{ id: b.id, sort_order: 5678 }
+			]
+		})
+		expect(error).toBeNull()
+
+		const { data } = await clientA
+			.from('document_categories')
+			.select('id, sort_order')
+			.in('id', [a.id, b.id])
+		const byId = new Map(
+			((data ?? []) as Array<{ id: string; sort_order: number }>).map(r => [
+				r.id,
+				r.sort_order
+			])
+		)
+		expect(byId.get(a.id)).toBe(1234)
+		expect(byId.get(b.id)).toBe(5678)
+	})
+
+	it('reorder_document_categories: fail-closed when any referenced row is foreign', async () => {
+		const own = await seedCategory(
+			'phase66_reorder_own',
+			'Own'
+		)
+		// Insert a row under ownerB so we have a real foreign id.
+		const {
+			data: { user: uB }
+		} = await clientB.auth.getUser()
+		const { data: foreign } = await clientB
+			.from('document_categories')
+			.insert({
+				owner_user_id: uB!.id,
+				slug: 'phase66_reorder_foreign',
+				label: 'Foreign',
+				sort_order: 999,
+				is_default: false
+			})
+			.select('id')
+			.single()
+		expect(foreign?.id).toBeDefined()
+
+		const { error } = await clientA.rpc('reorder_document_categories', {
+			p_orders: [
+				{ id: own.id, sort_order: 100 },
+				{ id: foreign!.id, sort_order: 200 }
+			]
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/not found or not owned by caller/i)
+
+		// Cleanup the foreign row under ownerB.
+		await clientB.from('document_categories').delete().eq('id', foreign!.id)
+	})
+
+	it('reorder_document_categories: rejects non-array p_orders', async () => {
+		const { error } = await clientA.rpc('reorder_document_categories', {
+			p_orders: { not: 'an array' } as unknown as never
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/must be a json array/i)
+	})
+})

--- a/tests/integration/rls/document-category-mutations.rls.test.ts
+++ b/tests/integration/rls/document-category-mutations.rls.test.ts
@@ -284,6 +284,41 @@ describe('Phase 66 category mutation RPCs', () => {
 		expect(error!.message).toMatch(/must be a json array/i)
 	})
 
+	// Cycle-5 M-3: pin the null-param branches that the cycle-3 review
+	// flagged as missing coverage. These branches raise 22023 with a
+	// specific message. The RPC params are typed `string`/`Json`, so
+	// passing `null` is intentionally invalid at the type level and
+	// suppressed via @ts-expect-error rather than the Zero-Tolerance-
+	// banned `as unknown as` double-cast.
+	it('reassign_document_category: rejects null p_from_id', async () => {
+		const { error } = await clientA.rpc('reassign_document_category', {
+			// @ts-expect-error — intentionally null to exercise the runtime guard
+			p_from_id: null,
+			p_to_id: '00000000-0000-0000-0000-000000000001'
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/p_from_id and p_to_id are required/i)
+	})
+
+	it('reassign_document_category: rejects null p_to_id', async () => {
+		const { error } = await clientA.rpc('reassign_document_category', {
+			p_from_id: '00000000-0000-0000-0000-000000000001',
+			// @ts-expect-error — intentionally null to exercise the runtime guard
+			p_to_id: null
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/p_from_id and p_to_id are required/i)
+	})
+
+	it('reorder_document_categories: rejects null p_orders', async () => {
+		const { error } = await clientA.rpc('reorder_document_categories', {
+			// @ts-expect-error — intentionally null to exercise the runtime guard
+			p_orders: null
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/must be a json array/i)
+	})
+
 	// Phase 66 cycle-1 I-4: per-element shape validation. The RPC raises
 	// a clear 22023 instead of letting cast/null violations leak through
 	// as generic 500s.

--- a/tests/integration/rls/document-category-mutations.rls.test.ts
+++ b/tests/integration/rls/document-category-mutations.rls.test.ts
@@ -66,15 +66,17 @@ describe('Phase 66 category mutation RPCs', () => {
 			await clientA.from('documents').delete().eq('id', id)
 		}
 		// Idempotent cleanup — some category ids may already have been
-		// deleted in-test by the reassign RPC. The DELETE is a no-op
-		// when the row is gone (and `.catch(() => {})` swallows any
-		// transient error). Cycle-1 M-8.
+		// deleted in-test by the reassign RPC. PostgREST DELETEs return
+		// `{ error: null, data: [] }` on missing rows (no throw), so the
+		// loop is naturally idempotent. The try/catch is belt-and-
+		// suspenders against transient network errors so a single
+		// failed cleanup doesn't abort the whole afterAll. Cycle-1 M-8.
 		for (const id of insertedCategoryIds) {
-			await clientA
-				.from('document_categories')
-				.delete()
-				.eq('id', id)
-				.catch(() => undefined)
+			try {
+				await clientA.from('document_categories').delete().eq('id', id)
+			} catch {
+				/* swallow — best-effort cleanup */
+			}
 		}
 		if (propertyA)
 			await clientA.from('properties').delete().eq('id', propertyA.id)

--- a/tests/integration/rls/document-category-mutations.rls.test.ts
+++ b/tests/integration/rls/document-category-mutations.rls.test.ts
@@ -65,8 +65,16 @@ describe('Phase 66 category mutation RPCs', () => {
 		for (const id of insertedDocIds) {
 			await clientA.from('documents').delete().eq('id', id)
 		}
+		// Idempotent cleanup — some category ids may already have been
+		// deleted in-test by the reassign RPC. The DELETE is a no-op
+		// when the row is gone (and `.catch(() => {})` swallows any
+		// transient error). Cycle-1 M-8.
 		for (const id of insertedCategoryIds) {
-			await clientA.from('document_categories').delete().eq('id', id)
+			await clientA
+				.from('document_categories')
+				.delete()
+				.eq('id', id)
+				.catch(() => undefined)
 		}
 		if (propertyA)
 			await clientA.from('properties').delete().eq('id', propertyA.id)
@@ -266,10 +274,40 @@ describe('Phase 66 category mutation RPCs', () => {
 	})
 
 	it('reorder_document_categories: rejects non-array p_orders', async () => {
+		// Intentionally invalid input to verify runtime rejection — the
+		// RPC param is typed as `Json` so a plain object satisfies the
+		// type system, but the function checks `jsonb_typeof <> 'array'`.
 		const { error } = await clientA.rpc('reorder_document_categories', {
-			p_orders: { not: 'an array' } as unknown as never
+			p_orders: { not: 'an array' }
 		})
 		expect(error).not.toBeNull()
 		expect(error!.message).toMatch(/must be a json array/i)
+	})
+
+	// Phase 66 cycle-1 I-4: per-element shape validation. The RPC raises
+	// a clear 22023 instead of letting cast/null violations leak through
+	// as generic 500s.
+	it('reorder_document_categories: rejects entries missing sort_order', async () => {
+		const cat = await seedCategory(
+			'phase66_shape_probe',
+			'Shape Probe'
+		)
+		const { error } = await clientA.rpc('reorder_document_categories', {
+			p_orders: [{ id: cat.id }]
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/each entry must have id .* and sort_order/i)
+	})
+
+	it('reorder_document_categories: rejects entries with non-numeric sort_order', async () => {
+		const cat = await seedCategory(
+			'phase66_shape_string',
+			'Shape String'
+		)
+		const { error } = await clientA.rpc('reorder_document_categories', {
+			p_orders: [{ id: cat.id, sort_order: 'not_a_number' }]
+		})
+		expect(error).not.toBeNull()
+		expect(error!.message).toMatch(/each entry must have id .* and sort_order/i)
 	})
 })


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37m- Settings page at `/settings?tab=categories` for CRUD on per-owner document categories[0m
[38;5;8m   4[0m [37m- Two new SECURITY DEFINER RPCs: `reassign_document_category` (atomic UPDATE+DELETE) and `reorder_document_categories` (bulk sort_order update)[0m
[38;5;8m   5[0m [37m- Drag-reorder via `@dnd-kit/sortable` with optimistic UI + rollback[0m
[38;5;8m   6[0m [37m- Default-flag protection: seven seeded slugs can be renamed/reordered but not deleted (UI tooltip + server-side RPC guard)[0m
[38;5;8m   7[0m 
[38;5;8m   8[0m [37m## Migration[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37m`20260428000019_v26_phase_66_category_mutations_rpcs.sql` already applied to prod via MCP. Both RPCs gate on `auth.uid()`, re-derive ownership, and fail-closed on cross-owner references.[0m
[38;5;8m  11[0m 
[38;5;8m  12[0m [37m## Test plan[0m
[38;5;8m  13[0m 
[38;5;8m  14[0m [37m- [x] 7,557 unit tests pass (CategoriesSettings: 9 new test cases)[0m
[38;5;8m  15[0m [37m- [x] typecheck + lint clean[0m
[38;5;8m  16[0m [37m- [x] tests/integration/rls/document-category-mutations.rls.test.ts covers: reassign atomicity, default protection, self-reference rejection, cross-owner rejection, reorder persistence, foreign-id fail-closed, non-array rejection[0m
[38;5;8m  17[0m [37m- [ ] CI rls-security run validates the integration tests against prod[0m
[38;5;8m  18[0m [37m- [ ] Code review per perfect-PR gate (two consecutive zero-finding cycles)[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37m[hudsor01][0m