### PR TITLE
fix(ci): add contents:write to dependabot-auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,12 +16,14 @@ concurrency:
   group: dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Least-privilege: the job only flags an existing PR for auto-merge via the
-# pull_request_auto_merge_enable GraphQL mutation. It never pushes commits.
-# When auto-merge later finalizes, the merge commit is created by GitHub's
-# auto-merge runner using the PR author's token (Dependabot), not this
-# workflow's token — so `contents: write` is genuinely not required here.
+# The enablePullRequestAutoMerge GraphQL mutation needs `contents: write`
+# in addition to `pull-requests: write`. The actual merge commit is later
+# created by GitHub's auto-merge runner under Dependabot's token, but the
+# mutation that *flags* the PR for auto-merge is checked against the
+# caller's repo-write scope. Without `contents: write` the mutation 422s
+# with "Resource not accessible by integration".
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37m- PRs #660/#661/#663 failed at the `gh pr merge --auto` step with `GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)` despite all required checks (checks/e2e-smoke/rls-security) passing.[0m
[38;5;8m   3[0m [37m- Root cause: the `enablePullRequestAutoMerge` GraphQL mutation needs `contents: write` in the workflow token. Without it the call 422s — even though `pull-requests: write` is set.[0m
[38;5;8m   4[0m [37m- Comment block updated to reflect the actual constraint instead of the incorrect "least-privilege without contents:write" reasoning.[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37m## Test plan[0m
[38;5;8m   7[0m [37m- [x] Lefthook pre-commit (gitleaks, lockfile-verify, lint, typecheck, 99,727 unit tests) all pass locally.[0m
[38;5;8m   8[0m [37m- [ ] After merge, comment `@dependabot rebase` on PRs #660/#661/#663 to retrigger the workflow with the fix and watch auto-merge succeed.[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37m[hudsor01][0m