### PR TITLE
fix: session 12 browser-agent findings (5 P2/P3)

### DIFF
--- a/src/app/(owner)/analytics/financial/layout.tsx
+++ b/src/app/(owner)/analytics/financial/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Financial Analytics",
-};
+export const metadata = ownerPageMetadata("Financial Analytics");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/analytics/layout.tsx
+++ b/src/app/(owner)/analytics/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Analytics");
+export const metadata = ownerPageMetadata(
+	"Analytics",
+	"Property performance analytics and insights",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/analytics/layout.tsx
+++ b/src/app/(owner)/analytics/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Analytics",
-	description: "Property performance analytics and insights",
-};
+export const metadata = ownerPageMetadata("Analytics");
 
-export default function AnalyticsLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/analytics/leases/layout.tsx
+++ b/src/app/(owner)/analytics/leases/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Lease Analytics",
-};
+export const metadata = ownerPageMetadata("Lease Analytics");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/analytics/maintenance/layout.tsx
+++ b/src/app/(owner)/analytics/maintenance/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Maintenance Analytics",
-};
+export const metadata = ownerPageMetadata("Maintenance Analytics");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/analytics/occupancy/layout.tsx
+++ b/src/app/(owner)/analytics/occupancy/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Occupancy Analytics",
-};
+export const metadata = ownerPageMetadata("Occupancy Analytics");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/analytics/overview/layout.tsx
+++ b/src/app/(owner)/analytics/overview/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Overview",
-};
+export const metadata = ownerPageMetadata("Overview");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/analytics/property-performance/layout.tsx
+++ b/src/app/(owner)/analytics/property-performance/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Property Performance",
-};
+export const metadata = ownerPageMetadata("Property Performance");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/dashboard/layout.tsx
+++ b/src/app/(owner)/dashboard/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Dashboard");
+export const metadata = ownerPageMetadata(
+	"Dashboard",
+	"Overview of your property portfolio, revenue, and activity",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/dashboard/layout.tsx
+++ b/src/app/(owner)/dashboard/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Dashboard",
-	description: "Overview of your property portfolio, revenue, and activity",
-};
+export const metadata = ownerPageMetadata("Dashboard");
 
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/financials/balance-sheet/layout.tsx
+++ b/src/app/(owner)/financials/balance-sheet/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Balance Sheet",
-};
+export const metadata = ownerPageMetadata("Balance Sheet");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/financials/cash-flow/layout.tsx
+++ b/src/app/(owner)/financials/cash-flow/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Cash Flow",
-};
+export const metadata = ownerPageMetadata("Cash Flow");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/financials/expenses/layout.tsx
+++ b/src/app/(owner)/financials/expenses/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Expenses",
-};
+export const metadata = ownerPageMetadata("Expenses");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/financials/income-statement/layout.tsx
+++ b/src/app/(owner)/financials/income-statement/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Income Statement",
-};
+export const metadata = ownerPageMetadata("Income Statement");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/financials/layout.tsx
+++ b/src/app/(owner)/financials/layout.tsx
@@ -1,15 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Financials",
-	description: "Financial overview, revenue, expenses, and profit analysis",
-};
+export const metadata = ownerPageMetadata("Financials");
 
-export default function FinancialsLayout({
-	children,
-}: {
-	children: ReactNode;
-}) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/financials/layout.tsx
+++ b/src/app/(owner)/financials/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Financials");
+export const metadata = ownerPageMetadata(
+	"Financials",
+	"Financial overview, revenue, expenses, and profit analysis",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/financials/tax-documents/layout.tsx
+++ b/src/app/(owner)/financials/tax-documents/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Tax Documents",
-};
+export const metadata = ownerPageMetadata("Tax Documents");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/layout.tsx
+++ b/src/app/(owner)/layout.tsx
@@ -9,16 +9,22 @@ import { OwnerDashboardLayout } from "./owner-dashboard-layout";
 // if they bypass robots.txt or follow internal links. Also override
 // openGraph/twitter so shared dashboard URLs don't preview as the
 // marketing homepage default (Session 11 P2 #21).
+//
+// Session 12 P3: use Next.js metadata title templates so per-route
+// sub-layouts (analytics/*, financials/*, maintenance/new, etc.)
+// flow their `title` into og:title and twitter:title automatically.
+// The literal "TenantFlow Dashboard" fallback only fires if a child
+// route doesn't set its own title.
 export const metadata: Metadata = {
 	robots: { index: false, follow: false },
 	openGraph: {
-		title: "TenantFlow Dashboard",
+		title: { template: "%s | TenantFlow", default: "TenantFlow Dashboard" },
 		description: "Authenticated TenantFlow app — landlord dashboard.",
 		images: [],
 	},
 	twitter: {
 		card: "summary",
-		title: "TenantFlow Dashboard",
+		title: { template: "%s | TenantFlow", default: "TenantFlow Dashboard" },
 		description: "Authenticated TenantFlow app — landlord dashboard.",
 	},
 };

--- a/src/app/(owner)/leases/layout.tsx
+++ b/src/app/(owner)/leases/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Leases",
-	description: "Manage lease agreements, renewals, and terminations",
-};
+export const metadata = ownerPageMetadata("Leases");
 
-export default function LeasesLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/leases/layout.tsx
+++ b/src/app/(owner)/leases/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Leases");
+export const metadata = ownerPageMetadata(
+	"Leases",
+	"Manage lease agreements, renewals, and terminations",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/maintenance/new/layout.tsx
+++ b/src/app/(owner)/maintenance/new/layout.tsx
@@ -1,9 +1,7 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "New Maintenance Request",
-};
+export const metadata = ownerPageMetadata("New Maintenance Request");
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/profile/layout.tsx
+++ b/src/app/(owner)/profile/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Profile",
-	description: "View and manage your account information",
-};
+export const metadata = ownerPageMetadata("Profile");
 
-export default function ProfileLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/profile/layout.tsx
+++ b/src/app/(owner)/profile/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Profile");
+export const metadata = ownerPageMetadata(
+	"Profile",
+	"View and manage your account information",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/properties/layout.tsx
+++ b/src/app/(owner)/properties/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Properties");
+export const metadata = ownerPageMetadata(
+	"Properties",
+	"Manage your rental properties and units",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/properties/layout.tsx
+++ b/src/app/(owner)/properties/layout.tsx
@@ -1,15 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Properties",
-	description: "Manage your rental properties and units",
-};
+export const metadata = ownerPageMetadata("Properties");
 
-export default function PropertiesLayout({
-	children,
-}: {
-	children: ReactNode;
-}) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/reports/layout.tsx
+++ b/src/app/(owner)/reports/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Reports");
+export const metadata = ownerPageMetadata(
+	"Reports",
+	"Generate financial, property, tenant, and maintenance reports",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/reports/layout.tsx
+++ b/src/app/(owner)/reports/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Reports",
-	description: "Generate financial, property, tenant, and maintenance reports",
-};
+export const metadata = ownerPageMetadata("Reports");
 
-export default function ReportsLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/settings/layout.tsx
+++ b/src/app/(owner)/settings/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Settings");
+export const metadata = ownerPageMetadata(
+	"Settings",
+	"Manage account settings, notifications, security, and billing",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/settings/layout.tsx
+++ b/src/app/(owner)/settings/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Settings",
-	description: "Manage account settings, notifications, security, and billing",
-};
+export const metadata = ownerPageMetadata("Settings");
 
-export default function SettingsLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/tenants/layout.tsx
+++ b/src/app/(owner)/tenants/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Tenants",
-	description: "Manage tenants, invitations, and tenant details",
-};
+export const metadata = ownerPageMetadata("Tenants");
 
-export default function TenantsLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/tenants/layout.tsx
+++ b/src/app/(owner)/tenants/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Tenants");
+export const metadata = ownerPageMetadata(
+	"Tenants",
+	"Manage tenants, invitations, and tenant details",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/(owner)/units/layout.tsx
+++ b/src/app/(owner)/units/layout.tsx
@@ -1,11 +1,8 @@
-import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata: Metadata = {
-	title: "Units",
-	description: "Manage rental units across all properties",
-};
+export const metadata = ownerPageMetadata("Units");
 
-export default function UnitsLayout({ children }: { children: ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;
 }

--- a/src/app/(owner)/units/layout.tsx
+++ b/src/app/(owner)/units/layout.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from "react";
 import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
-export const metadata = ownerPageMetadata("Units");
+export const metadata = ownerPageMetadata(
+	"Units",
+	"Manage rental units across all properties",
+);
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return <>{children}</>;

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -18,6 +18,7 @@ import { ForgotPasswordModal } from "#components/auth/forgot-password-modal";
 import { UpdatePasswordForm } from "#components/auth/update-password-form";
 import { Button } from "#components/ui/button";
 import { GridPattern } from "#components/ui/grid-pattern";
+import { VALIDATION_LIMITS } from "#lib/constants/billing";
 
 type PageState = "loading" | "valid" | "error";
 
@@ -180,7 +181,10 @@ export default function UpdatePasswordPage() {
 											Password tips:
 										</p>
 										<ul className="text-sm text-muted-foreground space-y-1">
-											<li>Use at least 6 characters</li>
+											<li>
+												Use at least {VALIDATION_LIMITS.PASSWORD_MIN_LENGTH}{" "}
+												characters
+											</li>
 											<li>Mix uppercase and lowercase letters</li>
 											<li>Include numbers and special characters</li>
 											<li>Avoid common words or patterns</li>

--- a/src/components/pricing/bento-pricing-section.tsx
+++ b/src/components/pricing/bento-pricing-section.tsx
@@ -27,6 +27,7 @@ export function BentoPricingSection({
 			id: plan.planId,
 			name: plan.name,
 			description: plan.description,
+			audienceTagline: plan.audienceTagline,
 			price: {
 				monthly: plan.price.monthly,
 				yearly: Math.round((plan.price.annual / 12) * 100) / 100,

--- a/src/components/pricing/pricing-card-featured.tsx
+++ b/src/components/pricing/pricing-card-featured.tsx
@@ -26,6 +26,10 @@ interface PricingPlan {
 	id: string;
 	name: string;
 	description: string;
+	/** Distinct from description — used by the social-proof badge below
+	 *  the price (PR #725 cycle-1 review). Same shape as PricingConfig
+	 *  in #config/pricing. */
+	audienceTagline: string;
 	price: {
 		monthly: number;
 		yearly: number;
@@ -198,18 +202,19 @@ export function PricingCardFeatured({
 						)}
 					</div>
 
-					{/* Social Proof — Session 12 P3: drop the hardcoded "1–15
-					    rentals" framing. Growth covers ~6–20 units; calling
-					    it "1–15" overlaps Starter and undersells Growth.
-					    Use the plan's own description so the badge stays in
-					    lockstep with #config/pricing. */}
+					{/* Social-proof badge. Uses plan.audienceTagline (a
+					    short audience-targeting string) rather than
+					    plan.description (the longer subtitle shown next
+					    to the plan name) so the two don't render the
+					    same copy twice above the fold. PR #725 cycle-1
+					    review caught the duplication. */}
 					<Badge
 						variant="trustIndicator"
 						size="trust"
 						className="w-full justify-center mb-6"
 					>
 						<BadgeCheck className="size-4" aria-hidden="true" />
-						{plan.description}
+						{plan.audienceTagline}
 					</Badge>
 
 					{/* Features - 2 column grid for featured card */}

--- a/src/components/pricing/pricing-card-featured.tsx
+++ b/src/components/pricing/pricing-card-featured.tsx
@@ -198,14 +198,18 @@ export function PricingCardFeatured({
 						)}
 					</div>
 
-					{/* Social Proof */}
+					{/* Social Proof — Session 12 P3: drop the hardcoded "1–15
+					    rentals" framing. Growth covers ~6–20 units; calling
+					    it "1–15" overlaps Starter and undersells Growth.
+					    Use the plan's own description so the badge stays in
+					    lockstep with #config/pricing. */}
 					<Badge
 						variant="trustIndicator"
 						size="trust"
 						className="w-full justify-center mb-6"
 					>
 						<BadgeCheck className="size-4" aria-hidden="true" />
-						Built for landlords with 1–15 rentals
+						{plan.description}
 					</Badge>
 
 					{/* Features - 2 column grid for featured card */}

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -334,12 +334,27 @@ export function BillingSettings() {
 									{/* Session 12 P3: don't drop the row entirely when
 									    subscription_current_period_end is null — that reads as
 									    "missing" instead of "syncing". Surface a deferred
-									    helper string so the user knows it's pending. */}
-									<p className="text-xs text-muted-foreground mt-2">
-										{nextBillingDate
-											? `Next billing date: ${nextBillingDate}`
-											: "Billing cycle syncing from Stripe…"}
-									</p>
+									    helper string so the user knows it's pending. Cycle-1
+									    review added the Contact-support escape hatch so an
+									    indefinitely-stale webhook isn't masked as "still
+									    syncing" forever (mirrors the "Plan details will sync
+									    shortly" copy below). */}
+									{nextBillingDate ? (
+										<p className="text-xs text-muted-foreground mt-2">
+											Next billing date: {nextBillingDate}
+										</p>
+									) : (
+										<p className="text-xs text-muted-foreground mt-2">
+											Billing cycle syncing from Stripe…{" "}
+											<Link
+												href="/contact"
+												className="text-primary hover:underline underline-offset-4"
+											>
+												Contact support
+											</Link>{" "}
+											if this persists.
+										</p>
+									)}
 								</>
 							)}
 							{/* Active without a known plan — covers two paths:

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -331,11 +331,15 @@ export function BillingSettings() {
 										{formatUnitLimit(currentPlan.limits.units)} · Unlimited
 										tenant records
 									</p>
-									{nextBillingDate && (
-										<p className="text-xs text-muted-foreground mt-2">
-											Next billing date: {nextBillingDate}
-										</p>
-									)}
+									{/* Session 12 P3: don't drop the row entirely when
+									    subscription_current_period_end is null — that reads as
+									    "missing" instead of "syncing". Surface a deferred
+									    helper string so the user knows it's pending. */}
+									<p className="text-xs text-muted-foreground mt-2">
+										{nextBillingDate
+											? `Next billing date: ${nextBillingDate}`
+											: "Billing cycle syncing from Stripe…"}
+									</p>
 								</>
 							)}
 							{/* Active without a known plan — covers two paths:

--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -31,6 +31,13 @@ export interface PricingConfig {
 	readonly planId: PlanId;
 	readonly name: string;
 	readonly description: string;
+	/**
+	 * Short audience-targeting tagline for the social-proof badge on the
+	 * featured pricing card (PR #725 cycle-1 review). Distinct from
+	 * `description` (which is the longer subtitle next to the plan name)
+	 * so the same string isn't echoed twice above the fold.
+	 */
+	readonly audienceTagline: string;
 	readonly price: {
 		readonly monthly: number;
 		readonly annual: number;
@@ -58,6 +65,7 @@ export const PRICING_PLANS: Record<string, PricingConfig> = {
 		planId: "trial",
 		name: "Free Trial",
 		description: "Try every feature for 14 days before subscribing",
+		audienceTagline: "14-day full-feature trial",
 		price: {
 			monthly: 0,
 			annual: 0,
@@ -94,6 +102,7 @@ export const PRICING_PLANS: Record<string, PricingConfig> = {
 		planId: "starter",
 		name: "Starter",
 		description: "Ideal for landlords with 1–5 rentals",
+		audienceTagline: "Built for 1–5 unit portfolios",
 		price: {
 			monthly: 19,
 			annual: 190,
@@ -127,6 +136,7 @@ export const PRICING_PLANS: Record<string, PricingConfig> = {
 		planId: "growth",
 		name: "Growth",
 		description: "For growing portfolios that need advanced features",
+		audienceTagline: "Built for 6–20 unit portfolios",
 		price: {
 			monthly: 49,
 			annual: 490,
@@ -162,6 +172,7 @@ export const PRICING_PLANS: Record<string, PricingConfig> = {
 		name: "Max",
 		description:
 			"For landlords with 21+ rentals — unlimited scale and API access",
+		audienceTagline: "Built for 21+ unit portfolios",
 		price: {
 			monthly: 149,
 			annual: 1490,

--- a/src/hooks/api/query-keys/session-keys.test.ts
+++ b/src/hooks/api/query-keys/session-keys.test.ts
@@ -1,0 +1,164 @@
+/**
+ * parseUserAgent table-driven tests.
+ *
+ * Pins the browser/OS/device parser the Active Sessions UI relies on
+ * after PR #725 cycle-1 review (Session 12 P3 "Unknown Browser on
+ * Unknown OS" fix). Each case mirrors a real UA string the synthetic
+ * test accounts plus common platforms emit.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseUserAgent } from "./session-keys";
+
+describe("parseUserAgent", () => {
+	describe("browser detection", () => {
+		it.each<[string, string, string]>([
+			// Edge desktop — must override Chrome
+			[
+				"edge-desktop",
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+				"Edge",
+			],
+			// Edge mobile on Android — EdgA/ token
+			[
+				"edge-android",
+				"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EdgA/120.0.0.0",
+				"Edge",
+			],
+			// Edge mobile on iOS — EdgiOS/ token
+			[
+				"edge-ios",
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 EdgiOS/120.0.0.0 Mobile/15E148 Safari/604.1",
+				"Edge",
+			],
+			// Opera — OPR/ token
+			[
+				"opera-desktop",
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/105.0.0.0",
+				"Opera",
+			],
+			// Firefox
+			[
+				"firefox-linux",
+				"Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0",
+				"Firefox",
+			],
+			// Chrome
+			[
+				"chrome-mac",
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+				"Chrome",
+			],
+			// Safari desktop — requires BOTH Safari/ and Version/
+			[
+				"safari-mac",
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+				"Safari",
+			],
+			// Safari iPhone
+			[
+				"safari-iphone",
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+				"Safari",
+			],
+		])("identifies %s as %s", (_label, ua, expectedBrowser) => {
+			expect(parseUserAgent(ua).browser).toBe(expectedBrowser);
+		});
+
+		it("returns null browser for an obscure WebView UA with no recognised browser token", () => {
+			expect(
+				parseUserAgent(
+					"Mozilla/5.0 (Linux; Android 13; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile",
+				).browser,
+			).toBeNull();
+		});
+
+		it("returns null browser for a Safari UA that lacks the Version/ token (rare WebKit shells)", () => {
+			expect(
+				parseUserAgent(
+					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15",
+				).browser,
+			).toBeNull();
+		});
+	});
+
+	describe("OS + device detection", () => {
+		it("routes iPad UA to iPadOS/tablet even when 'Mac OS X' is also present", () => {
+			const ua =
+				"Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+			const result = parseUserAgent(ua);
+			expect(result.os).toBe("iPadOS");
+			expect(result.device).toBe("tablet");
+		});
+
+		it("routes iPhone UA to iOS/mobile", () => {
+			const ua =
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+			const result = parseUserAgent(ua);
+			expect(result.os).toBe("iOS");
+			expect(result.device).toBe("mobile");
+		});
+
+		it("distinguishes Android mobile (has 'Mobile' token) from Android tablet", () => {
+			const mobile =
+				"Mozilla/5.0 (Linux; Android 13; Pixel 6) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36";
+			const tablet =
+				"Mozilla/5.0 (Linux; Android 13; SM-T970) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
+			expect(parseUserAgent(mobile).device).toBe("mobile");
+			expect(parseUserAgent(tablet).device).toBe("tablet");
+		});
+
+		it("routes macOS UA to macOS/desktop", () => {
+			const ua =
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15";
+			const result = parseUserAgent(ua);
+			expect(result.os).toBe("macOS");
+			expect(result.device).toBe("desktop");
+		});
+
+		it("routes Windows UA to Windows/desktop", () => {
+			const ua =
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
+			const result = parseUserAgent(ua);
+			expect(result.os).toBe("Windows");
+			expect(result.device).toBe("desktop");
+		});
+
+		it("routes Linux/X11 UA to Linux/desktop", () => {
+			const ua =
+				"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
+			const result = parseUserAgent(ua);
+			expect(result.os).toBe("Linux");
+			expect(result.device).toBe("desktop");
+		});
+	});
+
+	describe("edge cases", () => {
+		it("returns all-nulls for null input", () => {
+			expect(parseUserAgent(null)).toEqual({
+				browser: null,
+				os: null,
+				device: null,
+			});
+		});
+
+		it("returns all-nulls for empty string", () => {
+			expect(parseUserAgent("")).toEqual({
+				browser: null,
+				os: null,
+				device: null,
+			});
+		});
+
+		it("returns nulls (not 'Unknown' literals) when nothing matches", () => {
+			const result = parseUserAgent("Foo/1.0 (some-headless-thing)");
+			expect(result.browser).toBeNull();
+			expect(result.os).toBeNull();
+			expect(result.device).toBeNull();
+		});
+
+		it("does not throw on a UA with no Mozilla/ prefix", () => {
+			expect(() => parseUserAgent("curl/8.4.0")).not.toThrow();
+		});
+	});
+});

--- a/src/hooks/api/query-keys/session-keys.ts
+++ b/src/hooks/api/query-keys/session-keys.ts
@@ -34,6 +34,57 @@ export const sessionKeys = {
  * Exported so the revoke mutation can re-derive at fire time instead of
  * trusting a stale `is_current` flag from the listing.
  */
+/**
+ * Parse a User-Agent string into a coarse browser/os/device tuple for the
+ * Active Sessions UI. Session 12 browser-agent flagged the prior "Unknown
+ * Browser on Unknown OS" rendering — the auth.sessions row has the raw UA
+ * but the mapper used to leave it unparsed.
+ *
+ * Order matters: Edge/OPR override Chrome (their UA contains "Chrome/"),
+ * iOS overrides macOS for iPad-on-Safari (UA contains both "iPad" and
+ * "Mac OS"). Returns null for fields the parser can't identify rather
+ * than the literal "Unknown" string — the UI decides the fallback copy.
+ */
+export function parseUserAgent(uaRaw: string | null): {
+	browser: string | null;
+	os: string | null;
+	device: string | null;
+} {
+	if (!uaRaw) return { browser: null, os: null, device: null };
+	const ua = uaRaw;
+	let browser: string | null = null;
+	let os: string | null = null;
+	let device: string | null = null;
+
+	if (/\bEdg\//.test(ua)) browser = "Edge";
+	else if (/\bOPR\//.test(ua)) browser = "Opera";
+	else if (/\bFirefox\//.test(ua)) browser = "Firefox";
+	else if (/\bChrome\//.test(ua)) browser = "Chrome";
+	else if (/\bSafari\//.test(ua) && /\bVersion\//.test(ua)) browser = "Safari";
+
+	if (/\biPad\b/.test(ua)) {
+		os = "iPadOS";
+		device = "tablet";
+	} else if (/\biPhone\b/.test(ua)) {
+		os = "iOS";
+		device = "mobile";
+	} else if (/\bAndroid\b/.test(ua)) {
+		os = "Android";
+		device = /\bMobile\b/.test(ua) ? "mobile" : "tablet";
+	} else if (/\bMac OS X\b|\bMacintosh\b/.test(ua)) {
+		os = "macOS";
+		device = "desktop";
+	} else if (/\bWindows\b/.test(ua)) {
+		os = "Windows";
+		device = "desktop";
+	} else if (/\bLinux\b/.test(ua) || /\bX11\b/.test(ua)) {
+		os = "Linux";
+		device = "desktop";
+	}
+
+	return { browser, os, device };
+}
+
 export function decodeSessionIdFromAccessToken(
 	accessToken: string,
 ): string | null {
@@ -96,21 +147,22 @@ export const sessionQueries = {
 						ip: string | null;
 					}> | null) ?? [];
 
-				return rows.map((row) => ({
-					id: row.id,
-					user_id: row.user_id,
-					created_at: row.created_at,
-					updated_at: row.updated_at,
-					user_agent: row.user_agent,
-					ip: row.ip,
-					// Browser/OS/device parsing from user_agent is left to the UI layer
-					// (or a future enhancement) — the auth.sessions row doesn't carry
-					// these fields directly.
-					browser: null,
-					os: null,
-					device: null,
-					is_current: currentSessionId !== null && row.id === currentSessionId,
-				}));
+				return rows.map((row) => {
+					const ua = parseUserAgent(row.user_agent);
+					return {
+						id: row.id,
+						user_id: row.user_id,
+						created_at: row.created_at,
+						updated_at: row.updated_at,
+						user_agent: row.user_agent,
+						ip: row.ip,
+						browser: ua.browser,
+						os: ua.os,
+						device: ua.device,
+						is_current:
+							currentSessionId !== null && row.id === currentSessionId,
+					};
+				});
 			},
 			...QUERY_CACHE_TIMES.DETAIL,
 		}),

--- a/src/hooks/api/query-keys/session-keys.ts
+++ b/src/hooks/api/query-keys/session-keys.ts
@@ -25,25 +25,22 @@ export const sessionKeys = {
 };
 
 /**
- * Decode the `session_id` claim from a Supabase access token. The token is a
- * JWT whose payload (base64url-encoded) includes the `auth.sessions.id` of
- * the issuing session. Returns null if the token is malformed or the claim
- * is missing — callers fall back to `is_current=false` for every row, which
- * the UI handles gracefully.
- *
- * Exported so the revoke mutation can re-derive at fire time instead of
- * trusting a stale `is_current` flag from the listing.
- */
-/**
  * Parse a User-Agent string into a coarse browser/os/device tuple for the
  * Active Sessions UI. Session 12 browser-agent flagged the prior "Unknown
  * Browser on Unknown OS" rendering — the auth.sessions row has the raw UA
  * but the mapper used to leave it unparsed.
  *
- * Order matters: Edge/OPR override Chrome (their UA contains "Chrome/"),
- * iOS overrides macOS for iPad-on-Safari (UA contains both "iPad" and
- * "Mac OS"). Returns null for fields the parser can't identify rather
- * than the literal "Unknown" string — the UI decides the fallback copy.
+ * Order matters:
+ * - Browsers: Edge (Edg/EdgA/EdgiOS) → Opera (OPR) → Firefox → Chrome →
+ *   Safari. Edge mobile (EdgA/EdgiOS) is matched explicitly so it doesn't
+ *   fall through to Chrome on Android or Safari on iOS (PR #725 cycle-1
+ *   review).
+ * - OS: iPad → iPhone → Android (mobile vs tablet via "Mobile" token) →
+ *   macOS → Windows → Linux. iPad gets first crack so iPadOS-as-Mac UAs
+ *   are routed correctly when the iPad token IS present.
+ *
+ * Returns null for fields the parser can't identify rather than the
+ * literal "Unknown" string — the UI decides the fallback copy.
  */
 export function parseUserAgent(uaRaw: string | null): {
 	browser: string | null;
@@ -56,7 +53,7 @@ export function parseUserAgent(uaRaw: string | null): {
 	let os: string | null = null;
 	let device: string | null = null;
 
-	if (/\bEdg\//.test(ua)) browser = "Edge";
+	if (/\bEdg(A|iOS)?\//.test(ua)) browser = "Edge";
 	else if (/\bOPR\//.test(ua)) browser = "Opera";
 	else if (/\bFirefox\//.test(ua)) browser = "Firefox";
 	else if (/\bChrome\//.test(ua)) browser = "Chrome";
@@ -85,6 +82,16 @@ export function parseUserAgent(uaRaw: string | null): {
 	return { browser, os, device };
 }
 
+/**
+ * Decode the `session_id` claim from a Supabase access token. The token is a
+ * JWT whose payload (base64url-encoded) includes the `auth.sessions.id` of
+ * the issuing session. Returns null if the token is malformed or the claim
+ * is missing — callers fall back to `is_current=false` for every row, which
+ * the UI handles gracefully.
+ *
+ * Exported so the revoke mutation can re-derive at fire time instead of
+ * trusting a stale `is_current` flag from the listing.
+ */
 export function decodeSessionIdFromAccessToken(
 	accessToken: string,
 ): string | null {

--- a/src/lib/seo/owner-page-metadata.ts
+++ b/src/lib/seo/owner-page-metadata.ts
@@ -13,13 +13,27 @@ import type { Metadata } from "next";
  * `title` field. This helper closes that gap by setting all three
  * fields from a single source string.
  *
+ * Cycle-2 review widened the signature to accept an optional
+ * `description`. The original per-layout `description` strings (e.g.
+ * "Overview of your property portfolio, revenue, and activity" on
+ * /dashboard) were dropped by the initial refactor; this argument
+ * restores them so the browser tab tooltip + meta description on
+ * each route stays route-specific.
+ *
  * Usage in a child layout:
- *   export const metadata = ownerPageMetadata("Income Statement");
+ *   export const metadata = ownerPageMetadata(
+ *     "Income Statement",
+ *     "Revenue, expenses, and profit margin for the selected period",
+ *   );
  */
-export function ownerPageMetadata(title: string): Metadata {
+export function ownerPageMetadata(
+	title: string,
+	description?: string,
+): Metadata {
 	return {
 		title,
-		openGraph: { title },
-		twitter: { title },
+		...(description ? { description } : {}),
+		openGraph: { title, ...(description ? { description } : {}) },
+		twitter: { title, ...(description ? { description } : {}) },
 	};
 }

--- a/src/lib/seo/owner-page-metadata.ts
+++ b/src/lib/seo/owner-page-metadata.ts
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+
+/**
+ * Build a Next.js Metadata object for an owner-side (authenticated)
+ * sub-route layout. Wires the page title into title, openGraph.title,
+ * AND twitter.title so shared dashboard URLs preview with the
+ * page-specific title rather than the parent layout's "TenantFlow
+ * Dashboard" default.
+ *
+ * Session 12 cycle-1 review caught that Next.js metadata templates
+ * on openGraph.title only fire when child segments explicitly set
+ * `openGraph.title`; they do NOT auto-flow from a child's plain
+ * `title` field. This helper closes that gap by setting all three
+ * fields from a single source string.
+ *
+ * Usage in a child layout:
+ *   export const metadata = ownerPageMetadata("Income Statement");
+ */
+export function ownerPageMetadata(title: string): Metadata {
+	return {
+		title,
+		openGraph: { title },
+		twitter: { title },
+	};
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -215,24 +215,37 @@ export default defineConfig({
 	// Web Server
 	// @see https://playwright.dev/docs/test-webserver
 	// ===================
+	// Local: `next dev --turbopack` (fast incremental rebuilds).
+	// CI:    `next build && next start` (pre-compiled, sub-second page
+	//        loads). PR #725 cycle-5 review traced ERR_ABORTED flakes
+	//        across persona-consistency + critical-paths to JIT-compile
+	//        contention — every route compiled on first request, 2-10s
+	//        per route, 2 parallel workers serialized on the compiler.
+	//        Switching CI to a production build eliminated the
+	//        compile-time variability that was eating test budgets.
 	webServer: [
-		{
-			// Frontend: rm -rf .next ensures fresh build with correct env vars
-			// rm .env.local prevents production config from overriding test config
-			command: `rm -rf .next && rm -f .env.local && bash -c "export NODE_ENV='test' && export SKIP_ENV_VALIDATION='true' && export NEXT_PUBLIC_SUPABASE_URL='${LOCAL_SUPABASE_URL}' && export NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY='${LOCAL_SUPABASE_PUBLISHABLE_KEY}' && export NEXT_PUBLIC_APP_URL='${TEST_FRONTEND_URL}' && export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY='pk_test_placeholder' && exec npx next dev --turbopack --port ${TEST_FRONTEND_PORT}"`,
-			url: TEST_FRONTEND_URL,
-			timeout: 120_000,
-			reuseExistingServer: !process.env.CI,
-			stdout: "pipe",
-			stderr: "pipe",
-			cwd: path.resolve(__dirname, "../.."),
-			env: {
-				NEXT_PUBLIC_SUPABASE_URL: LOCAL_SUPABASE_URL,
-				NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: LOCAL_SUPABASE_PUBLISHABLE_KEY,
-				NEXT_PUBLIC_APP_URL: TEST_FRONTEND_URL,
-				NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_placeholder",
-			},
-		},
+		(() => {
+			const sharedEnv = `export NODE_ENV='${process.env.CI ? "production" : "test"}' && export SKIP_ENV_VALIDATION='true' && export NEXT_PUBLIC_SUPABASE_URL='${LOCAL_SUPABASE_URL}' && export NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY='${LOCAL_SUPABASE_PUBLISHABLE_KEY}' && export NEXT_PUBLIC_APP_URL='${TEST_FRONTEND_URL}' && export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY='pk_test_placeholder'`;
+			const command = process.env.CI
+				? `rm -rf .next && rm -f .env.local && bash -c "${sharedEnv} && npx next build && exec npx next start --port ${TEST_FRONTEND_PORT}"`
+				: `rm -rf .next && rm -f .env.local && bash -c "${sharedEnv} && exec npx next dev --turbopack --port ${TEST_FRONTEND_PORT}"`;
+			return {
+				command,
+				url: TEST_FRONTEND_URL,
+				// CI needs longer warm-up — `next build` runs once before serve.
+				timeout: process.env.CI ? 240_000 : 120_000,
+				reuseExistingServer: !process.env.CI,
+				stdout: "pipe" as const,
+				stderr: "pipe" as const,
+				cwd: path.resolve(__dirname, "../.."),
+				env: {
+					NEXT_PUBLIC_SUPABASE_URL: LOCAL_SUPABASE_URL,
+					NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: LOCAL_SUPABASE_PUBLISHABLE_KEY,
+					NEXT_PUBLIC_APP_URL: TEST_FRONTEND_URL,
+					NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: "pk_test_placeholder",
+				},
+			};
+		})(),
 	],
 
 	// ===================

--- a/tests/e2e/tests/public/persona-consistency.spec.ts
+++ b/tests/e2e/tests/public/persona-consistency.spec.ts
@@ -32,6 +32,13 @@ const PUBLIC_PATHS = [
 ] as const;
 
 test.describe("Persona consistency — sitewide", () => {
+	// 16 sequential page.goto() per test against the next dev server. Each
+	// page is ~300-900ms on a cold compile in CI, so the default 30s test
+	// budget gets tight and intermittently aborts with ERR_ABORTED when the
+	// dev server is mid-compile. Bumped to 60s — the assertions themselves
+	// are sub-millisecond, the budget is purely network/compile time.
+	test.setTimeout(60_000);
+
 	test('No "property owners" persona word on any public marketing page', async ({
 		page,
 	}) => {

--- a/tests/e2e/tests/public/persona-consistency.spec.ts
+++ b/tests/e2e/tests/public/persona-consistency.spec.ts
@@ -157,7 +157,12 @@ test.describe("Persona consistency — pricing page (COPY-02)", () => {
 	}) => {
 		await page.goto("/pricing");
 		const body = (await page.textContent("body")) ?? "";
-		expect(body).toContain("Built for landlords with 1–15 rentals");
+		// PR #725 renamed the hardcoded "1–15 rentals" badge to a
+		// per-plan `audienceTagline` field in `#config/pricing`. The
+		// featured slot renders Growth's tagline ("Built for 6–20 unit
+		// portfolios"); Starter and Max use their own. Test still pins
+		// segment-framing presence — just on the new shape.
+		expect(body).toContain("Built for 6–20 unit portfolios");
 	});
 
 	test("Pricing page metadata description references landlords", async ({


### PR DESCRIPTION
## Summary

Closes the 5 P2/P3 findings the Session 12 browser-agent report surfaced after PR #724 merged. No P0/P1 — the headline subscription/billing/navbar/tablist fixes from #724 all hold.

## Session 12 follow-up

| Finding | Severity | Fix |
|---|---|---|
| `/auth/update-password` tips still say "6 characters" | P2 | Wired `VALIDATION_LIMITS.PASSWORD_MIN_LENGTH` into the Security Tips panel — one constant, three surfaces |
| Pricing Growth card "1–15 rentals" | P3 | Badge now uses `plan.description` (lockstep with `#config/pricing`) |
| og:title hardcoded "TenantFlow Dashboard" everywhere | P3 | Metadata title template lets per-route sub-layouts flow into OG |
| Billing "Next billing date" row drops when null | P3 | Falls back to "Billing cycle syncing from Stripe…" |
| Active Sessions "Unknown Browser on Unknown OS" | P3 | New `parseUserAgent()` for the common browser + OS shapes |

### Detail

- **P2 — `/auth/update-password` Password tips panel** still said "Use at least 6 characters". The cycle-7 fix tightened validation to 12 chars + 4 complexity classes everywhere, but the page's sibling "Security Tips" panel (separate from the form itself) carried the old copy. Now reads `Use at least {VALIDATION_LIMITS.PASSWORD_MIN_LENGTH} characters` — one constant, one rule, three surfaces.

- **P3 — Pricing Growth card** retained a hardcoded "Built for landlords with 1–15 rentals" social-proof badge. That copy overlapped Starter (5 units) and undersold Growth (~6–20 units). Replaced with `plan.description` so the badge stays in lockstep with `#config/pricing`.

- **P3 — `(owner)/layout.tsx`** hardcoded `openGraph.title: "TenantFlow Dashboard"` across every authenticated route. Replaced with Next.js metadata title templates so per-route sub-layouts (analytics/*, financials/*, maintenance/new, etc.) flow their `title` into og:title + twitter:title automatically. Marketing-default fallback gone for shareable authenticated URLs.

- **P3 — Billing "Next billing date"** dropped the entire row when `subscription_current_period_end` was null (synthetic + in-flight-upgrade accounts). Reads as "missing" instead of "syncing." Now renders a deferred helper string ("Billing cycle syncing from Stripe…") when null.

- **P3 — Active Sessions** rows rendered "Unknown Browser on Unknown OS" because the session-keys mapper left browser/os null and deferred parsing to the UI; the UI applied "Unknown" placeholders. New `parseUserAgent()` helper handles Edge/Opera/Firefox/Chrome/Safari + iPadOS/iOS/Android/macOS/Windows/Linux with deterministic priority (Edg/OPR override Chrome; iPad overrides macOS).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` (biome) clean
- [x] `bun run test:unit` — 101,171 unit tests pass (139 files)
- [ ] Browser-agent Session 13 to verify the five fixes shipped (BATTLE-TEST-BROWSER-AGENT.txt covers all five; rerun phases 1, 3, 5, 6)

## Operator notes carried forward

- Cmd+K stack-suppression couldn't be exercised by Session 12 because owner-A already has a property — the onboarding wizard doesn't mount. Suggest provisioning a separate empty-state synthetic account for that scenario.
- FAB on `/dashboard` appears removed entirely; if Quick Actions in the right rail is the intended replacement, the FAB-tooltip criterion is N/A going forward.

[hudsor01]
