### PR TITLE
fix: session-9 residual findings (banner/wizard/chart)

### DIFF
--- a/src/components/billing/__tests__/subscription-status-banner.test.tsx
+++ b/src/components/billing/__tests__/subscription-status-banner.test.tsx
@@ -19,6 +19,25 @@ describe("SubscriptionStatusBanner", () => {
 		expect(container.innerHTML).toBe("");
 	});
 
+	it("renders nothing when the subscription query errors (does not fall through to upsell)", () => {
+		// Battle-test Session 9 P1 regression guard: paid users with a
+		// transient subscription-query failure were seeing the blue
+		// "Start your subscription" upsell. Fix: skip the banner on
+		// isError. BillingSettings owns the explicit error UI surface.
+		mockUseSubscriptionStatus.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new Error("PGRST301: JWT expired"),
+		});
+
+		const { container } = render(<SubscriptionStatusBanner />);
+		expect(container.innerHTML).toBe("");
+		expect(
+			screen.queryByText(/start your subscription/i),
+		).not.toBeInTheDocument();
+	});
+
 	it("renders blue info banner when subscription is null (no stripe customer)", () => {
 		mockUseSubscriptionStatus.mockReturnValue({
 			data: null,

--- a/src/components/billing/subscription-status-banner.tsx
+++ b/src/components/billing/subscription-status-banner.tsx
@@ -16,11 +16,20 @@ import { useSubscriptionStatus } from "#hooks/api/use-billing";
  * Include in owner layout to show across all owner pages.
  */
 export function SubscriptionStatusBanner() {
-	const { data: subscription, isLoading } = useSubscriptionStatus();
+	const { data: subscription, isLoading, isError } = useSubscriptionStatus();
 
 	if (isLoading) return null;
 
-	// No subscription at all — user needs to subscribe
+	// Battle-test Session 9 P1: when the subscription query errors (auth
+	// hiccup, RLS rejection, transient DB), the previous fall-through
+	// rendered the "Start your subscription" banner to paid users —
+	// misleading them into thinking they had no subscription. Skip the
+	// banner on error; BillingSettings owns the explicit error UI.
+	if (isError) return null;
+
+	// No subscription at all — user needs to subscribe. Only render when
+	// the query SUCCEEDED with no subscription on file (genuine new-user
+	// state), not when the lookup couldn't resolve a status.
 	if (!subscription || subscription.subscriptionStatus === null) {
 		return (
 			<div className="flex items-center gap-3 rounded-lg border border-blue-300 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-700 dark:bg-blue-950/50 dark:text-blue-200">

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -12,10 +12,12 @@
  * Marks onboarding complete or skipped on close.
  */
 
+import { VisuallyHidden } from "radix-ui";
 import { useState } from "react";
 import {
 	Dialog,
 	DialogContent,
+	DialogDescription,
 	DialogHeader,
 	DialogTitle,
 } from "#components/ui/dialog";
@@ -125,6 +127,12 @@ export function OnboardingWizard() {
 						</DialogTitle>
 						<StepIndicator currentStep={currentStep} />
 					</div>
+					<VisuallyHidden.Root asChild>
+						<DialogDescription>
+							Multi-step onboarding wizard to add your first property and
+							complete account setup.
+						</DialogDescription>
+					</VisuallyHidden.Root>
 				</DialogHeader>
 
 				{currentStep === "welcome" && (

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -130,8 +130,8 @@ export function OnboardingWizard() {
 					<VisuallyHidden.Root asChild>
 						<DialogDescription>
 							Set up your TenantFlow account by adding your first property. Use
-							Next to advance, Skip to skip a step, or close the dialog to
-							finish later.
+							the primary action on each step to advance, the Skip option to
+							bypass a step, or close the dialog to finish later.
 						</DialogDescription>
 					</VisuallyHidden.Root>
 				</DialogHeader>

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -129,8 +129,9 @@ export function OnboardingWizard() {
 					</div>
 					<VisuallyHidden.Root asChild>
 						<DialogDescription>
-							Multi-step onboarding wizard to add your first property and
-							complete account setup.
+							Set up your TenantFlow account by adding your first property. Use
+							Next to advance, Skip to skip a step, or close the dialog to
+							finish later.
 						</DialogDescription>
 					</VisuallyHidden.Root>
 				</DialogHeader>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -70,8 +70,8 @@ function ChartContainer({
 	// the `aspect-video` flex child has its computed dimensions.
 	const [mounted, setMounted] = useState(false);
 	useEffect(() => {
-		const id = requestAnimationFrame(() => setMounted(true));
-		return () => cancelAnimationFrame(id);
+		const rafId = requestAnimationFrame(() => setMounted(true));
+		return () => cancelAnimationFrame(rafId);
 	}, []);
 
 	return (

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -59,15 +59,19 @@ function ChartContainer({
 	const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`;
 
 	// Defer ResponsiveContainer mount until the parent div has been laid
-	// out, so Recharts never measures a zero-sized container on its first
-	// pass. Without this gate, Recharts logs "The width(-1) and height(-1)
-	// of chart should be greater than 0" to the console on every chart
-	// render (battle-test Session 8 flagged this as cosmetic console noise).
-	// The wrapper div retains its sizing classes so the layout reservation
-	// is unchanged — only the Recharts measurement is deferred one tick.
+	// out AND painted at least once, so Recharts never measures a zero-
+	// sized container on its first ResizeObserver callback. Battle-test
+	// Session 8 reported "The width(-1) and height(-1) of chart should be
+	// greater than 0" once per chart on dashboard mount; PR #722's
+	// useEffect-only gate wasn't enough — `useEffect` runs after first
+	// commit but before browser layout settles, so ResponsiveContainer's
+	// own measurement still caught a zero-sized parent in some flows.
+	// `requestAnimationFrame` waits for the next paint, by which point
+	// the `aspect-video` flex child has its computed dimensions.
 	const [mounted, setMounted] = useState(false);
 	useEffect(() => {
-		setMounted(true);
+		const id = requestAnimationFrame(() => setMounted(true));
+		return () => cancelAnimationFrame(id);
 	}, []);
 
 	return (


### PR DESCRIPTION
## Summary
Three residual findings from battle-test Session 9.

### P1 — `SubscriptionStatusBanner` misled paid users on query error
When `useSubscriptionStatus` returned `isError` (auth hiccup, RLS rejection, transient DB), the banner fell through to "Start your subscription to unlock all property management features" — an upsell that should only render for genuine no-subscription state. Session 9 caught this against paid synthetic owner-A: the agent saw the banner alongside the Billing tab's "No plan" card despite owner-A's `subscription_status = "active"` in DB (verified via Supabase MCP).

**Fix:** skip the banner when `isError`. `BillingSettings` already owns the explicit error UI surface (the auth-error vs generic-error early-return added in PR #720).

### P2 — Onboarding wizard `DialogContent` missing aria-description
PR #722 fixed `RouteModal` but the onboarding wizard — which mounts on `/dashboard` — still emitted the Radix a11y warning. Added a visually-hidden `DialogDescription` describing the multi-step setup flow.

### P2 — Recharts `width(-1)/height(-1)` warning still fired once on /dashboard
PR #722's `useEffect`-only mount-gate ran after first commit but before browser layout settled, so `ResponsiveContainer`'s first `ResizeObserver` callback still caught a zero-sized parent. Switched to `requestAnimationFrame` inside the effect — waits for the next paint, by which point `aspect-video` has computed dimensions.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` (biome) clean
- [x] `bun run test:unit` — 99,695 tests pass (138 files)
- [ ] Browser-agent Session 10: verify SubscriptionStatusBanner doesn't show for paid users on error; zero DialogContent + Recharts warnings on /dashboard mount

[hudsor01]