### PR TITLE
feat(phase-10): cta + conversion standardization (CONS-06/07/08, TRUST-01..04)

### DIFF
--- a/.planning/phases/10-cta-conversion/10-CONTEXT.md
+++ b/.planning/phases/10-cta-conversion/10-CONTEXT.md
@@ -1,0 +1,82 @@
+# Phase 10: CTA & Conversion Standardization — Context
+
+**Gathered:** 2026-05-11
+**Status:** Implementation complete; TRUST-01/02 deferred per zero-customer reality
+
+<domain>
+## Phase Boundary
+
+Seven requirements: CONS-06 (CTA labels), CONS-07 (neutral `/compare/*` framing), CONS-08 (`/contact` form default), TRUST-01 (testimonials), TRUST-02 (review badges), TRUST-03 (monitored inboxes), TRUST-04 (auto-derived from above).
+
+**In scope (shipped this PR):**
+- CONS-06: replaced "Talk to Sales", "Connect with sales", "Schedule a walkthrough" with canonical "Contact Sales" across `/about`, `/pricing` (4 string swaps).
+- CONS-07: added `'na'` variant to `FeatureSupport` type + `FeatureIcon` renderer (neutral `Minus` in `text-muted-foreground`); flipped 3 ACH/Payment Processing rows + 1 HOA Management row in `compare-data.ts` from `'no'` (red ✗) to `'na'` with positioning-anchored notes.
+- CONS-08: `/contact` form "How did you hear about us?" SelectValue placeholder changed from "Select an option" to "Please select" — explicit-action ask, no false-positive Search-Engine bias.
+
+**Deferred to post-customer (TRUST-01, TRUST-02):**
+- TRUST-01 real testimonials: zero current customers. Per Phase 4 lesson ("Phase 67 deleted fabricated testimonials"), fabricating quotes is REJECTED. Wait until first 3 paying customers exist + opt-in to public quote.
+- TRUST-02 G2/Capterra/Trustpilot review badges: same reality — no reviews exist yet. Document deferred here; revisit after customer feedback accumulates.
+
+**TRUST-03 — Monitored inbox documentation (shipped):**
+- `security@tenantflow.app` — already documented in `/security-policy` (24h acknowledgement, 72h assessment, 90d coordinated disclosure). Inbox monitored by orchestrator account.
+- `sales@tenantflow.app` — added to security-policy footer with same monitoring SLA (response within 1 business day).
+
+**Out of scope** (deferred to other phases):
+- Real testimonials integration mechanism (component already exists at `src/components/sections/testimonials-section.tsx`; gates on `testimonials.length === 0`).
+- Customer migration testimonial collection workflow.
+- G2/Capterra/Trustpilot listing creation (operational, not code).
+
+**Branch:** `gsd/phase-10-cta-conversion`
+**Phase requirement IDs:** CONS-06, CONS-07, CONS-08, TRUST-01 (deferred), TRUST-02 (deferred), TRUST-03, TRUST-04
+**Cross-cutting design-token constraint:** No new hex/rgb/`bg-white`/inline-ms tokens.
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### CONS-06 — Canonical "Contact Sales" label
+Standardize on "Contact Sales" sitewide. Variants killed: "Talk to Sales", "Connect with sales", "Schedule a walkthrough", "Schedule a demo".
+
+### CONS-07 — Neutral framing for positioning choices
+Added `'na'` variant to `FeatureSupport` (`'yes' | 'no' | 'partial' | 'addon' | 'na'`). Renders as muted-foreground Minus, not destructive red X. Flipped ACH/Payment Processing (3 rows) and HOA Management (1 row) in `compare-data.ts`.
+
+Rows that genuinely lack a feature (red ✗) keep `tenantflow: 'no'`. Rows that don't have a feature **by design** use `tenantflow: 'na'` + a `tenantflowNote` like "By design — landlord-only platform".
+
+### CONS-08 — Contact form placeholder
+Form field "How did you hear about us?" — placeholder is "Please select" (explicit ask). Default to a specific value would skew first-touch attribution to false positives.
+
+### TRUST-01 / TRUST-02 — Honest deferral
+Both require real customer data. Zero customers today. Fabricating testimonials or badges would re-introduce the exact problem Phase 67 + Phase 4 (COPY-02 social proof) killed. Deferred; component scaffolding ready for real data when it exists.
+
+### TRUST-03 — Inbox monitoring documentation
+- `security@tenantflow.app` — public via `/security-policy` § 2 (vulnerability disclosure)
+- `sales@tenantflow.app` — added to `/security-policy` § 7 (general contact) as separate channel with 1-business-day SLA
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+- `.planning/REQUIREMENTS.md § CONS-06..08, TRUST-01..04`
+- `.planning/ROADMAP.md § Phase 10`
+- `src/types/sections/compare.ts` (FeatureSupport union)
+- `src/app/compare/[competitor]/compare-sections.tsx` (FeatureIcon renderer)
+- `src/app/compare/[competitor]/compare-data.ts` (feature row data)
+- `src/components/contact/contact-form-fields.tsx`
+- `src/components/sections/testimonials-section.tsx` (testimonials-empty-state gating, Phase 67)
+- `src/app/security-policy/page.tsx`
+- `CLAUDE.md`
+
+</canonical_refs>
+
+<deferred>
+
+- **TRUST-01 real testimonials** — reactivate when first 3 paying customers opt-in. Implementation surface already exists in `testimonials-section.tsx`. Pass `testimonials={[...]}` from a server component fetching real quotes.
+- **TRUST-02 review badges** — reactivate when reviews exist on G2/Capterra/Trustpilot. Component lift is small (badge row above footer).
+- **Customer testimonial collection workflow** — separate ops process (email outreach + opt-in form), not v1.0 code work.
+- **Featured-page top-nav CTA pill consolidation** — only one CTA pill currently exists on `/features` per Phase 9 cleanup; nothing to consolidate. Roadmap line satisfied trivially.
+
+</deferred>
+
+---
+
+*Phase 10 context locked: 2026-05-11*

--- a/.planning/phases/10-cta-conversion/10-REVIEW-cycle-1.md
+++ b/.planning/phases/10-cta-conversion/10-REVIEW-cycle-1.md
@@ -1,0 +1,68 @@
+---
+phase: 10-cta-conversion
+cycle: 1
+reviewed: 2026-05-11T00:00:00Z
+depth: standard
+files_reviewed: 8
+files_reviewed_list:
+  - src/types/sections/compare.ts
+  - src/app/compare/[competitor]/compare-sections.tsx
+  - src/app/compare/[competitor]/compare-data.ts
+  - src/app/about/page.tsx
+  - src/app/pricing/pricing-content.tsx
+  - src/components/contact/contact-form-fields.tsx
+  - src/app/security-policy/page.tsx
+  - .planning/phases/10-cta-conversion/10-CONTEXT.md
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+---
+
+# Phase 10: Code Review Report — Cycle 1
+
+**Reviewed:** 2026-05-11
+**Depth:** standard
+**Files Reviewed:** 8 (1 commit `7f173b034`, +117/-15)
+**Status:** clean
+
+## Summary
+
+Phase 10 ships CONS-06/07/08 + TRUST-03 cleanly. TRUST-01/02 are documented as deferred in `10-CONTEXT.md` with explicit rationale (zero customers; Phase 67 anti-fabrication lesson). All 8 changed files were read end-to-end and cross-validated against the locked decisions, requirement IDs, Phase 4 banlist test, and CLAUDE.md zero-tolerance rules. No P0 or P1 issues. No P2/P3 polish callouts.
+
+## Verification Matrix
+
+| Requirement | Verification | Result |
+|---|---|---|
+| **CONS-06** — zero "Talk to Sales" / "Connect with sales" / "Schedule a walkthrough" / "Schedule a demo" in `src/` | `grep -rn -E "Talk to Sales\|Connect with sales\|Schedule a walkthrough\|Schedule a demo" src/` → zero hits. Canonical `Contact Sales` confirmed in 12 locations across about (×2), pricing-content (×2), faq, help (×2), home-faq, kibo-style-pricing, pricing-card-standard. | PASS |
+| **CONS-07a** — `'na'` added to `FeatureSupport` union | `src/types/sections/compare.ts:5` — `export type FeatureSupport = 'yes' \| 'no' \| 'partial' \| 'addon' \| 'na'`. JSDoc on lines 1-4 documents intent. | PASS |
+| **CONS-07b** — `'na'` case in `FeatureIcon` switch | `src/app/compare/[competitor]/compare-sections.tsx:16-20` — renders `<Minus className="size-5 text-muted-foreground" aria-label="Not applicable" />`. Switch is exhaustive (TS would error otherwise under strict mode). | PASS |
+| **CONS-07c** — 3 ACH + 1 HOA rows flipped from `'no'` to `'na'` with positioning-anchored notes | `compare-data.ts`: Buildium ACH L82-86 (`By design — landlord-only platform`), Buildium HOA L88-93 (`Not applicable — landlord-only platform`), AppFolio ACH L191-195 (`By design — landlord-only platform`), RentRedi ACH L320-324 (`By design — landlord-only platform`). All four rows carry accurate `tenantflowNote`. Rows that genuinely lack a feature (Background Checks, Listing Syndication, Commercial Properties, Native Mobile App, Unlimited Units) correctly keep `tenantflow: 'no'`. | PASS |
+| **CONS-08** — placeholder `Please select` (not `Select an option`) | `contact-form-fields.tsx:169` — `<SelectValue placeholder="Please select" />`. `grep "Select an option" src/` → zero hits. | PASS |
+| **TRUST-03** — `/security-policy` § 7 documents BOTH inboxes with SLAs | `security-policy/page.tsx:211-248` — § header renamed to "Contact & Monitored Inboxes". `security@` documented with "Acknowledged within 24 hours per § 3". `sales@` documented with "Responded to within 1 business day (US business hours, Monday through Friday)". `support@` retained. SLA carve-out in `marketing-copy-landlord-only.test.ts:272` (`'src/app/security-policy/page.tsx': ['sla']`) protects the documented timelines from the SLA banlist. | PASS |
+| **TRUST-01/02 deferral** — explicit documentation, not silent drop | `10-CONTEXT.md:16-18, 48-49, 73-75` — deferral rationale (zero customers, Phase 67 lesson, scaffold ready in `testimonials-section.tsx`). | PASS |
+| **TRUST-04** — auto-derived from CONS-06 + TRUST-03 | Both upstream requirements satisfied. | PASS |
+
+## Cross-cutting Regression Checks
+
+| Check | Result |
+|---|---|
+| Phase 4 banlist (`marketing-copy-landlord-only.test.ts`) — new strings (`Contact Sales`, `Please select`, `By design — landlord-only platform`, `Not applicable — landlord-only platform`, `Acknowledged within 24 hours per § 3`) introduce zero hits across BANNED_PHRASES, BANNED_NUMERIC_CLAIMS, BANNED_FEATURE_CLAIMS, BANNED_STALE_PLAN_REFS, BANNED_SLA_CLAIMS, BANNED_SUPERLATIVES, BANNED_FABRICATED_IDENTITY_CLAIMS. `security-policy/page.tsx` SLA exemption pre-existing; the new `1 business day` phrase does not match any BANNED_SLA_CLAIMS entry regardless. | PASS |
+| `FeatureSupport` discriminated-union exhaustiveness — adding `'na'` to the union without the matching `case` in `FeatureIcon` would cause the switch to return `undefined` (silent UI break). Case is present. TS strict mode enforces. | PASS |
+| Phase 2/4/5/8/9 regression — no overlap with touched files. | PASS |
+| CLAUDE.md compliance — no `any`, no `as unknown as`, no barrel/re-export, no inline styles, no commented-out code, no emojis. New tokens: `text-muted-foreground` (existing token), no new hex / `bg-white` / inline-ms. Icons via `lucide-react` (`Minus`). | PASS |
+| Accessibility — `aria-label="Not applicable"` on the neutral Minus icon distinguishes it from the partial-support `Minus` (amber) for screen readers, since both glyphs render the same character. | PASS |
+| Soft-FK / shape consistency on `compare-data.ts` — all four flipped rows carry a `tenantflowNote`. AppFolio HOA / Listing Syndication / Commercial Properties stay as `'no'` (true gaps, not by-design choices) — consistent with the locked decision in `10-CONTEXT.md:43-44`. | PASS |
+
+## Findings
+
+None.
+
+---
+
+_Reviewed: 2026-05-11_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_
+_Cycle: 1 of N (perfect-PR gate)_

--- a/.planning/phases/10-cta-conversion/10-REVIEW-cycle-2.md
+++ b/.planning/phases/10-cta-conversion/10-REVIEW-cycle-2.md
@@ -1,0 +1,104 @@
+---
+phase: 10-cta-conversion
+cycle: 2
+reviewed: 2026-05-11T00:00:00Z
+depth: standard
+files_reviewed: 8
+files_reviewed_list:
+  - src/types/sections/compare.ts
+  - src/app/compare/[competitor]/compare-sections.tsx
+  - src/app/compare/[competitor]/compare-data.ts
+  - src/app/about/page.tsx
+  - src/app/pricing/pricing-content.tsx
+  - src/components/contact/contact-form-fields.tsx
+  - src/app/security-policy/page.tsx
+  - .planning/phases/10-cta-conversion/10-CONTEXT.md
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+---
+
+# Phase 10: Code Review Report — Cycle 2 (FINAL, perfect-PR gate)
+
+**Reviewed:** 2026-05-11
+**Depth:** standard
+**Files Reviewed:** 8 (commit `7f173b034` — unchanged since cycle 1, +117/-15)
+**Status:** clean
+**Gate:** Two consecutive zero-finding cycles satisfied (cycle 1 + cycle 2).
+
+## Summary
+
+Independent re-verification of cycle 1's PASS verdict. No new commits since cycle 1 — same commit `7f173b034` re-inspected against the same dimensions, plus a from-scratch diff replay to confirm cycle 1 didn't miss anything inside the actual change surface. All claims in `10-REVIEW-cycle-1.md` reproduce verbatim. No P0/P1/P2/P3 findings.
+
+## Diff Replay (cycle 1 used `git diff main..HEAD`; cycle 2 used `git diff HEAD~1 HEAD`, same single-commit branch)
+
+| File | Lines changed | What changed | Cycle-1 claim reproduces? |
+|---|---|---|---|
+| `src/types/sections/compare.ts` | +5/-1 | JSDoc + `'na'` added to `FeatureSupport` union | YES (cycle-1 § CONS-07a) |
+| `src/app/compare/[competitor]/compare-sections.tsx` | +5/-0 | `case 'na'` added to `FeatureIcon` switch with `aria-label="Not applicable"` | YES (cycle-1 § CONS-07b) |
+| `src/app/compare/[competitor]/compare-data.ts` | +9/-6 | Buildium ACH (L82-86) + Buildium HOA (L88-93) + AppFolio ACH (L191-195) + RentRedi ACH (L320-324) flipped `'no' → 'na'` with positioning-anchored notes | YES (cycle-1 § CONS-07c, all 4 row coordinates verified) |
+| `src/app/about/page.tsx` | +2/-2 | Two `Talk to Sales` → `Contact Sales` swaps (hero secondaryCta L60 + footer CTA L265) | YES (cycle-1 § CONS-06) |
+| `src/app/pricing/pricing-content.tsx` | +2/-2 | `Connect with sales` → `Contact Sales` (L149) + `Schedule a walkthrough` → `Contact Sales` (L183) | YES (cycle-1 § CONS-06) |
+| `src/components/contact/contact-form-fields.tsx` | +1/-1 | Referral-source placeholder `Select an option` → `Please select` (L169) | YES (cycle-1 § CONS-08) |
+| `src/app/security-policy/page.tsx` | +12/-2 | § 7 header renamed to `7. Contact & Monitored Inboxes`; `security@` gains `Acknowledged within 24 hours per § 3` clause; `sales@` paragraph added with `Responded to within 1 business day (US business hours, Monday through Friday)` SLA | YES (cycle-1 § TRUST-03) |
+| `.planning/phases/10-cta-conversion/10-CONTEXT.md` | +82/-0 (new file) | Domain, decisions, canonical refs, deferred items | n/a (planning artifact) |
+
+## Independent Verification
+
+### Banned-CTA sweep
+`grep -rn -E "Talk to Sales|Connect with sales|Schedule a walkthrough|Schedule a demo" src/` → **zero hits**. Cycle 1's claim reproduces.
+
+### Canonical "Contact Sales" presence
+12 occurrences across 8 files (about ×2, pricing-content ×2, faq, help ×2, home-faq, kibo-style-pricing, pricing-card-standard). Matches cycle 1 verbatim.
+
+### Old contact placeholder sweep
+`grep -rn "Select an option" src/` → **zero hits**. Cycle 1's claim reproduces.
+
+### `'na'` union/case parity
+- `src/types/sections/compare.ts:5` — `'na'` in union.
+- `src/app/compare/[competitor]/compare-sections.tsx:16-20` — `case 'na'` returns neutral `Minus` in `text-muted-foreground` with `aria-label="Not applicable"`.
+- 4 `tenantflow: 'na'` row uses in `compare-data.ts` (L83, L89, L192, L321) — exactly matches the 3 ACH + 1 HOA flip count described in cycle 1.
+
+### Phase 4 banlist (`src/app/__tests__/marketing-copy-landlord-only.test.ts`) collision check
+Iterated every BANNED_* list against the five new strings introduced by this phase:
+- `Contact Sales` — not in `BANNED_PHRASES`, `BANNED_FEATURE_CLAIMS`, `BANNED_FABRICATED_IDENTITY_CLAIMS`, `BANNED_STALE_PLAN_REFS`, `BANNED_SLA_CLAIMS`, `BANNED_SUPERLATIVES`, `BANNED_NUMERIC_CLAIMS`.
+- `Please select` — not in any list.
+- `By design — landlord-only platform` — not in any list.
+- `Not applicable — landlord-only platform` — not in any list.
+- `Acknowledged within 24 hours per § 3` and `Responded to within 1 business day` — `BANNED_SLA_CLAIMS` exists, but `security-policy/page.tsx` has the SLA carve-out at test L272 (`'src/app/security-policy/page.tsx': ['sla']`) which pre-emptively whitelists the legitimate vulnerability-disclosure + sales SLAs. The whitelist is scoped narrowly to that file, so the carve-out does not bleed elsewhere.
+
+### CLAUDE.md zero-tolerance rules
+- No `any`, no `as unknown as` — grep across all 7 source files returns zero hits.
+- No barrel/re-export — none of the touched files are `index.ts`.
+- No duplicate types — `FeatureSupport` lives in `src/types/sections/compare.ts` (already canonical) and is imported by `compare-sections.tsx` and `compare-data.ts`.
+- No commented-out code — the JSDoc on `compare.ts:1-4` documents the `'na'` intent (live doc); the `// CONS-07` block in `compare-sections.tsx:17-19` documents the case rationale (live doc). Neither is dead code.
+- No inline styles introduced in the phase diff — the `style={{ animationDelay }}` on `pricing-content.tsx:70` is **pre-existing** (predates this phase, not in `git diff HEAD~1 HEAD`).
+- No `bg-white` introduced — grep across all 7 files returns zero hits.
+- No emojis — none introduced; the JSDoc uses ✗ as a Unicode glyph in prose describing why `'na'` is NOT rendered red ✗. That's a documentation reference, not a UI emoji.
+- No `@radix-ui/react-icons` — `lucide-react` is the sole icon source. `Minus` and `Plus` glyphs come from `lucide-react`.
+
+### Exhaustive-switch safety
+`FeatureSupport` is a union of 5 string literals. Under TS strict mode + `noFallthroughCasesInSwitch`, omitting any `case` would cause the switch to return `undefined`. The 5 cases (`yes`, `no`, `partial`, `addon`, `na`) are all present. The two `Minus` cases (partial = amber, na = muted-foreground with `aria-label`) are visually distinguishable in UI and unambiguous in DOM, so a11y is preserved.
+
+### TRUST-01 / TRUST-02 deferral honesty
+`10-CONTEXT.md:16-18, 48-49, 73-75` documents the explicit deferral rationale (zero customers + Phase 67 anti-fabrication lesson). Component scaffolding (`src/components/sections/testimonials-section.tsx`) is unchanged and gates on `testimonials.length === 0`. No fabricated quotes shipped.
+
+### Cross-cutting regression
+- Phase 2 (CTA hierarchy), Phase 4 (banlist), Phase 5 (pricing accuracy), Phase 8 (nav), Phase 9 (page-level cleanup) — no overlap with the 7 source files touched here.
+- The `'na'` rendering relies on the same `text-muted-foreground` token already used elsewhere; no new design tokens added.
+
+## Findings
+
+None. Two consecutive zero-finding cycles satisfy the perfect-PR merge gate.
+
+---
+
+## REVIEW COMPLETE — VERDICT: PASS
+
+_Reviewed: 2026-05-11_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_
+_Cycle: 2 of 2 (perfect-PR gate satisfied — cycle 1 PASS + cycle 2 PASS)_

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -57,7 +57,7 @@ export default function AboutPage() {
 				titleHighlight="built for landlords"
 				subtitle="One platform for property records, leases, maintenance, and the document vault. Tenants are records you keep for your own tracking — never users on the platform."
 				primaryCta={{ label: 'Start Free Trial', href: '/pricing' }}
-				secondaryCta={{ label: 'Talk to Sales', href: '/contact' }}
+				secondaryCta={{ label: 'Contact Sales', href: '/contact' }}
 				image={{
 					src: 'https://images.unsplash.com/photo-1522071820081-009f0129c71c?q=80&w=2070&auto=format&fit=crop',
 					alt: 'Professional team collaborating on property management solutions'
@@ -262,7 +262,7 @@ export default function AboutPage() {
 									</Link>
 								</Button>
 								<Button asChild variant="outline" size="lg">
-									<Link href="/contact">Talk to Sales</Link>
+									<Link href="/contact">Contact Sales</Link>
 								</Button>
 							</div>
 							<p className="text-muted-foreground">

--- a/src/app/compare/[competitor]/compare-data.ts
+++ b/src/app/compare/[competitor]/compare-data.ts
@@ -80,13 +80,14 @@ export const COMPETITORS: Record<string, CompetitorData> = {
 			},
 			{
 				name: 'ACH / Payment Processing',
-				tenantflow: 'no',
-				tenantflowNote: 'Landlord-only platform',
+				tenantflow: 'na',
+				tenantflowNote: 'By design — landlord-only platform',
 				competitor: 'yes',
 			},
 			{
 				name: 'HOA Management',
-				tenantflow: 'no',
+				tenantflow: 'na',
+				tenantflowNote: 'Not applicable — landlord-only platform',
 				competitor: 'yes',
 				competitorNote: 'Violation tracking included',
 			},
@@ -188,8 +189,8 @@ export const COMPETITORS: Record<string, CompetitorData> = {
 			},
 			{
 				name: 'ACH / Payment Processing',
-				tenantflow: 'no',
-				tenantflowNote: 'Landlord-only platform',
+				tenantflow: 'na',
+				tenantflowNote: 'By design — landlord-only platform',
 				competitor: 'yes',
 			},
 			{
@@ -317,8 +318,8 @@ export const COMPETITORS: Record<string, CompetitorData> = {
 			},
 			{
 				name: 'ACH / Payment Processing',
-				tenantflow: 'no',
-				tenantflowNote: 'Landlord-only platform',
+				tenantflow: 'na',
+				tenantflowNote: 'By design — landlord-only platform',
 				competitor: 'yes',
 			},
 			{

--- a/src/app/compare/[competitor]/compare-sections.tsx
+++ b/src/app/compare/[competitor]/compare-sections.tsx
@@ -13,6 +13,11 @@ function FeatureIcon({ support }: { support: FeatureSupport }) {
 			return <Minus className="size-5 text-amber-500" />
 		case 'addon':
 			return <Plus className="size-5 text-blue-500" />
+		case 'na':
+			// CONS-07: neutral framing for "by design" feature absences
+			// (ACH/Payment, HOA Management) — these are positioning
+			// choices on the landlord-only platform, not gaps.
+			return <Minus className="size-5 text-muted-foreground" aria-label="Not applicable" />
 	}
 }
 

--- a/src/app/pricing/pricing-content.tsx
+++ b/src/app/pricing/pricing-content.tsx
@@ -146,7 +146,7 @@ export function PricingFaqSection() {
 							</Link>
 							<Button size="lg" className="px-7" asChild>
 								<Link href="/contact">
-									Connect with sales
+									Contact Sales
 									<ArrowRight className="ml-2 h-4 w-4" />
 								</Link>
 							</Button>
@@ -180,7 +180,7 @@ export function PricingCtaSection() {
 								</Link>
 							</Button>
 							<Button size="lg" variant="outline" className="px-8" asChild>
-								<Link href="/contact">Schedule a walkthrough</Link>
+								<Link href="/contact">Contact Sales</Link>
 							</Button>
 						</div>
 					</div>

--- a/src/app/security-policy/page.tsx
+++ b/src/app/security-policy/page.tsx
@@ -208,7 +208,7 @@ export default function SecurityPolicyPage() {
 					</section>
 
 					<section className="mb-8">
-						<h2 className="mb-4 typography-h3">7. Contact</h2>
+						<h2 className="mb-4 typography-h3">7. Contact &amp; Monitored Inboxes</h2>
 						<p>
 							For security-related inquiries, contact us at{' '}
 							<a
@@ -217,7 +217,17 @@ export default function SecurityPolicyPage() {
 							>
 								security@tenantflow.app
 							</a>
-							.
+							. Acknowledged within 24 hours per § 3.
+						</p>
+						<p className="mt-3">
+							For sales and product inquiries, contact{' '}
+							<a
+								href="mailto:sales@tenantflow.app"
+								className="text-primary hover:underline"
+							>
+								sales@tenantflow.app
+							</a>
+							. Responded to within 1 business day (US business hours, Monday through Friday).
 						</p>
 						<p>
 							For general support, visit our{' '}

--- a/src/components/contact/contact-form-fields.tsx
+++ b/src/components/contact/contact-form-fields.tsx
@@ -166,7 +166,7 @@ export function ContactFormFields({
 					}
 				>
 					<SelectTrigger id="type">
-						<SelectValue placeholder="Select an option" />
+						<SelectValue placeholder="Please select" />
 					</SelectTrigger>
 					<SelectContent>
 						<SelectItem value="search">Google Search</SelectItem>

--- a/src/types/sections/compare.ts
+++ b/src/types/sections/compare.ts
@@ -1,4 +1,8 @@
-export type FeatureSupport = 'yes' | 'no' | 'partial' | 'addon'
+// `na` — Not applicable / by design. Used for features that TenantFlow
+// intentionally does NOT support (e.g. ACH rent collection, HOA management
+// on the landlord-only platform). Renders with neutral muted styling, not a
+// destructive red ✗, since these are positioning choices not gaps.
+export type FeatureSupport = 'yes' | 'no' | 'partial' | 'addon' | 'na'
 
 export interface FeatureRow {
 	name: string


### PR DESCRIPTION
## Summary
**Shipped (5 of 7 reqs):**
- **CONS-06** — Canonical "Contact Sales" sitewide. Killed "Talk to Sales" (about ×2), "Connect with sales" (pricing), "Schedule a walkthrough" (pricing).
- **CONS-07** — `/compare/*` neutral framing. Added `'na'` variant to `FeatureSupport` union; `FeatureIcon` renders `Minus` in `text-muted-foreground` for "by design" rows. Flipped 3 ACH/Payment Processing rows + 1 HOA Management row from `'no'` (red ✗) to `'na'` with positioning-anchored notes ("By design — landlord-only platform" / "Not applicable — landlord-only platform").
- **CONS-08** — `/contact` "How did you hear about us?" placeholder `"Select an option"` → `"Please select"`.
- **TRUST-03** — `/security-policy` § 7 expanded with `sales@tenantflow.app` inbox monitoring (1 business day SLA). `security@` already documented with 24h/72h/90d SLAs.
- **TRUST-04** — auto-derived from TRUST-03 + Phase 9's legal-page date refresh.

**Deferred (2 of 7 reqs):**
- **TRUST-01 real testimonials** — zero current customers. Per Phase 67 + Phase 4 COPY-02 anti-fabrication locks. Component scaffolding ready (`testimonials-section.tsx` gates on `testimonials.length === 0`); reactivate when first 3 paying customers opt-in.
- **TRUST-02 review badges** — same reality; no G2/Capterra/Trustpilot reviews exist yet. Reactivate when reviews accumulate.

Deferrals documented in `.planning/phases/10-cta-conversion/10-CONTEXT.md` as honest gating, not technical scope reduction.

8 files, +117/-15. Phase 2/4/5/8/9 regression guards untouched. Zero new tokens.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test:unit` — 98,578 tests pass
- [x] No new hex / rgba / `bg-white` / inline-ms additions
- [ ] Post-deploy: `/about`, `/pricing` show "Contact Sales" (no "Talk to Sales", "Connect", "Walkthrough")
- [ ] `/compare/buildium`, `/compare/appfolio`, `/compare/rentredi` ACH + HOA rows render neutral Minus with "By design" / "Not applicable" notes
- [ ] `/contact` form shows "Please select" placeholder
- [ ] `/security-policy` § 7 shows both `security@` and `sales@` with their SLAs

[hudsor01]