### PR TITLE
chore: drop dead TODO.md REACT-001 pointers

### DIFF
--- a/src/app/(owner)/leases/page.tsx
+++ b/src/app/(owner)/leases/page.tsx
@@ -5,8 +5,6 @@
  *
  * Uses Zustand store for state management (useLeasesStore).
  * See stores/leases-store.ts for state structure.
- *
- * @see TODO.md REACT-001 - State consolidated from 13 useState calls
  */
 
 import { useEffect, Suspense } from 'react'

--- a/src/stores/leases-store.ts
+++ b/src/stores/leases-store.ts
@@ -10,8 +10,6 @@
  * - Pagination: current page
  * - Selection: selected row IDs
  * - Dialogs: selected lease, dialog visibility states
- *
- * @see TODO.md REACT-001 for context
  */
 
 import { create } from 'zustand'

--- a/src/stores/properties-store.ts
+++ b/src/stores/properties-store.ts
@@ -9,8 +9,6 @@
  * - Filters: search, status filter, type filter
  * - Selection: selected row IDs
  * - Bulk Edit: dialog state and form values
- *
- * @see TODO.md REACT-001 pattern
  */
 
 import { create } from 'zustand'

--- a/src/stores/tenants-store.ts
+++ b/src/stores/tenants-store.ts
@@ -9,8 +9,6 @@
  * - Filters: search, status filter
  * - Selection: selected row IDs
  * - Modals: detail sheet
- *
- * @see TODO.md REACT-001 pattern
  */
 
 import { create } from 'zustand'


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37m- Four files carried `@see TODO.md REACT-001` JSDoc lines pointing at a `TODO.md` that no longer exists in the repo. Removed the dangling pointers; each JSDoc's surrounding prose already explains the *why* (state-consolidation refactor) and the dead reference only confuses future readers grepping for the file.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m## Files[0m
[38;5;8m   5[0m [37m- `src/app/(owner)/leases/page.tsx`[0m
[38;5;8m   6[0m [37m- `src/stores/properties-store.ts`[0m
[38;5;8m   7[0m [37m- `src/stores/leases-store.ts`[0m
[38;5;8m   8[0m [37m- `src/stores/tenants-store.ts`[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37m## Test plan[0m
[38;5;8m  11[0m [37m- [ ] CI green (typecheck + lint + e2e-smoke + rls-security)[0m
[38;5;8m  12[0m [37m- [ ] `grep -rn "TODO.md\|REACT-001" src/ tests/` returns empty (verified locally)[0m
[38;5;8m  13[0m 
[38;5;8m  14[0m [37m[hudsor01][0m