### PR TITLE
chore(ci): split Dependabot groups + extend auto-merge to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,21 +7,39 @@ version: 2
 # group's `update-type` and `dependency-type` outputs from fetch-metadata.
 #
 # Auto-merge wiring (.github/workflows/dependabot-auto-merge.yml):
-#   - Any patch                  → auto-merge
-#   - dev minor (direct only)    → auto-merge
-#   - GitHub Actions any         → auto-merge
+#   - Any patch                       → auto-merge
+#   - dev minor (direct only)         → auto-merge
+#   - GitHub Actions non-major        → auto-merge
 #   - prod minor / vendor / any major → manual review
 #
 # Note on transitive patches: groups without `dependency-type` capture both
 # direct and indirect dependencies. `npm-patches` therefore auto-merges
 # transitive patches too — this is the Dependabot default and matches how
 # security advisories propagate.
+#
+# Security-sensitive package families: `&security-excludes` is the single
+# source of truth, aliased into all 3 npm groups. Add new
+# security-sensitive families here once and they apply everywhere. As of
+# 2026-05-02 the only direct deps in this list are `@supabase/*`, `stripe`,
+# `next`, `react`, `react-dom`, `@vercel/*` (analytics + speed-insights);
+# the remaining entries are forward-looking guards for security-sensitive
+# packages that may be added later.
 # ─────────────────────────────────────────────────────────────────────────
 
-# Security-sensitive package families excluded from auto-merge groups.
-# When editing, mirror the same list across npm-patches / npm-dev-minor /
-# npm-prod-minor so a future framework or auth bump always lands in its own
-# manual-review PR.
+# YAML anchor: declared at top-level scope so all 3 groups can alias it.
+x-security-excludes: &security-excludes
+  - '@supabase/*'
+  - 'stripe'
+  - '@stripe/*'
+  - 'next'
+  - '@next/*'
+  - 'react'
+  - 'react-dom'
+  - '@vercel/*'
+  - 'jose'
+  - 'cookie'
+  - 'dompurify'
+  - 'crypto-js'
 
 updates:
   # ─────────────────────────────────────────
@@ -47,67 +65,27 @@ updates:
     # ── Grouped PRs ──────────────────────────
     groups:
       # Patch updates across the tree — auto-merged.
-      # Excludes security-sensitive vendors so any patch to those families
-      # always lands in its own PR for manual review.
+      # `*security-excludes` aliases the YAML anchor declared at the top of
+      # this file so any vendor added there is automatically excluded from
+      # all 3 npm auto-merge fences.
       npm-patches:
         update-types:
           - patch
-        exclude-patterns:
-          - '@supabase/*'
-          - 'stripe'
-          - '@stripe/*'
-          - 'next'
-          - '@next/*'
-          - 'react'
-          - 'react-dom'
-          - '@vercel/*'
-          - '@octokit/*'
-          - 'jose'
-          - 'cookie'
-          - 'dompurify'
-          - 'crypto-js'
+        exclude-patterns: *security-excludes
 
       # Dev-only minor bumps — auto-merged.
-      # Same security-sensitive exclude list applied defensively in case any
-      # of those packages ever lands as a devDependency.
       npm-dev-minor:
         dependency-type: development
         update-types:
           - minor
-        exclude-patterns:
-          - '@supabase/*'
-          - 'stripe'
-          - '@stripe/*'
-          - 'next'
-          - '@next/*'
-          - 'react'
-          - 'react-dom'
-          - '@vercel/*'
-          - '@octokit/*'
-          - 'jose'
-          - 'cookie'
-          - 'dompurify'
-          - 'crypto-js'
+        exclude-patterns: *security-excludes
 
       # Prod minor bumps — manual review required.
       npm-prod-minor:
         dependency-type: production
         update-types:
           - minor
-        exclude-patterns:
-          - '@supabase/*'
-          - 'stripe'
-          - '@stripe/*'
-          - 'next'
-          - '@next/*'
-          - 'react'
-          - 'react-dom'
-          - '@vercel/*'
-          - '@octokit/*'
-          - 'jose'
-          - 'cookie'
-          - 'dompurify'
-          - 'crypto-js'
+        exclude-patterns: *security-excludes
 
       # Security-sensitive: separate PR for review.
       supabase:
@@ -137,7 +115,8 @@ updates:
         update-types: ['version-update:semver-patch']
 
   # ─────────────────────────────────────────
-  # GitHub Actions — monthly, all auto-merged
+  # GitHub Actions — monthly
+  # Non-major updates auto-merged; majors fall through to manual review.
   # ─────────────────────────────────────────
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
     assignees:
       - hudsor01
     labels:
@@ -19,8 +19,41 @@ updates:
       include: scope
 
     # ── Grouped PRs ──────────────────────────
+    # Groups are split by update-type + dependency-type so the auto-merge
+    # workflow can decide on each PR independently:
+    #   - patches (any kind)        → auto-merged
+    #   - dev-minor (devDeps minor) → auto-merged
+    #   - prod-minor (prod minor)   → requires review
+    #   - supabase / stripe         → requires review (security-sensitive)
+    #   - majors                    → NOT grouped, one PR per package, requires review
     groups:
-      # Security-sensitive: separate PR for review
+      # Patch updates across the tree — safe enough to auto-merge once CI is green.
+      npm-patches:
+        update-types:
+          - patch
+        # Exclude security-sensitive packages so they always get their own PR.
+        exclude-patterns:
+          - '@supabase/*'
+          - 'stripe'
+          - '@stripe/*'
+
+      # Dev-only minor bumps — auto-merged.
+      npm-dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+
+      # Prod minor bumps — manual review required.
+      npm-prod-minor:
+        dependency-type: production
+        update-types:
+          - minor
+        exclude-patterns:
+          - '@supabase/*'
+          - 'stripe'
+          - '@stripe/*'
+
+      # Security-sensitive: separate PR for review.
       supabase:
         patterns:
           - '@supabase/*'
@@ -30,15 +63,9 @@ updates:
           - 'stripe'
           - '@stripe/*'
 
-      # Everything else in one PR
-      minor-and-patch:
-        update-types:
-          - minor
-          - patch
-
     # ── Ignore rules ─────────────────────────
     ignore:
-      # Major bumps for frameworks — manual migration only
+      # Major bumps for frameworks — manual migration only, never opened by bot.
       - dependency-name: 'next'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react'
@@ -54,7 +81,7 @@ updates:
         update-types: ['version-update:semver-patch']
 
   # ─────────────────────────────────────────
-  # GitHub Actions — monthly
+  # GitHub Actions — monthly, all auto-merged
   # ─────────────────────────────────────────
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,29 +17,20 @@ version: 2
 # transitive patches too — this is the Dependabot default and matches how
 # security advisories propagate.
 #
-# Security-sensitive package families: `&security-excludes` is the single
-# source of truth, aliased into all 3 npm groups. Add new
-# security-sensitive families here once and they apply everywhere. As of
-# 2026-05-02 the only direct deps in this list are `@supabase/*`, `stripe`,
-# `next`, `react`, `react-dom`, `@vercel/*` (analytics + speed-insights);
-# the remaining entries are forward-looking guards for security-sensitive
-# packages that may be added later.
+# Security-sensitive package families: the same `exclude-patterns` list is
+# duplicated across all 3 npm groups (npm-patches, npm-dev-minor,
+# npm-prod-minor). YAML anchors + aliases would DRY this up but
+# dependabot-core's parser uses `Psych.safe_load` with the default
+# `aliases: false`, which raises Psych::BadAlias on any `*alias` reference
+# (verified empirically 2026-05-02). Manual mirroring is the only viable
+# pattern — when adding a new family, apply the change to all 3 groups.
+#
+# Of the families listed below, the real direct deps (per package.json as
+# of 2026-05-02) are: @supabase/*, stripe, next, react, react-dom,
+# @vercel/* (analytics + speed-insights), and dompurify. The remaining
+# entries (@next/*, @stripe/*, jose, cookie, crypto-js) are forward-
+# looking guards for security-sensitive packages that may be added later.
 # ─────────────────────────────────────────────────────────────────────────
-
-# YAML anchor: declared at top-level scope so all 3 groups can alias it.
-x-security-excludes: &security-excludes
-  - '@supabase/*'
-  - 'stripe'
-  - '@stripe/*'
-  - 'next'
-  - '@next/*'
-  - 'react'
-  - 'react-dom'
-  - '@vercel/*'
-  - 'jose'
-  - 'cookie'
-  - 'dompurify'
-  - 'crypto-js'
 
 updates:
   # ─────────────────────────────────────────
@@ -65,27 +56,62 @@ updates:
     # ── Grouped PRs ──────────────────────────
     groups:
       # Patch updates across the tree — auto-merged.
-      # `*security-excludes` aliases the YAML anchor declared at the top of
-      # this file so any vendor added there is automatically excluded from
-      # all 3 npm auto-merge fences.
+      # Excludes security-sensitive vendors so any patch to those families
+      # always lands in its own PR for manual review.
       npm-patches:
         update-types:
           - patch
-        exclude-patterns: *security-excludes
+        exclude-patterns:
+          - '@supabase/*'
+          - 'stripe'
+          - '@stripe/*'
+          - 'next'
+          - '@next/*'
+          - 'react'
+          - 'react-dom'
+          - '@vercel/*'
+          - 'jose'
+          - 'cookie'
+          - 'dompurify'
+          - 'crypto-js'
 
       # Dev-only minor bumps — auto-merged.
       npm-dev-minor:
         dependency-type: development
         update-types:
           - minor
-        exclude-patterns: *security-excludes
+        exclude-patterns:
+          - '@supabase/*'
+          - 'stripe'
+          - '@stripe/*'
+          - 'next'
+          - '@next/*'
+          - 'react'
+          - 'react-dom'
+          - '@vercel/*'
+          - 'jose'
+          - 'cookie'
+          - 'dompurify'
+          - 'crypto-js'
 
       # Prod minor bumps — manual review required.
       npm-prod-minor:
         dependency-type: production
         update-types:
           - minor
-        exclude-patterns: *security-excludes
+        exclude-patterns:
+          - '@supabase/*'
+          - 'stripe'
+          - '@stripe/*'
+          - 'next'
+          - '@next/*'
+          - 'react'
+          - 'react-dom'
+          - '@vercel/*'
+          - 'jose'
+          - 'cookie'
+          - 'dompurify'
+          - 'crypto-js'
 
       # Security-sensitive: separate PR for review.
       supabase:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,11 @@ version: 2
 # pattern — when adding a new family, apply the change to all 3 groups.
 #
 # Of the families listed below, the real direct deps (per package.json as
-# of 2026-05-02) are: @supabase/*, stripe, next, react, react-dom,
+# of 2026-05-02) are: @supabase/*, stripe, @stripe/* (react-stripe-js +
+# stripe-js), next, @next/* (eslint-plugin-next), react, react-dom,
 # @vercel/* (analytics + speed-insights), and dompurify. The remaining
-# entries (@next/*, @stripe/*, jose, cookie, crypto-js) are forward-
-# looking guards for security-sensitive packages that may be added later.
+# entries (jose, cookie, crypto-js) are forward-looking guards for
+# security-sensitive packages that may be added later.
 # ─────────────────────────────────────────────────────────────────────────
 
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,28 @@
 version: 2
 
+# ─────────────────────────────────────────────────────────────────────────
+# Group precedence: Dependabot uses FIRST-MATCH-WINS evaluation. A package
+# matching multiple groups lands in the first group declared below. Reorder
+# carefully when editing — the auto-merge workflow keys off the resulting
+# group's `update-type` and `dependency-type` outputs from fetch-metadata.
+#
+# Auto-merge wiring (.github/workflows/dependabot-auto-merge.yml):
+#   - Any patch                  → auto-merge
+#   - dev minor (direct only)    → auto-merge
+#   - GitHub Actions any         → auto-merge
+#   - prod minor / vendor / any major → manual review
+#
+# Note on transitive patches: groups without `dependency-type` capture both
+# direct and indirect dependencies. `npm-patches` therefore auto-merges
+# transitive patches too — this is the Dependabot default and matches how
+# security advisories propagate.
+# ─────────────────────────────────────────────────────────────────────────
+
+# Security-sensitive package families excluded from auto-merge groups.
+# When editing, mirror the same list across npm-patches / npm-dev-minor /
+# npm-prod-minor so a future framework or auth bump always lands in its own
+# manual-review PR.
+
 updates:
   # ─────────────────────────────────────────
   # npm / pnpm — monthly, security-focused
@@ -8,7 +31,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 8
+    # 5 new groups (npm-patches, npm-dev-minor, npm-prod-minor, supabase,
+    # stripe) plus 1-per-package ungrouped majors. 12 leaves headroom for
+    # months with multiple major bumps without exhausting the limit.
+    open-pull-requests-limit: 12
     assignees:
       - hudsor01
     labels:
@@ -19,29 +45,49 @@ updates:
       include: scope
 
     # ── Grouped PRs ──────────────────────────
-    # Groups are split by update-type + dependency-type so the auto-merge
-    # workflow can decide on each PR independently:
-    #   - patches (any kind)        → auto-merged
-    #   - dev-minor (devDeps minor) → auto-merged
-    #   - prod-minor (prod minor)   → requires review
-    #   - supabase / stripe         → requires review (security-sensitive)
-    #   - majors                    → NOT grouped, one PR per package, requires review
     groups:
-      # Patch updates across the tree — safe enough to auto-merge once CI is green.
+      # Patch updates across the tree — auto-merged.
+      # Excludes security-sensitive vendors so any patch to those families
+      # always lands in its own PR for manual review.
       npm-patches:
         update-types:
           - patch
-        # Exclude security-sensitive packages so they always get their own PR.
         exclude-patterns:
           - '@supabase/*'
           - 'stripe'
           - '@stripe/*'
+          - 'next'
+          - '@next/*'
+          - 'react'
+          - 'react-dom'
+          - '@vercel/*'
+          - '@octokit/*'
+          - 'jose'
+          - 'cookie'
+          - 'dompurify'
+          - 'crypto-js'
 
       # Dev-only minor bumps — auto-merged.
+      # Same security-sensitive exclude list applied defensively in case any
+      # of those packages ever lands as a devDependency.
       npm-dev-minor:
         dependency-type: development
         update-types:
           - minor
+        exclude-patterns:
+          - '@supabase/*'
+          - 'stripe'
+          - '@stripe/*'
+          - 'next'
+          - '@next/*'
+          - 'react'
+          - 'react-dom'
+          - '@vercel/*'
+          - '@octokit/*'
+          - 'jose'
+          - 'cookie'
+          - 'dompurify'
+          - 'crypto-js'
 
       # Prod minor bumps — manual review required.
       npm-prod-minor:
@@ -52,6 +98,16 @@ updates:
           - '@supabase/*'
           - 'stripe'
           - '@stripe/*'
+          - 'next'
+          - '@next/*'
+          - 'react'
+          - 'react-dom'
+          - '@vercel/*'
+          - '@octokit/*'
+          - 'jose'
+          - 'cookie'
+          - 'dompurify'
+          - 'crypto-js'
 
       # Security-sensitive: separate PR for review.
       supabase:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,10 +46,12 @@ jobs:
       #   (direct:production > direct:development > indirect), so requiring
       #   `direct:development` rejects any group containing a direct:production
       #   minor and reroutes it to manual review.
-      # - GitHub Actions non-major updates — Actions are pinned by SHA
-      #   upstream so minor/patch bumps are low-risk. Majors require manual
-      #   review because a broken CI workflow blocks every other PR's merge
-      #   gate.
+      # - GitHub Actions non-major updates — workflow files are CI-only and
+      #   never ship to prod artifacts, so a broken bump can't reach
+      #   production. The required-checks gate (checks / e2e-smoke /
+      #   rls-security) catches anything that breaks CI itself before merge.
+      #   Majors are still excluded because a major Actions bump can break
+      #   the merge gate for every other PR until it's reverted.
       # Everything else (prod minor including indirect, all majors,
       # security-sensitive vendor groups) falls through to manual review.
       - name: Auto-merge if eligible

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,12 @@
 name: Dependabot Auto-Merge
 
+# Re-runs on every Dependabot push so existing PRs (opened before this
+# workflow shipped) and new PRs both get evaluated. The actual merge is
+# deferred via `gh pr merge --auto`, which holds the PR until required CI
+# checks pass — branch protection still gates the merge.
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
@@ -14,14 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: dependabot/fetch-metadata@v2
+      - name: Fetch Dependabot metadata
         id: meta
+        uses: dependabot/fetch-metadata@v2
 
+      # Auto-merge rules:
+      # - Any patch update (npm or otherwise)
+      # - Minor updates to direct devDependencies (dev tooling only)
+      # - Any GitHub Actions update (pinned by SHA upstream; safe enough)
+      # Everything else (prod minor, all majors, security-sensitive groups)
+      # falls through to manual review.
       - name: Auto-merge eligible updates
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
-           steps.meta.outputs.dependency-type == 'direct:development')
+           steps.meta.outputs.dependency-type == 'direct:development') ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,13 +3,16 @@ name: Dependabot Auto-Merge
 # Re-runs on every Dependabot push so existing PRs (opened before this
 # workflow shipped) and new PRs both get evaluated. The actual merge is
 # deferred via `gh pr merge --auto`, which holds the PR until required CI
-# checks pass — branch protection still gates the merge.
+# checks pass — branch protection on `main` requires checks / e2e-smoke /
+# rls-security before any PR can merge.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Least-privilege: the job only flags an existing PR for auto-merge via the
+# pull_request_auto_merge_enable mutation; it never pushes commits, so
+# `contents: write` is not required.
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:
@@ -18,23 +21,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Pinned by commit SHA per supply-chain best practice. v2.5.0 release.
+      # Bump alongside any `dependabot/fetch-metadata` Dependabot bump in
+      # the github-actions group.
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
 
-      # Auto-merge rules:
-      # - Any patch update (npm or otherwise)
-      # - Minor updates to direct devDependencies (dev tooling only)
-      # - Any GitHub Actions update (pinned by SHA upstream; safe enough)
-      # Everything else (prod minor, all majors, security-sensitive groups)
-      # falls through to manual review.
-      - name: Auto-merge eligible updates
+      # Auto-merge rules (first-match wins):
+      # - Any patch update (npm or otherwise) — fetch-metadata's `update-type`
+      #   for grouped PRs returns the highest semver level in the group, so
+      #   `update-type == patch` means EVERY package in the group is a patch.
+      # - Minor updates to direct devDependencies (dev tooling only) —
+      #   `dependency-type` for grouped PRs returns the highest priority
+      #   (direct:production > direct:development > indirect), so requiring
+      #   `direct:development` rejects any group containing a direct:production
+      #   minor and reroutes it to manual review.
+      # - Any GitHub Actions update — Actions are pinned by SHA upstream and
+      #   the group's blast radius is limited to CI workflow files.
+      # Everything else (prod minor including indirect, all majors,
+      # security-sensitive vendor groups) falls through to manual review.
+      - name: Auto-merge if eligible
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
            steps.meta.outputs.dependency-type == 'direct:development') ||
           steps.meta.outputs.package-ecosystem == 'github_actions'
-        run: gh pr merge --auto --squash "$PR_URL"
+        # `--merge` matches the repo's allow_merge_commit=true /
+        # allow_squash_merge=false setting (verified via the GitHub API).
+        # Switching to `--squash` would 422 on the enable-auto-merge mutation.
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,9 +9,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Cancel any in-flight run for the same PR if Dependabot rebases mid-run;
+# `gh pr merge --auto` is idempotent so a re-run on the latest head is
+# always safe and saves runner-minutes during the monthly batch.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 # Least-privilege: the job only flags an existing PR for auto-merge via the
-# pull_request_auto_merge_enable mutation; it never pushes commits, so
-# `contents: write` is not required.
+# pull_request_auto_merge_enable GraphQL mutation. It never pushes commits.
+# When auto-merge later finalizes, the merge commit is created by GitHub's
+# auto-merge runner using the PR author's token (Dependabot), not this
+# workflow's token — so `contents: write` is genuinely not required here.
 permissions:
   pull-requests: write
 
@@ -37,8 +46,10 @@ jobs:
       #   (direct:production > direct:development > indirect), so requiring
       #   `direct:development` rejects any group containing a direct:production
       #   minor and reroutes it to manual review.
-      # - Any GitHub Actions update — Actions are pinned by SHA upstream and
-      #   the group's blast radius is limited to CI workflow files.
+      # - GitHub Actions non-major updates — Actions are pinned by SHA
+      #   upstream so minor/patch bumps are low-risk. Majors require manual
+      #   review because a broken CI workflow blocks every other PR's merge
+      #   gate.
       # Everything else (prod minor including indirect, all majors,
       # security-sensitive vendor groups) falls through to manual review.
       - name: Auto-merge if eligible
@@ -46,7 +57,8 @@ jobs:
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
            steps.meta.outputs.dependency-type == 'direct:development') ||
-          steps.meta.outputs.package-ecosystem == 'github_actions'
+          (steps.meta.outputs.package-ecosystem == 'github_actions' &&
+           steps.meta.outputs.update-type != 'version-update:semver-major')
         # `--merge` matches the repo's allow_merge_commit=true /
         # allow_squash_merge=false setting (verified via the GitHub API).
         # Switching to `--squash` would 422 on the enable-auto-merge mutation.

--- a/scripts/mirror-secrets-to-dependabot.sh
+++ b/scripts/mirror-secrets-to-dependabot.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Mirror Actions-scope secrets into the Dependabot scope so Dependabot PRs
+# can pass the e2e-smoke + rls-security required CI checks.
+#
+# Why this exists:
+#   GitHub Actions secrets and Dependabot secrets live in separate scopes.
+#   Dependabot-triggered workflows only see secrets explicitly set under
+#   the Dependabot scope; the Actions scope is invisible to them. Without
+#   this mirror, every Dependabot PR fails the secret-precheck in
+#   .github/workflows/ci-cd.yml and never satisfies branch protection.
+#
+# How to run:
+#   1. `gh auth status` to confirm you're logged in with admin on the repo
+#   2. Run this script and paste each secret value when prompted (values
+#      are read silently, never echoed). Press Enter on a blank line to
+#      skip a secret you've already mirrored.
+#   3. Re-run any time you rotate one of these secrets — the Actions and
+#      Dependabot scopes do not auto-sync.
+#
+# Verify:
+#   gh api repos/hudsor01/tenant-flow/dependabot/secrets --jq '.secrets[].name'
+#   should list all 6 names below.
+set -euo pipefail
+
+REPO="${REPO:-hudsor01/tenant-flow}"
+
+SECRETS=(
+	E2E_OWNER_EMAIL
+	E2E_OWNER_PASSWORD
+	E2E_OWNER_B_EMAIL
+	E2E_OWNER_B_PASSWORD
+	NEXT_PUBLIC_SUPABASE_URL
+	NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+)
+
+echo "Mirroring ${#SECRETS[@]} Actions secrets into the Dependabot scope on ${REPO}."
+echo "Leave any prompt blank to skip that secret."
+echo
+
+for name in "${SECRETS[@]}"; do
+	read -rsp "  ${name}: " value
+	echo
+	if [[ -z "${value}" ]]; then
+		echo "  ↳ skipped"
+		continue
+	fi
+	gh secret set "${name}" --app dependabot --repo "${REPO}" --body "${value}"
+done
+
+echo
+echo "Done. Verify:"
+echo "  gh api repos/${REPO}/dependabot/secrets --jq '.secrets[].name'"

--- a/scripts/mirror-secrets-to-dependabot.sh
+++ b/scripts/mirror-secrets-to-dependabot.sh
@@ -19,8 +19,9 @@
 #      Dependabot scopes do not auto-sync.
 #
 # Verify:
-#   gh api repos/<owner>/<repo>/dependabot/secrets --jq '.secrets[].name'
-#   should list all 6 names below.
+#   gh api "repos/${REPO}/dependabot/secrets" --jq '.secrets[].name'
+#   (where ${REPO} defaults to hudsor01/tenant-flow). The output should
+#   list all 6 names below.
 set -euo pipefail
 
 REPO="${REPO:-hudsor01/tenant-flow}"

--- a/scripts/mirror-secrets-to-dependabot.sh
+++ b/scripts/mirror-secrets-to-dependabot.sh
@@ -77,4 +77,4 @@ done
 
 echo
 echo "Done. Verify:"
-echo "  gh api repos/${REPO}/dependabot/secrets --jq '.secrets[].name'"
+echo "  gh api \"repos/${REPO}/dependabot/secrets\" --jq '.secrets[].name'"

--- a/scripts/mirror-secrets-to-dependabot.sh
+++ b/scripts/mirror-secrets-to-dependabot.sh
@@ -13,12 +13,13 @@
 #   1. `gh auth status` to confirm you're logged in with admin on the repo
 #   2. Run this script and paste each secret value when prompted (values
 #      are read silently, never echoed). Press Enter on a blank line to
-#      skip a secret you've already mirrored.
+#      skip a secret you've already mirrored — already-set secrets are
+#      annotated `[already set]` so you know which prompts can be skipped.
 #   3. Re-run any time you rotate one of these secrets — the Actions and
 #      Dependabot scopes do not auto-sync.
 #
 # Verify:
-#   gh api repos/hudsor01/tenant-flow/dependabot/secrets --jq '.secrets[].name'
+#   gh api repos/<owner>/<repo>/dependabot/secrets --jq '.secrets[].name'
 #   should list all 6 names below.
 set -euo pipefail
 
@@ -33,12 +34,38 @@ SECRETS=(
 	NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 )
 
+# Pre-flight: ensure gh CLI is authed with sufficient scope. `gh secret set
+# --app dependabot` requires admin on the repo (the API endpoint is
+# /repos/{owner}/{repo}/dependabot/secrets/{name}).
+if ! gh auth status >/dev/null 2>&1; then
+	echo "Error: gh CLI is not authenticated. Run 'gh auth login' first." >&2
+	exit 1
+fi
+
+if ! gh api "repos/${REPO}" --jq '.permissions.admin' 2>/dev/null | grep -q '^true$'; then
+	echo "Error: current gh auth lacks admin on ${REPO}. The dependabot/secrets endpoint requires admin." >&2
+	exit 1
+fi
+
+# Fetch the names already set in the Dependabot scope so the operator
+# knows which prompts can be skipped vs. which need a value.
+existing="$(gh api "repos/${REPO}/dependabot/secrets" --jq '[.secrets[].name] | join(" ")' 2>/dev/null || echo '')"
+
+is_set() {
+	local name="$1"
+	[[ " ${existing} " == *" ${name} "* ]]
+}
+
 echo "Mirroring ${#SECRETS[@]} Actions secrets into the Dependabot scope on ${REPO}."
-echo "Leave any prompt blank to skip that secret."
+echo "Press Enter on a blank line to skip a prompt."
 echo
 
 for name in "${SECRETS[@]}"; do
-	read -rsp "  ${name}: " value
+	suffix=""
+	if is_set "${name}"; then
+		suffix=" [already set]"
+	fi
+	read -rsp "  ${name}${suffix}: " value
 	echo
 	if [[ -z "${value}" ]]; then
 		echo "  ↳ skipped"


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37m- Split the `minor-and-patch` Dependabot group into 3 (`npm-patches`, `npm-dev-minor`, `npm-prod-minor`) so the auto-merge workflow can decide on each PR independently[0m
[38;5;8m   4[0m [37m- Extended the auto-merge workflow to cover non-major GitHub Actions updates and re-trigger on `synchronize` / `reopened`[0m
[38;5;8m   5[0m [37m- Configured branch protection on `main` (required: `checks`, `e2e-smoke`, `rls-security`; force-push + deletion blocked)[0m
[38;5;8m   6[0m [37m- Added `scripts/mirror-secrets-to-dependabot.sh` for the one-time mirror of the 6 secrets the required CI checks need on Dependabot-triggered runs[0m
[38;5;8m   7[0m 
[38;5;8m   8[0m [37m## Behavior matrix[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37m| Update class | Group | Auto-merge |[0m
[38;5;8m  11[0m [37m|---|---|---|[0m
[38;5;8m  12[0m [37m| Any patch (excl. security-sensitive families) | `npm-patches` | yes |[0m
[38;5;8m  13[0m [37m| devDeps minor | `npm-dev-minor` | yes |[0m
[38;5;8m  14[0m [37m| Prod deps minor (excl. security-sensitive) | `npm-prod-minor` | review |[0m
[38;5;8m  15[0m [37m| `@supabase/*` any | `supabase` | review |[0m
[38;5;8m  16[0m [37m| `stripe` / `@stripe/*` any | `stripe` | review |[0m
[38;5;8m  17[0m [37m| GitHub Actions non-major | `github-actions` | yes |[0m
[38;5;8m  18[0m [37m| GitHub Actions major | `github-actions` | review |[0m
[38;5;8m  19[0m [37m| Any major (npm) | not grouped — one PR per package | review |[0m
[38;5;8m  20[0m [37m| `next` / `react` / `react-dom` / `@tanstack/*` / `@supabase/*` major | ignored — never opened | n/a |[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37mSecurity-sensitive exclude families (duplicated across `npm-patches` / `npm-dev-minor` / `npm-prod-minor` — dependabot-core's `Psych.safe_load` runs with `aliases: false` so YAML anchors raise `Psych::BadAlias`, manual mirroring is the only viable pattern): `@supabase/*`, `stripe`, `@stripe/*`, `next`, `@next/*`, `react`, `react-dom`, `@vercel/*`, `jose`, `cookie`, `dompurify`, `crypto-js`.[0m
[38;5;8m  23[0m 
[38;5;8m  24[0m [37m## Required pre-merge actions[0m
[38;5;8m  25[0m 
[38;5;8m  26[0m [37m- [ ] **Run `bash scripts/mirror-secrets-to-dependabot.sh`** to mirror the 6 secrets (`E2E_OWNER_EMAIL`, `E2E_OWNER_PASSWORD`, `E2E_OWNER_B_EMAIL`, `E2E_OWNER_B_PASSWORD`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`) into the Dependabot scope. Without this, every Dependabot PR will park in "Auto-merge enabled, waiting for required checks" forever because `e2e-smoke` and `rls-security` will fail their secret-precheck.[0m
[38;5;8m  27[0m [37m- [ ] Verify with `gh api "repos/hudsor01/tenant-flow/dependabot/secrets" --jq '.secrets[].name'` — all 6 names should appear.[0m
[38;5;8m  28[0m 
[38;5;8m  29[0m [37m## Post-merge actions[0m
[38;5;8m  30[0m 
[38;5;8m  31[0m [37m- [ ] Comment `@dependabot recreate` on each of the 6 currently-open Dependabot PRs (#647-#652). `recreate` (not `rebase`) is required because Dependabot only re-evaluates group membership when a PR is regenerated from scratch — rebasing keeps the old grouping.[0m
[38;5;8m  32[0m [37m- [ ] Verify #647 (github-actions group: actions/checkout 4→6, pnpm/action-setup 5→6, actions/upload-artifact 4→7, dependabot/fetch-metadata 2→3 — all majors) STAYS OPEN for manual review. fetch-metadata reports the group's max-semver as major, and the auto-merge workflow's clause 3 explicitly excludes majors, so this PR correctly bypasses auto-merge.[0m
[38;5;8m  33[0m [37m- [ ] Verify #649 is replaced by 3 new PRs (npm-patches, npm-dev-minor, npm-prod-minor) on Dependabot's next run; npm-patches and npm-dev-minor auto-merge once CI passes, npm-prod-minor stays open for review.[0m
[38;5;8m  34[0m [37m- [ ] Verify #648 (stripe major) is recreated as a stripe-group PR and remains open for manual review.[0m
[38;5;8m  35[0m [37m- [ ] Verify #650 (vitejs/plugin-react major), #651 (jsdom major), #652 (vercel/analytics major) stay as individual major PRs awaiting manual review.[0m
[38;5;8m  36[0m 
[38;5;8m  37[0m [37m[hudsor01][0m