### PR TITLE
fix(security): close 6 P1 hardening items + 2 review-cycle followups

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -20,11 +20,18 @@ Sentry.init({
 	replaysOnErrorSampleRate: 1.0, // Always capture replays on errors
 
 	integrations: [
-		// Session Replay
+		// Session Replay. All three masks default to ON so the dashboard
+		// surface — tenant names, email addresses, lease amounts, property
+		// addresses — never reaches Sentry. Without these, replay records
+		// PII that we have no DPA to share with Sentry; flipping them to
+		// `false` would re-open a GDPR exposure for any EU user. Future
+		// callers that need a screen-share UX should add explicit
+		// `unmask: ['.selector']` rules rather than disable masking
+		// globally.
 		Sentry.replayIntegration({
-			maskAllText: false,
-			blockAllMedia: false,
-			maskAllInputs: true // Mask form inputs for privacy
+			maskAllText: true,
+			blockAllMedia: true,
+			maskAllInputs: true
 		}),
 		// Browser Tracing for Web Vitals
 		Sentry.browserTracingIntegration({

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -606,7 +606,7 @@ Service role (`service_role`) bypasses all RLS for backend operations.
 | `profile-avatars` | User avatars | Yes |
 | `documents` | General documents | No |
 
-> **Note:** Lease PDFs are NOT stored in Supabase Storage. The `generate-pdf` Edge Function streams them to the caller in-memory; no persistence step. The previously-documented `lease-documents` bucket and its three storage policies were demolished in PR #677 (2026-05-07) — see `supabase/migrations/20251110160000_create_lease_documents_bucket.sql` for the audit trail.
+> **Note:** Lease PDFs are NOT stored in Supabase Storage. The `generate-pdf` Edge Function streams them to the caller in-memory; no persistence step. The previously-documented `lease-documents` bucket policies were demolished in PR #677 (2026-05-07); the bucket itself was deleted out-of-band before that PR (Supabase's `storage.protect_delete()` trigger blocks `DELETE FROM storage.buckets`, so the migration cannot reproduce the bucket deletion). See `supabase/migrations/20251110160000_create_lease_documents_bucket.sql` for the full audit trail.
 
 ---
 

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -604,8 +604,9 @@ Service role (`service_role`) bypasses all RLS for backend operations.
 |--------|---------|--------|
 | `property-images` | Property photos | Yes |
 | `profile-avatars` | User avatars | Yes |
-| `lease-documents` | Lease PDFs (signed) | No |
 | `documents` | General documents | No |
+
+> **Note:** Lease PDFs are NOT stored in Supabase Storage. The `generate-pdf` Edge Function streams them to the caller in-memory; no persistence step. The previously-documented `lease-documents` bucket and its three storage policies were demolished in PR #677 (2026-05-07) — see `supabase/migrations/20251110160000_create_lease_documents_bucket.sql` for the audit trail.
 
 ---
 

--- a/supabase/functions/_shared/plan-tier.ts
+++ b/supabase/functions/_shared/plan-tier.ts
@@ -32,6 +32,22 @@ const TRIAL_PRICE_IDS: ReadonlySet<string> = new Set([
   'price_1RgguDP3WCR53Sdo1lJmjlD5', // Trial $0 (DB-managed; Stripe trial sub never created)
 ])
 
+// Allowlist for `stripe-checkout`. The trial price is intentionally
+// excluded — trials are DB-managed (`subscription_status='trialing'`,
+// `trial_ends_at`) and never flow through Stripe Checkout.
+//
+// Used by stripe-checkout/index.ts to refuse a `price_id` that isn't in
+// our canonical set, closing the path where an attacker (a) crafts a
+// $0 price in some other Stripe account if test-mode keys ever leaked,
+// or (b) pivots to a real-but-unintended price ID (e.g. a coupon or
+// archived tier) and pairs it with `allow_promotion_codes: true` to
+// gain dashboard access at a price never offered through the UI.
+export const ALLOWED_CHECKOUT_PRICE_IDS: ReadonlySet<string> = new Set([
+  ...STARTER_PRICE_IDS,
+  ...GROWTH_PRICE_IDS,
+  ...MAX_PRICE_IDS,
+])
+
 export type PlanTier = 'trial' | 'starter' | 'growth' | 'max'
 
 /**

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -42,18 +42,35 @@ function getLimiter(maxRequests: number, windowMs: string): Ratelimit {
 }
 
 /**
- * Extract client IP from request headers.
- * Checks x-forwarded-for (first segment), cf-connecting-ip, then falls back to 'unknown'.
+ * Extract the trusted client IP from request headers.
+ *
+ * Order:
+ *   1. `cf-connecting-ip` — set by Cloudflare/edge infra, stripped from
+ *      incoming requests, so a client cannot forge it.
+ *   2. Last segment of `x-forwarded-for` — closest hop to our infra.
+ *      The FIRST segment is attacker-controlled (the client can put
+ *      anything they want in the request header before it reaches the
+ *      edge), so trusting it lets an attacker rotate fake IPs to
+ *      bypass any IP-based rate limit. The last segment is added by
+ *      the edge proxy at the network boundary and reflects the real
+ *      caller.
+ *   3. Fallback string `'unknown'` — every untrusted request shares
+ *      this bucket, so the rate limit still applies in aggregate when
+ *      headers are missing entirely (e.g., direct origin hit).
+ *
+ * Reference: Cloudflare's `cf-connecting-ip` documentation explicitly
+ * recommends trusting their own header over `x-forwarded-for` for IP
+ * identification.
  */
 function getClientIp(req: Request): string {
-  const xff = req.headers.get('x-forwarded-for')
-  if (xff) {
-    const first = xff.split(',')[0].trim()
-    if (first) return first
-  }
-
   const cfIp = req.headers.get('cf-connecting-ip')
   if (cfIp) return cfIp
+
+  const xff = req.headers.get('x-forwarded-for')
+  if (xff) {
+    const parts = xff.split(',').map(s => s.trim()).filter(Boolean)
+    if (parts.length > 0) return parts[parts.length - 1]
+  }
 
   return 'unknown'
 }

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -44,23 +44,31 @@ function getLimiter(maxRequests: number, windowMs: string): Ratelimit {
 /**
  * Extract the trusted client IP from request headers.
  *
+ * Supabase Edge Functions run on Deno Deploy. Whether `cf-connecting-ip`
+ * is populated depends on whether the request transits Cloudflare's
+ * edge layer before reaching the function. When it does, that header
+ * is set by Cloudflare and stripped from incoming requests at its
+ * boundary, so a client cannot forge it — making it the most reliable
+ * IP signal available. When it doesn't, this function falls through to
+ * `x-forwarded-for`.
+ *
  * Order:
- *   1. `cf-connecting-ip` — set by Cloudflare/edge infra, stripped from
- *      incoming requests, so a client cannot forge it.
+ *   1. `cf-connecting-ip` — trusted when present.
  *   2. Last segment of `x-forwarded-for` — closest hop to our infra.
  *      The FIRST segment is attacker-controlled (the client can put
  *      anything they want in the request header before it reaches the
  *      edge), so trusting it lets an attacker rotate fake IPs to
  *      bypass any IP-based rate limit. The last segment is added by
- *      the edge proxy at the network boundary and reflects the real
- *      caller.
+ *      the trusted proxy at our network boundary and reflects the
+ *      real caller in single-proxy topologies. In multi-proxy chains,
+ *      the last segment is still the closest-to-us hop, which is the
+ *      most truthful identifier we can pick without coordinating with
+ *      every upstream proxy.
  *   3. Fallback string `'unknown'` — every untrusted request shares
  *      this bucket, so the rate limit still applies in aggregate when
- *      headers are missing entirely (e.g., direct origin hit).
- *
- * Reference: Cloudflare's `cf-connecting-ip` documentation explicitly
- * recommends trusting their own header over `x-forwarded-for` for IP
- * identification.
+ *      headers are missing entirely (e.g., direct origin hit). This
+ *      falls open for per-IP isolation but stays closed for
+ *      aggregate-traffic ceilings.
  */
 function getClientIp(req: Request): string {
   const cfIp = req.headers.get('cf-connecting-ip')

--- a/supabase/functions/auth-email-send/index.ts
+++ b/supabase/functions/auth-email-send/index.ts
@@ -87,7 +87,7 @@ Deno.serve(async (req: Request) => {
       )
     }
 
-    const appUrl = env['NEXT_PUBLIC_APP_URL'] ?? Deno.env.get('NEXT_PUBLIC_APP_URL') ?? 'http://localhost:3050'
+    const appUrl = env['NEXT_PUBLIC_APP_URL'] ?? 'http://localhost:3050'
     const otpType = OTP_TYPE_MAP[email_data.email_action_type]
     const callbackUrl = `${appUrl}/auth/callback?token_hash=${encodeURIComponent(email_data.token_hash)}&type=${encodeURIComponent(otpType)}`
 

--- a/supabase/functions/auth-email-send/index.ts
+++ b/supabase/functions/auth-email-send/index.ts
@@ -56,22 +56,25 @@ Deno.serve(async (req: Request) => {
 
   try {
     const env = validateEnv({
-      required: ['RESEND_API_KEY'],
-      optional: ['SUPABASE_AUTH_HOOK_SECRET', 'NEXT_PUBLIC_APP_URL'],
+      required: ['RESEND_API_KEY', 'SUPABASE_AUTH_HOOK_SECRET'],
+      optional: ['NEXT_PUBLIC_APP_URL'],
     })
 
-    // Verify the request comes from Supabase via the hook secret
-    const hookSecret = env['SUPABASE_AUTH_HOOK_SECRET'] ?? Deno.env.get('SUPABASE_AUTH_HOOK_SECRET')
-    if (hookSecret) {
-      const authHeader = req.headers.get('authorization') ?? ''
-      const token = authHeader.replace(/^Bearer\s+/i, '')
-      if (token !== hookSecret) {
-        captureWebhookError(new Error('Unauthorized: invalid hook secret'), { message: '[AUTH_EMAIL] Unauthorized: invalid hook secret' })
-        return new Response(
-          JSON.stringify({ error: 'Unauthorized' }),
-          { status: 401, headers: jsonHeaders },
-        )
-      }
+    // Verify the request comes from Supabase via the hook secret. The
+    // secret is now required at startup (see validateEnv above), so the
+    // function refuses to serve when it's unset — closing the
+    // fail-open path where a missing/dropped env var let any caller
+    // POST arbitrary token_hash + email_data and trigger Resend mails
+    // to attacker-chosen recipients.
+    const hookSecret = env['SUPABASE_AUTH_HOOK_SECRET']
+    const authHeader = req.headers.get('authorization') ?? ''
+    const token = authHeader.replace(/^Bearer\s+/i, '')
+    if (token !== hookSecret) {
+      captureWebhookError(new Error('Unauthorized: invalid hook secret'), { message: '[AUTH_EMAIL] Unauthorized: invalid hook secret' })
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: jsonHeaders },
+      )
     }
 
     const payload = (await req.json()) as AuthEmailHookPayload

--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -9,6 +9,7 @@ import { errorResponse } from '../_shared/errors.ts'
 import { validateBearerAuth } from '../_shared/auth.ts'
 import { getStripeClient } from '../_shared/stripe-client.ts'
 import { createAdminClient } from '../_shared/supabase-client.ts'
+import { ALLOWED_CHECKOUT_PRICE_IDS } from '../_shared/plan-tier.ts'
 
 Deno.serve(async (req: Request) => {
   const optionsResponse = handleCorsOptions(req)
@@ -47,6 +48,18 @@ Deno.serve(async (req: Request) => {
 
     if (!priceId) {
       return new Response(JSON.stringify({ error: 'price_id is required' }), {
+        status: 400, headers: getJsonHeaders(req),
+      })
+    }
+
+    // Refuse a price_id that isn't in our canonical set. Without this
+    // guard a caller can pass any string and Stripe will accept it as
+    // long as the price exists in our account — including coupon
+    // prices, archived tiers, or test-mode-leaked prices. Combined
+    // with `allow_promotion_codes: true` this is a known cheap-tier
+    // bypass shape.
+    if (!ALLOWED_CHECKOUT_PRICE_IDS.has(priceId)) {
+      return new Response(JSON.stringify({ error: 'price_id not allowed' }), {
         status: 400, headers: getJsonHeaders(req),
       })
     }

--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -19,7 +19,7 @@ Deno.serve(async (req: Request) => {
   try {
     env = validateEnv({
       required: ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'STRIPE_SECRET_KEY'],
-      optional: ['FRONTEND_URL', 'STRIPE_PRO_PRICE_ID'],
+      optional: ['FRONTEND_URL'],
     })
   } catch (err) {
     return errorResponse(req, 500, err, { action: 'env_validation' })
@@ -44,7 +44,7 @@ Deno.serve(async (req: Request) => {
   try {
     const body = await req.json()
     // Accept both snake_case (preferred) and camelCase (legacy frontend) forms
-    const priceId: string = body.price_id ?? body.priceId ?? env.STRIPE_PRO_PRICE_ID ?? ''
+    const priceId: string = body.price_id ?? body.priceId ?? ''
 
     if (!priceId) {
       return new Response(JSON.stringify({ error: 'price_id is required' }), {

--- a/supabase/migrations/20251110160000_create_lease_documents_bucket.sql
+++ b/supabase/migrations/20251110160000_create_lease_documents_bucket.sql
@@ -24,9 +24,13 @@
 -- The three dropped policies, for the audit trail:
 --   * `Property owners can read own lease documents` (FOR SELECT,
 --     auth.uid() = (storage.foldername(name))[1])
---   * `Tenants can read their lease documents` (FOR SELECT, joins
---     public.leases.primary_tenant_id) — the JOIN became invalid when
---     the `tenants` model was demolished in 20260418183608
+--   * `Tenants can read their lease documents` (FOR SELECT, matches
+--     `auth.uid() = leases.primary_tenant_id`) — became dead when
+--     20260418140000_demolish_rent_and_tenant_portal removed the
+--     tenant-portal/auth path. `public.tenants` and
+--     `leases.primary_tenant_id` still exist, but `auth.uid()` no
+--     longer resolves to any tenant identity (tenants are records,
+--     not users), so the join can never match.
 --   * `Service can manage lease documents` (FOR ALL TO authenticated,
 --     auth.uid() = (storage.foldername(name))[1]) — the audit-failing
 --     one

--- a/supabase/migrations/20251110160000_create_lease_documents_bucket.sql
+++ b/supabase/migrations/20251110160000_create_lease_documents_bucket.sql
@@ -1,6 +1,41 @@
 -- Create lease-documents storage bucket for storing generated lease PDFs
 -- File size limit: 512 KB (500 KB with safety margin)
 -- Typical PDF size: 25-35 KB, Maximum realistic: 50-60 KB, Safety margin: 10x
+--
+-- ## Historical edit (2026-05-07, PR #677)
+--
+-- The original migration created three storage RLS policies on this
+-- bucket. All three are gone in prod (cleaned up out-of-band) and the
+-- bucket itself is unused — no app code reads or writes
+-- `lease-documents` (lease PDFs are generated in-memory by the
+-- `generate-pdf` Edge Function and returned to the caller; no Storage
+-- saves).
+--
+-- One of the dropped policies, `Service can manage lease documents
+-- FOR ALL TO authenticated`, is the exact shape that the
+-- `for-all-audit` migration at 20260304130000 raises an exception
+-- against ("Cannot proceed: % authenticated FOR ALL policies found").
+-- Leaving the policy in this file meant a fresh `supabase db reset`
+-- aborted at step 20260304130000 and never reached the cleanup
+-- migration at 20260507191140 — the `db reset` failure described in
+-- the cleanup migration's comment was never actually fixed by that
+-- migration; this file's policy creation was the only fix that worked.
+--
+-- The three dropped policies, for the audit trail:
+--   * `Property owners can read own lease documents` (FOR SELECT,
+--     auth.uid() = (storage.foldername(name))[1])
+--   * `Tenants can read their lease documents` (FOR SELECT, joins
+--     public.leases.primary_tenant_id) — the JOIN became invalid when
+--     the `tenants` model was demolished in 20260418183608
+--   * `Service can manage lease documents` (FOR ALL TO authenticated,
+--     auth.uid() = (storage.foldername(name))[1]) — the audit-failing
+--     one
+--
+-- The bucket itself stays in this migration: prod's bucket was deleted
+-- but `storage.protect_delete()` blocks `DELETE FROM storage.buckets`
+-- so the cleanup migration can't reproduce that. Local devs `db reset`
+-- gets the bucket with no policies attached — harmless because no app
+-- code uses it.
 
 -- Create the bucket (ignore if already exists)
 INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
@@ -12,62 +47,3 @@ VALUES (
   ARRAY['application/pdf']::text[]
 )
 ON CONFLICT (id) DO NOTHING;
-
--- Note: storage.objects RLS is already enabled by Supabase by default
-
--- RLS Policy: Property owners can read their own lease documents
--- Path structure: lease-documents/{userId}/{leaseId}/lease-{timestamp}-{uuid}.pdf
-CREATE POLICY "Property owners can read own lease documents"
-ON storage.objects FOR SELECT
-TO authenticated
-USING (
-  bucket_id = 'lease-documents'
-  AND (storage.foldername(name))[1] = auth.uid()::text
-);
-
--- RLS Policy: Tenants can read leases they're associated with
--- Checks if authenticated user is the tenant_id in the lease record
---
--- IMPORTANT: This policy is prepared for future use when the backend implements storage saves.
--- Expected path structure: {userId}/{leaseId}/{filename}
--- The controller currently generates PDFs in-memory only (no storage saves).
--- When implementing storage:
---   1. Ensure the path structure matches this policy's assumptions
---   2. Add integration tests to verify RLS works correctly
---   3. Consider adding validation for (storage.foldername(name))[2] as a valid UUID
---
--- Note: This policy references public.leases which is created via the Supabase dashboard.
--- For local development, we create this policy only if the table exists.
-DO $$
-BEGIN
-  IF EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'leases') THEN
-    EXECUTE $policy$
-      CREATE POLICY "Tenants can read their lease documents"
-      ON storage.objects FOR SELECT
-      TO authenticated
-      USING (
-        bucket_id = 'lease-documents'
-        AND (storage.foldername(name))[2] ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-        AND EXISTS (
-          SELECT 1 FROM public.leases
-          WHERE id::text = (storage.foldername(name))[2]
-          AND primary_tenant_id = auth.uid()
-        )
-      )
-    $policy$;
-  END IF;
-END $$;
-
--- RLS Policy: Backend service can insert/update/delete (service role bypasses RLS automatically)
--- This policy is for application-level access control
-CREATE POLICY "Service can manage lease documents"
-ON storage.objects FOR ALL
-TO authenticated
-USING (
-  bucket_id = 'lease-documents'
-  AND (storage.foldername(name))[1] = auth.uid()::text
-)
-WITH CHECK (
-  bucket_id = 'lease-documents'
-  AND (storage.foldername(name))[1] = auth.uid()::text
-);

--- a/supabase/migrations/20260115185056_verify_auth_uid_performance_optimization.sql
+++ b/supabase/migrations/20260115185056_verify_auth_uid_performance_optimization.sql
@@ -30,9 +30,18 @@
 --   - Final hardening pass on all policies
 --
 -- STORAGE POLICIES:
--- Storage policies in 20251110160000_create_lease_documents_bucket.sql use
--- auth.uid()::text with storage.foldername() function. This is the correct
--- pattern for storage objects and does not benefit from SELECT wrapping.
+-- This audit originally covered the three lease-documents storage
+-- policies in 20251110160000_create_lease_documents_bucket.sql. Those
+-- policies were demolished in PR #677 (cycle-1 followup, 2026-05-07)
+-- because the audit-failing `Service can manage lease documents FOR
+-- ALL TO authenticated` policy aborted `supabase db reset` at the
+-- 20260304130000 for-all-audit step, and the other two SELECT
+-- policies referenced the demolished `tenants` model. They no longer
+-- exist anywhere in the migration history. Other storage policies in
+-- the repo (property-images, maintenance-photos, inspection-photos,
+-- profile-avatars) follow the same correct `auth.uid()::text` +
+-- `storage.foldername()` pattern and likewise do not benefit from
+-- SELECT wrapping.
 --
 -- CONCLUSION:
 -- No additional fixes required. All RLS policies use optimal (SELECT auth.uid())

--- a/supabase/migrations/20260115185056_verify_auth_uid_performance_optimization.sql
+++ b/supabase/migrations/20260115185056_verify_auth_uid_performance_optimization.sql
@@ -32,16 +32,23 @@
 -- STORAGE POLICIES:
 -- This audit originally covered the three lease-documents storage
 -- policies in 20251110160000_create_lease_documents_bucket.sql. Those
--- policies were demolished in PR #677 (cycle-1 followup, 2026-05-07)
--- because the audit-failing `Service can manage lease documents FOR
--- ALL TO authenticated` policy aborted `supabase db reset` at the
--- 20260304130000 for-all-audit step, and the other two SELECT
--- policies referenced the demolished `tenants` model. They no longer
--- exist anywhere in the migration history. Other storage policies in
--- the repo (property-images, maintenance-photos, inspection-photos,
--- profile-avatars) follow the same correct `auth.uid()::text` +
--- `storage.foldername()` pattern and likewise do not benefit from
--- SELECT wrapping.
+-- policies were demolished in PR #677 (cycle-1 followup, 2026-05-07).
+-- The audit-failing `Service can manage lease documents FOR ALL TO
+-- authenticated` policy aborted `supabase db reset` at the
+-- 20260304130000 for-all-audit step. The other two SELECT policies
+-- (`Property owners can read own lease documents`, `Tenants can read
+-- their lease documents`) became dead when
+-- 20260418140000_demolish_rent_and_tenant_portal removed the
+-- tenant-portal/auth path — `public.tenants` and
+-- `leases.primary_tenant_id` still exist, but `auth.uid()` no longer
+-- resolves to any tenant identity. None of the three policies exist
+-- anywhere in the migration history after the cycle-1 historical
+-- edit.
+--
+-- Other storage policies in the repo (property-images,
+-- maintenance-photos, inspection-photos, profile-avatars) follow the
+-- same correct `auth.uid()::text` + `storage.foldername()` pattern
+-- and likewise do not benefit from SELECT wrapping.
 --
 -- CONCLUSION:
 -- No additional fixes required. All RLS policies use optimal (SELECT auth.uid())

--- a/supabase/migrations/20260115185056_verify_auth_uid_performance_optimization.sql
+++ b/supabase/migrations/20260115185056_verify_auth_uid_performance_optimization.sql
@@ -46,9 +46,11 @@
 -- edit.
 --
 -- Other storage policies in the repo (property-images,
--- maintenance-photos, inspection-photos, profile-avatars) follow the
--- same correct `auth.uid()::text` + `storage.foldername()` pattern
--- and likewise do not benefit from SELECT wrapping.
+-- maintenance-photos, inspection-photos) already use the
+-- `(select auth.uid())` subquery wrapping pattern in their
+-- folder-ownership joins (see 20260218032800, 20260420010000,
+-- 20260220110001 respectively) — they're already optimized and
+-- need no further changes.
 --
 -- CONCLUSION:
 -- No additional fixes required. All RLS policies use optimal (SELECT auth.uid())

--- a/supabase/migrations/20260507191140_p1_security_hardening.sql
+++ b/supabase/migrations/20260507191140_p1_security_hardening.sql
@@ -7,8 +7,16 @@
 -- invoices, charges, customers, products, prices. No is_admin() check.
 -- Granting EXECUTE to authenticated lets any user estimate the platform's
 -- subscriber count + churn — useful for competitor surveillance, useless
--- for any legitimate authenticated caller. service_role retains EXECUTE
--- so admin observability tooling still works.
+-- for any legitimate authenticated caller.
+--
+-- Caveat (closed in followup migration 20260507210516): the function's
+-- prior ACL only granted EXECUTE explicitly to `authenticated`;
+-- service_role had reachability via the implicit `PUBLIC=X/postgres`
+-- grant Postgres assigns to every function. The `revoke ... from
+-- public` below also strips that implicit path, so service_role loses
+-- EXECUTE here too. The followup migration restores the explicit
+-- service_role grant; until that migration runs, only `postgres`
+-- (the function owner) can call this RPC.
 revoke execute on function public.check_stripe_sync_status() from public, authenticated;
 
 ------------------------------------------------------------
@@ -25,19 +33,23 @@ revoke execute on function public.check_stripe_sync_status() from public, authen
 revoke execute on function public.get_user_id_by_stripe_customer(text) from public, authenticated;
 
 ------------------------------------------------------------
--- P1-7: drop the legacy lease-documents storage policies + bucket
+-- P1-7: drop the legacy lease-documents storage policies (bucket
+-- retention is unavoidable — see comment below)
 ------------------------------------------------------------
--- Migration `20251110160000_create_lease_documents_bucket.sql` left a
--- `Service can manage lease documents ON storage.objects FOR ALL TO
--- authenticated` policy in the migration history. The
--- `for-all-audit` migration at 20260304130000 raises an exception when
--- it sees `FOR ALL TO authenticated`, so a fresh `supabase db reset`
--- against this repo would explode mid-replay even though prod is fine
--- (the policy was manually cleaned up out-of-band).
---
--- This migration brings the repo + prod into agreement by explicitly
--- dropping the legacy policies + bucket. `IF EXISTS` keeps it safe to
--- re-run.
+-- Migration `20251110160000_create_lease_documents_bucket.sql`
+-- originally created three storage policies on `lease-documents`,
+-- one of which was `Service can manage lease documents ON
+-- storage.objects FOR ALL TO authenticated`. The for-all-audit
+-- migration at 20260304130000 raises an exception when it sees
+-- `FOR ALL TO authenticated`. Cycle-1 review of this PR caught that
+-- the DROP POLICY statements below run AFTER the audit, so they
+-- can't actually fix `db reset` — the audit aborts at step
+-- 20260304130000 first. The real fix is in the historical edit to
+-- `20251110160000` (also in this PR) which removes all three policy
+-- creations from history. The DROPs here remain for prod alignment
+-- (prod cleaned the policies out-of-band before this PR; the DROPs
+-- formalize that cleanup in migration history). `IF EXISTS` keeps
+-- them safe to re-run.
 drop policy if exists "Service can manage lease documents" on storage.objects;
 drop policy if exists "Property owners can read own lease documents" on storage.objects;
 drop policy if exists "Tenants can read their lease documents" on storage.objects;

--- a/supabase/migrations/20260507191140_p1_security_hardening.sql
+++ b/supabase/migrations/20260507191140_p1_security_hardening.sql
@@ -1,0 +1,52 @@
+-- P1 security hardening — three SQL-only fixes from the 2026-05-07 audit.
+
+------------------------------------------------------------
+-- P1-2: revoke check_stripe_sync_status from authenticated
+------------------------------------------------------------
+-- Returns row counts + last-synced timestamps for stripe.subscriptions,
+-- invoices, charges, customers, products, prices. No is_admin() check.
+-- Granting EXECUTE to authenticated lets any user estimate the platform's
+-- subscriber count + churn — useful for competitor surveillance, useless
+-- for any legitimate authenticated caller. service_role retains EXECUTE
+-- so admin observability tooling still works.
+revoke execute on function public.check_stripe_sync_status() from public, authenticated;
+
+------------------------------------------------------------
+-- P1-6: revoke get_user_id_by_stripe_customer from authenticated
+------------------------------------------------------------
+-- SECURITY DEFINER function that maps a Stripe customer ID → internal
+-- auth.users.id with no caller validation. If an attacker leaks/guesses
+-- any stripe_customer_id (sometimes visible in third-party emails), they
+-- get the platform's user UUID — which is then a primary key for chained
+-- attacks (e.g., the lease-signature IDOR closed in P0-2 needed UUIDs
+-- as input). The function is only called by service_role flows
+-- (Stripe webhook handlers); revoking from authenticated has zero
+-- behavioral impact on the app.
+revoke execute on function public.get_user_id_by_stripe_customer(text) from public, authenticated;
+
+------------------------------------------------------------
+-- P1-7: drop the legacy lease-documents storage policies + bucket
+------------------------------------------------------------
+-- Migration `20251110160000_create_lease_documents_bucket.sql` left a
+-- `Service can manage lease documents ON storage.objects FOR ALL TO
+-- authenticated` policy in the migration history. The
+-- `for-all-audit` migration at 20260304130000 raises an exception when
+-- it sees `FOR ALL TO authenticated`, so a fresh `supabase db reset`
+-- against this repo would explode mid-replay even though prod is fine
+-- (the policy was manually cleaned up out-of-band).
+--
+-- This migration brings the repo + prod into agreement by explicitly
+-- dropping the legacy policies + bucket. `IF EXISTS` keeps it safe to
+-- re-run.
+drop policy if exists "Service can manage lease documents" on storage.objects;
+drop policy if exists "Property owners can read own lease documents" on storage.objects;
+drop policy if exists "Tenants can read their lease documents" on storage.objects;
+
+-- The bucket itself is gone in prod (verified via storage.buckets).
+-- We deliberately do NOT `DELETE FROM storage.buckets` here — Supabase
+-- guards `storage.buckets` with a `protect_delete()` BEFORE-DELETE
+-- trigger that aborts direct deletes (`Direct deletion from storage
+-- tables is not allowed. Use the Storage API instead.`). Local devs
+-- doing `supabase db reset` will see an empty `lease-documents` bucket
+-- with no policies attached — harmless, since the policies are what
+-- actually granted access.

--- a/supabase/migrations/20260507210516_p1_security_review_followups.sql
+++ b/supabase/migrations/20260507210516_p1_security_review_followups.sql
@@ -1,0 +1,20 @@
+-- Cycle-1 followup for PR #677 (P1 security hardening).
+--
+-- ## P1-A — restore service_role EXECUTE on check_stripe_sync_status
+--
+-- The prior migration (20260507191140_p1_security_hardening.sql) ran
+-- `revoke execute on function public.check_stripe_sync_status() from
+-- public, authenticated`. The function was originally granted EXECUTE
+-- only to `authenticated`; service_role had reachability via the
+-- default `PUBLIC=X/postgres` grant Postgres assigns to every function.
+-- Revoking from PUBLIC therefore removed service_role's path too —
+-- contrary to the prior migration's comment which claimed
+-- "service_role retains EXECUTE for admin observability".
+--
+-- This migration restores the explicit service_role grant so the
+-- documentation matches reality. There's no immediate operational
+-- impact because no Edge Function or app code calls this RPC via
+-- service_role today (admin observability runs as the postgres
+-- superuser via the SQL editor), but the implicit-grant ambiguity
+-- is exactly the kind of drift that causes future breakage.
+grant execute on function public.check_stripe_sync_status() to service_role;

--- a/supabase/migrations/20260507210516_p1_security_review_followups.sql
+++ b/supabase/migrations/20260507210516_p1_security_review_followups.sql
@@ -7,14 +7,13 @@
 -- public, authenticated`. The function was originally granted EXECUTE
 -- only to `authenticated`; service_role had reachability via the
 -- default `PUBLIC=X/postgres` grant Postgres assigns to every function.
--- Revoking from PUBLIC therefore removed service_role's path too —
--- contrary to the prior migration's comment which claimed
--- "service_role retains EXECUTE for admin observability".
+-- Revoking from PUBLIC therefore removed service_role's path too. See
+-- `20260507191140`'s "Caveat" block (lines 12-19) for the full
+-- explanation.
 --
--- This migration restores the explicit service_role grant so the
--- documentation matches reality. There's no immediate operational
--- impact because no Edge Function or app code calls this RPC via
--- service_role today (admin observability runs as the postgres
--- superuser via the SQL editor), but the implicit-grant ambiguity
--- is exactly the kind of drift that causes future breakage.
+-- This migration restores the explicit service_role grant. There's no
+-- immediate operational impact because no Edge Function or app code
+-- calls this RPC via service_role today (admin observability runs as
+-- the postgres superuser via the SQL editor), but the implicit-grant
+-- ambiguity is exactly the kind of drift that causes future breakage.
 grant execute on function public.check_stripe_sync_status() to service_role;

--- a/tests/integration/rls/admin-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/admin-rpc-grants.rls.test.ts
@@ -30,20 +30,42 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 
 describe('admin RPC grants — authenticated cannot reach revoked admin functions', () => {
 	let clientA: SupabaseClient
+	let clientB: SupabaseClient
 
 	beforeAll(async () => {
-		const { ownerA } = getTestCredentials()
+		// Dual-client per the project's RLS-test convention. The contract
+		// under test is role-level (`authenticated` ROLE has no EXECUTE),
+		// not user-level, so a single user is logically sufficient — but
+		// using both ownerA and ownerB also catches the unlikely case
+		// where one synthetic owner has anomalous EXECUTE through some
+		// other path while the other doesn't.
+		const { ownerA, ownerB } = getTestCredentials()
 		clientA = await createTestClient(ownerA.email, ownerA.password)
+		clientB = await createTestClient(ownerB.email, ownerB.password)
 	})
 
-	it('check_stripe_sync_status: revoked from authenticated', async () => {
+	it('check_stripe_sync_status: revoked from ownerA', async () => {
 		const { error } = await clientA.rpc('check_stripe_sync_status')
 		expect(error).not.toBeNull()
 		expect(['42501', '42883', 'PGRST202']).toContain(error!.code)
 	})
 
-	it('get_user_id_by_stripe_customer: revoked from authenticated', async () => {
+	it('check_stripe_sync_status: revoked from ownerB', async () => {
+		const { error } = await clientB.rpc('check_stripe_sync_status')
+		expect(error).not.toBeNull()
+		expect(['42501', '42883', 'PGRST202']).toContain(error!.code)
+	})
+
+	it('get_user_id_by_stripe_customer: revoked from ownerA', async () => {
 		const { error } = await clientA.rpc('get_user_id_by_stripe_customer', {
+			p_stripe_customer_id: 'cus_does_not_matter'
+		})
+		expect(error).not.toBeNull()
+		expect(['42501', '42883', 'PGRST202']).toContain(error!.code)
+	})
+
+	it('get_user_id_by_stripe_customer: revoked from ownerB', async () => {
+		const { error } = await clientB.rpc('get_user_id_by_stripe_customer', {
 			p_stripe_customer_id: 'cus_does_not_matter'
 		})
 		expect(error).not.toBeNull()

--- a/tests/integration/rls/admin-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/admin-rpc-grants.rls.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Integration tests pinning the EXECUTE-grant state of two admin-only
+ * RPCs that were tightened in PR #677 (P1-2 + P1-6 from the 2026-05-07
+ * security audit) and corrected in the cycle-1 followup.
+ *
+ * Migrations:
+ *   - 20260507191140_p1_security_hardening.sql (P1-2 + P1-6 revokes)
+ *   - 20260507210516_p1_security_review_followups.sql (P1-A: restore
+ *     service_role EXECUTE on check_stripe_sync_status that the prior
+ *     migration's `REVOKE FROM public` accidentally took away)
+ *
+ * These tests pin two contracts:
+ *
+ *   1. authenticated callers cannot reach either RPC. PostgREST
+ *      surfaces a revoked EXECUTE on a SECURITY DEFINER function as
+ *      42501 in current versions (older variants returned 42883 /
+ *      PGRST202). Accept any of the three so the test pins
+ *      "function is unreachable", not a specific error code.
+ *
+ *   2. The functions still exist and are owned by `postgres`. If a
+ *      future migration accidentally drops one or transfers ownership
+ *      to a less-privileged role, this assertion catches it.
+ */
+
+import { createTestClient, getTestCredentials } from '../setup/supabase-client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+describe('admin RPC grants — authenticated cannot reach revoked admin functions', () => {
+	let clientA: SupabaseClient
+
+	beforeAll(async () => {
+		const { ownerA } = getTestCredentials()
+		clientA = await createTestClient(ownerA.email, ownerA.password)
+	})
+
+	it('check_stripe_sync_status: revoked from authenticated', async () => {
+		const { error } = await clientA.rpc('check_stripe_sync_status')
+		expect(error).not.toBeNull()
+		expect(['42501', '42883', 'PGRST202']).toContain(error!.code)
+	})
+
+	it('get_user_id_by_stripe_customer: revoked from authenticated', async () => {
+		const { error } = await clientA.rpc('get_user_id_by_stripe_customer', {
+			p_stripe_customer_id: 'cus_does_not_matter'
+		})
+		expect(error).not.toBeNull()
+		expect(['42501', '42883', 'PGRST202']).toContain(error!.code)
+	})
+})

--- a/tests/integration/rls/admin-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/admin-rpc-grants.rls.test.ts
@@ -11,15 +11,18 @@
  *
  * These tests pin two contracts:
  *
- *   1. authenticated callers cannot reach either RPC. PostgREST
- *      surfaces a revoked EXECUTE on a SECURITY DEFINER function as
- *      42501 in current versions (older variants returned 42883 /
- *      PGRST202). Accept any of the three so the test pins
- *      "function is unreachable", not a specific error code.
+ * authenticated callers cannot reach either RPC. PostgREST surfaces a
+ * revoked EXECUTE on a SECURITY DEFINER function as 42501 in current
+ * versions (older variants returned 42883 / PGRST202). Accept any of
+ * the three so the test pins "function is unreachable from
+ * authenticated", not a specific error-code string.
  *
- *   2. The functions still exist and are owned by `postgres`. If a
- *      future migration accidentally drops one or transfers ownership
- *      to a less-privileged role, this assertion catches it.
+ * Note: PGRST202 ("function not found via PostgREST schema cache")
+ * also fires if the function were genuinely dropped from the schema —
+ * so this test's contract is "authenticated cannot CALL these
+ * functions", not "these functions exist". A separate test (or DB
+ * advisory) should pin existence + ownership if that becomes a
+ * concern.
  */
 
 import { createTestClient, getTestCredentials } from '../setup/supabase-client'


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mSix P1 items from the 2026-05-07 audit + two review-cycle followups (P1-A, P1-B) from cycle-1. None were exploitable today the way the P0s in #676 were — these close defense-in-depth gaps that would compound if other layers slipped.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m## Audit P1s (original 6)[0m
[38;5;8m   5[0m [37m- **P1-1** `auth-email-send` — `SUPABASE_AUTH_HOOK_SECRET` promoted from optional to required. Closes the fail-open path where a missing secret accepts arbitrary callers triggering Resend mail to attacker-chosen recipients.[0m
[38;5;8m   6[0m [37m- **P1-2** `check_stripe_sync_status` revoked from `authenticated`. No more leaking platform subscriber/churn counts.[0m
[38;5;8m   7[0m [37m- **P1-3** `stripe-checkout` validates `price_id` against `ALLOWED_CHECKOUT_PRICE_IDS` (new export from `_shared/plan-tier.ts`). Closes the cheap-tier bypass via promo-code + arbitrary price.[0m
[38;5;8m   8[0m [37m- **P1-4** `getClientIp` in `_shared/rate-limit.ts` now prefers `cf-connecting-ip` (when present, unforgeable) and falls back to the LAST trusted XFF segment, not the FIRST attacker-controlled one. IP-based rate limits actually rate-limit now.[0m
[38;5;8m   9[0m [37m- **P1-6** `get_user_id_by_stripe_customer` revoked from `authenticated`. Closes the customer-ID → user-UUID lookup that fed chained attacks.[0m
[38;5;8m  10[0m [37m- **P1-7** legacy `lease-documents` storage policies dropped at the source — the historical migration `20251110160000_create_lease_documents_bucket.sql` was edited to remove three policies that prod cleaned up out-of-band, fixing the `db reset` abort at the for-all-audit step (cycle-1 P1-B caught that the cleanup migration's DROPs ran too late to help).[0m
[38;5;8m  11[0m [37m- **P1-8** Sentry session replay flipped to `maskAllText: true, blockAllMedia: true`. Closes a GDPR exposure where dashboard PII (tenant names, addresses, amounts) was captured in replay.[0m
[38;5;8m  12[0m 
[38;5;8m  13[0m [37m## Cycle review followups[0m
[38;5;8m  14[0m [37m- **P1-A** (cycle-1) — restore `service_role` EXECUTE on `check_stripe_sync_status` that the cycle-0 `REVOKE FROM PUBLIC` accidentally stripped. The function had no explicit service_role grant; reachability came through the implicit `PUBLIC=X/postgres` grant Postgres assigns to every function. Followup migration `20260507210516_p1_security_review_followups.sql` makes the explicit grant.[0m
[38;5;8m  15[0m [37m- **P1-B** (cycle-1) — historical migration edit at `20251110160000_create_lease_documents_bucket.sql` is the actual fix for the `db reset` claim. The cleanup migration's `DROP POLICY` statements run AFTER the for-all-audit migration that aborts on the broken policy.[0m
[38;5;8m  16[0m [37m- 2 doc-only cycle-2 fixes: removed misleading docstring claim in `admin-rpc-grants.rls.test.ts`; updated stale audit-trail comment in `20260115185056_verify_auth_uid_performance_optimization.sql`.[0m
[38;5;8m  17[0m [37m- 3 cycle-3 fixes: removed defunct `lease-documents` row from `supabase/SCHEMA.md`; added ownerB dual-client coverage to the admin-rpc-grants test (matches project convention); refreshed this PR description to reflect the actual merge surface.[0m
[38;5;8m  18[0m [37m- 4 cycle-4 doc fixes: replaced misleading "service_role retains EXECUTE" comment with a Caveat block; corrected misclaimed-as-demolished `tenants` model description; corrected a non-repo migration timestamp citation; refined SCHEMA.md attribution between PR #677 (policy cleanup) and prior out-of-band bucket deletion.[0m
[38;5;8m  19[0m [37m- 1 cycle-5 fix: dropped a phantom-quote rebuttal in `20260507210516` whose source quote was removed in cycle-4.[0m
[38;5;8m  20[0m [37m- 1 cycle-6 fix: corrected an inaccurate claim about other storage policies' RLS pattern in `20260115185056`.[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m## Migrations[0m
[38;5;8m  23[0m [37m- `supabase/migrations/20260507191140_p1_security_hardening.sql` — REVOKEs + storage-policy DROPs.[0m
[38;5;8m  24[0m [37m- `supabase/migrations/20260507210516_p1_security_review_followups.sql` — restore service_role EXECUTE.[0m
[38;5;8m  25[0m [37m- `supabase/migrations/20251110160000_create_lease_documents_bucket.sql` — historical edit (lease-documents bucket policies removed).[0m
[38;5;8m  26[0m [37m- `supabase/migrations/20260115185056_verify_auth_uid_performance_optimization.sql` — audit-trail comment refresh.[0m
[38;5;8m  27[0m 
[38;5;8m  28[0m [37mBoth runtime migrations applied to prod via Supabase MCP and verified via `pg_proc.proacl` + `pg_policies` + `information_schema.column_privileges`.[0m
[38;5;8m  29[0m 
[38;5;8m  30[0m [37m## Test plan[0m
[38;5;8m  31[0m [37m- [x] `pnpm typecheck` clean[0m
[38;5;8m  32[0m [37m- [x] `pnpm lint` clean[0m
[38;5;8m  33[0m [37m- [x] 225 integration tests pass (was 218 pre-PR; +7 from new admin-rpc-grants suite + extensions)[0m
[38;5;8m  34[0m [37m- [x] Migration applied to prod; ACL/policy state verified[0m
[38;5;8m  35[0m [37m- [x] CI: typecheck + lint + e2e-smoke + rls-security all green (after one Turbopack cold-compile flake rerun)[0m
[38;5;8m  36[0m 
[38;5;8m  37[0m [37m## ⚠ Manual deploy step required after merge[0m
[38;5;8m  38[0m [37mThe Edge Function changes (`auth-email-send`, `stripe-checkout`) and the shared module change (`_shared/rate-limit.ts`) require manual deployment — there is no CI step that deploys Edge Functions in this repo. After merge, run:[0m
[38;5;8m  39[0m 
[38;5;8m  40[0m [37m```bash[0m
[38;5;8m  41[0m [37msupabase functions deploy auth-email-send --project-ref bshjmbshupiibfiewpxb[0m
[38;5;8m  42[0m [37msupabase functions deploy stripe-checkout --project-ref bshjmbshupiibfiewpxb[0m
[38;5;8m  43[0m [37m# Plus any other function that imports _shared/rate-limit.ts (newsletter-subscribe, etc.) — see supabase/functions/ for the full list.[0m
[38;5;8m  44[0m [37m```[0m
[38;5;8m  45[0m 
[38;5;8m  46[0m [37mUntil these deploys land, P1-1 (hook secret enforcement), P1-3 (price allowlist), and P1-4 (XFF parsing) won't take effect in prod even though the code is merged.[0m
[38;5;8m  47[0m 
[38;5;8m  48[0m [37m## Review cycle history[0m
[38;5;8m  49[0m [37m- Cycle 1: 6 findings (2 P1, 4 P2). All fixed in `e5308ec20`.[0m
[38;5;8m  50[0m [37m- Cycle 2: 2 P2 findings (doc-only). Both fixed in `70b1e20be`.[0m
[38;5;8m  51[0m [37m- Cycle 3: 3 P3 findings (sub-floor — SCHEMA.md drift, PR description drift, single-client test). All fixed in `2352898a0`.[0m
[38;5;8m  52[0m [37m- Cycle 4: 4 doc-only findings (3 P2, 1 P3 — service_role caveat, header/body mismatch, tenants-model mischaracterization, bad timestamp citation, SCHEMA.md attribution). All fixed in `f037592e8`.[0m
[38;5;8m  53[0m [37m- Cycle 5: 1 P3 finding (phantom-quote rebuttal in followup migration referencing text cycle-4 had removed). Fixed in `28a9035fb`.[0m
[38;5;8m  54[0m [37m- Cycle 6: 3 P3 findings (PR-description drift, inaccurate "other storage policies" claim, line-range citation fragility flagged for awareness). Two actionable fixes in cycle-6 commit; line-range citation kept as-is per reviewer's awareness-only flag.[0m
[38;5;8m  55[0m [37m- Cycle 7 + 8 needed: two consecutive zero-finding cycles required for the merge gate.[0m
[38;5;8m  56[0m 
[38;5;8m  57[0m [37m## Scope notes[0m
[38;5;8m  58[0m [37mP1-5 (PreviewPanel SSR sanitizer) is intentionally not in this PR — the audit flagged it as "not exploitable today" because all current callers sanitize upstream.[0m
[38;5;8m  59[0m 
[38;5;8m  60[0m [37m[hudsor01][0m