### PR TITLE
fix(proxy): coerce auth getUser() errors to user:null (S7 P1)

### DIFF
--- a/src/lib/supabase/__tests__/middleware.test.ts
+++ b/src/lib/supabase/__tests__/middleware.test.ts
@@ -5,9 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetUser = vi.fn();
 const mockCreateServerClient = vi.fn();
+const mockCaptureException = vi.fn();
 
 vi.mock("@supabase/ssr", () => ({
 	createServerClient: (...args: unknown[]) => mockCreateServerClient(...args),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+	captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
 
 // Mock next/server for NextResponse.next and NextResponse.redirect
@@ -169,5 +174,31 @@ describe("updateSession", () => {
 
 		expect(result.user).toBeNull();
 		expect(result.supabaseResponse).toBeDefined();
+	});
+
+	it("coerces a thrown getUser() error to user:null and captures to Sentry", async () => {
+		// Battle-test Session 7 P1: when supabase.auth.getUser() threw on a
+		// malformed JWT or transient auth-server error, the unhandled throw
+		// bubbled out of the proxy and Vercel surfaced it as a 503. The fix
+		// is to swallow the throw, mark the request unauthenticated, and let
+		// the caller proceed (it will redirect to /login or fall through to
+		// a public route).
+		mockGetUser.mockRejectedValue(new Error("AuthApiError: jwt malformed"));
+
+		const request = buildRequest("/dashboard");
+		const result = await updateSession(request);
+
+		expect(result.user).toBeNull();
+		expect(result.supabaseResponse).toBeDefined();
+		expect(mockCaptureException).toHaveBeenCalledOnce();
+		const [capturedError, capturedContext] = mockCaptureException.mock
+			.calls[0] as [Error, { tags: Record<string, string>; level: string }];
+		expect(capturedError).toBeInstanceOf(Error);
+		expect(capturedError.message).toMatch(/jwt malformed/);
+		expect(capturedContext.tags).toMatchObject({
+			component: "supabase/middleware",
+			check: "auth_get_user",
+		});
+		expect(capturedContext.level).toBe("warning");
 	});
 });

--- a/src/lib/supabase/__tests__/middleware.test.ts
+++ b/src/lib/supabase/__tests__/middleware.test.ts
@@ -55,10 +55,16 @@ import { updateSession } from "#lib/supabase/middleware";
 function buildRequest(pathname: string): NextRequest {
 	const url = new URL(pathname, "http://localhost:3050");
 	const cookieStore = new Map<string, { name: string; value: string }>();
+	const headerStore = new Map<string, string>();
 
 	return {
 		nextUrl: url,
 		url: url.toString(),
+		headers: {
+			get: (name: string) => headerStore.get(name.toLowerCase()) ?? null,
+			set: (name: string, value: string) =>
+				headerStore.set(name.toLowerCase(), value),
+		},
 		cookies: {
 			getAll: () => [...cookieStore.values()],
 			set: (name: string, value: string) => {
@@ -176,14 +182,17 @@ describe("updateSession", () => {
 		expect(result.supabaseResponse).toBeDefined();
 	});
 
-	it("coerces a thrown getUser() error to user:null and captures to Sentry", async () => {
+	it("coerces a thrown getUser() error to user:null and captures to Sentry at warning level for 4xx auth errors", async () => {
 		// Battle-test Session 7 P1: when supabase.auth.getUser() threw on a
 		// malformed JWT or transient auth-server error, the unhandled throw
 		// bubbled out of the proxy and Vercel surfaced it as a 503. The fix
 		// is to swallow the throw, mark the request unauthenticated, and let
 		// the caller proceed (it will redirect to /login or fall through to
 		// a public route).
-		mockGetUser.mockRejectedValue(new Error("AuthApiError: jwt malformed"));
+		const authError = Object.assign(new Error("AuthApiError: jwt malformed"), {
+			status: 401,
+		});
+		mockGetUser.mockRejectedValue(authError);
 
 		const request = buildRequest("/dashboard");
 		const result = await updateSession(request);
@@ -192,13 +201,57 @@ describe("updateSession", () => {
 		expect(result.supabaseResponse).toBeDefined();
 		expect(mockCaptureException).toHaveBeenCalledOnce();
 		const [capturedError, capturedContext] = mockCaptureException.mock
-			.calls[0] as [Error, { tags: Record<string, string>; level: string }];
+			.calls[0] as [
+			Error,
+			{
+				tags: Record<string, string>;
+				level: string;
+				extra: Record<string, unknown>;
+			},
+		];
 		expect(capturedError).toBeInstanceOf(Error);
 		expect(capturedError.message).toMatch(/jwt malformed/);
 		expect(capturedContext.tags).toMatchObject({
 			component: "supabase/middleware",
 			check: "auth_get_user",
 		});
+		// 4xx auth error → warning (routine, don't page)
 		expect(capturedContext.level).toBe("warning");
+		expect(capturedContext.extra.pathname).toBe("/dashboard");
+	});
+
+	it("escalates to error level on 5xx auth-server outage (worth paging on)", async () => {
+		// Real Supabase auth-server outage should NOT be hidden as a warning
+		// — the Sentry alert config can then page on `level:error` to surface
+		// the outage while routine 4xx JWT failures stay quiet.
+		const outageError = Object.assign(new Error("AuthRetryableFetchError"), {
+			status: 503,
+		});
+		mockGetUser.mockRejectedValue(outageError);
+
+		const request = buildRequest("/dashboard");
+		const result = await updateSession(request);
+
+		expect(result.user).toBeNull();
+		const [, capturedContext] = mockCaptureException.mock.calls[0] as [
+			Error,
+			{ level: string },
+		];
+		expect(capturedContext.level).toBe("error");
+	});
+
+	it("escalates to error level on network failures with no status code", async () => {
+		// fetch() network errors don't carry a `status` property — treat the
+		// same as 5xx (outage-like) so we don't silently degrade.
+		mockGetUser.mockRejectedValue(new Error("fetch failed"));
+
+		const request = buildRequest("/dashboard");
+		await updateSession(request);
+
+		const [, capturedContext] = mockCaptureException.mock.calls[0] as [
+			Error,
+			{ level: string },
+		];
+		expect(capturedContext.level).toBe("error");
 	});
 });

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -62,13 +62,29 @@ export async function updateSession(
 		// all mean "no validated user", and the caller will redirect to /login
 		// or pass through as public. Capture to Sentry so real outages are
 		// still visible, but don't let one bad request poison the response.
+		//
+		// Level discrimination: 4xx AuthApiError responses (malformed/expired
+		// JWT, rate-limit) are routine and stay at `warning` so they don't
+		// page on-call. Anything else — network errors with no `status`, or
+		// 5xx auth-server outages — escalates to `error` so a real Supabase
+		// outage gets the right alert weight.
+		const status =
+			error && typeof error === "object" && "status" in error
+				? (error as { status?: unknown }).status
+				: undefined;
+		const isClientAuthError =
+			typeof status === "number" && status >= 400 && status < 500;
 		Sentry.captureException(error, {
 			tags: {
 				component: "supabase/middleware",
 				check: "auth_get_user",
 			},
-			extra: { pathname: request.nextUrl.pathname },
-			level: "warning",
+			extra: {
+				pathname: request.nextUrl.pathname,
+				requestId: request.headers.get("x-vercel-id") ?? undefined,
+				userAgent: request.headers.get("user-agent") ?? undefined,
+			},
+			level: isClientAuthError ? "warning" : "error",
 		});
 	}
 

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 import type { User } from "@supabase/supabase-js";
 import { type NextRequest, NextResponse } from "next/server";
@@ -10,7 +11,14 @@ import { type NextRequest, NextResponse } from "next/server";
  * server-validated auth (never getSession()).
  *
  * Returns the authenticated user (or null) and the response with
- * updated cookies.
+ * updated cookies. **Never throws** — auth failures (malformed JWT,
+ * Supabase auth-server outage, network errors) are coerced to `user:
+ * null` so the proxy can fall through to the public-route / login-
+ * redirect path instead of returning 503. A thrown auth error in
+ * middleware causes Vercel to surface a 5xx for what's actually a
+ * routine "no valid session" outcome — battle-test Session 7 saw ~25
+ * such 503s on RSC prefetches because the agent's hand-crafted
+ * workaround cookie occasionally tripped Supabase's JWT validator.
  */
 export async function updateSession(
 	request: NextRequest,
@@ -44,9 +52,25 @@ export async function updateSession(
 
 	// IMPORTANT: Use getUser(), never getSession(), for server-validated auth.
 	// getUser() validates the JWT with the Supabase auth server.
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
+	let user: User | null = null;
+	try {
+		const result = await supabase.auth.getUser();
+		user = result.data.user;
+	} catch (error) {
+		// Throw-paths: malformed JWT (cookie decode fail), Supabase auth-server
+		// network error, rate limit. None of these should 503 the page — they
+		// all mean "no validated user", and the caller will redirect to /login
+		// or pass through as public. Capture to Sentry so real outages are
+		// still visible, but don't let one bad request poison the response.
+		Sentry.captureException(error, {
+			tags: {
+				component: "supabase/middleware",
+				check: "auth_get_user",
+			},
+			extra: { pathname: request.nextUrl.pathname },
+			level: "warning",
+		});
+	}
 
 	return { user, supabaseResponse };
 }


### PR DESCRIPTION
## Summary
Battle-test Session 7 reported ~25 503s on \`_rsc=…\` RSC prefetch payloads across the dashboard surface. Vercel runtime logs showed zero 503s from our function output (verified via MCP — 12h sweep returned no 503/500/error-level logs), so the 5xx was happening at the function-invoke layer when \`supabase.auth.getUser()\` inside \`updateSession()\` threw.

## Root cause
\`updateSession()\` called \`supabase.auth.getUser()\` without error handling and destructured the result with no `error` capture:
\`\`\`ts
const { data: { user } } = await supabase.auth.getUser()
\`\`\`
Throw paths for \`getUser()\`:
- Malformed JWT (the agent's hand-crafted \`auth/v1/token\` workaround cookie occasionally trips Supabase's validator)
- Transient Supabase auth-server network error / rate-limit response
- 5xx parse failure

In all three cases the correct user-facing outcome is "no validated session" → proxy either redirects to \`/login\` or falls through to a public route. There is no scenario where a malformed/unverifiable JWT should surface a 503 to the visitor.

## Fix
Wrap \`getUser()\` in try/catch. Coerce throw paths to \`user: null\` and capture to Sentry as \`warning\` so real outages stay observable. Caller behavior unchanged on the happy path.

The two DB-query throw paths in \`proxy.ts\` (admin gate, subscription gate) are intentionally \`throw error\` per their comments — silently redirecting an admin away or silently letting through an unpaid user are the prior security bugs those throws were added to prevent. **Unchanged.**

## Test plan
- [x] New \`middleware.test.ts\` case pins the regression guard: a thrown \`getUser()\` resolves to \`user: null\` + Sentry capture (not propagated as exception)
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` (biome) clean
- [x] \`bun run test:unit\` — 99,688 tests pass (138 files)
- [ ] Browser-agent Session 8: re-burst dashboard prefetches with the workaround cookie, confirm 503 rate is zero

[hudsor01]