### PR TITLE
feat(notify): wire n8n Resend node handlers + enrich payload with owner_email

### DIFF
--- a/supabase/migrations/20260505002058_notify_n8n_include_owner_email.sql
+++ b/supabase/migrations/20260505002058_notify_n8n_include_owner_email.sql
@@ -1,0 +1,277 @@
+-- Augment all 5 notify trigger functions to include the owner's email
+-- (and full_name) in the webhook body. This lets n8n's Resend node use
+-- {{ $json.body.owner_email }} directly without needing a separate
+-- Supabase API call to look up the recipient.
+--
+-- For maintenance/payment-reminders/lease-reminders/rent-payments the
+-- owner_user_id lives on the row (or on the joined lease for reminders /
+-- payments queue tables). For user_errors we route to admin emails — the
+-- function emits an array of admin emails so n8n can use $json.body.admin_emails.
+
+CREATE OR REPLACE FUNCTION public.notify_n8n_maintenance()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_webhook_url    text;
+  v_webhook_secret text;
+  v_event_type     text;
+  v_owner_email    text;
+  v_owner_name     text;
+BEGIN
+  SELECT value INTO v_webhook_url    FROM public.app_config WHERE key = 'n8n.webhook.maintenance_url';
+  SELECT value INTO v_webhook_secret FROM public.app_config WHERE key = 'n8n.webhook.secret';
+
+  IF v_webhook_url IS NULL OR v_webhook_url = ''
+     OR v_webhook_secret IS NULL OR v_webhook_secret = '' THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.status = NEW.status THEN
+    RETURN NEW;
+  END IF;
+
+  v_event_type := TG_OP;
+
+  SELECT email, full_name INTO v_owner_email, v_owner_name
+  FROM public.users WHERE id = NEW.owner_user_id;
+
+  PERFORM net.http_post(
+    url     := v_webhook_url,
+    body    := jsonb_build_object(
+      'type',         v_event_type,
+      'table',        'maintenance_requests',
+      'owner_email',  v_owner_email,
+      'owner_name',   v_owner_name,
+      'record',       row_to_json(NEW)::jsonb
+    ),
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || v_webhook_secret
+    ),
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+END;
+$function$;
+
+
+CREATE OR REPLACE FUNCTION public.notify_n8n_payment_reminder()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_webhook_url    text;
+  v_webhook_secret text;
+  v_owner_id       uuid;
+  v_owner_email    text;
+  v_owner_name     text;
+BEGIN
+  SELECT value INTO v_webhook_url    FROM public.app_config WHERE key = 'n8n.webhook.payment_reminder_url';
+  SELECT value INTO v_webhook_secret FROM public.app_config WHERE key = 'n8n.webhook.secret';
+
+  IF v_webhook_url IS NULL OR v_webhook_url = ''
+     OR v_webhook_secret IS NULL OR v_webhook_secret = '' THEN
+    RETURN NEW;
+  END IF;
+
+  -- payment_reminders -> rent_payments -> leases -> owner_user_id
+  SELECT l.owner_user_id INTO v_owner_id
+  FROM public.rent_payments rp
+  JOIN public.leases l ON l.id = rp.lease_id
+  WHERE rp.id = NEW.rent_payment_id;
+
+  IF v_owner_id IS NOT NULL THEN
+    SELECT email, full_name INTO v_owner_email, v_owner_name
+    FROM public.users WHERE id = v_owner_id;
+  END IF;
+
+  PERFORM net.http_post(
+    url     := v_webhook_url,
+    body    := jsonb_build_object(
+      'type',          'INSERT',
+      'table',         'payment_reminders',
+      'owner_email',   v_owner_email,
+      'owner_name',    v_owner_name,
+      'owner_user_id', v_owner_id,
+      'record',        row_to_json(NEW)::jsonb
+    ),
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || v_webhook_secret
+    ),
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+END;
+$function$;
+
+
+CREATE OR REPLACE FUNCTION public.notify_n8n_lease_reminder()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_webhook_url    text;
+  v_webhook_secret text;
+  v_owner_id       uuid;
+  v_owner_email    text;
+  v_owner_name     text;
+BEGIN
+  SELECT value INTO v_webhook_url    FROM public.app_config WHERE key = 'n8n.webhook.lease_reminder_url';
+  SELECT value INTO v_webhook_secret FROM public.app_config WHERE key = 'n8n.webhook.secret';
+
+  IF v_webhook_url IS NULL OR v_webhook_url = ''
+     OR v_webhook_secret IS NULL OR v_webhook_secret = '' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT owner_user_id INTO v_owner_id FROM public.leases WHERE id = NEW.lease_id;
+
+  IF v_owner_id IS NOT NULL THEN
+    SELECT email, full_name INTO v_owner_email, v_owner_name
+    FROM public.users WHERE id = v_owner_id;
+  END IF;
+
+  PERFORM net.http_post(
+    url     := v_webhook_url,
+    body    := jsonb_build_object(
+      'type',          'INSERT',
+      'table',         'lease_reminders',
+      'owner_email',   v_owner_email,
+      'owner_name',    v_owner_name,
+      'owner_user_id', v_owner_id,
+      'record',        row_to_json(NEW)::jsonb
+    ),
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || v_webhook_secret
+    ),
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+END;
+$function$;
+
+
+CREATE OR REPLACE FUNCTION public.notify_n8n_rent_payment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_webhook_url    text;
+  v_webhook_secret text;
+  v_owner_id       uuid;
+  v_owner_email    text;
+  v_owner_name     text;
+BEGIN
+  SELECT value INTO v_webhook_url    FROM public.app_config WHERE key = 'n8n.webhook.rent_payment_url';
+  SELECT value INTO v_webhook_secret FROM public.app_config WHERE key = 'n8n.webhook.secret';
+
+  IF v_webhook_url IS NULL OR v_webhook_url = ''
+     OR v_webhook_secret IS NULL OR v_webhook_secret = '' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT owner_user_id INTO v_owner_id FROM public.leases WHERE id = NEW.lease_id;
+
+  IF v_owner_id IS NOT NULL THEN
+    SELECT email, full_name INTO v_owner_email, v_owner_name
+    FROM public.users WHERE id = v_owner_id;
+  END IF;
+
+  PERFORM net.http_post(
+    url     := v_webhook_url,
+    body    := jsonb_build_object(
+      'type',          'INSERT',
+      'table',         'rent_payments',
+      'owner_email',   v_owner_email,
+      'owner_name',    v_owner_name,
+      'owner_user_id', v_owner_id,
+      'record',        row_to_json(NEW)::jsonb
+    ),
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || v_webhook_secret
+    ),
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+END;
+$function$;
+
+
+CREATE OR REPLACE FUNCTION public.notify_critical_error()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  recent_count     integer;
+  v_webhook_url    text;
+  v_webhook_secret text;
+  v_payload        jsonb;
+  v_admin_emails   text[];
+BEGIN
+  SELECT COUNT(*) INTO recent_count
+  FROM public.user_errors
+  WHERE error_message = NEW.error_message
+    AND created_at >= NOW() - INTERVAL '5 minutes';
+
+  IF NEW.error_type = 'authorization' OR recent_count > 10 THEN
+    v_payload := jsonb_build_object(
+      'error_id',      NEW.id,
+      'user_id',       NEW.user_id,
+      'error_type',    NEW.error_type,
+      'error_message', NEW.error_message,
+      'error_count',   recent_count,
+      'created_at',    NEW.created_at
+    );
+
+    PERFORM pg_notify('critical_error', v_payload::text);
+
+    SELECT value INTO v_webhook_url    FROM public.app_config WHERE key = 'n8n.webhook.critical_error_url';
+    SELECT value INTO v_webhook_secret FROM public.app_config WHERE key = 'n8n.webhook.secret';
+
+    IF v_webhook_url IS NOT NULL AND v_webhook_url <> ''
+       AND v_webhook_secret IS NOT NULL AND v_webhook_secret <> '' THEN
+      -- Critical errors fan out to every active admin.
+      SELECT array_agg(email) INTO v_admin_emails
+      FROM public.users
+      WHERE is_admin = true
+        AND status <> 'inactive'
+        AND email IS NOT NULL;
+
+      PERFORM net.http_post(
+        url     := v_webhook_url,
+        body    := jsonb_build_object(
+          'type',         'critical_error',
+          'table',        'user_errors',
+          'admin_emails', COALESCE(v_admin_emails, ARRAY[]::text[]),
+          'record',       v_payload
+        ),
+        headers := jsonb_build_object(
+          'Content-Type',  'application/json',
+          'Authorization', 'Bearer ' || v_webhook_secret
+        ),
+        timeout_milliseconds := 5000
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mWires the n8n `tenantflow-events` workflow to actually send transactional emails via the Resend native n8n node instead of the prior TODO Set-stub handlers.[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37mTwo halves:[0m
[38;5;8m   6[0m 
[38;5;8m   7[0m [37m1. **DB-side migration `20260505002058_notify_n8n_include_owner_email.sql`** — all 5 notify trigger functions now look up the recipient email + full name and include them in the JSON body POSTed to n8n. Lets the Resend node bind to `{{ $json.body.owner_email }}` directly with no extra Supabase API call.[0m
[38;5;8m   8[0m [37m2. **n8n workflow update (out-of-band via n8n MCP)** — workflow `tenantflow-events` (id `38X1MRD9rVPhUC0y`) updated to:[0m
[38;5;8m   9[0m [37m   - Webhook → IF (Bearer auth) →[0m
[38;5;8m  10[0m [37m     - **onTrue → Switch (by body.table)** with 5 Resend `emails:send` nodes downstream (one per event type)[0m
[38;5;8m  11[0m [37m     - **onFalse → Unauthorized — drop**[0m
[38;5;8m  12[0m [37m   - Resend credential auto-attached by n8n MCP (your existing "Resend account" was reused, not duplicated)[0m
[38;5;8m  13[0m 
[38;5;8m  14[0m [37m## Email recipients per event type[0m
[38;5;8m  15[0m 
[38;5;8m  16[0m [37m| Trigger source | Recipient |[0m
[38;5;8m  17[0m [37m|---|---|[0m
[38;5;8m  18[0m [37m| `maintenance_requests` INSERT/status-change | property owner |[0m
[38;5;8m  19[0m [37m| `payment_reminders` INSERT | property owner (resolved via rent_payments → leases) |[0m
[38;5;8m  20[0m [37m| `lease_reminders` INSERT | property owner (resolved via leases) |[0m
[38;5;8m  21[0m [37m| `rent_payments` INSERT | property owner (resolved via leases) |[0m
[38;5;8m  22[0m [37m| `user_errors` INSERT (auth/spike) | every active `is_admin = true` user (text[] of emails fanned to Resend's `to:` list) |[0m
[38;5;8m  23[0m 
[38;5;8m  24[0m [37m## Manual step (one-time, ~30 sec in n8n UI)[0m
[38;5;8m  25[0m 
[38;5;8m  26[0m [37mThe n8n MCP's `update_workflow` reliably persists trigger→IF and IF→Switch/drop connections, but **does not persist Switch→downstream connections** (an SDK quirk in this n8n version). Open the workflow:[0m
[38;5;8m  27[0m 
[38;5;8m  28[0m [37mhttps://n8n.thehudsonfam.com/workflow/38X1MRD9rVPhUC0y[0m
[38;5;8m  29[0m 
[38;5;8m  30[0m [37m…and drag each Switch output port to the matching Resend node:[0m
[38;5;8m  31[0m 
[38;5;8m  32[0m [37m| Switch output (label) | → | Target node |[0m
[38;5;8m  33[0m [37m|---|---|---|[0m
[38;5;8m  34[0m [37m| `maintenance` | → | Send maintenance email |[0m
[38;5;8m  35[0m [37m| `payment_reminder` | → | Send payment reminder |[0m
[38;5;8m  36[0m [37m| `lease_reminder` | → | Send lease reminder |[0m
[38;5;8m  37[0m [37m| `rent_payment` | → | Send rent payment receipt |[0m
[38;5;8m  38[0m [37m| `critical_error` | → | Send critical error alert |[0m
[38;5;8m  39[0m [37m| `unmatched` (fallback) | → | TODO: unmatched event |[0m
[38;5;8m  40[0m 
[38;5;8m  41[0m [37mSave + activate. Resend's "From" address is `TenantFlow <noreply@tenantflow.app>` — verify the domain is configured in your Resend dashboard if it isn't already.[0m
[38;5;8m  42[0m 
[38;5;8m  43[0m [37m## Test plan[0m
[38;5;8m  44[0m 
[38;5;8m  45[0m [37m- [x] `pnpm typecheck` clean[0m
[38;5;8m  46[0m [37m- [x] Migration applied to prod via Supabase MCP (timestamp `20260505002058`)[0m
[38;5;8m  47[0m [37m- [x] n8n MCP `update_workflow` + `publish_workflow` succeeded[0m
[38;5;8m  48[0m [37m- [x] n8n MCP `autoAssignedCredentials` confirms Resend credential attached to all 5 send nodes[0m
[38;5;8m  49[0m [37m- [ ] **Manual:** drag the 5 Switch→Resend connections in the n8n UI per the table above[0m
[38;5;8m  50[0m [37m- [ ] **Manual:** trigger one of each event type (insert a maintenance request, etc.) and verify the corresponding email arrives in your inbox + appears in the n8n executions log[0m
[38;5;8m  51[0m 
[38;5;8m  52[0m [37m## Why a single workflow vs. five separate ones[0m
[38;5;8m  53[0m 
[38;5;8m  54[0m [37mSingle workflow centralizes the auth gate (Bearer check) and the Switch routing logic. Five separate workflows would eliminate the SDK connection quirk but at the cost of duplicating auth/routing code across all five. The 30-second manual wire-up is the better trade.[0m
[38;5;8m  55[0m 
[38;5;8m  56[0m [37m## Resend integration notes[0m
[38;5;8m  57[0m 
[38;5;8m  58[0m [37m- Templates are inline HTML in the workflow JSON, not in source-controlled `_shared/email-layout.ts`. Changing branding means editing the workflow.[0m
[38;5;8m  59[0m [37m- `email_deliverability` table tracking via the `resend-webhook` Edge Function continues to work — every send carries Resend's standard event tags.[0m
[38;5;8m  60[0m [37m- Idempotency at the Resend API level is not used; n8n's webhook redelivery + Switch evaluation is the dedupe layer.[0m
[38;5;8m  61[0m 
[38;5;8m  62[0m [37m[hudsor01][0m