### PR TITLE
fix(deps): pin ip-address >= 10.1.1 (Dependabot #142)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
 			"yaml": ">=2.8.3",
 			"smol-toml": ">=1.6.1",
 			"uuid": ">=14.0.0",
-			"postcss": ">=8.5.14"
+			"postcss": ">=8.5.14",
+			"ip-address": ">=10.1.1"
 		},
 		"peerDependencyRules": {
 			"allowedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ overrides:
   smol-toml: '>=1.6.1'
   uuid: '>=14.0.0'
   postcss: '>=8.5.14'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -4538,8 +4539,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -10004,7 +10005,7 @@ snapshots:
   express-rate-limit@8.5.0(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -10444,7 +10445,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mCloses Dependabot alert #142 (medium severity, GHSA-v2v4-37r5-5v8g — XSS in `Address6` HTML-emitting methods).[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37mResolution path: `shadcn@4.7.0` (devDependency, CLI tool) → `@modelcontextprotocol/sdk@1.29.0` → `express-rate-limit@8.5.0` → `ip-address@10.1.0`. Practical exposure is zero (not imported in `src/` or `supabase/functions/`), but `pnpm.overrides` clears the alert and matches the pattern used for #140/#141.[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37m## Change[0m
[38;5;8m   7[0m [37mSingle line added to `package.json#pnpm.overrides`:[0m
[38;5;8m   8[0m [37m```json[0m
[38;5;8m   9[0m [37m"ip-address": ">=10.1.1"[0m
[38;5;8m  10[0m [37m```[0m
[38;5;8m  11[0m 
[38;5;8m  12[0m [37mAfter `pnpm install`, `pnpm why ip-address` reports `10.2.0`.[0m
[38;5;8m  13[0m 
[38;5;8m  14[0m [37m## Test plan[0m
[38;5;8m  15[0m [37m- [x] `pnpm typecheck` clean[0m
[38;5;8m  16[0m [37m- [x] `pnpm lint` clean[0m
[38;5;8m  17[0m [37m- [x] `pnpm why ip-address` shows `10.2.0` (>= patched threshold `10.1.1`)[0m
[38;5;8m  18[0m [37m- [ ] CI green[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37m[hudsor01][0m