### PR TITLE
chore: change license from MIT to FSL-1.1-MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,102 @@
-MIT License
+# Functional Source License, Version 1.1, MIT Future License
 
-Copyright (c) 2025-2026 Richard Hudson
+## Abbreviation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+FSL-1.1-MIT
+
+## Notice
+
+Copyright 2025-2026 Richard Hudson
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the second anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,13 @@ Routine security verification: paste the prompt in [`scripts/verify-security-pos
 
 ## License
 
-[MIT](./LICENSE) © 2025-2026 Richard Hudson. The hosted service at `tenantflow.app` is operated as a commercial SaaS by the copyright holder.
+[FSL-1.1-MIT](./LICENSE) — [Functional Source License v1.1, MIT Future License](https://fsl.software/) © 2025-2026 Richard Hudson.
+
+You may use, copy, modify, redistribute, and run the Software for any **Permitted Purpose** — including internal commercial use, non-commercial research and education, and professional services delivered to other licensees. You may **not** use the Software to offer a hosted product or service that substitutes for or competes with TenantFlow itself.
+
+Each release auto-converts to the **MIT License** on the **second anniversary of its publication date**. After that date, that release is yours to use without restriction.
+
+The hosted service at `tenantflow.app` is operated as a commercial SaaS by the copyright holder. For commercial licensing inquiries (e.g., embedding TenantFlow into a competing product), contact support@tenantflow.app.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -98,7 +98,8 @@ Major security work is reviewed via the perfect-PR gate (two consecutive zero-fi
 
 - **Tenant authentication / portal** — TenantFlow is landlord-only by design. Anyone offering "tenant access" is misrepresenting the product.
 - **Rent payment processing** — payment collection happens through whatever channels the landlord already uses; we don't custodian funds.
-- **Self-hosted deployments** — production is a single hosted instance at `tenantflow.app`. Local development environments are not within scope of this policy.
+- **Self-hosted deployments** — production is a single hosted instance at `tenantflow.app`. Self-hosted instances permitted under [FSL-1.1-MIT](./LICENSE) are not within scope of this policy; users running their own instances are responsible for their own security posture, including applying upstream patches.
+- **Forks / derivative works** — security reports are accepted only for the canonical hosted instance at `tenantflow.app` and the source as published in this repository.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"name": "tenantflow",
 	"private": true,
 	"version": "1.0.1",
+	"license": "SEE LICENSE IN LICENSE",
 	"type": "module",
 	"engines": {
 		"node": ">=24",


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mSwitches the project license from **MIT** to **[FSL-1.1-MIT](https://fsl.software/)** (Functional Source License v1.1 with MIT Future License clause).[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37mThe change is **forward-only** — every commit before this PR remains MIT-licensed in perpetuity. This commit and all future commits are governed by FSL-1.1-MIT.[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37m## Why[0m
[38;5;8m   7[0m [37mTenantFlow is a public-source commercial SaaS hosted at `tenantflow.app`. MIT is technically valid but commercially exposed: any party can fork the codebase and stand up a competing hosted service with no obligation back to the project.[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37mFSL-1.1-MIT is the modern Sentry / n8n / Resend / Trigger.dev pattern:[0m
[38;5;8m  10[0m 
[38;5;8m  11[0m [37m- ✅ **Anyone can read, fork, modify, redistribute, and run** the Software for a "Permitted Purpose" (internal commercial use, education, research, consulting delivered to a licensee).[0m
[38;5;8m  12[0m [37m- ❌ **"Competing Use" is forbidden** — standing up a hosted product or service that substitutes for or competes with TenantFlow itself.[0m
[38;5;8m  13[0m [37m- ⏳ **Auto-converts to MIT** on the second anniversary of each release — hard guarantee against vendor lock-in.[0m
[38;5;8m  14[0m 
[38;5;8m  15[0m [37m## Trade-offs[0m
[38;5;8m  16[0m [37m- FSL is **not OSI-approved** ("source-available", not "open source" by strict OSI definition).[0m
[38;5;8m  17[0m [37m- Change is **non-retroactive** — past contributions remain MIT.[0m
[38;5;8m  18[0m 
[38;5;8m  19[0m [37m## Files changed[0m
[38;5;8m  20[0m [37m| File | Change |[0m
[38;5;8m  21[0m [37m|------|--------|[0m
[38;5;8m  22[0m [37m| `LICENSE` | Replaced MIT text with the canonical [FSL-1.1-MIT template](https://fsl.software/FSL-1.1-MIT.template.md) — copyright `2025-2026 Richard Hudson` |[0m
[38;5;8m  23[0m [37m| `README.md` | License section rewritten to describe Permitted Purpose, Competing Use, the 2-year MIT conversion, and the contact for commercial inquiries |[0m
[38;5;8m  24[0m [37m| `SECURITY.md` | Out-of-Scope section expanded: forks/derivative works out of scope; FSL-permitted self-hosted instances responsible for their own posture |[0m
[38;5;8m  25[0m [37m| `package.json` | Added `"license": "SEE LICENSE IN LICENSE"` per npm convention for non-SPDX licenses |[0m
[38;5;8m  26[0m 
[38;5;8m  27[0m [37m## What this does NOT change[0m
[38;5;8m  28[0m [37m- Public repo stays public.[0m
[38;5;8m  29[0m [37m- Hosted service at `tenantflow.app` continues to operate as before.[0m
[38;5;8m  30[0m [37m- Existing contributors' prior contributions remain MIT-licensed.[0m
[38;5;8m  31[0m [37m- Third-party dependencies retain their own licenses; no audit change required.[0m
[38;5;8m  32[0m [37m- Security posture unchanged (already covered by SECURITY.md + the audit-locked migrations from #676/#677).[0m
[38;5;8m  33[0m 
[38;5;8m  34[0m [37m## Test plan[0m
[38;5;8m  35[0m [37m- [x] `pnpm typecheck` clean[0m
[38;5;8m  36[0m [37m- [x] `pnpm lint` clean[0m
[38;5;8m  37[0m [37m- [x] `LICENSE` matches the canonical fsl.software template byte-for-byte (modulo the filled-in `${year}` and `${licensor name}` fields)[0m
[38;5;8m  38[0m [37m- [ ] CI: typecheck + lint + e2e-smoke + rls-security all green[0m
[38;5;8m  39[0m 
[38;5;8m  40[0m [37m[hudsor01][0m