### PR TITLE
chore: gitignore BATTLE-TEST-BROWSER-AGENT.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ build/
 !.github/actions/*/dist
 .swc/
 
+# Local-only browser-agent battle test prompt — contains a synthetic-account
+# password and must NEVER be committed. Rotated via the documented Supabase +
+# GitHub-Secrets path in memory/github-secrets.md.
+BATTLE-TEST-BROWSER-AGENT.txt
+
 # TypeScript build artifacts
 *.tsbuildinfo
 **/dist/**/*.d.ts


### PR DESCRIPTION
Prompt file for the claude-in-chrome battle test embeds the rotated synthetic-account password. Adding it to .gitignore so it can never be committed. Rotation path documented in memory/github-secrets.md.

[hudsor01]