### PR TITLE
fix: session 15 polish — billing/plans metadata, vault title casing, pricing product schema (3 P2/P3)

### DIFF
--- a/src/app/(owner)/billing/plans/layout.tsx
+++ b/src/app/(owner)/billing/plans/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
+
+export const metadata = ownerPageMetadata(
+	"Plans",
+	"Compare TenantFlow plans and upgrade or downgrade your subscription.",
+);
+
+export default function Layout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/src/app/(owner)/documents/vault/page.tsx
+++ b/src/app/(owner)/documents/vault/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { DocumentsVaultClient } from "#components/documents/documents-vault.client";
 
 export const metadata: Metadata = {
-	title: "Documents vault",
+	title: "Document Vault",
 	description:
 		"Search and filter every document attached to your properties, leases, tenants, and maintenance requests.",
 };

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -39,7 +39,7 @@ export default async function PricingPage() {
 	const productJsonLd = createProductJsonLd({
 		name: "TenantFlow Property Management Software",
 		description:
-			"Professional property management software for landlords. Starter $19/mo (5 properties), Growth $49/mo (20 properties), Max $149/mo (unlimited properties). 14-day free trial, no credit card required.",
+			"Property administration software for independent landlords. Starter $19/mo (5 properties), Growth $49/mo (20 properties), Max $149/mo (unlimited properties). 14-day free trial, no credit card required.",
 		offers: [
 			{ name: "Starter", price: "19.00" },
 			{ name: "Growth", price: "49.00" },

--- a/src/components/documents/__tests__/documents-vault.test.tsx
+++ b/src/components/documents/__tests__/documents-vault.test.tsx
@@ -194,7 +194,7 @@ describe("DocumentsVaultClient", () => {
 			isError: false,
 		});
 		renderVault();
-		expect(screen.getByText("Documents vault")).toBeInTheDocument();
+		expect(screen.getByText("Document Vault")).toBeInTheDocument();
 		expect(screen.getByLabelText(/search documents/i)).toBeInTheDocument();
 		expect(screen.getByLabelText(/filter by entity type/i)).toBeInTheDocument();
 	});

--- a/src/components/documents/documents-vault.client.tsx
+++ b/src/components/documents/documents-vault.client.tsx
@@ -378,7 +378,7 @@ export function DocumentsVaultClient() {
 			<div className="flex items-center gap-3">
 				<FolderArchive className="size-8 text-primary" />
 				<div>
-					<h1 className="typography-h2">Documents vault</h1>
+					<h1 className="typography-h2">Document Vault</h1>
 					<p className="text-muted-foreground">
 						Every PDF or image attached to your portfolio, in one place.
 					</p>


### PR DESCRIPTION
## Summary

Three polish items from the Session 15 browser-agent sweep against PR #727's merge tip. No P0/P1 — all scope-adjacent metadata/JSON-LD/copy alignment.

| Finding | Severity | Fix |
|---|---|---|
| /billing/plans rendered the marketing-homepage default title | P2 | New `(owner)/billing/plans/layout.tsx` wraps the client-component page with `ownerPageMetadata("Plans", "...")` |
| /documents/vault title "Documents vault" (lowercase v) | P3 | Renamed to "Document Vault" — matches sidebar nav |
| /pricing Product JSON-LD description used old "Professional property management software for landlords" lead | P3 | Aligned with the WebSite / Organization / SoftwareApplication descriptions: "Property administration software for independent landlords." |

## Detail

**P2 — /billing/plans metadata gap.** The page is a `"use client"` component, so `export const metadata` isn't allowed on the page itself. It had no sibling layout.tsx either, so the document title fell through to the (owner) layout — but PR #727 removed the (owner) `title.template`, so it cascaded further up to the ROOT `title.default = "TenantFlow — Property Management Software for Landlords"`. The browser-agent caught a homepage-default title on /billing/plans. New layout.tsx wraps the page with `ownerPageMetadata("Plans", "Compare TenantFlow plans and upgrade or downgrade your subscription.")` so doc + og + twitter all read "Plans | TenantFlow".

**P3 — /documents/vault casing.** Page title was "Documents vault" (lowercase 'v'), inconsistent with the sidebar nav ("Documents") and other plural-noun titles. Renamed to "Document Vault" — same naming convention as "Lease Template" and other content-noun page titles.

**P3 — /pricing Product schema description.** PR #726/#727 aligned the WebSite, Organization, and SoftwareApplication schema descriptions on "Property administration software for independent landlords." The Product schema on /pricing (which carries the Starter/Growth/Max offers) still led with "Professional property management software for landlords." — same audience phrase as the old surface. Updated to match.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` (biome) clean
- [x] `bun run test:unit` — 101,464 unit tests pass (141 files)
- [ ] Browser-agent Session 16 to verify the three metadata/JSON-LD updates

[hudsor01]
