### PR TITLE
fix: session 13 browser-agent findings (1 P1, 2 P2)

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -41,9 +41,9 @@ export async function generateMetadata({
 	const params = await searchParams;
 	const page = Number(params.page) || 1;
 	return createPageMetadata({
-		title: "Property Management Blog — Tips for Landlords with 1–15 Rentals",
+		title: "Property Management Blog — Tips for Independent Landlords",
 		description:
-			"Operational guides for landlords with 1–15 rentals: leases, maintenance, tax season, and the document vault.",
+			"Operational guides for independent landlords: leases, maintenance, tax season, and the document vault.",
 		path: "/blog",
 		noindex: page > 1,
 	});
@@ -127,7 +127,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 			<section className="section-spacing">
 				<div className="mx-auto max-w-4xl px-6 text-center lg:px-8">
 					<h1 className="text-responsive-display-xl font-bold tracking-tight">
-						The blog for landlords with 1–15 rentals
+						The blog for independent landlords
 					</h1>
 					<p className="mt-4 text-lg text-muted-foreground">
 						Operational guides for leases, maintenance, tax season, and the

--- a/src/app/marketing-home.tsx
+++ b/src/app/marketing-home.tsx
@@ -45,9 +45,9 @@ export default function MarketingHomePage() {
 									</h1>
 
 									<p className="text-xl text-muted-foreground leading-relaxed max-w-lg">
-										The operations tool for landlords with 1–15 rentals. Track
-										properties, leases, and maintenance in one place — tenants
-										stay off the platform.
+										The operations tool for landlords with small portfolios.
+										Track properties, leases, and maintenance in one place —
+										tenants stay off the platform.
 									</p>
 								</div>
 
@@ -69,8 +69,8 @@ export default function MarketingHomePage() {
 								</div>
 
 								<p className="text-muted-foreground text-sm">
-									Built for landlords with 1–15 rentals. 14-day free trial, no
-									credit card.
+									Built for landlords with small portfolios. 14-day free trial,
+									no credit card.
 								</p>
 							</div>
 

--- a/src/components/marketing/lead-capture-modal.tsx
+++ b/src/components/marketing/lead-capture-modal.tsx
@@ -134,7 +134,7 @@ export function LeadCaptureModal({
 					</DialogTitle>
 					<DialogDescription>
 						Monthly tips on leases, maintenance, and tax season — written for
-						landlords with 1–15 rentals.
+						independent landlords.
 					</DialogDescription>
 				</DialogHeader>
 				<form onSubmit={handleSubmit}>

--- a/src/components/pricing/pricing-card-standard.tsx
+++ b/src/components/pricing/pricing-card-standard.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { Badge } from "#components/ui/badge";
 import { Button } from "#components/ui/button";
 import { createLogger } from "#lib/frontend-logger";
 import { checkoutRateLimiter } from "#lib/security";
@@ -25,6 +26,11 @@ interface PricingPlan {
 	id: string;
 	name: string;
 	description: string;
+	/** Short audience-targeting badge string. Same shape as
+	 *  PricingConfig in #config/pricing. PR #725 introduced this on the
+	 *  featured card; PR #726 (Session 13 #2) brings it to standard
+	 *  Starter/Max cards so all three tiers carry segment framing. */
+	audienceTagline: string;
 	price: {
 		monthly: number;
 		yearly: number;
@@ -191,6 +197,18 @@ export function PricingCardStandard({
 						</p>
 					)}
 				</div>
+
+				{/* Social-proof audience badge (PR #726 Session 13 #2: same
+				    treatment the featured card got in PR #725, but for
+				    Starter and Max so every tier carries segment framing). */}
+				<Badge
+					variant="trustIndicator"
+					size="trust"
+					className="w-full justify-center mb-6"
+				>
+					<BadgeCheck className="size-4" aria-hidden="true" />
+					{plan.audienceTagline}
+				</Badge>
 
 				{/* Features */}
 				<div className="space-y-2.5 mb-6 flex-1">

--- a/src/lib/generate-metadata.ts
+++ b/src/lib/generate-metadata.ts
@@ -32,7 +32,7 @@ function createDefaultMetadata(): Metadata {
 			default: "TenantFlow — Property Management Software for Landlords",
 		},
 		description:
-			"Property administration software built for landlords with 1–15 rentals. Track leases, maintenance, tenants, and finances in one place. 14-day free trial.",
+			"Property administration software built for independent landlords. Track leases, maintenance, tenants, and finances in one place. 14-day free trial.",
 		// `keywords` meta is ignored by Google (confirmed unchanged since
 		// the 2009 Search Central post) and Bing. Stripped — was dead
 		// bytes in every page <head>.
@@ -141,7 +141,7 @@ export function getJsonLd() {
 		url: SITE_URL,
 		logo: `${SITE_URL}/tenant-flow-logo.png`,
 		description:
-			"Property administration software for landlords with 1–15 rentals. Track leases, maintenance, and tenants. 14-day free trial.",
+			"Property administration software for independent landlords. Track leases, maintenance, and tenants. 14-day free trial.",
 		foundingDate: "2024",
 		// E.164-formatted business line (Schema.org expects digits-only,
 		// hyphens optional). The previous vanity `+1-888-TENANT-1`
@@ -170,7 +170,7 @@ export function getJsonLd() {
 		applicationSubCategory: "Property Management Software",
 		operatingSystem: "Web Browser",
 		description:
-			"Property administration software for landlords with 1–15 rentals. Track leases, maintenance, tenants, and financial reporting. 14-day free trial.",
+			"Property administration software for independent landlords. Track leases, maintenance, tenants, and financial reporting. 14-day free trial.",
 		url: SITE_URL,
 		image: [
 			`${SITE_URL}/images/property-management-og.jpg`,

--- a/src/lib/seo/__tests__/owner-page-metadata.test.ts
+++ b/src/lib/seo/__tests__/owner-page-metadata.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ownerPageMetadata helper tests.
+ *
+ * Pins the contract added in PR #725 (cycle-1 review of P1 og:title
+ * template) and PR #726 (Session 13 P2 — bake the " | TenantFlow"
+ * suffix into the helper output so deep (owner) sub-route layouts
+ * get the full title without depending on parent template merge,
+ * which intermediate layouts clobber via shallow merge).
+ */
+
+import { describe, expect, it } from "vitest";
+import { ownerPageMetadata } from "../owner-page-metadata";
+
+describe("ownerPageMetadata", () => {
+	it("sets the plain page title on the document title field", () => {
+		// The root `(owner)/layout.tsx` declares `title.template = "%s | TenantFlow"`,
+		// which Next.js handles specially for top-level `title` — it propagates
+		// across the metadata merge. So child layouts pass just the page name.
+		const meta = ownerPageMetadata("Income Statement");
+		expect(meta.title).toBe("Income Statement");
+	});
+
+	it("bakes ' | TenantFlow' suffix into openGraph.title and twitter.title", () => {
+		// PR #726 P2 fix: intermediate layouts setting `openGraph: { title: "X" }`
+		// shallow-replace the parent's entire openGraph object, including its
+		// title.template. The helper now writes a complete ogTitle string so
+		// deep leaves don't depend on template propagation working through
+		// shallow merge.
+		const meta = ownerPageMetadata("Income Statement");
+		expect(meta.openGraph).toMatchObject({
+			title: "Income Statement | TenantFlow",
+		});
+		expect(meta.twitter).toMatchObject({
+			title: "Income Statement | TenantFlow",
+		});
+	});
+
+	it("omits description fields entirely when no description arg is provided", () => {
+		const meta = ownerPageMetadata("Income Statement");
+		expect(meta.description).toBeUndefined();
+		expect(meta.openGraph).not.toHaveProperty("description");
+		expect(meta.twitter).not.toHaveProperty("description");
+	});
+
+	it("propagates description into top-level + openGraph + twitter when provided", () => {
+		// PR #725 cycle-2 fix: the original refactor dropped per-route
+		// description strings on 10 layouts (dashboard, settings, etc.).
+		// The helper restores them in all three metadata surfaces.
+		const meta = ownerPageMetadata(
+			"Dashboard",
+			"Overview of your property portfolio, revenue, and activity",
+		);
+		expect(meta.description).toBe(
+			"Overview of your property portfolio, revenue, and activity",
+		);
+		expect(meta.openGraph).toMatchObject({
+			title: "Dashboard | TenantFlow",
+			description: "Overview of your property portfolio, revenue, and activity",
+		});
+		expect(meta.twitter).toMatchObject({
+			title: "Dashboard | TenantFlow",
+			description: "Overview of your property portfolio, revenue, and activity",
+		});
+	});
+
+	it("handles a title that already contains characters Next.js might escape", () => {
+		// Guards against future regression if someone tries to template-substitute
+		// inside the title string. The helper does plain concatenation.
+		const meta = ownerPageMetadata("Tax & Compliance");
+		expect(meta.title).toBe("Tax & Compliance");
+		expect(meta.openGraph).toMatchObject({
+			title: "Tax & Compliance | TenantFlow",
+		});
+	});
+});

--- a/src/lib/seo/owner-page-metadata.ts
+++ b/src/lib/seo/owner-page-metadata.ts
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+const OG_TITLE_SUFFIX = " | TenantFlow";
+
 /**
  * Build a Next.js Metadata object for an owner-side (authenticated)
  * sub-route layout. Wires the page title into title, openGraph.title,
@@ -10,15 +12,23 @@ import type { Metadata } from "next";
  * Session 12 cycle-1 review caught that Next.js metadata templates
  * on openGraph.title only fire when child segments explicitly set
  * `openGraph.title`; they do NOT auto-flow from a child's plain
- * `title` field. This helper closes that gap by setting all three
- * fields from a single source string.
+ * `title` field.
  *
- * Cycle-2 review widened the signature to accept an optional
- * `description`. The original per-layout `description` strings (e.g.
- * "Overview of your property portfolio, revenue, and activity" on
- * /dashboard) were dropped by the initial refactor; this argument
- * restores them so the browser tab tooltip + meta description on
- * each route stays route-specific.
+ * Session 13 surfaced a second metadata-merge bug: when an
+ * intermediate layout sets `openGraph: { title: "Analytics" }`
+ * (a plain string), Next.js's shallow-merge REPLACES the parent's
+ * entire `openGraph` object — including the title.template the
+ * (owner) parent set. Deeper leaves like /analytics/overview then
+ * had no template to apply, so og:title rendered "Overview" with
+ * no "| TenantFlow" suffix. Baking the suffix in here removes the
+ * dependency on parent template merge entirely.
+ *
+ * The document `title` field is unaffected — Next.js handles top-
+ * level `title.template` specially and it propagates correctly
+ * across the merge.
+ *
+ * The `description` arg restores the per-layout description that
+ * the original refactor accidentally dropped (cycle-2 review fix).
  *
  * Usage in a child layout:
  *   export const metadata = ownerPageMetadata(
@@ -30,10 +40,11 @@ export function ownerPageMetadata(
 	title: string,
 	description?: string,
 ): Metadata {
+	const ogTitle = `${title}${OG_TITLE_SUFFIX}`;
 	return {
 		title,
 		...(description ? { description } : {}),
-		openGraph: { title, ...(description ? { description } : {}) },
-		twitter: { title, ...(description ? { description } : {}) },
+		openGraph: { title: ogTitle, ...(description ? { description } : {}) },
+		twitter: { title: ogTitle, ...(description ? { description } : {}) },
 	};
 }

--- a/tests/e2e/tests/public/persona-consistency.spec.ts
+++ b/tests/e2e/tests/public/persona-consistency.spec.ts
@@ -82,12 +82,15 @@ test.describe("Persona consistency — homepage hero (COPY-01 + COPY-03)", () =>
 		expect(body).not.toContain("tenants never have to log in");
 	});
 
-	test('Hero subhead contains "landlords with 1–15 rentals"', async ({
+	test('Hero subhead contains "landlords with small portfolios"', async ({
 		page,
 	}) => {
 		await page.goto("/");
 		const body = (await page.textContent("body")) ?? "";
-		expect(body).toContain("landlords with 1–15 rentals");
+		// PR #726 (Session 13 P1): scrubbed the "1–15 rentals" literal
+		// across the public surface. Test pins the new framing so the
+		// scrub doesn't get accidentally reverted on a future copy edit.
+		expect(body).toContain("landlords with small portfolios");
 	});
 
 	test('Hero subhead contains "tenants stay off the platform"', async ({


### PR DESCRIPTION
## Summary

Closes the 3 findings from the Session 13 browser-agent report (post PR #725 merge).

| Finding | Severity | Fix |
|---|---|---|
| "1–15 rentals" literal still in 8 places (homepage hero, /blog title+meta, lead-capture modal, Organization JSON-LD, SoftwareApplication JSON-LD, site description) | P1 | Scrubbed all 8 occurrences. Replaced with "small portfolios" (homepage user-facing copy) and "independent landlords" (meta/JSON-LD/blog). |
| Only Growth featured card renders audienceTagline badge; Starter and Max don't | P2 | `PricingCardStandard` interface widened to require `audienceTagline`; same `<Badge>/<BadgeCheck>` block added after the price block. |
| og:title missing " \| TenantFlow" suffix on /analytics/overview and /financials/income-statement (deep authenticated leaves) | P2 | Baked the suffix into the `ownerPageMetadata` helper output, removing the dependency on parent template merge that intermediate layouts were clobbering. |

## Detail

**P1 — "1–15 rentals" scrub.** The Session 12 P3 #2 fix swapped the hardcoded badge on the featured pricing card but missed the same literal in 8 other places. Session 13 walked the public surface and flagged every occurrence:
- `src/app/marketing-home.tsx` — hero subtitle + trial line
- `src/app/blog/page.tsx` — page title metadata + meta description + page <h1>
- `src/components/marketing/lead-capture-modal.tsx` — modal description
- `src/lib/generate-metadata.ts` — site description + Organization JSON-LD description + SoftwareApplication JSON-LD description

**P2 — Standard cards' social-proof badge.** PR #725 introduced `audienceTagline` on `PricingConfig` and used it on the featured Growth card. Starter and Max use `PricingCardStandard`, which never got the field. Now widened: every plan card renders its tagline ("Built for 1–5 unit portfolios" / "6–20" / "21+"), three-way segment framing across all tiers.

**P2 — Authenticated og:title template merge bug.** When an intermediate layout sets `openGraph: { title: "Analytics" }` (plain string), Next.js's shallow merge replaces the entire `openGraph` object from the parent — including the `title.template` the (owner) parent had set. Deep leaves like /analytics/overview lost the template and rendered `og:title = "Overview"` (no suffix). Baking the suffix into the helper output removes the template dependency entirely; the doc `<title>` tag is unaffected because Next.js handles top-level `title.template` specially.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` (biome) clean
- [x] `bun run test:unit` — 101,324 unit tests pass (140 files)
- [ ] Browser-agent Session 14 to verify the three fixes shipped

## Operator note

Session 13 flagged that `/signup` no longer exists as a password-form surface — it redirects to `/pricing` and signup funnels through Stripe Checkout. The four-surface password-policy invariant (signup + settings + reset + change-password dialog) collapses to three surfaces in practice. If `/signup` should be restored, that's a separate PR. The remaining three surfaces all enforce the unified 12-char + 4-class rule per cycle-1 of PR #725.

[hudsor01]
