### PR TITLE
fix(navbar): bump desktop nav breakpoint from md to lg (no more overlap at 768-1023px)

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -118,7 +118,9 @@ export function Navbar({
 						)}
 					</div>
 
-					{/* Mobile Toggle */}
+					{/* Mobile Toggle — hidden at `lg:` to match the desktop nav
+					    breakpoint (was `md:hidden`, which let nav items collide
+					    with the logo at 768-1023px viewports). */}
 					<button
 						onClick={toggleMobileMenu}
 						aria-label={
@@ -127,7 +129,7 @@ export function Navbar({
 								: "Open navigation menu"
 						}
 						data-testid="mobile-nav-toggle"
-						className="md:hidden inline-flex items-center justify-center min-h-11 min-w-11 p-2 text-foreground/70 hover:text-foreground hover:bg-muted/50 rounded-lg transition-colors duration-fast"
+						className="lg:hidden inline-flex items-center justify-center min-h-11 min-w-11 p-2 text-foreground/70 hover:text-foreground hover:bg-muted/50 rounded-lg transition-colors duration-fast"
 					>
 						{isMobileMenuOpen ? (
 							<X className="size-5" />

--- a/src/components/layout/navbar/navbar-desktop-nav.tsx
+++ b/src/components/layout/navbar/navbar-desktop-nav.tsx
@@ -84,7 +84,7 @@ export function NavbarDesktopNav({
 	};
 
 	return (
-		<div className="hidden md:flex items-center gap-1">
+		<div className="hidden lg:flex items-center gap-1">
 			{navItems.map((item) => (
 				<div
 					key={item.name}


### PR DESCRIPTION
## Summary

User screenshot at ~768-900px viewport showed the "TenantFlow" logo text visually overlapping "Features" and "Sign In" wrapping to two lines. The desktop nav was trying to render at viewport widths it doesn't fit at.

**Root cause:** `NavbarDesktopNav` used `hidden md:flex` (≥768px) and the mobile toggle used `md:hidden`. At 768-1023px the layout fights to fit logo + 5 nav items (Features / Pricing / Compare / About / Resources) + Sign In + Get Started — more horizontal space than `max-w-7xl` + `px-6` provides at that width. flex-between then visually collapses the gap between sections.

**Fix:** Move desktop nav breakpoint from `md:` (≥768px) to `lg:` (≥1024px). Same for the mobile toggle's hide breakpoint. Result:

| Viewport | Before | After |
|---|---|---|
| `< 640px` | logo + hamburger | logo + hamburger (unchanged) |
| `640-767px` | logo + Sign In + Get Started + hamburger | same (unchanged) |
| `768-1023px` | logo + nav items + Sign In + Get Started ← **overlapping** | logo + Sign In + Get Started + hamburger ← **clean** |
| `≥1024px` | logo + nav items + Sign In + Get Started | same (unchanged) |

The Sign In + Get Started CTAs stay at `sm:flex` so they're visible from 640px+ alongside the hamburger — matching the typical "compact-fits, expanded-nav fits" responsive ladder used by most marketing sites with 5+ nav items.

## Files

- `src/components/layout/navbar/navbar-desktop-nav.tsx` — `hidden md:flex` → `hidden lg:flex`
- `src/components/layout/navbar.tsx` — mobile toggle `md:hidden` → `lg:hidden` + rationale comment

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] navbar tests (4 tests) pass
- [ ] Browser-agent verification post-merge: at 768px, 900px, 1023px the hamburger is visible and clicking opens the mobile menu; at 1024px+ desktop nav appears without overlap.

[hudsor01]