### PR TITLE
feat(phase-09): page-level cleanup (CONS-04/13/14)

### DIFF
--- a/.planning/phases/09-page-cleanup/09-REVIEW-cycle-1.md
+++ b/.planning/phases/09-page-cleanup/09-REVIEW-cycle-1.md
@@ -1,0 +1,86 @@
+---
+phase: 09-page-cleanup
+cycle: 1
+reviewed: 2026-05-11T16:35:00Z
+depth: standard
+files_reviewed: 8
+files_reviewed_list:
+  - src/app/marketing-home.tsx
+  - src/app/privacy/page.tsx
+  - src/app/terms/page.tsx
+  - src/app/security-policy/page.tsx
+  - src/app/sitemap.ts
+  - src/app/sitemap.test.ts
+  - src/components/sections/logo-cloud.tsx
+  - src/app/features/features-client.tsx
+findings:
+  critical: 0
+  warning: 0
+  info: 1
+  total: 1
+status: issues_found
+verdict: PASS
+---
+
+# Phase 9: Cycle 1 Code Review — Page-Level Cleanup (CONS-04 / CONS-13 / CONS-14)
+
+**Reviewed:** 2026-05-11T16:35:00Z
+**Depth:** standard
+**Scope:** 1 commit (`e86a82709`), 7 files changed, +14/-19
+**Verdict:** PASS (zero P0 + zero P1 — one P3 doc-drift note)
+
+## Summary
+
+Tight, focused phase. All three CONS items land exactly as scoped:
+
+- **CONS-04:** Three legal pages now read `Last Updated: May 11, 2026` (privacy, terms, security-policy). Sitemap constants `TERMS_LAST_UPDATED`, `PRIVACY_LAST_UPDATED`, `SECURITY_POLICY_LAST_UPDATED` all flipped to `2026-05-11`. Drift-guard test fixture (`Test 4b`) updated to match. Terms `Effective Date: October 5, 2025` left intact per scope.
+- **CONS-13:** `grayscale opacity-80 hover:grayscale-0 hover:opacity-100 transition-all` → `opacity-90 hover:opacity-100 transition-opacity` on the logo-cloud wrapper. Supabase green wordmark + Stripe purple + DocuSeal indigo render at native color now.
+- **CONS-14:** `ComparisonTable` import and `<LazySection>` wrapper removed from `marketing-home.tsx`. Inline comment left as a tombstone explaining the de-dup. Component stays imported + rendered on `/features` via `features-client.tsx` (verified by grep — only those two source files referenced it; the homepage no longer does).
+
+Verification:
+- `pnpm typecheck` — clean
+- `pnpm lint` — clean
+- `pnpm test:unit --run src/app/sitemap.test.ts` — 98,578 tests pass (full unit suite invoked by the runner)
+- Drift guard (`Test 4b` + the three `describe('sitemap legal-page lastmod drift guard')` cases) confirms the regex `Last Updated:?\s*(?<date>[A-Z][a-z]+ \d{1,2}, \d{4})` lands on line 20 of each page (first match wins; the `&quot;Last Updated&quot; date` boilerplate on terms line 449 + privacy line 391 doesn't carry an adjacent date, so it's skipped). Terms line 521 also reads `May 11, 2026`, consistent with line 20 — no internal drift inside terms.
+
+No CLAUDE.md violations: no `any`, no barrel files, no inline styles, no hex/rgb introduced outside the existing `color-tokens/no-hex-colors` opt-out in logo-cloud.tsx (which the file already had at the top for brand SVG paths — unchanged).
+
+Phase 2/4/5/8 regression surfaces (NumberTicker, mobile hero, persona copy, nav active states, dashboard icon) are not touched by this commit.
+
+## Critical Issues
+
+None.
+
+## Warnings
+
+None.
+
+## Info
+
+### IN-01: Stale JSDoc on `LogoCloud` references the removed grayscale effect
+
+**File:** `src/components/sections/logo-cloud.tsx:14`
+**Issue:** The JSDoc comment immediately above the component reads:
+
+```tsx
+/**
+ * Logo cloud showing integration partners and technology stack
+ * Uses SVG logos with grayscale-to-color hover effect
+ */
+export function LogoCloud({
+```
+
+The grayscale-to-color hover effect was the whole point of CONS-13 to remove. The current behavior is an opacity-only hover (`opacity-90 → opacity-100`). Doc drift, not a bug.
+
+**Fix:**
+```tsx
+/**
+ * Logo cloud showing integration partners and technology stack
+ * Uses SVG logos with opacity-only hover effect (CONS-13: grayscale
+ * removed so brand colors render at native intensity).
+ */
+```
+
+P3 / non-blocking under the perfect-PR gate (Info severity). Worth a one-line touch-up in cycle-2 if the cycle runs anyway, but not on its own a NEEDS-FIX trigger.
+
+## REVIEW COMPLETE — VERDICT: PASS

--- a/.planning/phases/09-page-cleanup/09-REVIEW-cycle-2.md
+++ b/.planning/phases/09-page-cleanup/09-REVIEW-cycle-2.md
@@ -1,0 +1,174 @@
+---
+phase: 09-page-cleanup
+cycle: 2
+reviewed: 2026-05-11T00:00:00Z
+depth: standard
+files_reviewed: 8
+files_reviewed_list:
+  - src/app/privacy/page.tsx
+  - src/app/terms/page.tsx
+  - src/app/security-policy/page.tsx
+  - src/app/sitemap.ts
+  - src/app/sitemap.test.ts
+  - src/components/sections/logo-cloud.tsx
+  - src/app/marketing-home.tsx
+  - src/app/features/features-client.tsx
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+verdict: PASS
+gate: SATISFIED
+---
+
+# Phase 9: Cycle 2 Code Review — Page-Level Cleanup (CONS-04 / CONS-13 / CONS-14)
+
+**Reviewed:** 2026-05-11
+**Depth:** standard
+**Scope:** Re-verification of cycle-1 fixes plus the uncommitted logo-cloud.tsx JSDoc refresh
+**Cycle 1 verdict:** PASS (0 P0 + 0 P1, 1 P3 info — stale JSDoc on `LogoCloud`)
+**Cycle 2 verdict:** PASS — **GATE SATISFIED** (two consecutive zero-finding cycles when counting P0+P1; cycle-2 is also zero across all severities, including the cycle-1 P3 doc-drift now resolved)
+
+## Summary
+
+Independent re-verification against the full diff state, including the working-tree edit to `src/components/sections/logo-cloud.tsx`. Every dimension in scope checks out clean.
+
+---
+
+## Dimension-by-dimension verification
+
+### CONS-04 — Legal "Last Updated" dates + sitemap parity
+
+All three legal pages render `Last Updated: May 11, 2026` on the visible body line that the drift-guard regex targets:
+
+| File | Line | Visible text |
+|------|------|--------------|
+| `src/app/privacy/page.tsx` | 20 | `Last Updated: May 11, 2026` |
+| `src/app/terms/page.tsx` | 20 | `Last Updated: May 11, 2026` |
+| `src/app/security-policy/page.tsx` | 20 | `Last Updated: May 11, 2026` |
+
+`src/app/terms/page.tsx:521` also reads `Last Updated:` `May 11, 2026` — consistent with line 20 (no intra-page drift). Sitemap constants match:
+
+```ts
+// src/app/sitemap.ts:19-21
+const TERMS_LAST_UPDATED = '2026-05-11'
+const PRIVACY_LAST_UPDATED = '2026-05-11'
+const SECURITY_POLICY_LAST_UPDATED = '2026-05-11'
+```
+
+Drift-guard test fixture (`Test 4b` at `sitemap.test.ts:169-185`) pins all three to `'2026-05-11'`. The describe-block at `sitemap.test.ts:273-326` reads the actual `.tsx` source via `readFileSync` and verifies the visible "Last Updated:" line round-trips to the same ISO date the sitemap emits — bidirectional guard intact.
+
+Effective Dates untouched as required:
+- `src/app/privacy/page.tsx:467` still reads `"effective as of October 5, 2025"`
+- `src/app/terms/page.tsx:524` still reads `"Effective Date:" October 5, 2025`
+
+CONS-04: clean.
+
+### CONS-13 — Logo cloud opacity-only hover
+
+`src/components/sections/logo-cloud.tsx:74-78`:
+
+```tsx
+className={cn(
+  'h-8 flex items-center justify-center opacity-90 hover:opacity-100 transition-opacity duration-300',
+  integration.width
+)}
+```
+
+No `grayscale` / `grayscale-0` token anywhere in the file. Transition narrowed from `transition-all` to `transition-opacity` (correct — nothing else animates). Opacity baseline raised from `opacity-80` to `opacity-90`, hover hits `opacity-100`. Brand colors (Stripe `#635BFF`, Supabase `#3ECF8E`, DocuSeal `#4F46E5`) render at native intensity. The existing `eslint-disable color-tokens/no-hex-colors` opt-out at line 1 is justified by the brand-SVG paths and is unchanged.
+
+**Cycle-1 IN-01 follow-through:** JSDoc at lines 12-15 now reads:
+
+```tsx
+/**
+ * Logo cloud showing integration partners and technology stack.
+ * SVG logos render at native color with a subtle opacity bump on hover.
+ */
+```
+
+The stale "grayscale-to-color hover effect" claim is gone. Doc matches behavior.
+
+CONS-13: clean.
+
+### CONS-14 — ComparisonTable only on /features
+
+`src/app/marketing-home.tsx`:
+- No `ComparisonTable` import (verified across the full file's imports at lines 1-17).
+- No `<ComparisonTable>` render. Tombstone comment at lines 106-108 documents the removal:
+
+```tsx
+{/* CONS-14: "Why Landlords Choose TenantFlow" ComparisonTable
+    removed from homepage to de-duplicate with /features (which is
+    its natural home). Kept on /features only. */}
+```
+
+This is an explanatory anchor comment, not commented-out code — does not violate CLAUDE.md Zero Tolerance #4.
+
+`src/app/features/features-client.tsx`:
+- Imports `ComparisonTable` at line 10.
+- Renders it inside a `<LazySection>` at lines 67-72 — present, single instance, only homepage occurrence removed.
+
+No orphan imports in `marketing-home.tsx` (`LazySection` and `SectionSkeleton` remain in use by HowItWorks/Features/Stats/FAQ/CTA sections).
+
+CONS-14: clean.
+
+### CLAUDE.md compliance (full sweep across the 8 files)
+
+- No `any` types introduced.
+- No barrel files / re-exports — every file imports from the defining module via `#`-prefixed subpath aliases.
+- No duplicate types created.
+- No commented-out code (the CONS-14 tombstone is an explanatory comment).
+- No inline styles — Tailwind utilities only.
+- No `as unknown as` type assertions.
+- No string-literal query keys (legal pages and home don't query data).
+- No `@radix-ui/react-icons` imports.
+- No emojis.
+- `lucide-react` is the only icon library referenced (`ArrowRight`, `Lock` in marketing-home/features-client).
+- `text-muted-foreground` used correctly throughout legal pages (never bare `text-muted`).
+- `bg-muted` on legal contact callouts (semantic token, dark-mode safe).
+- Marketing pages wrapped in `PageLayout` — no re-added `page-offset-navbar` on children.
+- Legal pages use `max-w-4xl` (CLAUDE.md Marketing Pages rule), homepage uses `max-w-7xl` — both correct.
+
+CLAUDE.md: clean.
+
+### Phase 2 / 4 / 5 / 8 regression guards
+
+None of the eight reviewed files touch the surfaces those phases delivered:
+
+- Phase 2 (NumberTicker / `stats-showcase.tsx`) — `marketing-home.tsx` still renders `<StatsShowcase />` unchanged inside its LazySection.
+- Phase 4 (mobile hero / persona copy) — hero block in `marketing-home.tsx:26-75` unmodified versus prior phase output.
+- Phase 5 (nav active states) — no nav code in scope.
+- Phase 8 (dashboard icon / hero dashboard mockup) — `<HeroDashboardMockup />` still rendered at `marketing-home.tsx:72` unchanged.
+
+No regressions.
+
+### Test infrastructure sanity
+
+`sitemap.test.ts` mock query-builder (lines 70-106) correctly orders by the column production uses (`published_at` desc), so `Test 5` (updated_at preference) and the `/blog` hub-lastmod test (line 249-259) reflect production semantics. `Test 4b` and the drift-guard `describe` block at lines 273-326 form a bidirectional pin between the page bodies and the sitemap constants — exactly the kind of "fake-lastmod teaches Google to ignore the sitemap" guard the production code comment warns about (lines 25-39 of sitemap.ts).
+
+The drift-guard regex `/Last Updated:?\s*(?<date>[A-Z][a-z]+ \d{1,2}, \d{4})/` is anchored on "Last Updated" followed by a longform-month date. First-match-wins is safe here:
+- `terms/page.tsx` first match is line 20 (`Last Updated: May 11, 2026`). Line 449's `&quot;Last Updated&quot;` boilerplate lacks an adjacent date so the regex skips it; line 521's `<strong>Last Updated:</strong> May 11, 2026` is the second match but the test only consumes the first.
+- Identical structure on `privacy/page.tsx` (boilerplate at line 391, no second date; only line 20 matches).
+- `security-policy/page.tsx` has a single visible "Last Updated" on line 20.
+
+No false positives, no false negatives in the guard.
+
+---
+
+## Critical Issues
+
+None.
+
+## Warnings
+
+None.
+
+## Info
+
+None. Cycle-1's IN-01 (stale grayscale-to-color JSDoc claim) is resolved by the working-tree edit reviewed here.
+
+---
+
+## REVIEW COMPLETE — VERDICT: PASS

--- a/src/app/marketing-home.tsx
+++ b/src/app/marketing-home.tsx
@@ -9,7 +9,6 @@ import { PageLayout } from '#components/layout/page-layout'
 import { HeroDashboardMockup } from '#components/sections/hero-dashboard-mockup'
 import { LogoCloud } from '#components/sections/logo-cloud'
 import { HowItWorks } from '#components/sections/how-it-works'
-import { ComparisonTable } from '#components/sections/comparison-table'
 import { HomeFaq } from '#components/sections/home-faq'
 import { LazySection } from '#components/ui/lazy-section'
 import { SectionSkeleton } from '#components/ui/section-skeleton'
@@ -104,13 +103,9 @@ export default function MarketingHomePage() {
 				<StatsShowcase />
 			</LazySection>
 
-			{/* Comparison Table */}
-			<LazySection
-				fallback={<SectionSkeleton height={600} variant="grid" />}
-				minHeight={600}
-			>
-				<ComparisonTable />
-			</LazySection>
+			{/* CONS-14: "Why Landlords Choose TenantFlow" ComparisonTable
+			    removed from homepage to de-duplicate with /features (which is
+			    its natural home). Kept on /features only. */}
 
 			{/* FAQ Section */}
 			<LazySection

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -17,7 +17,7 @@ export default function PrivacyPage() {
 			<JsonLdScript schema={createBreadcrumbJsonLd('/privacy')} />
 			<div className="mx-auto min-h-screen max-w-4xl px-6 section-spacing">
 				<h1 className="mb-8 typography-h1">Privacy Policy</h1>
-				<p className="mb-6 text-muted-foreground">Last Updated: October 5, 2025</p>
+				<p className="mb-6 text-muted-foreground">Last Updated: May 11, 2026</p>
 
 				<div className="prose prose-gray dark:prose-invert max-w-none">
 					<section className="mb-8">

--- a/src/app/security-policy/page.tsx
+++ b/src/app/security-policy/page.tsx
@@ -17,7 +17,7 @@ export default function SecurityPolicyPage() {
 			<JsonLdScript schema={createBreadcrumbJsonLd('/security-policy')} />
 			<div className="mx-auto min-h-screen max-w-4xl px-6 section-spacing">
 				<h1 className="mb-8 typography-h1">Security Policy</h1>
-				<p className="mb-6 text-muted-foreground">Last Updated: February 27, 2026</p>
+				<p className="mb-6 text-muted-foreground">Last Updated: May 11, 2026</p>
 
 				<div className="prose prose-gray dark:prose-invert max-w-none">
 					<section className="mb-8">

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -171,17 +171,17 @@ describe('sitemap()', () => {
 		const entries = await sitemap()
 
 		const terms = entries.find(e => e.url === 'https://tenantflow.app/terms')
-		expect(terms?.lastModified).toBe('2025-10-05')
+		expect(terms?.lastModified).toBe('2026-05-11')
 
 		const privacy = entries.find(
 			e => e.url === 'https://tenantflow.app/privacy'
 		)
-		expect(privacy?.lastModified).toBe('2025-10-05')
+		expect(privacy?.lastModified).toBe('2026-05-11')
 
 		const securityPolicy = entries.find(
 			e => e.url === 'https://tenantflow.app/security-policy'
 		)
-		expect(securityPolicy?.lastModified).toBe('2026-02-27')
+		expect(securityPolicy?.lastModified).toBe('2026-05-11')
 	})
 
 	it('Test 5: blog post entries prefer updated_at then published_at', async () => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,9 +16,9 @@ const logger = createLogger({ component: 'Sitemap' })
 //
 // Source: src/app/{terms,privacy,security-policy}/page.tsx visible
 // "Last Updated" line.
-const TERMS_LAST_UPDATED = '2025-10-05'
-const PRIVACY_LAST_UPDATED = '2025-10-05'
-const SECURITY_POLICY_LAST_UPDATED = '2026-02-27'
+const TERMS_LAST_UPDATED = '2026-05-11'
+const PRIVACY_LAST_UPDATED = '2026-05-11'
+const SECURITY_POLICY_LAST_UPDATED = '2026-05-11'
 
 // `changeFrequency` is no longer consulted by Google as of 2023, and the
 // `lastmod` field is the only freshness signal that still affects crawl

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -17,7 +17,7 @@ export default function TermsPage() {
 			<JsonLdScript schema={createBreadcrumbJsonLd('/terms')} />
 			<div className="mx-auto min-h-screen max-w-4xl px-6 section-spacing">
 				<h1 className="mb-8 typography-h1">Terms of Service</h1>
-				<p className="mb-6 text-muted-foreground">Last Updated: October 5, 2025</p>
+				<p className="mb-6 text-muted-foreground">Last Updated: May 11, 2026</p>
 
 				<div className="prose prose-gray dark:prose-invert max-w-none">
 					<section className="mb-8">
@@ -518,7 +518,7 @@ export default function TermsPage() {
 							understood, and agree to be bound by these Terms of Service.
 						</p>
 						<p className="mt-4">
-							<strong>Last Updated:</strong> October 5, 2025
+							<strong>Last Updated:</strong> May 11, 2026
 						</p>
 						<p className="mt-2">
 							<strong>Effective Date:</strong> October 5, 2025

--- a/src/components/sections/logo-cloud.tsx
+++ b/src/components/sections/logo-cloud.tsx
@@ -10,8 +10,8 @@ interface LogoCloudProps {
 }
 
 /**
- * Logo cloud showing integration partners and technology stack
- * Uses SVG logos with grayscale-to-color hover effect
+ * Logo cloud showing integration partners and technology stack.
+ * SVG logos render at native color with a subtle opacity bump on hover.
  */
 export function LogoCloud({
 	className,

--- a/src/components/sections/logo-cloud.tsx
+++ b/src/components/sections/logo-cloud.tsx
@@ -72,7 +72,7 @@ export function LogoCloud({
 								<div className="group relative flex flex-col items-center gap-2">
 									<div
 										className={cn(
-											'h-8 flex items-center justify-center grayscale opacity-80 hover:grayscale-0 hover:opacity-100 transition-all duration-300',
+											'h-8 flex items-center justify-center opacity-90 hover:opacity-100 transition-opacity duration-300',
 											integration.width
 										)}
 									>


### PR DESCRIPTION
## Summary
- **CONS-04** — Legal-page "Last Updated" dates bumped to `May 11, 2026` (Privacy, Terms, Security Policy) reflecting the v1.0 launch-pass review. Effective dates left at the original `October 5, 2025` (legal binding date — separate from revision-bookkeeping). Sitemap `TERMS_LAST_UPDATED` / `PRIVACY_LAST_UPDATED` / `SECURITY_POLICY_LAST_UPDATED` constants + drift-guard test fixture updated to match.
- **CONS-13** — `logo-cloud.tsx` wrapper dropped `grayscale opacity-80` → `opacity-90`. The grayscale filter was washing out Supabase's green wordmark while leaving black-text logos legible — inconsistent visual weight. Removing grayscale gives every logo equal presence; hover still bumps to 100% opacity.
- **CONS-14** — `ComparisonTable` removed from `/` homepage (kept on `/features`). De-duplicates the "Why Landlords Choose TenantFlow" surface; drops ~600px of homepage scroll.

7 files, 14 inserts / 19 deletes. Zero new tokens. Phase 2/4/5/8 regression guards untouched.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test:unit` — 98,578 tests pass; sitemap drift-guard pinned against new dates
- [x] No new hex / rgba / `bg-white` / inline-ms additions
- [ ] Post-deploy: `/privacy`, `/terms`, `/security-policy` each show `Last Updated: May 11, 2026`
- [ ] Logo cloud row renders all 5 logos at consistent visual weight (no faded Supabase)
- [ ] `/` no longer has the comparison table section between StatsShowcase and HomeFaq; `/features` still has it

[hudsor01]