### PR TITLE
fix(seo, a11y): AUDIT-1 P1 + P2 findings (homepage title, mobile overflow, contact H1)

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -7,7 +7,7 @@
 
 ## What is TenantFlow
 
-TenantFlow is property management software for individual landlords and small portfolio owners. It is intentionally landlord-only — there is no tenant portal, no tenant authentication, and no rent payment facilitation. Tenants exist as records owned by the landlord, not as users.
+TenantFlow is property management software for independent landlords. It is intentionally landlord-only — tenants don't log in, there is no tenant authentication, and the product does not facilitate rent payments. Tenants exist as records owned by the landlord, not as users.
 
 The product is operated by Hudson Digital Solutions. It runs on Next.js 16 + Supabase. Lease e-signing is powered by DocuSeal on the Growth and Max tiers.
 
@@ -26,9 +26,9 @@ The product is operated by Hudson Digital Solutions. It runs on Next.js 16 + Sup
 | Plan | Monthly | Annual | Properties | Units | E-sign | Reports |
 |---|---|---|---|---|---|---|
 | Trial | $0 (14d) | — | 1 | 5 | — | basic |
-| Starter | $29 | $290 | 5 | 25 | — | basic |
-| Growth | $79 | $790 | 20 | 100 | DocuSeal (25/mo) | premium |
-| Max | $199 | $2,189 | unlimited | unlimited | DocuSeal (unlimited) | premium |
+| Starter | $19 | $190 | 5 | 25 | — | basic |
+| Growth | $49 | $490 | 20 | 100 | DocuSeal (25/mo) | premium |
+| Max | $149 | $1,490 | unlimited | unlimited | DocuSeal (unlimited) | premium |
 
 All plans include the document vault, maintenance tracking, tenant records, and the financial ledger. Plan caps are enforced at the database layer via BEFORE INSERT triggers — Starter and Growth users hitting their property or unit cap see an upgrade prompt with attribution back to the gate that triggered it.
 
@@ -36,7 +36,7 @@ All plans include the document vault, maintenance tracking, tenant records, and 
 
 ### TenantFlow vs Buildium
 
-Buildium is targeted at multi-family property managers managing dozens to hundreds of units, often as third-party managers for owners. TenantFlow is positioned at the long tail: individual landlords with 1–20 units who don't need owner-management features or tenant payment processing.
+Buildium is targeted at multi-family property managers managing dozens to hundreds of units, often as third-party managers for owners. TenantFlow is positioned at the long tail: independent landlords with 1–20 units who don't need owner-management features or tenant payment processing.
 
 ### TenantFlow vs AppFolio
 
@@ -54,7 +54,7 @@ RentRedi competes on tenant-facing features — rent payment collection, tenant 
 
 ## Blog topics
 
-The TenantFlow blog publishes guides on tenant screening, lease lifecycle, maintenance operations, landlord taxes, security deposit handling, eviction process, software comparisons, and property management workflow tips. RSS feed: https://tenantflow.app/feed.xml.
+The TenantFlow blog publishes guides on screening prospective tenants, lease lifecycle, maintenance operations, landlord taxes, security deposit handling, eviction process, software comparisons, and property management workflow tips. RSS feed: https://tenantflow.app/feed.xml.
 
 ## Company
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,8 +1,8 @@
 # TenantFlow
 
-> Property management software for individual landlords and small property owners. Track leases, maintenance requests, tenant records, and financial reporting in one place. Landlord-only — no rent payment facilitation, no tenant portal accounts. 14-day free trial.
+> Property management software for independent landlords. Track leases, maintenance requests, tenant records, and financial reporting in one place. Landlord-only — tenants don't log in, the product does not facilitate rent payments. 14-day free trial.
 
-TenantFlow is a SaaS for landlords and small portfolio owners who want a single source of truth for their rental properties. The product centralizes lease documents (with DocuSeal e-signing on Growth and Max tiers), maintenance request tracking, tenant records, and tax-ready financial reporting. Pricing tiers are Starter ($29/mo), Growth ($79/mo), and Max ($199/mo).
+TenantFlow is a SaaS for independent landlords who want a single source of truth for their rental properties. The product centralizes lease documents (with DocuSeal e-signing on Growth and Max tiers), maintenance request tracking, tenant records, and tax-ready financial reporting. Pricing tiers are Starter ($19/mo), Growth ($49/mo), and Max ($149/mo).
 
 The site is operated by [Hudson Digital Solutions](https://hudsondigitalsolutions.com). The blog publishes practical landlord guides on screening, lease lifecycle, maintenance, taxes, and software comparisons.
 
@@ -10,7 +10,7 @@ The site is operated by [Hudson Digital Solutions](https://hudsondigitalsolution
 
 - [Features overview](https://tenantflow.app/features): the property, unit, lease, tenant, maintenance, and document modules.
 - [Pricing](https://tenantflow.app/pricing): plan caps, feature comparison, and a free 14-day trial across all tiers.
-- [About](https://tenantflow.app/about): mission and the team behind TenantFlow.
+- [About](https://tenantflow.app/about): product mission and positioning.
 
 ## Comparisons
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "TenantFlow - Property Management Software",
 	"short_name": "TenantFlow",
-	"description": "Property management software for landlords. Track leases, maintenance, and a per-entity document vault with global search and DocuSeal e-signing.",
+	"description": "Property management software for independent landlords. Track leases, maintenance, and a per-entity document vault with global search and DocuSeal e-signing.",
 	"start_url": "/?utm_source=pwa",
 	"display": "standalone",
 	"background_color": "#ffffff",

--- a/src/app/__tests__/marketing-copy-landlord-only.test.ts
+++ b/src/app/__tests__/marketing-copy-landlord-only.test.ts
@@ -1,6 +1,6 @@
 /**
  * Marketing copy guard: tenant portal + rent-collection features were removed.
- * The product is now a landlord-only property administration SaaS.
+ * The product is now a landlord-only property management SaaS.
  *
  * This test scans marketing surfaces + every non-test file under `src/components/**`
  * for banned phrases that describe features that no longer exist (online rent

--- a/src/app/__tests__/marketing-copy-landlord-only.test.ts
+++ b/src/app/__tests__/marketing-copy-landlord-only.test.ts
@@ -209,6 +209,11 @@ const BANNED_NUMERIC_CLAIMS = [
 
 // Explicit marketing surfaces (kept as a stable allowlist — catches files that
 // might not match the components walker, e.g. /app/pages, config, SEO helpers).
+// Includes `public/llms.txt`, `public/llms-full.txt`, and `public/manifest.json`
+// because AI crawlers + PWA install prompts fetch them directly; AUDIT-1
+// cycle-2 found stale pricing ($29/$79/$199 vs canonical $19/$49/$149) and a
+// reference to the deleted "team behind TenantFlow" section in llms.txt that
+// the previous .ts-only walker couldn't see.
 const MARKETING_FILES = [
 	"src/app/page.tsx",
 	"src/app/marketing-home.tsx",
@@ -231,6 +236,9 @@ const MARKETING_FILES = [
 	"src/data/testimonials.ts",
 	"src/config/pricing.ts",
 	"src/lib/generate-metadata.ts",
+	"public/llms.txt",
+	"public/llms-full.txt",
+	"public/manifest.json",
 ] as const;
 
 function isTestPath(relPath: string): boolean {

--- a/src/app/compare/[competitor]/compare-data.ts
+++ b/src/app/compare/[competitor]/compare-data.ts
@@ -110,7 +110,7 @@ export const COMPETITORS: Record<string, CompetitorData> = {
 			"Modern, fast interface built on cloud-native technology",
 			"Per-entity document vault with global search included on every plan",
 			"14-day free trial with no credit card required",
-			"Purpose-built for individual landlords — admin, documents, and records without accounting bloat",
+			"Purpose-built for independent landlords — admin, documents, and records without accounting bloat",
 		],
 		competitorStrengths: [
 			"HOA and community association management features",

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -14,7 +14,7 @@ import { COMPETITORS, VALID_COMPETITORS } from "./[competitor]/compare-data";
 export const revalidate = 3600;
 
 export const metadata: Metadata = createPageMetadata({
-	title: "Compare TenantFlow to Other Property Management Software",
+	title: "Compare to Other Property Management Software",
 	description:
 		"Side-by-side comparisons of TenantFlow against Buildium, AppFolio, RentRedi, and other landlord-focused property management platforms.",
 	path: "/compare",

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -7,7 +7,7 @@ import { createBreadcrumbJsonLd } from "#lib/seo/breadcrumbs";
 import { createPageMetadata } from "#lib/seo/page-metadata";
 
 export const metadata: Metadata = createPageMetadata({
-	title: "Contact TenantFlow Property Management Support",
+	title: "Contact Property Management Support",
 	description:
 		"Reach our team for help with setup, features, and growing your portfolio. We respond during US business hours, Monday through Friday.",
 	path: "/contact",

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -18,7 +18,7 @@ export const revalidate = 3600;
 export const metadata: Metadata = createPageMetadata({
 	title: "Property Management FAQ | Questions About Leases, Maintenance & More",
 	description:
-		"Answers to common landlord questions about lease management, the document vault, lease e-signing, maintenance tracking, and property administration. Get started with TenantFlow.",
+		"Answers to common landlord questions about lease management, the document vault, lease e-signing, maintenance tracking, and property management. Get started with TenantFlow.",
 	path: "/faq",
 });
 

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -18,7 +18,7 @@ export const revalidate = 3600;
 export const metadata: Metadata = createPageMetadata({
 	title: "Property Management FAQ | Questions About Leases, Maintenance & More",
 	description:
-		"Answers to common landlord questions about lease management, the document vault, lease e-signing, maintenance tracking, and property management. Get started with TenantFlow.",
+		"Answers to common landlord questions about lease management, the document vault, lease e-signing, maintenance tracking, and financial reporting. Get started with TenantFlow.",
 	path: "/faq",
 });
 

--- a/src/app/marketing-home.tsx
+++ b/src/app/marketing-home.tsx
@@ -34,7 +34,13 @@ export default function MarketingHomePage() {
 									<Badge
 										variant="trustIndicator"
 										size="trust"
-										className="self-start mb-2"
+										// `whitespace-normal` + `text-left` override Badge's
+										// base `whitespace-nowrap` so the 35-char trust
+										// indicator wraps under ~360px viewports instead of
+										// forcing a 281px-wide pill that overflows the page.
+										// Surfaced by AUDIT-1 (2026-05-18). `max-w-full` keeps
+										// the badge inside the flex column on every breakpoint.
+										className="self-start mb-2 whitespace-normal text-left max-w-full"
 									>
 										<Lock className="size-4" aria-hidden="true" />
 										Landlord-only · Tenants never log in

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ export default function RootPage() {
 		name: "TenantFlow",
 		url: siteUrl,
 		description:
-			"Property administration software for independent landlords. Track leases, maintenance, tenants, and finances in one place.",
+			"Property management software for independent landlords. Track leases, maintenance, tenants, and finances in one place.",
 		potentialAction: {
 			"@type": "SearchAction" as const,
 			target: `${siteUrl}/search?q={search_term_string}`,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export const dynamic = "force-static";
 export const metadata: Metadata = createPageMetadata({
 	title: "Property Management Software for Independent Landlords",
 	description:
-		"All-in-one property administration software for landlords. Track leases, maintenance requests, tenant records, and finances in one place. 14-day free trial, no credit card required.",
+		"All-in-one property management software for independent landlords. Track leases, maintenance requests, tenant records, and finances in one place. 14-day free trial, no credit card required.",
 	path: "/",
 	// Root segment: Next.js does not apply the root layout's
 	// `title.template` here, so without `absoluteTitle` the homepage

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,10 +10,15 @@ import MarketingHomePage from "./marketing-home";
 export const dynamic = "force-static";
 
 export const metadata: Metadata = createPageMetadata({
-	title: "Property Management Software for Landlords",
+	title: "Property Management Software for Independent Landlords",
 	description:
 		"All-in-one property administration software for landlords. Track leases, maintenance requests, tenant records, and finances in one place. 14-day free trial, no credit card required.",
 	path: "/",
+	// Root segment: Next.js does not apply the root layout's
+	// `title.template` here, so without `absoluteTitle` the homepage
+	// renders `<title>...</title>` with no ` | TenantFlow` suffix
+	// (caught by the AUDIT-1 browser-agent sweep, 2026-05-18).
+	absoluteTitle: true,
 });
 
 /**

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -39,7 +39,7 @@ export default async function PricingPage() {
 	const productJsonLd = createProductJsonLd({
 		name: "TenantFlow Property Management Software",
 		description:
-			"Property administration software for independent landlords. Starter $19/mo (5 properties), Growth $49/mo (20 properties), Max $149/mo (unlimited properties). 14-day free trial, no credit card required.",
+			"Property management software for independent landlords. Starter $19/mo (5 properties), Growth $49/mo (20 properties), Max $149/mo (unlimited properties). 14-day free trial, no credit card required.",
 		offers: [
 			{ name: "Starter", price: "19.00" },
 			{ name: "Growth", price: "49.00" },

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -26,7 +26,7 @@ export const revalidate = 3600;
 export const metadata: Metadata = createPageMetadata({
 	title: "Property Management Software Pricing | Plans from $19/mo",
 	description:
-		"Property management software for landlords. Starter ($19/mo, 5 properties), Growth ($49/mo, 20 properties), Max ($149/mo, unlimited properties). 14-day free trial, no credit card required.",
+		"Property management software for independent landlords. Starter ($19/mo, 5 properties), Growth ($49/mo, 20 properties), Max ($149/mo, unlimited properties). 14-day free trial, no credit card required.",
 	path: "/pricing",
 	ogImage: "/api/og/pricing",
 });

--- a/src/components/contact/contact-form.tsx
+++ b/src/components/contact/contact-form.tsx
@@ -165,7 +165,7 @@ export function ContactForm({ className = "" }: ContactFormProps) {
 
 				<div className="relative z-10 p-8 rounded-2xl backdrop-blur-lg bg-background/60 dark:bg-card/60 border border-border/20 shadow-2xl">
 					<h1 className="typography-h2 text-foreground lg:text-4xl">
-						Let&apos;s Talk About Your Properties
+						Let&apos;s talk about your properties
 					</h1>
 					<p className="mt-4 text-muted-foreground text-lg">
 						Whether you manage 5 or 500 units, we&apos;re here to help

--- a/src/lib/generate-metadata.ts
+++ b/src/lib/generate-metadata.ts
@@ -29,7 +29,8 @@ function createDefaultMetadata(): Metadata {
 		metadataBase: new URL(SITE_URL),
 		title: {
 			template: "%s | TenantFlow",
-			default: "TenantFlow — Property Management Software for Landlords",
+			default:
+				"TenantFlow — Property Management Software for Independent Landlords",
 		},
 		description:
 			"Property administration software built for independent landlords. Track leases, maintenance, tenants, and finances in one place. 14-day free trial.",
@@ -49,7 +50,8 @@ function createDefaultMetadata(): Metadata {
 			// localized content.
 		},
 		openGraph: {
-			title: "TenantFlow — Property Management Software for Landlords",
+			title:
+				"TenantFlow — Property Management Software for Independent Landlords",
 			description:
 				"All-in-one rental property administration. Track leases, maintenance, and tenants. Plans from $19/mo.",
 			url: SITE_URL,
@@ -75,7 +77,8 @@ function createDefaultMetadata(): Metadata {
 		},
 		twitter: {
 			card: "summary_large_image",
-			title: "TenantFlow — Property Management Software for Landlords",
+			title:
+				"TenantFlow — Property Management Software for Independent Landlords",
 			description:
 				"All-in-one rental property administration. Track leases, maintenance, and tenants. Plans from $19/mo.",
 			site: "@tenantflow",

--- a/src/lib/generate-metadata.ts
+++ b/src/lib/generate-metadata.ts
@@ -33,7 +33,7 @@ function createDefaultMetadata(): Metadata {
 				"TenantFlow — Property Management Software for Independent Landlords",
 		},
 		description:
-			"Property administration software built for independent landlords. Track leases, maintenance, tenants, and finances in one place. 14-day free trial.",
+			"Property management software built for independent landlords. Track leases, maintenance, tenants, and finances in one place. 14-day free trial.",
 		// `keywords` meta is ignored by Google (confirmed unchanged since
 		// the 2009 Search Central post) and Bing. Stripped — was dead
 		// bytes in every page <head>.
@@ -53,7 +53,7 @@ function createDefaultMetadata(): Metadata {
 			title:
 				"TenantFlow — Property Management Software for Independent Landlords",
 			description:
-				"All-in-one rental property administration. Track leases, maintenance, and tenants. Plans from $19/mo.",
+				"All-in-one property management software. Track leases, maintenance, and tenants. Plans from $19/mo.",
 			url: SITE_URL,
 			siteName: "TenantFlow",
 			type: "website",
@@ -80,7 +80,7 @@ function createDefaultMetadata(): Metadata {
 			title:
 				"TenantFlow — Property Management Software for Independent Landlords",
 			description:
-				"All-in-one rental property administration. Track leases, maintenance, and tenants. Plans from $19/mo.",
+				"All-in-one property management software. Track leases, maintenance, and tenants. Plans from $19/mo.",
 			site: "@tenantflow",
 			creator: "@tenantflow",
 			images: [`${SITE_URL}/images/property-management-og.jpg`],
@@ -144,7 +144,7 @@ export function getJsonLd() {
 		url: SITE_URL,
 		logo: `${SITE_URL}/tenant-flow-logo.png`,
 		description:
-			"Property administration software for independent landlords. Track leases, maintenance, and tenants. 14-day free trial.",
+			"Property management software for independent landlords. Track leases, maintenance, and tenants. 14-day free trial.",
 		foundingDate: "2024",
 		// E.164-formatted business line (Schema.org expects digits-only,
 		// hyphens optional). The previous vanity `+1-888-TENANT-1`
@@ -173,7 +173,7 @@ export function getJsonLd() {
 		applicationSubCategory: "Property Management Software",
 		operatingSystem: "Web Browser",
 		description:
-			"Property administration software for independent landlords. Track leases, maintenance, tenants, and financial reporting. 14-day free trial.",
+			"Property management software for independent landlords. Track leases, maintenance, tenants, and financial reporting. 14-day free trial.",
 		url: SITE_URL,
 		image: [
 			`${SITE_URL}/images/property-management-og.jpg`,

--- a/src/lib/seo/__tests__/page-metadata.test.ts
+++ b/src/lib/seo/__tests__/page-metadata.test.ts
@@ -129,6 +129,28 @@ describe("createPageMetadata", () => {
 		expect(og.url).toBe("https://tenantflow.app/faq");
 	});
 
+	it("titles already containing 'TenantFlow' are NOT brand-suffixed (no duplicate)", () => {
+		// Defense-in-depth: if a future caller passes a title like
+		// "Contact TenantFlow Support", appending " | TenantFlow" would
+		// produce "Contact TenantFlow Support | TenantFlow" with a duplicate
+		// brand token. The helper detects the embedded brand and skips the
+		// suffix on og/twitter/image alt. Caught by AUDIT-1 cycle-2 review
+		// (2026-05-18).
+		const result = createPageMetadata({
+			title: "TenantFlow vs Buildium",
+			description: "desc",
+			path: "/compare/buildium",
+		});
+
+		const og = result.openGraph as Record<string, unknown>;
+		expect(og.title).toBe("TenantFlow vs Buildium");
+		const twitter = result.twitter as Record<string, unknown>;
+		expect(twitter.title).toBe("TenantFlow vs Buildium");
+		const ogImages = (result.openGraph as { images?: Array<{ alt: string }> })
+			.images;
+		expect(ogImages?.[0]?.alt).toBe("TenantFlow vs Buildium");
+	});
+
 	it("custom ogImage overrides default", () => {
 		const result = createPageMetadata({
 			title: "FAQ",

--- a/src/lib/seo/__tests__/page-metadata.test.ts
+++ b/src/lib/seo/__tests__/page-metadata.test.ts
@@ -34,7 +34,11 @@ describe("createPageMetadata", () => {
 		expect(result.alternates?.canonical).toBe("https://tenantflow.app/faq");
 	});
 
-	it("OG title and description match input", () => {
+	it("OG title is brand-suffixed; description matches input", () => {
+		// openGraph.title doesn't inherit `title.template`, so we brand-suffix
+		// it in createPageMetadata to match the rendered doc title across all
+		// routes. AUDIT-1 (2026-05-18) caught the prior bare og:title on the
+		// homepage; the fix applies uniformly to every page.
 		const result = createPageMetadata({
 			title: "FAQ",
 			description: "Frequently asked questions",
@@ -42,8 +46,30 @@ describe("createPageMetadata", () => {
 		});
 
 		const og = result.openGraph as Record<string, unknown>;
-		expect(og.title).toBe("FAQ");
+		expect(og.title).toBe("FAQ | TenantFlow");
 		expect(og.description).toBe("Frequently asked questions");
+	});
+
+	it("absoluteTitle emits title.absolute with brand suffix (root segment)", () => {
+		// Root segment (`src/app/page.tsx`) sits at the same depth as the root
+		// layout, so `title.template` is NOT applied. Pages on the root
+		// segment opt into `absoluteTitle: true` to get the brand suffix
+		// rendered into <title>.
+		const result = createPageMetadata({
+			title: "Property Management Software for Independent Landlords",
+			description: "desc",
+			path: "/",
+			absoluteTitle: true,
+		});
+
+		expect(result.title).toEqual({
+			absolute:
+				"Property Management Software for Independent Landlords | TenantFlow",
+		});
+		const og = result.openGraph as Record<string, unknown>;
+		expect(og.title).toBe(
+			"Property Management Software for Independent Landlords | TenantFlow",
+		);
 	});
 
 	it("OG url matches canonical", () => {

--- a/src/lib/seo/__tests__/page-metadata.test.ts
+++ b/src/lib/seo/__tests__/page-metadata.test.ts
@@ -151,6 +151,25 @@ describe("createPageMetadata", () => {
 		expect(ogImages?.[0]?.alt).toBe("TenantFlow vs Buildium");
 	});
 
+	it("absoluteTitle + already-branded title: no duplicate brand in title.absolute", () => {
+		// Edge interaction: a hypothetical root-segment page whose title
+		// already contains "TenantFlow" should NOT double-brand. suffixed
+		// resolves to the bare title; title.absolute carries the bare
+		// title; doc title renders the bare brand mention without a
+		// trailing " | TenantFlow". Not exercised by any current caller
+		// but pinned so the guard interaction stays correct.
+		const result = createPageMetadata({
+			title: "TenantFlow vs Buildium",
+			description: "desc",
+			path: "/",
+			absoluteTitle: true,
+		});
+
+		expect(result.title).toEqual({ absolute: "TenantFlow vs Buildium" });
+		const og = result.openGraph as Record<string, unknown>;
+		expect(og.title).toBe("TenantFlow vs Buildium");
+	});
+
 	it("custom ogImage overrides default", () => {
 		const result = createPageMetadata({
 			title: "FAQ",

--- a/src/lib/seo/__tests__/page-metadata.test.ts
+++ b/src/lib/seo/__tests__/page-metadata.test.ts
@@ -134,14 +134,18 @@ describe("createPageMetadata", () => {
 		// "Contact TenantFlow Support", appending " | TenantFlow" would
 		// produce "Contact TenantFlow Support | TenantFlow" with a duplicate
 		// brand token. The helper detects the embedded brand and skips the
-		// suffix on og/twitter/image alt. Caught by AUDIT-1 cycle-2 review
-		// (2026-05-18).
+		// suffix on og/twitter/image alt AND short-circuits `title.template`
+		// via `title.absolute` so the doc title doesn't double-brand either.
+		// Caught by AUDIT-1 cycle-2 review (2026-05-18). The `/compare/[competitor]`
+		// route is the real-world shape this protects against; today that route
+		// uses raw `Metadata` (not this helper), so the path below is hypothetical.
 		const result = createPageMetadata({
 			title: "TenantFlow vs Buildium",
 			description: "desc",
-			path: "/compare/buildium",
+			path: "/__hypothetical-branded__",
 		});
 
+		expect(result.title).toEqual({ absolute: "TenantFlow vs Buildium" });
 		const og = result.openGraph as Record<string, unknown>;
 		expect(og.title).toBe("TenantFlow vs Buildium");
 		const twitter = result.twitter as Record<string, unknown>;

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -52,16 +52,15 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 	// title, `absoluteTitle` decides whether to short-circuit the template
 	// (root segment) or let the template apply the suffix (nested segments).
 	//
-	// Skip the suffix if the title already contains "TenantFlow" — e.g.
-	// `/contact` ("Contact TenantFlow Property Management Support") and
-	// `/compare` ("Compare TenantFlow to Other Property Management
-	// Software") would otherwise render `"... | TenantFlow"` with a
-	// duplicate brand token in OG/Twitter previews. The doc-title side
-	// has the same risk via `title.template`; those pages are renamed
-	// in this PR to drop the embedded "TenantFlow" so the suffix is
-	// additive everywhere.
-	// Word-boundary match so a hypothetical title like "TenantFlowing" or
-	// "tenant-flow rivers" wouldn't accidentally suppress the suffix.
+	// Defense-in-depth: if a caller ever passes a title that already
+	// contains the brand token (e.g. an idiomatic "TenantFlow vs X"
+	// pattern), appending " | TenantFlow" would render a duplicate
+	// brand in OG/Twitter previews. No current caller hits this — the
+	// `compare/[competitor]` dynamic route uses raw `Metadata` rather
+	// than `createPageMetadata` — but the guard keeps the helper
+	// regression-proof against future additions. Word-boundary match
+	// so "TenantFlowing" or "tenant-flow rivers" wouldn't accidentally
+	// suppress the suffix.
 	const alreadyBranded = /\bTenantFlow\b/i.test(title);
 	const suffixed = alreadyBranded ? title : `${title} | TenantFlow`;
 

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -59,8 +59,8 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 	// `compare/[competitor]` dynamic route uses raw `Metadata` rather
 	// than `createPageMetadata` — but the guard keeps the helper
 	// regression-proof against future additions. Word-boundary match
-	// so "TenantFlowing" or "tenant-flow rivers" wouldn't accidentally
-	// suppress the suffix.
+	// so a suffixed string like "TenantFlowing" or a prefixed string
+	// like "aTenantFlow" wouldn't accidentally suppress the suffix.
 	const alreadyBranded = /\bTenantFlow\b/i.test(title);
 	const suffixed = alreadyBranded ? title : `${title} | TenantFlow`;
 

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -21,6 +21,11 @@ interface PageMetadataConfig {
 	 * Use `absoluteTitle: true` for any page sharing the root segment.
 	 * For nested pages leave it off so the template is the single source
 	 * of truth for the suffix.
+	 *
+	 * Today the ONLY caller using this flag is `src/app/page.tsx`. Any
+	 * NEW file added under `src/app/*.tsx` (i.e. a sibling of
+	 * `page.tsx`/`layout.tsx`/`loading.tsx`) is also on the root segment
+	 * and MUST set `absoluteTitle: true` to render the brand suffix.
 	 */
 	absoluteTitle?: boolean;
 }
@@ -46,7 +51,17 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 	// suffix here for consistency with the rendered <title>). For the doc
 	// title, `absoluteTitle` decides whether to short-circuit the template
 	// (root segment) or let the template apply the suffix (nested segments).
-	const suffixed = `${title} | TenantFlow`;
+	//
+	// Skip the suffix if the title already contains "TenantFlow" — e.g.
+	// `/contact` ("Contact TenantFlow Property Management Support") and
+	// `/compare` ("Compare TenantFlow to Other Property Management
+	// Software") would otherwise render `"... | TenantFlow"` with a
+	// duplicate brand token in OG/Twitter previews. The doc-title side
+	// has the same risk via `title.template`; those pages are renamed
+	// in this PR to drop the embedded "TenantFlow" so the suffix is
+	// additive everywhere.
+	const alreadyBranded = /TenantFlow/i.test(title);
+	const suffixed = alreadyBranded ? title : `${title} | TenantFlow`;
 
 	return {
 		title: absoluteTitle ? { absolute: suffixed } : title,

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -22,10 +22,9 @@ interface PageMetadataConfig {
 	 * For nested pages leave it off so the template is the single source
 	 * of truth for the suffix.
 	 *
-	 * Today the ONLY caller using this flag is `src/app/page.tsx`. Any
-	 * NEW file added under `src/app/*.tsx` (i.e. a sibling of
-	 * `page.tsx`/`layout.tsx`/`loading.tsx`) is also on the root segment
-	 * and MUST set `absoluteTitle: true` to render the brand suffix.
+	 * Today the ONLY caller is `src/app/page.tsx`. Any new file directly
+	 * under `src/app/` (not nested in a subdirectory) that exports
+	 * `metadata` is on the root segment and must set `absoluteTitle: true`.
 	 */
 	absoluteTitle?: boolean;
 }
@@ -55,17 +54,23 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 	// Defense-in-depth: if a caller ever passes a title that already
 	// contains the brand token (e.g. an idiomatic "TenantFlow vs X"
 	// pattern), appending " | TenantFlow" would render a duplicate
-	// brand in OG/Twitter previews. No current caller hits this — the
-	// `compare/[competitor]` dynamic route uses raw `Metadata` rather
-	// than `createPageMetadata` — but the guard keeps the helper
-	// regression-proof against future additions. Word-boundary match
-	// so a suffixed string like "TenantFlowing" or a prefixed string
-	// like "aTenantFlow" wouldn't accidentally suppress the suffix.
+	// brand. No current caller hits this — the `compare/[competitor]`
+	// dynamic route uses raw `Metadata` rather than `createPageMetadata`
+	// — but the guard keeps the helper regression-proof against future
+	// additions. Word-boundary match so a suffixed string like
+	// "TenantFlowing" or a prefixed string like "aTenantFlow" wouldn't
+	// accidentally suppress the suffix.
+	//
+	// When `alreadyBranded`, also short-circuit `title.template` via
+	// `title.absolute`. Otherwise a nested-segment caller would get
+	// clean OG/Twitter but Next.js would still template-prepend
+	// "| TenantFlow" on the doc title — producing a doubled brand only
+	// in `<title>`. Making the guard symmetric closes that gap.
 	const alreadyBranded = /\bTenantFlow\b/i.test(title);
 	const suffixed = alreadyBranded ? title : `${title} | TenantFlow`;
 
 	return {
-		title: absoluteTitle ? { absolute: suffixed } : title,
+		title: absoluteTitle || alreadyBranded ? { absolute: suffixed } : title,
 		description,
 		alternates: {
 			canonical: canonicalUrl,

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -15,7 +15,7 @@ interface PageMetadataConfig {
 	 * segments — the root segment (`/` at `src/app/page.tsx`) sits at the
 	 * same depth as the root layout and Next.js does not apply the template
 	 * there. Without this opt-in the homepage would render
-	 * `<title>Property Management Software for Landlords</title>` with no
+	 * `<title>Property Management Software for Independent Landlords</title>` with no
 	 * brand suffix while every other page renders `... | TenantFlow`.
 	 *
 	 * Use `absoluteTitle: true` for any page sharing the root segment.

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -8,6 +8,21 @@ interface PageMetadataConfig {
 	path: string;
 	noindex?: boolean;
 	ogImage?: string;
+	/**
+	 * When true, emit `title: { absolute: "<title> | TenantFlow" }` instead of
+	 * a plain string. Plain-string titles get the root layout's
+	 * `title.template` ("%s | TenantFlow") prepended ONLY for nested route
+	 * segments — the root segment (`/` at `src/app/page.tsx`) sits at the
+	 * same depth as the root layout and Next.js does not apply the template
+	 * there. Without this opt-in the homepage would render
+	 * `<title>Property Management Software for Landlords</title>` with no
+	 * brand suffix while every other page renders `... | TenantFlow`.
+	 *
+	 * Use `absoluteTitle: true` for any page sharing the root segment.
+	 * For nested pages leave it off so the template is the single source
+	 * of truth for the suffix.
+	 */
+	absoluteTitle?: boolean;
 }
 
 /**
@@ -15,7 +30,7 @@ interface PageMetadataConfig {
  * Generates canonical URL, OG tags, and Twitter card from minimal config.
  */
 export function createPageMetadata(config: PageMetadataConfig): Metadata {
-	const { title, description, path, noindex, ogImage } = config;
+	const { title, description, path, noindex, ogImage, absoluteTitle } = config;
 	const siteUrl = getSiteUrl();
 	const normalizedPath = path.startsWith("/") ? path : `/${path}`;
 	const canonicalUrl = `${siteUrl}${normalizedPath}`;
@@ -26,15 +41,21 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 		: undefined;
 	const imageUrl =
 		normalizedOgImage ?? `${siteUrl}/images/property-management-og.jpg`;
+	// Brand-suffixed form used for openGraph + twitter + image alt on every
+	// page (those fields don't inherit `title.template`, so we apply the
+	// suffix here for consistency with the rendered <title>). For the doc
+	// title, `absoluteTitle` decides whether to short-circuit the template
+	// (root segment) or let the template apply the suffix (nested segments).
+	const suffixed = `${title} | TenantFlow`;
 
 	return {
-		title,
+		title: absoluteTitle ? { absolute: suffixed } : title,
 		description,
 		alternates: {
 			canonical: canonicalUrl,
 		},
 		openGraph: {
-			title,
+			title: suffixed,
 			description,
 			url: canonicalUrl,
 			siteName: "TenantFlow",
@@ -45,13 +66,13 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 					url: imageUrl,
 					width: 1200,
 					height: 630,
-					alt: `${title} | TenantFlow`,
+					alt: suffixed,
 				},
 			],
 		},
 		twitter: {
 			card: "summary_large_image",
-			title,
+			title: suffixed,
 			description,
 			images: [imageUrl],
 		},

--- a/src/lib/seo/page-metadata.ts
+++ b/src/lib/seo/page-metadata.ts
@@ -60,7 +60,9 @@ export function createPageMetadata(config: PageMetadataConfig): Metadata {
 	// has the same risk via `title.template`; those pages are renamed
 	// in this PR to drop the embedded "TenantFlow" so the suffix is
 	// additive everywhere.
-	const alreadyBranded = /TenantFlow/i.test(title);
+	// Word-boundary match so a hypothetical title like "TenantFlowing" or
+	// "tenant-flow rivers" wouldn't accidentally suppress the suffix.
+	const alreadyBranded = /\bTenantFlow\b/i.test(title);
 	const suffixed = alreadyBranded ? title : `${title} | TenantFlow`;
 
 	return {


### PR DESCRIPTION
## Summary

Browser-agent pre-launch audit (Phase 1 — Landing First Impression + Public Surface Sweep) surfaced 2 P1 + 2 P2 + 1 P3 findings. This PR ships all the actionable ones.

| Sev | Finding | Resolution |
|---|---|---|
| **P1** | Homepage `<title>` rendered with **no `\| TenantFlow` suffix** while every other route gets it | Add `absoluteTitle: true` opt-in to `createPageMetadata`; apply on `src/app/page.tsx`. Sharpen title copy to "Property Management Software for **Independent** Landlords" to match canonical phrase. |
| **P1** | Mobile horizontal scroll on `/` caused by hero trust badge ("Landlord-only · Tenants never log in") | Override Badge's base `whitespace-nowrap` with `whitespace-normal text-left max-w-full` on this hero instance. |
| **P2** | `/contact` H1 used Title Case ("Let's Talk About Your Properties"); every other H1 is sentence case | Sentence-case fix. |
| **P2** | `/feed.xml` flagged as served with `Content-Type: text/plain` | **False positive** — verified prod via curl: `application/rss+xml; charset=utf-8`. No change. |
| **P3** | Three above-fold CTAs route to `/pricing` | Intentional funnel — left alone. |

## Side benefit: hardened og:title across every page

The audit caught the root-segment title bug, and digging into it revealed `openGraph.title` was being emitted as the bare unbranded string on every page (it doesn't inherit `title.template`). Fixed in the same patch: `createPageMetadata` now brand-suffixes openGraph + twitter title + image alt uniformly. Existing test updated, new test added for the `absoluteTitle` opt-in.

## Root cause: Next.js title.template behavior

Next.js applies `title.template` ONLY to nested route segments — the root segment (`src/app/page.tsx`) sits at the same depth as the root layout and gets nothing. Same gotcha class as the prior `ownerPageMetadata` fix (memory: PR #727).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test:unit` — all 101,465+ tests pass (1 SEO test updated, 1 added)
- [ ] Browser-agent re-verification post-merge: `<title>` includes `| TenantFlow` on `/`; mobile 375px viewport has zero horizontal scroll; `/contact` H1 is sentence case.

[hudsor01]