### PR TITLE
chore: pull deferred items into scope (sentry, a11y, helper extraction)

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -68,7 +68,7 @@ export default async function PricingPage() {
 							Simple, transparent pricing for{' '}
 							<span className="hero-highlight">every portfolio</span>
 						</h1>
-						<p className="mx-auto max-w-2xl text-balance text-lg text-muted-foreground text-sm-foreground">
+						<p className="mx-auto max-w-2xl text-balance text-lg text-muted-foreground">
 							Choose your plan and start your 14-day free trial. Upgrade anytime
 							as your portfolio grows.
 						</p>
@@ -76,7 +76,7 @@ export default async function PricingPage() {
 					<div id="plans">
 						<PricingSection />
 					</div>
-					<div className="flex flex-wrap items-center justify-center gap-6 text-sm text-muted-foreground text-sm-foreground">
+					<div className="flex flex-wrap items-center justify-center gap-6 text-sm text-muted-foreground">
 						<div className="flex items-center gap-2">
 							<CheckCircle2 className="h-4 w-4 text-success" />
 							No credit card required

--- a/src/app/pricing/pricing-content.tsx
+++ b/src/app/pricing/pricing-content.tsx
@@ -73,13 +73,13 @@ export function PricingStatsGrid() {
 								<div className="mb-4 typography-h2 text-primary">
 									<stat.icon className="h-8 w-8" />
 								</div>
-								<p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground text-sm-foreground mb-2">
+								<p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
 									{stat.label}
 								</p>
 								<p className="mb-3 typography-h1 tracking-tight text-foreground">
 									{stat.value}
 								</p>
-								<p className="text-sm leading-relaxed text-muted-foreground text-sm-foreground">
+								<p className="text-sm leading-relaxed text-muted-foreground">
 									{stat.description}
 								</p>
 							</div>
@@ -100,7 +100,7 @@ export function PricingFaqSection() {
 						<h2 className="text-section-title tracking-tight text-foreground">
 							Frequently asked questions
 						</h2>
-						<p className="mt-4 text-base text-muted-foreground text-sm-foreground sm:text-lg">
+						<p className="mt-4 text-base text-muted-foreground sm:text-lg">
 							Details on trials, billing, switching plans, and how access works
 							for your team. Tenants are records, not users — they never log in.
 						</p>
@@ -120,7 +120,7 @@ export function PricingFaqSection() {
 									<AccordionTrigger className="text-left text-base font-medium leading-7 text-foreground hover:no-underline sm:text-lg sm:leading-8">
 										{faq.question}
 									</AccordionTrigger>
-									<AccordionContent className="pb-5 text-sm leading-6 text-muted-foreground text-sm-foreground sm:text-base sm:leading-7">
+									<AccordionContent className="pb-5 text-sm leading-6 text-muted-foreground sm:text-base sm:leading-7">
 										{faq.answer}
 									</AccordionContent>
 								</AccordionItem>
@@ -132,7 +132,7 @@ export function PricingFaqSection() {
 							<p className="text-base font-medium text-foreground">
 								Still unsure which plan fits best?
 							</p>
-							<p className="text-sm text-muted-foreground text-sm-foreground sm:text-base">
+							<p className="text-sm text-muted-foreground sm:text-base">
 								Our team can walk through your portfolio and recommend the right
 								setup.
 							</p>
@@ -167,7 +167,7 @@ export function PricingCtaSection() {
 						<h2 className="text-section-title tracking-tight text-foreground">
 							Ready to centralize your portfolio?
 						</h2>
-						<p className="text-base leading-relaxed text-muted-foreground text-sm-foreground sm:text-lg">
+						<p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
 							Start with the records and document vault built for self-managing owners,
 							then add teammates and integrations as your portfolio grows.
 							Your data carries across every plan.

--- a/src/components/blog/blog-post-breadcrumb.tsx
+++ b/src/components/blog/blog-post-breadcrumb.tsx
@@ -29,7 +29,7 @@ export function BlogPostBreadcrumb({ title, category }: BlogPostBreadcrumbProps)
 		: null
 
 	return (
-		<div className="container mx-auto max-w-4xl px-6 lg:px-8 pt-6">
+		<div className="max-w-4xl mx-auto px-6 lg:px-8 pt-6">
 			<Breadcrumb>
 				<BreadcrumbList>
 					<BreadcrumbItem>

--- a/src/components/error-boundary/error-boundary.tsx
+++ b/src/components/error-boundary/error-boundary.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import * as Sentry from '@sentry/nextjs'
 import { Button } from '#components/ui/button'
 import { CardLayout } from '#components/ui/card-layout'
 import { AlertTriangle, RefreshCw } from 'lucide-react'
@@ -7,10 +8,7 @@ import { useErrorBoundary } from '#hooks/use-error-boundary'
 import { useErrorBoundaryStore } from '#stores/error-boundary-store'
 import type { ErrorInfo, ReactNode } from 'react'
 import { Component } from 'react'
-import { createLogger } from '#lib/frontend-logger'
 import { useRouter } from 'next/navigation'
-
-const logger = createLogger({ component: 'ErrorBoundary' })
 
 interface Props {
 	children: ReactNode
@@ -37,14 +35,12 @@ export class ErrorBoundary extends Component<Props, State> {
 	}
 
 	override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-		// Log error locally for immediate debugging
-		logger.error('ErrorBoundary - Error caught by boundary', {
-			action: 'component_error_boundary',
-			metadata: {
-				error: error.message,
-				stack: error.stack,
-				componentStack: errorInfo.componentStack
-			}
+		// Route to Sentry as a proper exception event — preserves the stack
+		// trace and exception class. Previously routed through logger.error
+		// which falls through to captureMessage (no stack, no class).
+		Sentry.captureException(error, {
+			tags: { boundary: 'component-error-boundary' },
+			extra: { componentStack: errorInfo.componentStack }
 		})
 
 		// Persist error in global error boundary store for cross-page visibility

--- a/src/components/layout/navbar/navbar-desktop-nav.tsx
+++ b/src/components/layout/navbar/navbar-desktop-nav.tsx
@@ -3,6 +3,7 @@
 import type { KeyboardEvent } from 'react'
 
 import { cn } from '#lib/utils'
+import { isActiveLink } from '#lib/is-active-link'
 import { ChevronDown } from 'lucide-react'
 import Link from 'next/link'
 import { useRef, useState } from 'react'
@@ -30,11 +31,6 @@ export function NavbarDesktopNav({ navItems, pathname }: NavbarDesktopNavProps) 
 			setOpenDropdown(null)
 			closeTimeoutRef.current = null
 		}, 150)
-	}
-
-	const isActiveLink = (href: string) => {
-		if (href === '/') return pathname === '/'
-		return pathname === href || pathname.startsWith(`${href}/`)
 	}
 
 	const handleKeyDown = (
@@ -97,10 +93,10 @@ export function NavbarDesktopNav({ navItems, pathname }: NavbarDesktopNavProps) 
 					<Link
 						href={item.href}
 						onKeyDown={e => handleKeyDown(e, item)}
-						aria-current={isActiveLink(item.href) ? 'page' : undefined}
+						aria-current={isActiveLink(item.href, pathname) ? 'page' : undefined}
 						className={cn(
 							'flex items-center px-4 py-2 text-foreground/70 hover:text-foreground font-medium text-base rounded-lg transition-colors duration-fast',
-							isActiveLink(item.href) && 'text-foreground'
+							isActiveLink(item.href, pathname) && 'text-foreground'
 						)}
 					>
 						{item.name}
@@ -127,7 +123,7 @@ export function NavbarDesktopNav({ navItems, pathname }: NavbarDesktopNavProps) 
 									href={dropdownItem.href}
 									data-dropdown-item={`${item.name}-${index}`}
 									onKeyDown={e => handleKeyDown(e, item, index)}
-									aria-current={isActiveLink(dropdownItem.href) ? 'page' : undefined}
+									aria-current={isActiveLink(dropdownItem.href, pathname) ? 'page' : undefined}
 									className="block px-4 py-2.5 text-foreground/70 hover:text-foreground hover:bg-muted/50 transition-colors duration-fast text-base"
 								>
 									{dropdownItem.name}

--- a/src/components/layout/navbar/navbar-mobile-menu.tsx
+++ b/src/components/layout/navbar/navbar-mobile-menu.tsx
@@ -7,6 +7,7 @@ import {
 	SheetTitle
 } from '#components/ui/sheet'
 import { cn } from '#lib/utils'
+import { isActiveLink } from '#lib/is-active-link'
 import { ArrowRight, ChevronDown } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
@@ -33,11 +34,6 @@ export function NavbarMobileMenu({
 }: NavbarMobileMenuProps) {
 	const [openDropdown, setOpenDropdown] = useState<string | null>(null)
 
-	const isActiveLink = (href: string) => {
-		if (href === '/') return pathname === '/'
-		return pathname === href || pathname.startsWith(`${href}/`)
-	}
-
 	const handleDropdownToggle = (itemName: string) => {
 		setOpenDropdown(openDropdown === itemName ? null : itemName)
 	}
@@ -55,10 +51,10 @@ export function NavbarMobileMenu({
 								<Link
 									href={item.href}
 									onClick={() => !item.hasDropdown && onClose()}
-									aria-current={isActiveLink(item.href) ? 'page' : undefined}
+									aria-current={isActiveLink(item.href, pathname) ? 'page' : undefined}
 									className={cn(
 										'flex items-center justify-between px-4 py-3 text-foreground/70 hover:text-foreground hover:bg-muted/50 rounded-lg transition-colors duration-fast',
-										isActiveLink(item.href) && 'text-foreground bg-muted/50'
+										isActiveLink(item.href, pathname) && 'text-foreground bg-muted/50'
 									)}
 								>
 									{item.name}
@@ -84,7 +80,7 @@ export function NavbarMobileMenu({
 												key={dropdownItem.name}
 												href={dropdownItem.href}
 												onClick={() => onClose()}
-												aria-current={isActiveLink(dropdownItem.href) ? 'page' : undefined}
+												aria-current={isActiveLink(dropdownItem.href, pathname) ? 'page' : undefined}
 												className="block px-4 py-2.5 text-foreground/60 hover:text-foreground hover:bg-muted/30 rounded-lg transition-colors duration-fast text-sm"
 											>
 												{dropdownItem.name}

--- a/src/components/shell/main-nav.tsx
+++ b/src/components/shell/main-nav.tsx
@@ -216,6 +216,7 @@ export function MainNav({ onNavigate }: MainNavProps) {
 										key={child.href}
 										href={child.href}
 										onClick={handleNavigate}
+										aria-current={childActive ? 'page' : undefined}
 										className={`
 											w-full flex items-center gap-3 px-3 py-2 rounded-lg
 											text-sm transition-colors
@@ -241,6 +242,7 @@ export function MainNav({ onNavigate }: MainNavProps) {
 				key={item.href}
 				href={item.href}
 				onClick={handleNavigate}
+				aria-current={active ? 'page' : undefined}
 				className={`
 					w-full flex items-center gap-3 px-3 py-2.5 rounded-lg
 					text-sm font-medium transition-colors

--- a/src/hooks/api/query-keys/property-keys.ts
+++ b/src/hooks/api/query-keys/property-keys.ts
@@ -169,7 +169,7 @@ export const propertyQueries = {
 				if (error) throw new Error(error.message)
 
 				return (data as Tables<'property_images'>[]).map(image => {
-					const isFullUrl = image.image_url.startsWith('http')
+					const isFullUrl = /^https?:\/\//.test(image.image_url)
 					if (isFullUrl) {
 						return image
 					}

--- a/src/lib/__tests__/is-active-link.test.ts
+++ b/src/lib/__tests__/is-active-link.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Pins the active-link semantics so a refactor can't accidentally re-introduce
+ * the trailing-slash false-positive (`/blogger` matching `/blog`) or the
+ * root-href edge case (every route matching `/`).
+ */
+import { describe, it, expect } from 'vitest'
+
+import { isActiveLink } from '#lib/is-active-link'
+
+describe('isActiveLink', () => {
+	it('matches exact pathname', () => {
+		expect(isActiveLink('/pricing', '/pricing')).toBe(true)
+	})
+
+	it('matches subpaths via trailing-slash anchor', () => {
+		expect(isActiveLink('/blog', '/blog/some-post')).toBe(true)
+		expect(isActiveLink('/blog', '/blog/category/lease-law')).toBe(true)
+	})
+
+	it('does NOT match unrelated paths that share a prefix without separator', () => {
+		// Without the trailing-slash anchor `/blogger` would match `/blog`.
+		expect(isActiveLink('/blog', '/blogger')).toBe(false)
+		expect(isActiveLink('/pricing', '/pricing-archive')).toBe(false)
+	})
+
+	it('short-circuits root href against exact root pathname only', () => {
+		expect(isActiveLink('/', '/')).toBe(true)
+		// Without the short-circuit, every route would match `/`.
+		expect(isActiveLink('/', '/pricing')).toBe(false)
+		expect(isActiveLink('/', '/blog/anything')).toBe(false)
+	})
+
+	it('does not match when pathname is unrelated', () => {
+		expect(isActiveLink('/pricing', '/about')).toBe(false)
+	})
+})

--- a/src/lib/is-active-link.ts
+++ b/src/lib/is-active-link.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared active-link predicate for navigation surfaces.
+ *
+ * Used by:
+ * - `src/components/layout/navbar/navbar-desktop-nav.tsx` (marketing desktop nav)
+ * - `src/components/layout/navbar/navbar-mobile-menu.tsx` (marketing mobile sheet)
+ *
+ * Drives both visual active-state classes AND the `aria-current="page"`
+ * attribute. The trailing `/` in the `startsWith` check is critical — without
+ * it, `/blogger` would false-positive against `/blog`. The `href === '/'`
+ * short-circuit is also critical — without it, every route would match root.
+ */
+export function isActiveLink(href: string, pathname: string): boolean {
+	if (href === '/') return pathname === '/'
+	return pathname === href || pathname.startsWith(`${href}/`)
+}


### PR DESCRIPTION
## Summary

Six items deferred across the v1.0 milestone + Sentry coverage reviews. Pulling them in now per your request.

### Changes

1. **`error-boundary.tsx`** — class component `componentDidCatch` now routes to `Sentry.captureException` (was `logger.error → captureMessage`). Brings class boundary up to the same exception-event quality as the functional boundaries from PR #701.

2. **`text-sm-foreground`** — undefined utility class removed from 8 spots across `pricing-content.tsx` and `pricing/page.tsx`. Was co-applied with `text-muted-foreground` so visually a no-op, but the dead token confused readers.

3. **`property-keys.ts:172`** — `.startsWith('http')` swapped for `/^https?:\/\//.test()`. Same antipattern Phase 12 IN-03 fixed in `createPageMetadata`.

4. **`blog-post-breadcrumb.tsx:32`** — dropped redundant `container` class (same fix Phase 12 IN-02 applied to the compare breadcrumb).

5. **`main-nav.tsx`** (dashboard sidebar) — added `aria-current="page"` to active links + dropdown children. Was only changing className, no a11y attribute.

6. **`isActiveLink` extracted to shared helper** — `src/lib/is-active-link.ts`. Was byte-duplicated in `navbar-desktop-nav.tsx` + `navbar-mobile-menu.tsx`. Both files now import the shared version. New unit test pins the trailing-slash anchor (`/blog` doesn't match `/blogger`) and the root-href short-circuit (`/` only matches exact `/`).

## Test plan

- [x] `pnpm typecheck && pnpm lint` — clean
- [x] `pnpm test:unit` — 99,531 / 99,531 passing (+5 from new helper test)
- [ ] Review cycle 1 + 2 (perfect-PR gate)

[hudsor01]