### PR TITLE
chore(security): save SQL-editor verification prompt for the 2026-05-07 audit

### DIFF
--- a/.github/workflows/ci-cd-doc-only.yml
+++ b/.github/workflows/ci-cd-doc-only.yml
@@ -1,0 +1,55 @@
+name: CI
+
+# Paired no-op workflow for doc-only changes.
+#
+# ci-cd.yml (the real CI) skips on paths-ignore matching markdown,
+# .planning/, .vscode/, docs/, and LICENSE. Branch protection requires
+# the `checks` and `e2e-smoke` jobs to pass on every PR -- but a skipped
+# workflow never reports those check names, leaving them in "expected"
+# state and blocking merge for doc-only PRs.
+#
+# This workflow fires on the inverse path set and produces matching
+# `checks` and `e2e-smoke` job names that immediately succeed. From
+# branch-protection's perspective, the required checks are reported as
+# "success" regardless of which workflow ran, so doc-only PRs merge
+# cleanly without bypassing the gate.
+#
+# IMPORTANT: keep the path list here in lockstep with paths-ignore in
+# ci-cd.yml. Adding a path to one without the other re-introduces the bug.
+#
+# All `run:` steps below use only static strings (no GitHub expression
+# interpolation, no untrusted inputs), so this file is not subject to
+# the github.event injection class of vulnerabilities.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.md"
+      - ".planning/**"
+      - ".vscode/**"
+      - "docs/**"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**.md"
+      - ".planning/**"
+      - ".vscode/**"
+      - "docs/**"
+      - "LICENSE"
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Doc-only change; type/lint/build checks skipped"
+
+  e2e-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Doc-only change; E2E smoke skipped"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Richard Hudson
+Copyright (c) 2025-2026 Richard Hudson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,122 @@
+# TenantFlow
+
+Property management platform for independent landlords and small property managers. Track properties, leases, tenants, maintenance, and financials without the complexity (or cost) of enterprise PMS.
+
+**Production:** [tenantflow.app](https://tenantflow.app)
+
+> [!IMPORTANT]
+> TenantFlow is **landlord-only**. Tenants are records, not user accounts. There is no tenant portal, no rent-payment facilitation, and no tenant authentication. The platform helps landlords run their business; payment collection and tenant communication happen through whatever channels the landlord already uses.
+
+---
+
+## Tech Stack
+
+| Layer | Choice |
+|-------|--------|
+| Frontend | Next.js 16 (App Router) + React 19 + Tailwind CSS 4 + TanStack Query / Form + Zustand |
+| Backend | Supabase (PostgREST + RPCs + Edge Functions) |
+| Database | Postgres 17 with RLS on every table |
+| Payments | Stripe (Checkout + Subscriptions) |
+| Document signing | DocuSeal |
+| Monitoring | Sentry (Next.js SDK + source maps + tunnel route) |
+| Hosting | Vercel (frontend), Supabase (backend), deploys from `main` only |
+| Package manager | pnpm 10.x, Node 24.x |
+
+Architecture is intentionally backend-light: the Next.js app talks to Supabase directly via PostgREST. There is no custom API server. Edge Functions (Deno) handle webhooks (Stripe, DocuSeal, Resend) and operations that need privileged access.
+
+---
+
+## Quick Start
+
+```bash
+# Clone
+git clone https://github.com/hudsor01/tenant-flow.git
+cd tenant-flow
+
+# Install
+pnpm install
+
+# Environment
+cp .env.example .env.local   # populate Supabase + Stripe keys
+
+# Dev server (port 3050)
+pnpm dev
+```
+
+Common commands:
+
+```bash
+pnpm dev                          # dev server (Turbopack, port 3050)
+pnpm typecheck                    # tsc --noEmit (strict mode + noUncheckedIndexedAccess)
+pnpm lint                         # eslint
+pnpm test:unit                    # Vitest unit tests
+pnpm test:integration             # RLS integration tests (hits prod, see below)
+pnpm test:e2e                     # Playwright E2E
+pnpm db:types                     # regenerate src/types/supabase.ts atomically
+pnpm validate:quick               # types + lint + unit
+```
+
+> [!WARNING]
+> `pnpm test:integration` authenticates synthetic test users against **production** Supabase via dual-client (ownerA/ownerB) JWTs. Use only the synthetic accounts (`e2e-owner-a@tenantflow.app`, `e2e-owner-b@tenantflow.app`) — never personal credentials. Supabase auth rate-limits at ~45 sign-ins/minute, so don't run the suite back-to-back without a cooldown.
+
+---
+
+## Architecture
+
+- **Server Components by default.** `'use client'` only for hooks, event handlers, or browser APIs.
+- **Server state** via TanStack Query with `queryOptions()` factories in `src/hooks/api/query-keys/`.
+- **UI state** via Zustand (one store per domain).
+- **Forms** via TanStack Form.
+- **URL state** via nuqs.
+- **Mutations** invalidate related query keys plus `ownerDashboardKeys.all`.
+- **Soft delete:** properties use `status: 'inactive'`. List queries filter `.neq('status', 'inactive')`.
+- **Pagination:** Supabase `count: 'exact'` — never `data.length`.
+- **Stats:** consolidate into single RPCs (e.g. `get_maintenance_stats()`, `get_lease_stats()`).
+- **Auth:** `getAll`/`setAll` Supabase cookie methods only. `getUser()` for server-validated identity; `getSession()` only when reading the access token for Bearer headers.
+
+For the full developer contract (zero-tolerance rules, file conventions, RPC return-type mapping, naming, etc.), see [`CLAUDE.md`](./CLAUDE.md).
+
+---
+
+## Database
+
+- **Migrations:** `supabase/migrations/YYYYMMDDHHmmss_description.sql`. Applied via Supabase MCP `apply_migration`.
+- **RLS** on every table; the frontend never holds the service-role key.
+- **Generated types:** `src/types/supabase.ts` — never edit manually; regenerate via `pnpm db:types`.
+- **Migration drift:** prod-applied timestamps from MCP may differ from local filenames; always reconcile via `mcp__supabase__list_migrations` after each apply.
+
+`amount` columns store **dollars** as `numeric(10,2)`. Convert to cents only at the Stripe API boundary.
+
+---
+
+## CI
+
+| Trigger | Jobs |
+|---------|------|
+| PRs to `main` | `checks` (lint + typecheck + Next.js build) + `e2e-smoke` (Playwright) + `rls-security` (integration tests against prod) |
+| Push to `main` | Same set; deploys via Vercel auto-trigger |
+| Weekly cron + `workflow_dispatch` | `rls-security` (independent of branch state) |
+
+Doc-only PRs (`**.md`, `.planning/**`, `.vscode/**`, `docs/**`, `LICENSE`) are handled by a paired no-op workflow ([`.github/workflows/ci-cd-doc-only.yml`](./.github/workflows/ci-cd-doc-only.yml)) so required status checks remain satisfied without bypassing branch protection.
+
+Pre-commit hooks (lefthook): gitleaks, lockfile-verify, lint, typecheck, unit tests in parallel. Pre-push: lockfile sync. Commit messages enforced via commitlint (Conventional Commits).
+
+---
+
+## Security
+
+See [`SECURITY.md`](./SECURITY.md) for the full vulnerability disclosure process. The short version: report via [GitHub Security Advisories](https://github.com/hudsor01/tenant-flow/security/advisories/new), not public issues.
+
+Routine security verification: paste the prompt in [`scripts/verify-security-posture.md`](./scripts/verify-security-posture.md) into a browser agent at the Supabase SQL editor to validate the audit-locked posture against current prod state.
+
+---
+
+## License
+
+[MIT](./LICENSE) © 2025-2026 Richard Hudson. The hosted service at `tenantflow.app` is operated as a commercial SaaS by the copyright holder.
+
+---
+
+## Contact
+
+Issues and feature requests via GitHub Issues. Security: see [`SECURITY.md`](./SECURITY.md). Commercial / partnership inquiries: support@tenantflow.app.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,109 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not report security vulnerabilities via public GitHub issues, pull requests, or comments.**
+
+Use [GitHub's private vulnerability reporting](https://github.com/hudsor01/tenant-flow/security/advisories/new) instead.
+
+Please include:
+- Description of the vulnerability and its impact.
+- Steps to reproduce (a minimal proof-of-concept is appreciated).
+- Affected components or routes.
+- Suggested fix or mitigation, if you have one.
+
+You'll receive an acknowledgement within 2 business days. Resolution timelines depend on severity:
+
+| Severity | Initial response | Fix target |
+|---------|------------------|------------|
+| Critical (RCE, auth bypass, data breach) | < 24 hours | < 7 days |
+| High (privilege escalation, account takeover) | < 48 hours | < 14 days |
+| Medium (information disclosure, CSRF, XSS in dashboard) | < 5 business days | < 30 days |
+| Low (defense-in-depth, hardening) | Best effort | Triaged into roadmap |
+
+We follow [coordinated disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure) — please give us a reasonable window to ship a fix before any public discussion.
+
+---
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| `main` (production at tenantflow.app) | ✅ |
+| Anything else | ❌ |
+
+There is no semver release train. Production tracks `main`; security fixes ship as soon as they pass the perfect-PR review gate.
+
+---
+
+## Security Posture
+
+### Authentication and Authorization
+
+- **Supabase Auth** with `@supabase/ssr` (cookie-based sessions; `getAll`/`setAll` pattern only).
+- **Server-validated identity** via `getUser()` on every authenticated request path. `getSession()` is used only for reading the access-token string when constructing Bearer headers.
+- **Row-Level Security** is the only access-control layer. Every table in `public` and `storage` has RLS enabled. The frontend never holds the service-role key.
+- **Subscription gate** in `src/proxy.ts` blocks dashboard routes for users not in `subscription_status IN ('active', 'trialing')`.
+- **Admin gate** via the `is_admin` boolean on `users`. Admin-only RPCs check `is_admin()` server-side; the column is locked from PostgREST writes (see "Privileged Column Lockdown" below).
+
+### Privileged Column Lockdown (PR #676)
+
+`public.users` had a known escalation surface where any authenticated user could `update({ is_admin: true })` or `update({ subscription_status: 'active' })` on their own row. Closed by:
+1. `REVOKE UPDATE ON public.users FROM authenticated`.
+2. `GRANT UPDATE (col1, col2, ...) TO authenticated` on a 10-column allowlist (profile fields only).
+3. `BEFORE UPDATE` trigger `users_guard_self_update` (SECURITY INVOKER) that compares `to_jsonb(NEW) - allowed_cols` against `to_jsonb(OLD) - allowed_cols`; any privileged-column drift raises 42501.
+4. `REVOKE INSERT, DELETE ON public.users FROM authenticated` to close the delete-then-insert escalation path.
+
+### Storage RLS
+
+Every storage bucket policy enforces folder-uuid → owner ID via `storage.foldername(name)`. Verified with integration tests in `tests/integration/rls/`.
+
+### Edge Function Hygiene
+
+- **Auth**: Bearer + `supabase.auth.getUser(token)`. Identity is never derived from the request body.
+- **CORS**: fail-closed when `FRONTEND_URL` is unset.
+- **Errors**: generic `{ error: 'An error occurred' }` to clients; full detail to Sentry + structured console.
+- **Rate limiting**: Upstash sliding window. IP extraction prefers `cf-connecting-ip`, falls back to the *last* trusted `x-forwarded-for` segment (the first segment is attacker-controlled).
+- **HMAC** verification on webhooks (Stripe + DocuSeal) using `crypto.subtle.timingSafeEqual` with length pre-check.
+- **Stripe Checkout** validates `price_id` against an allowlist; arbitrary-price + promo-code bypass is closed.
+
+### Build, CI, and Dependency Hygiene
+
+- **Pre-commit:** gitleaks (secret scanning, push protection on), lockfile-verify, lint, typecheck, unit tests.
+- **CI:** lint + typecheck + Next.js build + Playwright smoke + RLS integration tests on every PR; required status checks via branch protection on `main`.
+- **Dependabot:** weekly scans; high/critical alerts auto-trigger Dependabot PRs. Resolved alerts to date: GHSA-w5hq-g745-h8pq (uuid), GHSA-qx2v-qp2m-jg93 (postcss), GHSA-v2v4-37r5-5v8g (ip-address).
+- **Secret scanning** with push protection enabled at the GitHub repo level.
+- **Branch protection** on `main`: required checks, force-push and deletion blocked, admin-bypass disabled.
+- **No `auth-helpers-nextjs`** anywhere — only `@supabase/ssr`.
+
+### Frontend Security
+
+- **CSP** in `vercel.json`: `script-src 'self' 'unsafe-inline' (nonce TBD)`, `frame-ancestors 'none'`, HSTS with `preload`.
+- **Markdown** rendering via `react-markdown` v9 + `rehype-raw` + `rehype-sanitize` (in that order).
+- **Sentry session replay** masks all text and blocks all media (GDPR alignment for EU users).
+
+### GDPR
+
+- 30-day grace period via `deletion_requested_at` on `users`.
+- `request_account_deletion()` SECURITY DEFINER RPC validates `auth.uid()` and the cron job `process_account_deletions()` uses `FOR UPDATE SKIP LOCKED` for race safety.
+- `anonymize_deleted_user(uuid)` replaces PII with `[deleted]` placeholders while preserving financial records.
+
+### Audit Trail
+
+Major security work is reviewed via the perfect-PR gate (two consecutive zero-finding independent review cycles before merge). Migrations include rationale comments; the most recent comprehensive audit (2026-05-07) is captured across PRs #676 and #677. Routine verification queries are in [`scripts/verify-security-posture.md`](./scripts/verify-security-posture.md) — run them quarterly or after any migration that touches `public.users` grants, admin RPC grants, or storage policies.
+
+---
+
+## Out of Scope
+
+- **Tenant authentication / portal** — TenantFlow is landlord-only by design. Anyone offering "tenant access" is misrepresenting the product.
+- **Rent payment processing** — payment collection happens through whatever channels the landlord already uses; we don't custodian funds.
+- **Self-hosted deployments** — production is a single hosted instance at `tenantflow.app`. Local development environments are not within scope of this policy.
+
+---
+
+## Hall of Fame
+
+Researchers who report verified vulnerabilities will be credited here with their consent.
+
+_(Empty — be the first.)_

--- a/scripts/verify-security-posture.md
+++ b/scripts/verify-security-posture.md
@@ -1,0 +1,192 @@
+# Security Posture Verification — 2026-05-07 Audit
+
+Browser-agent prompt for the Supabase SQL editor (project `bshjmbshupiibfiewpxb`).
+Validates every fix from the 2026-05-07 security audit (PRs #676 + #677 +
+followups) against current prod state. Read-only — no DDL, no data mutation.
+
+## Usage
+
+1. Log into the Supabase dashboard.
+2. Open the SQL editor for project `bshjmbshupiibfiewpxb`.
+3. Paste the **entire prompt below** (everything between the `<<<` and `>>>`
+   markers) into the browser agent's input.
+4. Read the resulting Markdown table. Any FAIL = drift to investigate.
+
+## When to re-run
+
+- After any migration that touches `public.users` GRANTs or the
+  `users_guard_self_update` trigger.
+- After any migration that REVOKEs/GRANTs an admin RPC (especially
+  `check_stripe_sync_status`, `get_user_id_by_stripe_customer`,
+  `sign_lease_and_check_activation`).
+- Before each release as a smoke test.
+- Quarterly as a security-posture sanity check.
+
+## Prompt
+
+```text
+<<<
+You are at the Supabase SQL editor for project bshjmbshupiibfiewpxb. Run
+the queries below ONE AT A TIME and collect the results into a single
+verification report. Each query has a PASS condition; flag any FAIL.
+
+This validates the 2026-05-07 security audit fixes (PRs #676 + #677). All
+queries are read-only; no DDL.
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 1 — public.users column-level UPDATE grants (P0-1)
+──────────────────────────────────────────────────────────────────────────
+SELECT array_agg(column_name ORDER BY column_name) AS update_cols
+FROM information_schema.column_privileges
+WHERE grantee='authenticated' AND table_schema='public'
+  AND table_name='users' AND privilege_type='UPDATE';
+
+PASS: Result is exactly these 10 columns (no more, no less):
+  avatar_url, emergency_contact_name, emergency_contact_phone,
+  emergency_contact_relationship, first_name, full_name, last_name,
+  onboarding_status, phone, updated_at
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 2 — public.users table-level grants (P0-B)
+──────────────────────────────────────────────────────────────────────────
+SELECT array_agg(privilege_type ORDER BY privilege_type) AS table_grants
+FROM information_schema.table_privileges
+WHERE grantee='authenticated' AND table_schema='public' AND table_name='users';
+
+PASS: Exactly {SELECT}. Must NOT include INSERT, UPDATE (table-wide), or
+DELETE. Note: column-level UPDATE grants are intentionally absent here —
+they live in `column_privileges` and are validated by Query 1. The hardened
+posture deliberately revoked the table-wide UPDATE so only the 10-column
+allowlist is writable from authenticated.
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 3 — guard_user_self_update trigger and security mode (P0-A)
+──────────────────────────────────────────────────────────────────────────
+SELECT
+  t.tgname,
+  CASE WHEN t.tgtype & 2 = 2 THEN 'BEFORE' ELSE 'AFTER' END AS timing,
+  p.prosecdef AS is_security_definer
+FROM pg_trigger t
+JOIN pg_proc p ON p.oid = t.tgfoid
+WHERE t.tgname='users_guard_self_update';
+
+PASS: timing=BEFORE, is_security_definer=false (must be SECURITY INVOKER).
+FAIL means the trigger never fires correctly — see PR #676 cycle-1 review.
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 4 — sign_lease_and_check_activation EXECUTE grants (P0-2)
+──────────────────────────────────────────────────────────────────────────
+SELECT proname, proacl::text AS acl
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname='public' AND p.proname='sign_lease_and_check_activation';
+
+PASS: ACL contains only postgres and service_role. Must NOT contain
+authenticated or PUBLIC ('=X/postgres' alone).
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 5 — admin RPC grants (P1-2 + P1-6 + P1-A)
+──────────────────────────────────────────────────────────────────────────
+SELECT proname, proacl::text AS acl
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname='public'
+  AND p.proname IN ('check_stripe_sync_status', 'get_user_id_by_stripe_customer')
+ORDER BY proname;
+
+PASS:
+  check_stripe_sync_status        → {postgres=X/postgres,service_role=X/postgres}
+  get_user_id_by_stripe_customer  → {postgres=X/postgres,service_role=X/postgres}
+Both must include service_role and must NOT include authenticated.
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 6 — property-images storage INSERT policies (P0-3)
+──────────────────────────────────────────────────────────────────────────
+SELECT policyname, with_check::text AS with_check
+FROM pg_policies
+WHERE schemaname='storage' AND tablename='objects' AND cmd='INSERT'
+  AND with_check::text ILIKE '%property-images%';
+
+PASS: Exactly 1 row, named "Property owners can upload images", with a
+WITH CHECK that joins storage.foldername(name) against properties.owner_user_id.
+Must NOT contain "Authenticated users can upload property images".
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 7 — legacy lease-documents storage policies (P1-7)
+──────────────────────────────────────────────────────────────────────────
+SELECT policyname FROM pg_policies
+WHERE schemaname='storage' AND tablename='objects'
+  AND policyname IN (
+    'Service can manage lease documents',
+    'Property owners can read own lease documents',
+    'Tenants can read their lease documents'
+  );
+
+PASS: Zero rows. All three legacy policies must be gone.
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 8 — synthetic E2E owner subscription state
+──────────────────────────────────────────────────────────────────────────
+SELECT email, subscription_status, is_admin, stripe_customer_id IS NOT NULL AS has_stripe_id
+FROM public.users
+WHERE email IN ('e2e-owner-a@tenantflow.app', 'e2e-owner-b@tenantflow.app')
+ORDER BY email;
+
+PASS: Both rows show subscription_status='active', is_admin=false,
+has_stripe_id=false. If subscription_status drifts to 'expired' or
+'trialing', CI's e2e-smoke "Dashboard loads for owner" test will start
+failing (the trial cron flips trialing→expired; active is durable).
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 9 — for-all-audit drift check (P1-7 db reset replay)
+──────────────────────────────────────────────────────────────────────────
+SELECT count(*) AS for_all_authenticated_count
+FROM pg_policies
+WHERE schemaname IN ('public', 'storage')
+  AND cmd = 'ALL'
+  AND 'authenticated' = ANY(roles);
+
+PASS: 0. Any FOR ALL TO authenticated policy in public/storage will abort
+`supabase db reset` at migration 20260304130000.
+
+──────────────────────────────────────────────────────────────────────────
+QUERY 10 — most recent migrations applied (sanity check)
+──────────────────────────────────────────────────────────────────────────
+SELECT version, name FROM supabase_migrations.schema_migrations
+ORDER BY version DESC LIMIT 5;
+
+PASS: The audit's four migrations must all be in the list:
+  20260507210516  p1_security_review_followups
+  20260507194555  p0_security_review_followups
+  20260507191140  p1_security_hardening
+  20260507190024  lock_privileged_user_columns_and_p0_security
+(There may be newer migrations above these — that's fine.)
+
+──────────────────────────────────────────────────────────────────────────
+REPORT FORMAT
+──────────────────────────────────────────────────────────────────────────
+Output a single Markdown table:
+
+| # | Check                              | Status |
+|---|------------------------------------|--------|
+| 1 | users column-level UPDATE grants   | PASS / FAIL: <reason> |
+| 2 | users table-level grants           | PASS / FAIL: <reason> |
+| 3 | guard_user_self_update SECURITY INVOKER | PASS / FAIL: <reason> |
+| 4 | sign_lease_and_check_activation revoked | PASS / FAIL: <reason> |
+| 5 | admin RPC grants                   | PASS / FAIL: <reason> |
+| 6 | property-images INSERT policy      | PASS / FAIL: <reason> |
+| 7 | legacy lease-documents policies gone | PASS / FAIL: <reason> |
+| 8 | synthetic E2E owners 'active'      | PASS / FAIL: <reason> |
+| 9 | for-all-audit drift                | PASS / FAIL: <reason> |
+|10 | recent migrations                  | PASS / FAIL: <reason> |
+
+If any FAIL, also output the raw query result so a human can diagnose.
+Do NOT run any DDL. Do NOT modify any data. SELECT-only.
+>>>
+```
+
+## Reference
+
+- PR #676 — P0 security hardening (users column lock, sign_lease IDOR, property-images cross-owner upload, delete-then-insert escalation).
+- PR #677 — P1 security hardening (auth-email-send hook secret, stripe-checkout price allowlist, IP rate-limit XFF parsing, admin RPC grants, lease-documents replay, Sentry replay PII masks).
+- Original audit: 2026-05-07 (see PR descriptions for full audit context).


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mSaves the browser-agent prompt for verifying the 2026-05-07 security audit posture against prod, with Query 2's pass condition tightened based on first-run feedback.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37mThe prompt's 10 SELECT-only queries cover every fix from PRs #676 + #677. Future operators (or me, in a future session) can paste it into a browser agent at the Supabase SQL editor and get a single PASS/FAIL table back.[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37m## Why[0m
[38;5;8m   7[0m [37mFirst-run verification flagged Query 2's original pass condition (`{SELECT, UPDATE}`) didn't match the hardened state (`{SELECT}` only). The hardened state deliberately revoked table-wide UPDATE — column-level UPDATE grants live in `information_schema.column_privileges` (already validated by Query 1) instead of `table_privileges`. The corrected pass condition is the stricter assertion.[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37m## Test plan[0m
[38;5;8m  10[0m [37m- [x] File added at `scripts/verify-security-posture.md`[0m
[38;5;8m  11[0m [37m- [x] No code changes, no migration, no test impact[0m
[38;5;8m  12[0m 
[38;5;8m  13[0m [37m[hudsor01][0m