### PR TITLE
fix(battle-test): session-6 P1+P2 + P3 investigation

### DIFF
--- a/src/components/layout/__tests__/navbar.test.tsx
+++ b/src/components/layout/__tests__/navbar.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Battle-test Session 6 P1 regression guard: the marketing navbar must
+ * render the signed-out CTA pair ("Sign In" + "Get Started") synchronously
+ * when no auth cookie is present, regardless of the supabase-session
+ * query's pending state. Pre-fix, a stuck `isPending: true` on cold-start
+ * (PersistQueryClientProvider restoration race) left the CTA slot empty.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { useSupabaseSessionMock, usePathnameMock, useNavigationMock } =
+	vi.hoisted(() => ({
+		useSupabaseSessionMock: vi.fn(),
+		usePathnameMock: vi.fn(),
+		useNavigationMock: vi.fn(),
+	}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: () => usePathnameMock(),
+}));
+
+vi.mock("#hooks/api/use-auth", () => ({
+	useSupabaseSession: () => useSupabaseSessionMock(),
+}));
+
+vi.mock("#hooks/use-navigation", () => ({
+	useNavigation: () => useNavigationMock(),
+}));
+
+vi.mock("#lib/supabase/cookie-name", () => ({
+	SUPABASE_AUTH_COOKIE_NAME: "sb-test-project-auth-token",
+}));
+
+function renderNavbar() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return import("../navbar").then(({ Navbar }) =>
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Navbar />
+			</QueryClientProvider>,
+		),
+	);
+}
+
+function clearAuthCookie() {
+	document.cookie =
+		"sb-test-project-auth-token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+}
+
+function setAuthCookie() {
+	document.cookie = "sb-test-project-auth-token=stub-token; path=/";
+}
+
+describe("Navbar — auth CTA branch", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		usePathnameMock.mockReturnValue("/pricing");
+		useNavigationMock.mockReturnValue({
+			isMobileMenuOpen: false,
+			toggleMobileMenu: vi.fn(),
+			closeMobileMenu: vi.fn(),
+		});
+	});
+
+	afterEach(() => {
+		clearAuthCookie();
+	});
+
+	it("renders Sign In + Get Started synchronously when no auth cookie (cold-start fast-path)", async () => {
+		clearAuthCookie();
+		// Simulate the PersistQueryClient restoration race that pre-fix
+		// left isPending stuck: the query never settles.
+		useSupabaseSessionMock.mockReturnValue({
+			data: undefined,
+			isPending: true,
+		});
+
+		await renderNavbar();
+
+		expect(screen.getByRole("link", { name: /Sign In/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /Get Started/i }),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /Dashboard/i })).toBeNull();
+	});
+
+	it("renders no CTA while the query is pending AND a cookie is present (defers to query for the signed-in branch)", async () => {
+		setAuthCookie();
+		useSupabaseSessionMock.mockReturnValue({
+			data: undefined,
+			isPending: true,
+		});
+
+		await renderNavbar();
+
+		// Mount runs useEffect → hasAuthCookie=true → authResolved gates on
+		// !authPending → renders nothing while the query is still pending.
+		expect(screen.queryByRole("link", { name: /Sign In/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /Get Started/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /Dashboard/i })).toBeNull();
+	});
+
+	it("renders Dashboard when cookie present and query resolves with a session", async () => {
+		setAuthCookie();
+		useSupabaseSessionMock.mockReturnValue({
+			data: { access_token: "stub", user: { id: "stub-user" } },
+			isPending: false,
+		});
+
+		await renderNavbar();
+
+		expect(
+			screen.getByRole("link", { name: /Dashboard/i }),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /^Sign In$/i })).toBeNull();
+	});
+});

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -14,6 +14,12 @@ import { NavbarDesktopNav } from "./navbar/navbar-desktop-nav";
 import { NavbarMobileMenu } from "./navbar/navbar-mobile-menu";
 import { DEFAULT_NAV_ITEMS, type NavbarProps } from "./navbar/types";
 
+// Supabase prod project ref. Sync cookie probe in this component MUST stay
+// in lockstep with the cookie name used by @supabase/ssr (the project ref
+// is part of the cookie name). Mirrors the same string in `proxy.ts` and
+// `lib/stripe/stripe-client.ts`.
+const SUPABASE_AUTH_COOKIE = "sb-bshjmbshupiibfiewpxb-auth-token";
+
 export function Navbar({
 	className,
 	logo = "TenantFlow",
@@ -24,16 +30,33 @@ export function Navbar({
 	...props
 }: NavbarProps & { ref?: Ref<HTMLElement> }) {
 	const [isScrolled, setIsScrolled] = useState(false);
+	// Synchronous cookie probe for the signed-OUT fast-path. Starts `false`
+	// so SSR and first-client-paint render identically (no hydration
+	// mismatch). useEffect below promotes it to `true` if the cookie is
+	// actually present — at which point we defer to the query. Without
+	// this fast-path the navbar would hang at authPending=true indefinitely
+	// for signed-out cold-start visitors on /pricing (PersistQueryClient
+	// can pause queries during IDB restoration even when the persisted
+	// namespace is excluded — battle-test Session 6 P1).
+	const [hasAuthCookie, setHasAuthCookie] = useState(false);
 
 	const { isMobileMenuOpen, toggleMobileMenu, closeMobileMenu } =
 		useNavigation();
 	const pathname = usePathname();
 	// Session-only check — reads local cookie cache via getSession(), no
-	// network round-trip. `authResolved` guards the CTA slot to prevent a
-	// flash of unauthenticated state during initial hydration.
+	// network round-trip.
 	const { data: authSession, isPending: authPending } = useSupabaseSession();
-	const authResolved = !authPending;
 	const isAuthenticated = !!authSession;
+	// `authResolved` semantics:
+	//   - If we know there's no auth cookie at all, render immediately
+	//     (no point waiting on a query that will resolve to null anyway).
+	//   - Otherwise the cookie may be present-and-valid OR
+	//     present-and-stale; wait for the query before choosing a branch.
+	const authResolved = !hasAuthCookie || !authPending;
+
+	useEffect(() => {
+		setHasAuthCookie(document.cookie.includes(`${SUPABASE_AUTH_COOKIE}=`));
+	}, []);
 
 	useEffect(() => {
 		const handleScroll = () => {

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -9,16 +9,11 @@ import { useEffect, useState } from "react";
 import { Button } from "#components/ui/button";
 import { useSupabaseSession } from "#hooks/api/use-auth";
 import { useNavigation } from "#hooks/use-navigation";
+import { SUPABASE_AUTH_COOKIE_NAME } from "#lib/supabase/cookie-name";
 import { cn } from "#lib/utils";
 import { NavbarDesktopNav } from "./navbar/navbar-desktop-nav";
 import { NavbarMobileMenu } from "./navbar/navbar-mobile-menu";
 import { DEFAULT_NAV_ITEMS, type NavbarProps } from "./navbar/types";
-
-// Supabase prod project ref. Sync cookie probe in this component MUST stay
-// in lockstep with the cookie name used by @supabase/ssr (the project ref
-// is part of the cookie name). Mirrors the same string in `proxy.ts` and
-// `lib/stripe/stripe-client.ts`.
-const SUPABASE_AUTH_COOKIE = "sb-bshjmbshupiibfiewpxb-auth-token";
 
 export function Navbar({
 	className,
@@ -55,7 +50,7 @@ export function Navbar({
 	const authResolved = !hasAuthCookie || !authPending;
 
 	useEffect(() => {
-		setHasAuthCookie(document.cookie.includes(`${SUPABASE_AUTH_COOKIE}=`));
+		setHasAuthCookie(document.cookie.includes(`${SUPABASE_AUTH_COOKIE_NAME}=`));
 	}, []);
 
 	useEffect(() => {

--- a/src/components/settings/__tests__/billing-settings.test.tsx
+++ b/src/components/settings/__tests__/billing-settings.test.tsx
@@ -315,4 +315,81 @@ describe("BillingSettings empty-state branches", () => {
 		).not.toBeInTheDocument();
 		expect(screen.queryByText("Current Plan")).not.toBeInTheDocument();
 	});
+
+	it("renders the auth-error branch with a Sign in again link", async () => {
+		// Battle-test Session 6 P2: when useSubscriptionStatus throws an
+		// auth error, the plan card must NOT silently fall through to
+		// "No plan" — it must surface the auth failure with a recovery path.
+		useSubscriptionStatusMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new Error("Not authenticated"),
+			refetch: vi.fn(),
+		});
+		useUserMock.mockReturnValue({ data: undefined });
+
+		const BillingSettings = await getBillingSettings();
+		renderWithProviders(<BillingSettings />);
+
+		expect(
+			screen.getByText(/Your session appears to have expired/),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /Sign in again/ })).toHaveAttribute(
+			"href",
+			"/login",
+		);
+		// "No plan" empty-state must NOT render alongside the error.
+		expect(screen.queryByText("No plan")).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/Upgrade to unlock premium features/),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders the generic-error branch with a working Retry button", async () => {
+		const refetchMock = vi.fn();
+		useSubscriptionStatusMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new Error("PGRST116: network failure"),
+			refetch: refetchMock,
+		});
+		useUserMock.mockReturnValue({ data: undefined });
+
+		const BillingSettings = await getBillingSettings();
+		renderWithProviders(<BillingSettings />);
+
+		expect(
+			screen.getByText(/Subscription details unavailable/),
+		).toBeInTheDocument();
+		const retry = screen.getByRole("button", { name: /Retry/ });
+		expect(retry).toBeInTheDocument();
+		retry.click();
+		expect(refetchMock).toHaveBeenCalledTimes(1);
+		expect(
+			screen.getByRole("link", { name: /contact support/ }),
+		).toHaveAttribute("href", "/contact");
+	});
+
+	it("classifies non-Error thrown values via String() coercion", async () => {
+		// Defensive: TanStack Query can hold any thrown value, not just
+		// Error instances. The regex runs against String(statusError).
+		useSubscriptionStatusMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: "JWT expired",
+			refetch: vi.fn(),
+		});
+		useUserMock.mockReturnValue({ data: undefined });
+
+		const BillingSettings = await getBillingSettings();
+		renderWithProviders(<BillingSettings />);
+
+		// "JWT expired" matches the auth-error regex even as a raw string.
+		expect(
+			screen.getByText(/Your session appears to have expired/),
+		).toBeInTheDocument();
+	});
 });

--- a/src/components/settings/__tests__/billing-settings.test.tsx
+++ b/src/components/settings/__tests__/billing-settings.test.tsx
@@ -337,7 +337,7 @@ describe("BillingSettings empty-state branches", () => {
 		).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: /Sign in again/ })).toHaveAttribute(
 			"href",
-			"/login",
+			"/login?redirect=%2Fsettings%3Ftab%3Dbilling",
 		);
 		// "No plan" empty-state must NOT render alongside the error.
 		expect(screen.queryByText("No plan")).not.toBeInTheDocument();

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -231,7 +231,7 @@ export function BillingSettings() {
 							<>
 								Your session appears to have expired.{" "}
 								<Link
-									href="/login"
+									href="/login?redirect=%2Fsettings%3Ftab%3Dbilling"
 									className="text-primary hover:underline underline-offset-4"
 								>
 									Sign in again

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -136,8 +136,13 @@ const RESUBSCRIBE_STATUSES = new Set([
 
 export function BillingSettings() {
 	const router = useRouter();
-	const { data: subscriptionStatus, isLoading: statusLoading } =
-		useSubscriptionStatus();
+	const {
+		data: subscriptionStatus,
+		isLoading: statusLoading,
+		isError: statusIsError,
+		error: statusError,
+		refetch: refetchStatus,
+	} = useSubscriptionStatus();
 	const { data: user } = useUser();
 
 	const createPortalSession = useBillingPortalMutation();
@@ -193,6 +198,68 @@ export function BillingSettings() {
 				<Skeleton className="h-40 rounded-lg" />
 				<Skeleton className="h-32 rounded-lg" />
 				<Skeleton className="h-48 rounded-lg" />
+			</div>
+		);
+	}
+
+	// Surface query errors explicitly instead of falling through to the
+	// "No plan" empty state — silently rendering "No plan" when the query
+	// actually errored hides auth/network problems and looks like a data
+	// issue the user can't act on (battle-test Session 6 P2: synthetic
+	// owner whose getCachedUser() fallback failed saw "No plan" instead
+	// of a real error). The auth-error variant offers a re-sign-in path;
+	// other errors offer retry.
+	if (statusIsError) {
+		const errorMessage =
+			statusError instanceof Error ? statusError.message : String(statusError);
+		const isAuthError = /not authenticated|jwt|unauthorized/i.test(
+			errorMessage,
+		);
+		return (
+			<div className="space-y-6">
+				<BlurFade delay={0.1} inView>
+					<div className="mb-6">
+						<h2 className="text-lg font-semibold">Billing & Subscription</h2>
+						<p className="text-sm text-muted-foreground">
+							We couldn&apos;t load your subscription details.
+						</p>
+					</div>
+				</BlurFade>
+				<section className="rounded-lg border bg-card p-6">
+					<p className="text-sm text-muted-foreground">
+						{isAuthError ? (
+							<>
+								Your session appears to have expired.{" "}
+								<Link
+									href="/login"
+									className="text-primary hover:underline underline-offset-4"
+								>
+									Sign in again
+								</Link>{" "}
+								to view your subscription.
+							</>
+						) : (
+							<>
+								Subscription details unavailable.{" "}
+								<button
+									type="button"
+									onClick={() => refetchStatus()}
+									className="text-primary hover:underline underline-offset-4"
+								>
+									Retry
+								</button>{" "}
+								or{" "}
+								<Link
+									href="/contact"
+									className="text-primary hover:underline underline-offset-4"
+								>
+									contact support
+								</Link>{" "}
+								if this persists.
+							</>
+						)}
+					</p>
+				</section>
 			</div>
 		);
 	}

--- a/src/lib/supabase/cookie-name.ts
+++ b/src/lib/supabase/cookie-name.ts
@@ -1,0 +1,27 @@
+/**
+ * Derives the @supabase/ssr auth-cookie name from the project URL.
+ *
+ * @supabase/ssr uses cookie names of the form `sb-<project-ref>-auth-token`,
+ * where `<project-ref>` is the subdomain prefix of the Supabase URL. The
+ * cookie name only changes if the project itself is swapped — so deriving
+ * it from `NEXT_PUBLIC_SUPABASE_URL` keeps the name in lockstep automatically.
+ *
+ * Useful for synchronous DOM probes that need to look up the cookie
+ * without invoking Supabase's full client (e.g., the marketing navbar's
+ * fast-path for the signed-out CTA render).
+ */
+import { env } from "#env";
+
+function deriveProjectRef(url: string): string {
+	try {
+		const hostname = new URL(url).hostname;
+		const ref = hostname.split(".")[0];
+		if (!ref) throw new Error("empty hostname");
+		return ref;
+	} catch {
+		throw new Error(`NEXT_PUBLIC_SUPABASE_URL is not a valid URL: ${url}`);
+	}
+}
+
+export const SUPABASE_AUTH_COOKIE_NAME =
+	`sb-${deriveProjectRef(env.NEXT_PUBLIC_SUPABASE_URL)}-auth-token` as const;


### PR DESCRIPTION
## Summary
Closes all three Session 6 findings: P1 navbar hang (real code bug), P2 silent billing error state (real UX bug), P3 RSC 503s (investigated via Vercel logs — non-actionable).

### P1 — Navbar cold-start hang (fix: navbar.tsx)
Battle-test Session 6 reproduced a regression introduced by PR #719: signed-out visitors hitting /pricing with cleared cookies + cleared IndexedDB saw a navbar with **no auth CTAs at all** — neither "Sign In", "Get Started", nor "Dashboard". The \`authResolved\` gate stayed false indefinitely because the \`useSupabaseSession()\` query paused inside PersistQueryClientProvider's restoration sequence on fresh IDB.

Fix: synchronous \`document.cookie\` fast-path. If no auth cookie at all, \`authResolved\` flips to true immediately, signed-out CTAs render, no waiting on a query that resolves to null anyway. Visitors with a cookie still defer to the query for sign-in/out reactivity. SSR-safe via \`useState(false)\` initial + mount useEffect — server render and first client paint identical.

### P2 — Silent billing-query error (fix: billing-settings.tsx)
Session 6 surfaced a contradictory pair on /settings → Billing for a session where the subscription query was failing:
- Plan card: "No plan" + "Upgrade to unlock premium features"
- Cancel section: "Subscription status unavailable. Retry"

Root cause: BillingSettings fell through to the empty-state regardless of WHY the query lacked data. Verified via Supabase MCP that owner-A's \`subscription_status = 'active'\` (real data is fine); the error was triggered by the agent's hand-crafted auth/v1/token workaround cookie, which @supabase/ssr can't fully resolve. Real production users won't hit this — but the silent fallback to "No plan" is bad UX regardless.

Fix: BillingSettings now early-returns an explicit error state when \`isError\`. The error message branches on auth-vs-generic — auth-related errors offer a "Sign in again" link; others offer Retry + Contact support. Eliminates the dual-message contradiction and gives users an actionable recovery path.

### P3 — RSC 503 rate (investigated, no fix)
Agent reported transient 503s on \`/maintenance\`, \`/billing/plans\`, \`/documents/lease-template\`, \`/leases/new\`, \`/settings?tab=notifications\` RSC fetches. Checked Vercel runtime logs:
- Last 24h: zero 503s in production
- Last 2h: zero error/fatal-level logs

Transient edge propagation during PR #719's deploy window; no ongoing issue to address in code.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` (biome) clean
- [x] \`bun run test:unit\` — 99,548 tests pass (137 files)
- [ ] Browser-agent Session 7: re-run cleared-cookie + cleared-IDB cold-start; confirm Sign In + Get Started render <200ms

[hudsor01]