### PR TITLE
fix(battle-test): session-5 P3 followups (navbar/billing/sitemap)

### DIFF
--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("#env", () => ({
 	env: { NEXT_PUBLIC_APP_URL: "https://tenantflow.app" },
@@ -367,6 +367,13 @@ describe("sitemap() — DB-failure fallback", () => {
 				}),
 			}),
 		}));
+	});
+
+	afterEach(() => {
+		// Defense-in-depth: this describe is currently the last in the
+		// file, but unmocking here keeps the "isolated" claim literally
+		// true if a future describe is appended below.
+		vi.doUnmock("#lib/supabase/server");
 	});
 
 	it("hub URLs fall back to STATIC_PAGES_LAST_UPDATED when the blog query throws", async () => {

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -144,16 +144,16 @@ describe("sitemap()", () => {
 		}
 	});
 
-	it("Test 4: static landing pages omit lastModified (no faked freshness)", async () => {
-		// Per Google's sitemap docs (last updated 2025-12-10): a stale or
-		// "always-now" lastmod teaches Google to ignore the field. The
-		// honest signal is "no lastmod" when we can't point to a real
-		// underlying timestamp. Marketing/company pages have no DB-backed
-		// timestamp so they emit no `lastModified`.
+	it("Test 4: static landing pages share STATIC_PAGES_LAST_UPDATED lastmod", async () => {
+		// Battle-test Session 5 (P3) flagged 16/19 sitemap URLs missing
+		// lastmod — sparse coverage looked unintentional. The marketing/
+		// company/compare/resource pages now share a manually-maintained
+		// `STATIC_PAGES_LAST_UPDATED` constant. Bumped together with each
+		// copy-refresh wave to stay verifiable.
 		const { default: sitemap } = await import("./sitemap");
 		const entries = await sitemap();
 
-		const noLastModUrls = [
+		const sharedLastmodUrls = [
 			"https://tenantflow.app",
 			"https://tenantflow.app/features",
 			"https://tenantflow.app/pricing",
@@ -162,11 +162,27 @@ describe("sitemap()", () => {
 			"https://tenantflow.app/faq",
 			"https://tenantflow.app/help",
 			"https://tenantflow.app/support",
+			"https://tenantflow.app/compare/buildium",
+			"https://tenantflow.app/compare/appfolio",
+			"https://tenantflow.app/compare/rentredi",
+			"https://tenantflow.app/resources/seasonal-maintenance-checklist",
+			"https://tenantflow.app/resources/landlord-tax-deduction-tracker",
+			"https://tenantflow.app/resources/security-deposit-reference-card",
 		];
-		for (const url of noLastModUrls) {
+
+		const firstLastmod = entries.find(
+			(e) => e.url === "https://tenantflow.app",
+		)?.lastModified;
+		expect(firstLastmod, "homepage lastmod must be set").toBeDefined();
+		expect(String(firstLastmod)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+		for (const url of sharedLastmodUrls) {
 			const entry = entries.find((e) => e.url === url);
 			expect(entry, `entry for ${url} should exist`).toBeDefined();
-			expect(entry!.lastModified).toBeUndefined();
+			expect(
+				entry!.lastModified,
+				`${url} should share the static lastmod`,
+			).toBe(firstLastmod);
 		}
 	});
 

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -350,3 +350,39 @@ describe("sitemap legal-page lastmod drift guard", () => {
 		expect(securityPolicy?.lastModified).toBe(visible);
 	});
 });
+
+/**
+ * Hub-URL fallback test — isolated describe so the override mock can't
+ * leak into the main suite. When the blog DB query fails, /blog and
+ * /resources must still ship a lastmod (fall back to STATIC_PAGES_LAST_UPDATED)
+ * so every URL keeps the freshness signal added in PR #719.
+ */
+describe("sitemap() — DB-failure fallback", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("#lib/supabase/server", () => ({
+			createClient: vi.fn().mockResolvedValue({
+				from: vi.fn().mockImplementation(() => {
+					throw new Error("Simulated DB outage");
+				}),
+			}),
+		}));
+	});
+
+	it("hub URLs fall back to STATIC_PAGES_LAST_UPDATED when the blog query throws", async () => {
+		const { default: sitemap } = await import("./sitemap");
+		const entries = await sitemap();
+
+		const home = entries.find((e) => e.url === "https://tenantflow.app");
+		const blogHub = entries.find(
+			(e) => e.url === "https://tenantflow.app/blog",
+		);
+		const resourcesHub = entries.find(
+			(e) => e.url === "https://tenantflow.app/resources",
+		);
+
+		expect(home?.lastModified).toBeDefined();
+		expect(blogHub?.lastModified).toBe(home?.lastModified);
+		expect(resourcesHub?.lastModified).toBe(home?.lastModified);
+	});
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,20 @@ const TERMS_LAST_UPDATED = "2026-05-11";
 const PRIVACY_LAST_UPDATED = "2026-05-11";
 const SECURITY_POLICY_LAST_UPDATED = "2026-05-11";
 
+// "Last meaningful copy refresh" for the static marketing/company/compare/
+// resource pages. These pages don't have visible "Last Updated" lines
+// like the legal pages, but they DO change in coordinated copy waves
+// (pricing refreshes, feature reframings, brand updates). Bump this
+// constant — together with whatever copy change triggered it — whenever
+// the marketing surface changes materially. Leaving it stale is worse
+// than fake-fresh: Google compares the lastmod to the rendered page
+// content and degrades trust in the entire sitemap on disagreement.
+//
+// Battle-test Session 5 (P3) flagged that sparse lastmod coverage looked
+// unintentional; this constant + per-page entries below close that gap
+// without resorting to file-mtime ("today" on every commit) noise.
+const STATIC_PAGES_LAST_UPDATED = "2026-05-15";
+
 // `changeFrequency` is no longer consulted by Google as of 2023, and the
 // `lastmod` field is the only freshness signal that still affects crawl
 // scheduling. We omit `changeFrequency` from every entry below — emitting
@@ -41,26 +55,33 @@ const SECURITY_POLICY_LAST_UPDATED = "2026-05-11";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = env.NEXT_PUBLIC_APP_URL || "https://tenantflow.app";
 
-	// High-priority marketing pages. No `lastModified` — content is
-	// hand-edited and the file's mtime would not reflect copy edits made
-	// in the same commit as a code-only change. The hub pages below DO
-	// derive lastmod from the most recent post; static landing pages
-	// don't have an equivalent signal.
+	// High-priority marketing pages. `lastModified` comes from
+	// `STATIC_PAGES_LAST_UPDATED` (single source of truth for the static
+	// marketing surface — bumped manually with each copy refresh wave).
 	const marketingPages: MetadataRoute.Sitemap = [
-		{ url: baseUrl, priority: 1.0 },
-		{ url: `${baseUrl}/features`, priority: 0.9 },
-		{ url: `${baseUrl}/pricing`, priority: 0.9 },
+		{ url: baseUrl, lastModified: STATIC_PAGES_LAST_UPDATED, priority: 1.0 },
+		{
+			url: `${baseUrl}/features`,
+			lastModified: STATIC_PAGES_LAST_UPDATED,
+			priority: 0.9,
+		},
+		{
+			url: `${baseUrl}/pricing`,
+			lastModified: STATIC_PAGES_LAST_UPDATED,
+			priority: 0.9,
+		},
 	];
 
-	// Comparison and resource detail pages — same reasoning. The
-	// per-competitor copy lives in `compare-data.ts`; if anyone touches
-	// it they should also bump a constant here. For now, omit lastmod.
+	// Comparison pages share the same refresh cadence as marketing copy.
+	// Per-competitor data lives in `src/data/compare-data.ts`; bump
+	// `STATIC_PAGES_LAST_UPDATED` when that file gets a material edit.
 	const comparePages: MetadataRoute.Sitemap = [
 		"buildium",
 		"appfolio",
 		"rentredi",
 	].map((competitor) => ({
 		url: `${baseUrl}/compare/${competitor}`,
+		lastModified: STATIC_PAGES_LAST_UPDATED,
 		priority: 0.8,
 	}));
 
@@ -70,15 +91,36 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		"security-deposit-reference-card",
 	].map((resource) => ({
 		url: `${baseUrl}/resources/${resource}`,
+		lastModified: STATIC_PAGES_LAST_UPDATED,
 		priority: 0.7,
 	}));
 
 	const companyPages: MetadataRoute.Sitemap = [
-		{ url: `${baseUrl}/about`, priority: 0.7 },
-		{ url: `${baseUrl}/contact`, priority: 0.7 },
-		{ url: `${baseUrl}/faq`, priority: 0.6 },
-		{ url: `${baseUrl}/help`, priority: 0.6 },
-		{ url: `${baseUrl}/support`, priority: 0.6 },
+		{
+			url: `${baseUrl}/about`,
+			lastModified: STATIC_PAGES_LAST_UPDATED,
+			priority: 0.7,
+		},
+		{
+			url: `${baseUrl}/contact`,
+			lastModified: STATIC_PAGES_LAST_UPDATED,
+			priority: 0.7,
+		},
+		{
+			url: `${baseUrl}/faq`,
+			lastModified: STATIC_PAGES_LAST_UPDATED,
+			priority: 0.6,
+		},
+		{
+			url: `${baseUrl}/help`,
+			lastModified: STATIC_PAGES_LAST_UPDATED,
+			priority: 0.6,
+		},
+		{
+			url: `${baseUrl}/support`,
+			lastModified: STATIC_PAGES_LAST_UPDATED,
+			priority: 0.6,
+		},
 	];
 
 	// Legal pages — real lastmod from constants above. The visible
@@ -194,15 +236,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		// blog freshness signal until the next ISR rebuild succeeds.
 	}
 
+	// Hub freshness derives from the most recent post (honest signal of
+	// what changed on the URL). If the DB lookup failed or the table is
+	// empty, fall back to the static-pages constant so the URL still
+	// ships with a lastmod — sparse coverage was the P3 finding from
+	// battle-test Session 5.
 	const contentHubs: MetadataRoute.Sitemap = [
 		{
 			url: `${baseUrl}/blog`,
-			lastModified: blogHubLastModified,
+			lastModified: blogHubLastModified ?? STATIC_PAGES_LAST_UPDATED,
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/resources`,
-			lastModified: resourcesHubLastModified,
+			lastModified: resourcesHubLastModified ?? STATIC_PAGES_LAST_UPDATED,
 			priority: 0.7,
 		},
 	];

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -229,11 +229,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			},
 		});
 		// Continue with static pages only. `blogHubLastModified` and
-		// `resourcesHubLastModified` stay undefined → the hub URLs ship
-		// without `lastModified`, which is the documented intent: emit
-		// no signal rather than a stale or fake one. The trade-off in
-		// the failure path is that a transient DB outage drops every
-		// blog freshness signal until the next ISR rebuild succeeds.
+		// `resourcesHubLastModified` stay undefined → the hub URLs fall
+		// back to `STATIC_PAGES_LAST_UPDATED` in the contentHubs block
+		// below so every URL ships with a lastmod (battle-test Session 5
+		// P3-3 — no sparse coverage). Trade-off: under DB failure the hub
+		// lastmod no longer reflects actual post freshness, but it's
+		// honest about "the marketing surface was last refreshed on this
+		// date" and crawlers don't see a missing-lastmod outlier.
 	}
 
 	// Hub freshness derives from the most recent post (honest signal of

--- a/src/components/settings/__tests__/billing-settings.test.tsx
+++ b/src/components/settings/__tests__/billing-settings.test.tsx
@@ -139,6 +139,34 @@ describe("BillingSettings empty-state branches", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders the trialing-with-unknown-priceId branch (no copy gap)", async () => {
+		// Cycle-1 P2 regression guard: prior to this fix, a trialing user with
+		// an unknown stripePriceId fell through to no helper copy (the trialing
+		// branch required `!stripePriceId`, the unified branch required
+		// `status === "active"`). Both now widen to cover this state.
+		useSubscriptionStatusMock.mockReturnValue({
+			data: {
+				subscriptionStatus: "trialing",
+				stripePriceId: "price_1LegacyTrialingFoo",
+				currentPeriodEnd: "2026-06-01T00:00:00.000Z",
+				stripeCustomerId: "cus_legacy_trial",
+				cancelAtPeriodEnd: false,
+				trialEndsAt: "2026-06-01T00:00:00.000Z",
+			},
+			isLoading: false,
+		});
+		useUserMock.mockReturnValue({
+			data: { stripe_customer_id: "cus_legacy_trial" },
+		});
+
+		const BillingSettings = await getBillingSettings();
+		renderWithProviders(<BillingSettings />);
+
+		expect(screen.getByText("Free trial")).toBeInTheDocument();
+		expect(screen.getByText("Trial")).toBeInTheDocument();
+		expect(screen.getByText(/Your trial is active/)).toBeInTheDocument();
+	});
+
 	it("renders the unknown-priceId branch and logs the unrecoverable state to Sentry", async () => {
 		useSubscriptionStatusMock.mockReturnValue({
 			data: {

--- a/src/components/settings/__tests__/billing-settings.test.tsx
+++ b/src/components/settings/__tests__/billing-settings.test.tsx
@@ -161,7 +161,7 @@ describe("BillingSettings empty-state branches", () => {
 		expect(screen.getByText("Active subscription")).toBeInTheDocument();
 		expect(screen.getByText("Active")).toBeInTheDocument();
 		expect(
-			screen.getByText(/Subscription details unavailable/),
+			screen.getByText(/Plan details will sync shortly/),
 		).toBeInTheDocument();
 		expect(
 			screen.getByRole("link", { name: /Contact support/ }),

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -271,7 +271,12 @@ export function BillingSettings() {
 									if this persists.
 								</p>
 							)}
-							{status === "trialing" && !currentPlan && !stripePriceId && (
+							{/* Trialing without a known plan — fires for both
+							    no-priceId AND unknown-priceId variants (the latter is
+							    Sentry-warned by hasUnknownPriceId above). Either way,
+							    the user is on a trial without a committed plan choice,
+							    so the "Choose a plan" prompt applies. */}
+							{status === "trialing" && !currentPlan && (
 								<p className="text-sm text-muted-foreground mt-1">
 									Your trial is active.{" "}
 									<Link

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -251,27 +251,26 @@ export function BillingSettings() {
 									)}
 								</>
 							)}
-							{hasUnknownPriceId && (
+							{/* Active without a known plan — covers two paths:
+							    (1) stripePriceId present but unknown to the local
+							        pricing config (legacy/comp plan ID), and
+							    (2) no stripePriceId at all (synthetic/internal
+							        accounts waiting on billing webhook sync).
+							    Single helpful message for both. Sentry-warns the
+							    unknown-priceId variant for ops follow-up. */}
+							{isActive && !currentPlan && status === "active" && (
 								<p className="text-sm text-muted-foreground mt-1">
-									Subscription details unavailable.{" "}
+									Your account has active access. Plan details will sync
+									shortly.{" "}
 									<Link
 										href="/contact"
 										className="text-primary hover:underline underline-offset-4"
 									>
 										Contact support
 									</Link>{" "}
-									to confirm your plan.
+									if this persists.
 								</p>
 							)}
-							{isActive &&
-								!stripePriceId &&
-								!currentPlan &&
-								status === "active" && (
-									<p className="text-sm text-muted-foreground mt-1">
-										Your account has active access. Plan details will appear
-										here once billing syncs.
-									</p>
-								)}
 							{status === "trialing" && !currentPlan && !stripePriceId && (
 								<p className="text-sm text-muted-foreground mt-1">
 									Your trial is active.{" "}

--- a/src/providers/query-persistence.ts
+++ b/src/providers/query-persistence.ts
@@ -10,7 +10,15 @@ type PersistOptions = {
 	buster: string;
 };
 
-const AUTH_QUERY_KEY = "auth";
+// Auth-namespace prefixes that must NEVER be persisted across reloads.
+// Both `authKeys.all` ("auth") and `authKeys.supabase.all` ("supabase-auth")
+// hold session/user data — persisting either lets a stale session survive
+// a cookie clear, causing the marketing navbar to render the signed-in
+// branch for a freshly-cleared visitor (battle-test Session 5, P3-1).
+const NON_PERSISTED_QUERY_NAMESPACES: ReadonlySet<string> = new Set([
+	"auth",
+	"supabase-auth",
+]);
 
 const isSerializable = (data: unknown) => {
 	try {
@@ -36,7 +44,7 @@ const shouldDehydrateQuery = (query: Query) => {
 	}
 
 	const queryKey = query.queryKey[0] as string | undefined;
-	if (queryKey === AUTH_QUERY_KEY) {
+	if (queryKey && NON_PERSISTED_QUERY_NAMESPACES.has(queryKey)) {
 		return false;
 	}
 

--- a/src/providers/query-persistence.ts
+++ b/src/providers/query-persistence.ts
@@ -20,6 +20,15 @@ const NON_PERSISTED_QUERY_NAMESPACES: ReadonlySet<string> = new Set([
 	"supabase-auth",
 ]);
 
+// Narrow auth-adjacent keys under the broader `["user", ...]` namespace
+// that ALSO hold per-identity data (email, stripe_customer_id, active
+// sessions). Excluding only these — not all of `["user", ...]` — keeps
+// other user-scoped caches (e.g. tenant lists, dashboards) persistable.
+const NON_PERSISTED_USER_SUBKEYS: ReadonlySet<string> = new Set([
+	"me", // authKeys.me() — UserWithStripe { id, email, stripe_customer_id }
+	"sessions", // sessionKeys.all — user's auth.sessions list
+]);
+
 const isSerializable = (data: unknown) => {
 	try {
 		JSON.stringify(data);
@@ -46,6 +55,12 @@ const shouldDehydrateQuery = (query: Query) => {
 	const queryKey = query.queryKey[0] as string | undefined;
 	if (queryKey && NON_PERSISTED_QUERY_NAMESPACES.has(queryKey)) {
 		return false;
+	}
+	if (queryKey === "user") {
+		const subKey = query.queryKey[1] as string | undefined;
+		if (subKey && NON_PERSISTED_USER_SUBKEYS.has(subKey)) {
+			return false;
+		}
 	}
 
 	if (queryState.data && !isSerializable(queryState.data)) {


### PR DESCRIPTION
## Summary
Closes the three P3 polish findings from browser-agent Session 5.

- **P3-1 Navbar signed-out hydration regression** — the new `useSupabaseSession()` hook (PR #718) used the `supabase-auth` query-key namespace, but `query-persistence.ts` only excluded the `auth` namespace from IndexedDB. The session payload was persisted across cookie clears, so the navbar's client-side hydration picked the signed-in branch for a freshly-cleared visitor. Extended the exclusion set to cover both auth namespaces.

- **P3-2 Billing helper copy unified** — the \`hasUnknownPriceId\` branch shipped an alarming legacy "Contact support" message for what's typically a non-emergency state. Merged the two overlapping branches (unknown priceId + no priceId) into one helpful message: "Your account has active access. Plan details will sync shortly. Contact support if this persists." Title/badge coherence preserved.

- **P3-3 sitemap.xml lastmod coverage** — only 3 of 19 URLs carried \`<lastmod>\`. Added a \`STATIC_PAGES_LAST_UPDATED\` constant (single source of truth for the static marketing surface), applied uniformly to 14 marketing/company/compare/resource URLs. Content-hub URLs fall back to it when the DB lookup returns no posts. Bumped together with each material copy refresh — same discipline as the per-page legal constants.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` (biome) clean
- [x] \`bun run test:unit\` — 99,546 unit tests pass (137 files); affected: \`sitemap.test.ts\` rewritten for shared-lastmod assertion, \`billing-settings.test.tsx\` updated for new copy
- [x] \`bun run build\` succeeds
- [ ] Browser-agent Session 6: verify signed-out navbar renders Sign In + Get Started after cookie clear

[hudsor01]