### PR TITLE
fix(blog): override global loading.tsx for [slug] — emit real 404 (Phase 1 follow-up #2)

### DIFF
--- a/.planning/phases/01-critical-stop-bleed-blog-unpublish-pricing-placeholder/01-FOLLOWUP-V2-REVIEW-cycle-1.md
+++ b/.planning/phases/01-critical-stop-bleed-blog-unpublish-pricing-placeholder/01-FOLLOWUP-V2-REVIEW-cycle-1.md
@@ -1,0 +1,86 @@
+---
+phase: 01-critical-stop-bleed-blog-unpublish-pricing-placeholder
+reviewed: 2026-05-09T00:00:00Z
+depth: deep
+files_reviewed: 1
+files_reviewed_list:
+  - src/app/blog/[slug]/loading.tsx
+findings:
+  critical: 0
+  warning: 0
+  info: 1
+  total: 1
+status: clean
+---
+
+# Phase 01 Follow-up v2: Code Review Report (Cycle 1)
+
+**Reviewed:** 2026-05-09
+**Depth:** deep
+**Files Reviewed:** 1
+**Status:** clean (1 informational note, no actionable findings)
+
+## Summary
+
+Single-file change: `src/app/blog/[slug]/loading.tsx` — a segment-scoped loading override that returns `null` to suppress the global `AppLoading` shell for `/blog/[slug]`.
+
+The fix is mechanically correct, CLAUDE.md-compliant, and TypeScript-clean. The comment block is accurate. One informational note on the TypeScript return type follows.
+
+---
+
+## Does this fix the problem?
+
+**Yes.** The mechanism is sound per Next.js App Router semantics:
+
+- `loading.tsx` files are colocated per-segment. A `loading.tsx` at `app/blog/[slug]/loading.tsx` wraps only the `/blog/[slug]` segment in its own `<Suspense>` boundary with the provided fallback — it does not inherit from `app/loading.tsx`.
+- Returning `null` means the Suspense boundary has no visible fallback UI. With `dynamic = 'force-dynamic'` on `page.tsx`, React will not stream any initial HTML for this segment until the async page component resolves. When `notFound()` fires during that resolution, the HTTP status is set to 404 before the first byte is sent.
+- The `app/loading.tsx` global loader (`PageLoader text="Loading TenantFlow..."`) is unaffected on all other routes — only `/blog/[slug]` overrides it.
+- The override does NOT apply to `/blog/[slug]/*` sub-segments (there are none currently), `/blog/category/[category]`, or the `/blog` index. Scoping is exact to the colocation directory.
+- No parallel routes or intercepting routes exist at this path, so those edge cases do not apply.
+
+The comment's claim — "the streaming HTTP response has already committed status 200 — so the framework swaps the body to the not-found UI but the wire-level status stays 200" — is accurate. This is the documented Next.js App Router behavior when a Suspense boundary has already flushed its fallback shell before `notFound()` can fire.
+
+**UX cost:** users navigating to an unpublished slug will see a momentary blank segment (no spinner) before the 404 page renders. Given that all 100 rows are currently drafts and organic traffic to these URLs is what is being fixed, this tradeoff is acceptable and correctly characterized in the comment.
+
+**Phase 6 cleanup path** (delete this file when `generateStaticParams` + ISR is in place) is accurate and appropriate to note here.
+
+---
+
+## Info
+
+### IN-01: Return type could be explicit for documentation clarity
+
+**File:** `src/app/blog/[slug]/loading.tsx:18`
+**Issue:** `BlogPostLoading` returns `null` with no explicit return type annotation. TypeScript infers the return type as `null`, which is valid and will typecheck under strict mode. React 19 + `@types/react` accepts `null` as a valid return from function components (the `ReactNode` union includes `null`). No typecheck failure will occur.
+
+This is informational only — the inferred type is correct and `pnpm typecheck` + `pnpm lint` will pass as-is.
+
+**Fix (optional):** If you want the return type to be self-documenting at a glance:
+```typescript
+export default function BlogPostLoading(): null {
+  return null
+}
+```
+`null` (not `JSX.Element | null`) is the right annotation here since the function unconditionally returns `null` — the broader union would be misleading.
+
+Do NOT use `JSX.Element | null` — that implies the function may return JSX, which it never does.
+
+---
+
+## CLAUDE.md Compliance
+
+| Rule | Status |
+|------|--------|
+| No `any` types | Pass — no types used |
+| No barrel files / re-exports | Pass |
+| No inline styles | Pass |
+| No emojis in code | Pass |
+| No `as unknown as` | Pass |
+| Comment block reasonable in length | Pass — 13 lines, content is load-bearing context, not noise |
+| No commented-out code | Pass — these are explanatory comments, not dead code |
+
+---
+
+_Reviewed: 2026-05-09_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: deep_

--- a/.planning/phases/01-critical-stop-bleed-blog-unpublish-pricing-placeholder/01-FOLLOWUP-V2-REVIEW-cycle-3.md
+++ b/.planning/phases/01-critical-stop-bleed-blog-unpublish-pricing-placeholder/01-FOLLOWUP-V2-REVIEW-cycle-3.md
@@ -1,0 +1,135 @@
+---
+phase: 01-critical-stop-bleed-blog-unpublish-pricing-placeholder
+reviewed: 2026-05-09T00:00:00Z
+depth: deep
+files_reviewed: 1
+files_reviewed_list:
+  - src/app/blog/[slug]/loading.tsx
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+---
+
+# Phase 01 Follow-up v2: Code Review Report (Cycle 3)
+
+**Reviewed:** 2026-05-09
+**Depth:** deep
+**Files Reviewed:** 1
+**Status:** clean — zero findings
+
+## Summary
+
+Cycle 3 fresh-eyes adversarial pass on `src/app/blog/[slug]/loading.tsx` (21 lines). No code changes since cycle 1's IN-01 fix (`: null` return type annotation added in commit `77c5bbd82`). All eight adversarial dimensions enumerated below were evaluated. No issues found.
+
+---
+
+## Adversarial Dimension Checks
+
+### 1. Inheritance + intercepting routes / parallel routes
+
+Inspected `src/app/blog/[slug]/` directory contents:
+
+```
+blog-post-page.tsx
+loading.tsx
+markdown-content.tsx
+page.test.tsx
+page.tsx
+```
+
+No `@*` parallel route slots and no `(.)blog/[slug]` intercepting route directories exist at this path. The `loading.tsx` applies only to the `[slug]` segment — no unintended interception.
+
+Inspected `src/app/blog/` directory:
+
+```
+[slug]/
+blog-client.tsx
+category/
+error.tsx
+page.test.tsx
+page.tsx
+```
+
+`category/` is a separate segment tree (`/blog/category/[category]/...`). It has its own loading boundary (or inherits from root) — unaffected by `[slug]/loading.tsx`. Scoping is correct.
+
+### 2. Effect on `/blog/category/[category]/[slug]` if it exists
+
+The `category/` subtree is sibling to `[slug]/`, not a child. Next.js App Router `loading.tsx` scoping is downward-only within the directory tree. `src/app/blog/[slug]/loading.tsx` has no effect on any path under `src/app/blog/category/`. Correct.
+
+### 3. 404 emission scenarios beyond `notFound()`
+
+- **Empty/whitespace slug:** Next.js URL routing will not match an empty segment — the router resolves empty paths to the parent route (the `/blog` index). A whitespace slug URL-encodes to `%20` etc. and will reach `getBlogPost('%20')`, which returns `PGRST116` (no row), then `null`, then `notFound()`. With `loading.tsx` returning `null`, no Suspense fallback has been flushed — `notFound()` correctly emits HTTP 404. Clean.
+
+- **URL-encoded special chars in slug:** Same path as above — they pass through to the DB query as literal strings. `getBlogPost` is parameterized via PostgREST's `.eq()` (no injection surface). Returns `null` → `notFound()` → HTTP 404. No effect on the loading.tsx mechanism.
+
+- **Network blip / DB error (PR #683 WR-01 error-throw path):** `getBlogPost` throws `new Error('Blog post query failed')` on non-PGRST116 errors and re-throws timeout errors. Both paths bubble past `notFound()` to Next.js's error boundary (HTTP 500). In this case `loading.tsx`'s `null` fallback still does not affect correctness — the Suspense boundary has no flushed content, so the error boundary takes over cleanly. No regression introduced.
+
+- **HTTP status correctness in each case:** With `dynamic = 'force-dynamic'` and `loading.tsx` returning `null`, the Suspense boundary has a `null` fallback — React does not flush any initial HTML shell for this segment before the page component resolves. All status codes (404 from `notFound()`, 500 from thrown errors) are set before the first byte is sent. The mechanism holds across all error paths.
+
+### 4. CDN / Vercel cache behavior
+
+`dynamic = 'force-dynamic'` on `page.tsx` sets `Cache-Control: no-store` on all responses from this route (Next.js behavior for force-dynamic). The 404 responses are therefore not cached at Vercel's edge — each request hits the runtime. No risk of a poisoned 200 cached response surviving after this fix. A prior 200 that reached Vercel's edge before the fix would have been served from cache, but `no-store` means no TTL to wait out — the cache simply does not write new entries. Any pre-fix cached 200s would have expired by normal cache churn. No action needed.
+
+### 5. Comment block accuracy re-read (lines 1–17)
+
+Each claim verified:
+
+| Claim | Accurate? |
+|-------|-----------|
+| "override the root `src/app/loading.tsx` for the /blog/[slug] segment" | Yes — confirmed by Next.js App Router segment-scoped loading convention |
+| "with the root `loading.tsx` active and `dynamic = 'force-dynamic'` on page.tsx, React Suspense streams the global 'Loading TenantFlow...' UI while `getBlogPost` awaits" | Yes — `app/loading.tsx` wraps the entire app in a Suspense boundary; any segment without its own override inherits it |
+| "By the time `notFound()` fires, the streaming HTTP response has already committed status 200" | Yes — documented Next.js behavior when a Suspense fallback has already flushed |
+| "the framework swaps the body to the not-found UI but the wire-level status stays 200, which Google reads as a soft-404" | Yes — accurate description of the soft-404 failure mode |
+| "Returning `null` here disables the loading shell for this segment only" | Yes — no fallback = no pre-flush; `notFound()` fires before any bytes stream |
+| "The await resolves before any HTML streams; `notFound()` short-circuits to a clean HTTP 404" | Yes — mechanically correct |
+| "Other routes keep the global loader" | Yes — confirmed by directory inspection |
+| "When Phase 6 (BLOG-02) rebuilds this route with `generateStaticParams` + per-slug ISR, this file can be deleted" | Yes — with ISR, `notFound()` fires at build time for unknown slugs; the Suspense fallback no longer races the status code |
+
+No inaccuracies found. The forward-carry note about "Phase 6 (BLOG-02)" is consistent with the same annotation in `page.tsx` (line 20: "Phase 6 (BLOG-02 server-rendered rebuild) restores ISR..."). Comment block is accurate and up-to-date.
+
+### 6. Bundle size impact
+
+`loading.tsx` exports a single constant function that unconditionally returns `null`. No imports. No JSX. The compiled output is a minimal module with a single function expression. The route boundary addition is negligible — Next.js would tree-shake this to essentially nothing in the route chunk. No concern.
+
+### 7. File metadata
+
+`file` utility confirms: UTF-8, no BOM. `xxd` tail confirms: file ends with `}\n` (0x7d 0x0a) — standard POSIX trailing newline. No issues.
+
+### 8. Cycle 2 systemic miss check
+
+- **`: null` literal type causing inference issues elsewhere:** `loading.tsx` is a Next.js reserved filename — the framework discovers and uses it via file-system convention, not via TypeScript import. No other module imports `BlogPostLoading`. TypeScript never needs to widen or narrow the return type in a calling context. No inference issues possible.
+
+- **React Compiler optimizing away the route boundary:** The React Compiler operates on components that use hooks or produce JSX. `BlogPostLoading` has neither — it returns a literal `null`. The Compiler will not transform it (no memoization target), but this is irrelevant: Next.js determines the existence of a `loading.tsx` route boundary at build/request time by file-system presence, not by runtime component behavior. The Compiler cannot remove a file from the file system. Route boundary is preserved.
+
+- **Cycle 1 IN-01 fix correctly applied:** Line 18 reads `export default function BlogPostLoading(): null {` — the `: null` annotation is present and correct. The fix from commit `77c5bbd82` is confirmed in the file.
+
+---
+
+## CLAUDE.md Compliance
+
+| Rule | Status |
+|------|--------|
+| No `any` types | Pass — no type annotations beyond `: null` |
+| No barrel files / re-exports | Pass |
+| No inline styles | Pass |
+| No emojis in code | Pass |
+| No `as unknown as` | Pass |
+| No commented-out code | Pass — comment block is explanatory documentation, not dead code |
+| No `@radix-ui/react-icons` | Pass — no imports |
+
+---
+
+## REVIEW COMPLETE
+
+**Status: clean. Zero findings.**
+
+This is the second consecutive zero-finding cycle (cycle 2 was also clean per prior reviewer; cycle 3 confirms independently). The perfect-PR gate is satisfied. PR `gsd/phase-1-followup-soft-404-v2` (#684) is merge-ready.
+
+---
+
+_Reviewed: 2026-05-09_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: deep_

--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -1,0 +1,20 @@
+// Phase 1 (CRIT-01) follow-up #2: override the root `src/app/loading.tsx`
+// for the /blog/[slug] segment.
+//
+// Why: with the root `loading.tsx` active and `dynamic = 'force-dynamic'` on
+// page.tsx, React Suspense streams the global "Loading TenantFlow..." UI
+// while `getBlogPost` awaits. By the time `notFound()` fires, the streaming
+// HTTP response has already committed status 200 — so the framework swaps
+// the body to the not-found UI but the wire-level status stays 200, which
+// Google reads as a soft-404.
+//
+// Returning `null` here disables the loading shell for this segment only.
+// The await resolves before any HTML streams; `notFound()` short-circuits
+// to a clean HTTP 404. Other routes keep the global loader.
+//
+// When Phase 6 (BLOG-02) rebuilds this route with `generateStaticParams` +
+// per-slug ISR, this file can be deleted (the loading shell becomes safe
+// again because the await resolves at build time, not request time).
+export default function BlogPostLoading() {
+	return null
+}

--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -15,6 +15,6 @@
 // When Phase 6 (BLOG-02) rebuilds this route with `generateStaticParams` +
 // per-slug ISR, this file can be deleted (the loading shell becomes safe
 // again because the await resolves at build time, not request time).
-export default function BlogPostLoading() {
+export default function BlogPostLoading(): null {
 	return null
 }


### PR DESCRIPTION
## Summary

Phase 1 follow-up #2. Force-dynamic alone (PR #683) didn't fix the soft-404. Live HTTP testing of the merged code showed `/blog/error-*` still returning HTTP 200 + the 404 UI body.

**Root cause** (found by inspecting the rendered HTML):

The body of `/blog/error-1778151609106` contained `"Loading TenantFlow... This should only take a moment"` followed by the 404 UI. That loading text comes from the **global** `src/app/loading.tsx`, which acts as a root React Suspense boundary for every async server component.

The streaming sequence:
1. Request hits `/blog/[slug]/page.tsx` (force-dynamic)
2. `await getBlogPost(slug)` triggers React Suspense
3. Framework streams global `loading.tsx` UI **and commits HTTP 200 in the initial response chunk**
4. `getBlogPost` resolves null → `notFound()` fires
5. Framework swaps body to not-found UI via streaming
6. But HTTP 200 is already on the wire → **soft-404**

**Fix:** add `src/app/blog/[slug]/loading.tsx` returning `null`. This overrides the global loader for this segment only. With nothing to stream during the suspense, the framework waits for the `await` to resolve BEFORE committing any HTTP status. `notFound()` now short-circuits to a clean HTTP 404.

Other routes keep the global loader untouched.

## Why this works

Per Next.js App Router docs, `loading.tsx` files at any segment level override parent loading.tsx for that subtree. A `null`-returning loading.tsx is the documented pattern for "I want no loading UI on this route while still using async server components".

## Verification (post-deploy)

```bash
curl -sI https://tenantflow.app/blog/error-1778151609106 | head -1
# Expected: HTTP/2 404  (currently: HTTP/2 200 — soft-404 with loading.tsx body)

curl -sI https://tenantflow.app/blog/this-slug-definitely-does-not-exist-xyz | head -1
# Expected: HTTP/2 404
```

## Phase 6 forward-carry

When BLOG-02 rebuilds the route with `generateStaticParams` + per-slug ISR, this `loading.tsx` can be deleted — the await resolves at build time so no streaming happens at request time.

## What stays untouched

- `src/app/blog/[slug]/page.tsx` (force-dynamic + try/catch error handling from PR #683 — unchanged)
- `src/app/loading.tsx` (global loader — unchanged; only overridden for `/blog/[slug]`)
- All Phase 1 pricing changes — verified live + working

[hudsor01]