### PR TITLE
feat(phase-12): per-page og images, compare breadcrumb, footer sitemap

### DIFF
--- a/src/app/api/og/compare/[competitor]/route.tsx
+++ b/src/app/api/og/compare/[competitor]/route.tsx
@@ -1,0 +1,91 @@
+import { ImageResponse } from '@vercel/og'
+import { COMPETITORS } from '../../../../compare/[competitor]/compare-data'
+
+export const runtime = 'edge'
+export const revalidate = 3600
+
+interface RouteParams {
+	params: Promise<{ competitor: string }>
+}
+
+export async function GET(_req: Request, { params }: RouteParams) {
+	const { competitor: slug } = await params
+	const data = COMPETITORS[slug]
+
+	if (!data) {
+		return new Response('Not found', { status: 404 })
+	}
+
+	const bgGradient =
+		'linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)'
+
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					height: '100%',
+					width: '100%',
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'space-between',
+					padding: '60px',
+					background: bgGradient,
+					color: 'oklch(1 0 0)',
+					fontFamily: 'sans-serif',
+				}}
+			>
+				<div
+					style={{
+						fontSize: 24,
+						textTransform: 'uppercase',
+						letterSpacing: '0.1em',
+						opacity: 0.85,
+					}}
+				>
+					Comparison
+				</div>
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 12,
+					}}
+				>
+					<div
+						style={{
+							fontSize: 72,
+							fontWeight: 900,
+							lineHeight: 1.05,
+							display: 'flex',
+						}}
+					>
+						TenantFlow vs {data.name}
+					</div>
+					<div
+						style={{
+							fontSize: 30,
+							fontWeight: 400,
+							opacity: 0.85,
+							display: 'flex',
+						}}
+					>
+						Feature & pricing comparison
+					</div>
+				</div>
+				<div
+					style={{
+						fontSize: 28,
+						fontWeight: 700,
+						opacity: 0.9,
+					}}
+				>
+					TenantFlow
+				</div>
+			</div>
+		),
+		{
+			width: 1200,
+			height: 630,
+		},
+	)
+}

--- a/src/app/api/og/compare/[competitor]/route.tsx
+++ b/src/app/api/og/compare/[competitor]/route.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from '@vercel/og'
-import { COMPETITORS } from '../../../../compare/[competitor]/compare-data'
+import { COMPETITORS } from '#app/compare/[competitor]/compare-data'
 
 // `@vercel/og` requires the edge runtime — it streams the rendered PNG
 // directly without spinning up a Node.js process per request. The CDN

--- a/src/app/api/og/compare/[competitor]/route.tsx
+++ b/src/app/api/og/compare/[competitor]/route.tsx
@@ -1,6 +1,10 @@
 import { ImageResponse } from '@vercel/og'
 import { COMPETITORS } from '../../../../compare/[competitor]/compare-data'
 
+// `@vercel/og` requires the edge runtime — it streams the rendered PNG
+// directly without spinning up a Node.js process per request. The CDN
+// caches each per-competitor PNG for one hour; competitor names are
+// stable so the cache key rarely shifts.
 export const runtime = 'edge'
 export const revalidate = 3600
 
@@ -16,6 +20,10 @@ export async function GET(_req: Request, { params }: RouteParams) {
 		return new Response('Not found', { status: 404 })
 	}
 
+	// Brand colors derived from globals.css `--color-primary` (oklch).
+	// `@vercel/og` requires inline CSS values so the canonical token
+	// literals are duplicated here. This is the ONE permitted exception
+	// to the no-hex/no-inline-color rule (Phase 6 CONTEXT.md § Design Token).
 	const bgGradient =
 		'linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)'
 

--- a/src/app/api/og/pricing/route.tsx
+++ b/src/app/api/og/pricing/route.tsx
@@ -1,9 +1,17 @@
 import { ImageResponse } from '@vercel/og'
 
+// `@vercel/og` requires the edge runtime — it streams the rendered PNG
+// directly without spinning up a Node.js process per request. The CDN
+// caches the PNG for one hour; the static pricing title rarely changes
+// so the cache hit rate is high.
 export const runtime = 'edge'
 export const revalidate = 3600
 
 export function GET() {
+	// Brand colors derived from globals.css `--color-primary` (oklch).
+	// `@vercel/og` requires inline CSS values so the canonical token
+	// literals are duplicated here. This is the ONE permitted exception
+	// to the no-hex/no-inline-color rule (Phase 6 CONTEXT.md § Design Token).
 	const bgGradient =
 		'linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)'
 

--- a/src/app/api/og/pricing/route.tsx
+++ b/src/app/api/og/pricing/route.tsx
@@ -1,0 +1,81 @@
+import { ImageResponse } from '@vercel/og'
+
+export const runtime = 'edge'
+export const revalidate = 3600
+
+export function GET() {
+	const bgGradient =
+		'linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)'
+
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					height: '100%',
+					width: '100%',
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'space-between',
+					padding: '60px',
+					background: bgGradient,
+					color: 'oklch(1 0 0)',
+					fontFamily: 'sans-serif',
+				}}
+			>
+				<div
+					style={{
+						fontSize: 24,
+						textTransform: 'uppercase',
+						letterSpacing: '0.1em',
+						opacity: 0.85,
+					}}
+				>
+					Pricing
+				</div>
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 16,
+					}}
+				>
+					<div
+						style={{
+							fontSize: 64,
+							fontWeight: 900,
+							lineHeight: 1.1,
+							maxWidth: '90%',
+							display: 'flex',
+						}}
+					>
+						Property management plans from $19/mo
+					</div>
+					<div
+						style={{
+							fontSize: 28,
+							fontWeight: 400,
+							lineHeight: 1.3,
+							opacity: 0.85,
+							display: 'flex',
+						}}
+					>
+						14-day free trial. No credit card required.
+					</div>
+				</div>
+				<div
+					style={{
+						fontSize: 28,
+						fontWeight: 700,
+						opacity: 0.9,
+					}}
+				>
+					TenantFlow
+				</div>
+			</div>
+		),
+		{
+			width: 1200,
+			height: 630,
+		},
+	)
+}

--- a/src/app/compare/[competitor]/page.tsx
+++ b/src/app/compare/[competitor]/page.tsx
@@ -12,6 +12,7 @@ import { PageLayout } from '#components/layout/page-layout'
 import { Button } from '#components/ui/button'
 import { RelatedArticles } from '#components/blog/related-articles'
 import { JsonLdScript } from '#components/seo/json-ld-script'
+import { CompareBreadcrumb } from '#components/compare/compare-breadcrumb'
 import { createBreadcrumbJsonLd } from '#lib/seo/breadcrumbs'
 import { getSiteUrl } from '#lib/generate-metadata'
 import { COMPETITORS, VALID_COMPETITORS } from './compare-data'
@@ -38,12 +39,13 @@ export async function generateMetadata({
 	if (!data) return {}
 
 	const baseUrl = getSiteUrl()
+	const ogImageUrl = `${baseUrl}/api/og/compare/${slug}`
 
 	return {
 		// `title.absolute` opts out of the parent template, otherwise
 		// rendered as "...Comparison | TenantFlow | TenantFlow".
 		title: {
-			absolute: `TenantFlow vs ${data.name}: Feature & Pricing Comparison`,
+			absolute: `TenantFlow vs ${data.name} | Feature & Pricing Comparison`,
 		},
 		description: data.metaDescription,
 		alternates: { canonical: `${baseUrl}/compare/${slug}` },
@@ -58,6 +60,7 @@ export async function generateMetadata({
 			// `siteName` explicitly so it doesn't depend on parent merge.
 			type: 'website',
 			siteName: 'TenantFlow',
+			images: [ogImageUrl],
 		},
 		twitter: {
 			card: 'summary_large_image',
@@ -65,6 +68,7 @@ export async function generateMetadata({
 			creator: '@tenantflow',
 			title: `TenantFlow vs ${data.name}`,
 			description: data.metaDescription,
+			images: [ogImageUrl],
 		},
 	}
 }
@@ -96,6 +100,8 @@ export default async function ComparePage({ params }: PageProps) {
 	return (
 		<PageLayout>
 			<JsonLdScript schema={breadcrumbSchema} />
+
+			<CompareBreadcrumb competitorName={data.name} />
 
 			{/* Hero */}
 			<section className="section-spacing">

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -19,10 +19,11 @@ import {
 } from './pricing-content'
 
 export const metadata: Metadata = createPageMetadata({
-	title: 'Property Management Software Pricing — Plans from $19/mo',
+	title: 'Property Management Software Pricing | Plans from $19/mo',
 	description:
 		'Property management software for landlords with 1–15 rentals. Starter ($19/mo, 5 properties), Growth ($49/mo, 20 properties), Max ($149/mo, unlimited properties). 14-day free trial, no credit card required.',
-	path: '/pricing'
+	path: '/pricing',
+	ogImage: '/api/og/pricing'
 })
 
 export default async function PricingPage() {

--- a/src/components/compare/__tests__/compare-breadcrumb.test.tsx
+++ b/src/components/compare/__tests__/compare-breadcrumb.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for CompareBreadcrumb.
+ *
+ * Pins the segment shape so the visible breadcrumb matches the JSON-LD
+ * BreadcrumbList emitted by `createBreadcrumbJsonLd` for the same competitor
+ * slug. Drift between visible and schema-form breadcrumbs is a documented
+ * search-penalty risk (Pitfall 2 — see Phase 6 research).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('next/link', () => ({
+	default: ({
+		children,
+		href,
+		...props
+	}: {
+		children: React.ReactNode
+		href: string
+		className?: string
+	}) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}))
+
+import { CompareBreadcrumb } from '#components/compare/compare-breadcrumb'
+
+describe('CompareBreadcrumb', () => {
+	it('renders 3 segments: Home > Compare > TenantFlow vs <competitor>', () => {
+		render(<CompareBreadcrumb competitorName="Buildium" />)
+
+		expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
+			'href',
+			'/'
+		)
+		expect(screen.getByRole('link', { name: 'Compare' })).toHaveAttribute(
+			'href',
+			'/compare'
+		)
+		expect(screen.getByText('TenantFlow vs Buildium')).toBeInTheDocument()
+	})
+
+	it('uses aria-current="page" on the comparison segment', () => {
+		render(<CompareBreadcrumb competitorName="AppFolio" />)
+		const current = screen.getByText('TenantFlow vs AppFolio')
+		expect(current).toHaveAttribute('aria-current', 'page')
+	})
+
+	it('renders inside a nav landmark with aria-label="breadcrumb"', () => {
+		render(<CompareBreadcrumb competitorName="RentRedi" />)
+		const nav = screen.getByRole('navigation', { name: /breadcrumb/i })
+		expect(nav).toBeInTheDocument()
+	})
+
+	it('embeds the competitor name verbatim (no transform)', () => {
+		render(<CompareBreadcrumb competitorName="App Folio Inc." />)
+		expect(
+			screen.getByText('TenantFlow vs App Folio Inc.')
+		).toBeInTheDocument()
+	})
+})

--- a/src/components/compare/compare-breadcrumb.tsx
+++ b/src/components/compare/compare-breadcrumb.tsx
@@ -20,7 +20,7 @@ export interface CompareBreadcrumbProps {
  */
 export function CompareBreadcrumb({ competitorName }: CompareBreadcrumbProps) {
 	return (
-		<div className="container mx-auto max-w-7xl px-6 lg:px-8 pt-6">
+		<div className="max-w-7xl mx-auto px-6 lg:px-8 pt-6">
 			<Breadcrumb>
 				<BreadcrumbList>
 					<BreadcrumbItem>

--- a/src/components/compare/compare-breadcrumb.tsx
+++ b/src/components/compare/compare-breadcrumb.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from '#components/ui/breadcrumb'
+
+export interface CompareBreadcrumbProps {
+	competitorName: string
+}
+
+/**
+ * Visible breadcrumb for /compare/[competitor] pages.
+ *
+ * Path MUST match the segments emitted by `createBreadcrumbJsonLd` for the
+ * same competitor so visible-vs-schema parity is preserved.
+ */
+export function CompareBreadcrumb({ competitorName }: CompareBreadcrumbProps) {
+	return (
+		<div className="container mx-auto max-w-7xl px-6 lg:px-8 pt-6">
+			<Breadcrumb>
+				<BreadcrumbList>
+					<BreadcrumbItem>
+						<BreadcrumbLink asChild>
+							<Link href="/">Home</Link>
+						</BreadcrumbLink>
+					</BreadcrumbItem>
+					<BreadcrumbSeparator />
+					<BreadcrumbItem>
+						<BreadcrumbLink asChild>
+							<Link href="/compare">Compare</Link>
+						</BreadcrumbLink>
+					</BreadcrumbItem>
+					<BreadcrumbSeparator />
+					<BreadcrumbItem>
+						<BreadcrumbPage>TenantFlow vs {competitorName}</BreadcrumbPage>
+					</BreadcrumbItem>
+				</BreadcrumbList>
+			</Breadcrumb>
+		</div>
+	)
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -42,6 +42,7 @@ const FOOTER_SECTIONS: ReadonlyArray<{
 			{ label: 'Terms of Service', href: '/terms' },
 			{ label: 'Privacy Policy', href: '/privacy' },
 			{ label: 'Security Policy', href: '/security-policy' },
+			{ label: 'Sitemap', href: '/sitemap.xml', external: true },
 		],
 	},
 ]

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -20,7 +20,7 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 	const normalizedPath = path.startsWith('/') ? path : `/${path}`
 	const canonicalUrl = `${siteUrl}${normalizedPath}`
 	const normalizedOgImage = ogImage
-		? ogImage.startsWith('http')
+		? /^https?:\/\//.test(ogImage)
 			? ogImage
 			: `${siteUrl}${ogImage.startsWith('/') ? ogImage : `/${ogImage}`}`
 		: undefined

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -19,7 +19,13 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 	const siteUrl = getSiteUrl()
 	const normalizedPath = path.startsWith('/') ? path : `/${path}`
 	const canonicalUrl = `${siteUrl}${normalizedPath}`
-	const imageUrl = ogImage ?? `${siteUrl}/images/property-management-og.jpg`
+	const normalizedOgImage = ogImage
+		? ogImage.startsWith('http')
+			? ogImage
+			: `${siteUrl}${ogImage.startsWith('/') ? ogImage : `/${ogImage}`}`
+		: undefined
+	const imageUrl =
+		normalizedOgImage ?? `${siteUrl}/images/property-management-og.jpg`
 
 	return {
 		title,


### PR DESCRIPTION
## Summary

Phase 12 — the four SEO/metadata items from `audit-ui-2026-05-08.md` that survived the SEO PR #674 sweep.

### What's in
- **Per-page OG images** for `/pricing` and `/compare/[competitor]` — two new `@vercel/og` edge routes mirror the existing `/api/og/blog/[slug]` pattern (1200×630, branded gradient, 1h CDN cache)
- **Visible compare breadcrumb** — new `<CompareBreadcrumb>` rendered on `/compare/[competitor]`, path matches existing BreadcrumbList JSON-LD so visible↔schema parity holds
- **Title separator standardized to `|`** — `/pricing` was using `—`, `/compare/[competitor]` was using `:`. Root template `'%s | TenantFlow'` now joins cleanly across all marketing pages
- **Footer sitemap link** — Legal section gains `Sitemap → /sitemap.xml`
- **`createPageMetadata` accepts relative `ogImage`** — auto-prefixes with `siteUrl`; absolute URLs pass through unchanged

### Out of scope (already covered by SEO PR #674)
- Organization + SoftwareApplication JSON-LD (root layout via `SeoJsonLd`)
- Blog post breadcrumbs (`BlogPostBreadcrumb` renders on `/blog/[slug]`)
- `aria-current="page"` (already wired in `navbar-desktop-nav.tsx` + `mobile-nav.tsx`)

## Test plan

- [x] `pnpm typecheck && pnpm lint` — clean
- [x] `pnpm dev` smoke — HTTP 200 on `/`, `/pricing`, `/compare/buildium`
- [x] OG routes return `image/png` (HTTP 200) for `/api/og/pricing` + `/api/og/compare/buildium`
- [x] Rendered `<title>` uses `|` consistently across pricing + compare
- [x] `og:image` meta resolves to absolute URLs
- [x] `aria-current="page"` present in new compare breadcrumb
- [ ] Review cycle 1 + 2 (perfect-PR gate)

[hudsor01]