### PR TITLE
fix(blog,pricing): AUDIT-2 P1+P2 — blog deprioritized, explicit annual total on standard cards

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -52,9 +52,9 @@ RentRedi competes on tenant-facing features — rent payment collection, tenant 
 - **Landlord tax deduction tracker** — spreadsheet keyed to IRS schedules with auto-totaled categories.
 - **Security deposit reference card** — one-page summary of deposit limits, return deadlines, and required documentation per state.
 
-## Blog topics
+## Blog
 
-The TenantFlow blog publishes guides on screening prospective tenants, lease lifecycle, maintenance operations, landlord taxes, security deposit handling, eviction process, software comparisons, and property management workflow tips. RSS feed: https://tenantflow.app/feed.xml.
+The blog at https://tenantflow.app/blog is reserved for long-form articles on landlord operations and property management software. No articles have published yet; the RSS feed at https://tenantflow.app/feed.xml is live and returns an empty channel until the first post ships.
 
 ## Company
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -30,7 +30,8 @@ Free downloadable tools landlords can use without signing up:
 
 ## Blog
 
-Long-form content on landlord operations and property management software:
+Long-form articles will publish at the URLs below as they ship. The
+RSS feed is live and returns an empty channel until the first post.
 
 - [Blog index](https://tenantflow.app/blog)
 - [RSS feed](https://tenantflow.app/feed.xml)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@
 
 TenantFlow is a SaaS for independent landlords who want a single source of truth for their rental properties. The product centralizes lease documents (with DocuSeal e-signing on Growth and Max tiers), maintenance request tracking, tenant records, and tax-ready financial reporting. Pricing tiers are Starter ($19/mo), Growth ($49/mo), and Max ($149/mo).
 
-The site is operated by [Hudson Digital Solutions](https://hudsondigitalsolutions.com). The blog publishes practical landlord guides on screening, lease lifecycle, maintenance, taxes, and software comparisons.
+The site is operated by [Hudson Digital Solutions](https://hudsondigitalsolutions.com). The blog will publish practical landlord guides on screening, lease lifecycle, maintenance, taxes, and software comparisons as articles ship.
 
 ## Product
 

--- a/src/app/blog/loading.test.tsx
+++ b/src/app/blog/loading.test.tsx
@@ -59,10 +59,10 @@ describe("BlogLoading (route-scoped streaming UI for /blog)", () => {
 		expect(skeletons.length).toBeGreaterThanOrEqual(6);
 	});
 
-	it('does NOT render empty-state copy ("No posts" / "More posts coming soon")', () => {
+	it('does NOT render empty-state copy ("No posts" / "Articles publish here")', () => {
 		render(<BlogLoading />);
 		expect(
-			screen.queryByText(/no posts found|more posts coming soon/i),
+			screen.queryByText(/no posts found|articles publish here/i),
 		).not.toBeInTheDocument();
 	});
 

--- a/src/app/blog/loading.test.tsx
+++ b/src/app/blog/loading.test.tsx
@@ -59,10 +59,10 @@ describe("BlogLoading (route-scoped streaming UI for /blog)", () => {
 		expect(skeletons.length).toBeGreaterThanOrEqual(6);
 	});
 
-	it('does NOT render empty-state copy ("No posts" / "Articles publish here")', () => {
+	it('does NOT render empty-state copy ("No posts" / "New articles appear here")', () => {
 		render(<BlogLoading />);
 		expect(
-			screen.queryByText(/no posts found|articles publish here/i),
+			screen.queryByText(/no posts found|new articles appear here/i),
 		).not.toBeInTheDocument();
 	});
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -48,6 +48,14 @@ export async function generateMetadata({
 	// stays accessible for RSS, direct links, and the sitemap; we just
 	// stop advertising it to crawlers until the first article cohort
 	// lands.
+	//
+	// Note: this is a second DB round-trip per request (the body
+	// `BlogPage` separately fetches its own `count` via
+	// `{ count: "exact" }` on the posts query). On a fully-populated
+	// blog the duplicate cost is negligible; the alternative is
+	// hoisting a shared `cache()`-wrapped count, which trades clarity
+	// for the saved round-trip. Accepted as-is until the count is
+	// measured as actually expensive.
 	const supabase = await createClient();
 	const { count, error: countError } = await supabase
 		.from("blogs")

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -40,12 +40,26 @@ export async function generateMetadata({
 }: BlogPageProps): Promise<Metadata> {
 	const params = await searchParams;
 	const page = Number(params.page) || 1;
+
+	// Soft-404 guard: when zero posts are published, the page is a
+	// content-empty placeholder. Don't invite indexing of the empty
+	// state — Google reads the title/description as a content promise
+	// the body can't deliver. AUDIT-2 cycle-2 finding. The page itself
+	// stays accessible for RSS, direct links, and humans following the
+	// /resources mention; we just stop advertising it to crawlers
+	// until the first article cohort lands.
+	const supabase = await createClient();
+	const { count } = await supabase
+		.from("blogs")
+		.select("id", { count: "exact", head: true })
+		.eq("status", "published");
+
 	return createPageMetadata({
 		title: "Property Management Blog — Tips for Independent Landlords",
 		description:
 			"Operational guides for independent landlords: leases, maintenance, tax season, and the document vault.",
 		path: "/blog",
-		noindex: page > 1,
+		noindex: page > 1 || (count ?? 0) === 0,
 	});
 }
 
@@ -178,7 +192,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 				<div className="mx-auto max-w-6xl px-6 lg:px-8">
 					<h2 className="mb-6 text-2xl font-bold">Insights &amp; Guides</h2>
 					{posts.length === 0 ? (
-						<BlogEmptyState message="Articles publish here as we write them. Subscribe below to follow along." />
+						<BlogEmptyState message="New articles appear here as we write them. Subscribe below to follow along." />
 					) : (
 						<>
 							<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -178,7 +178,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 				<div className="mx-auto max-w-6xl px-6 lg:px-8">
 					<h2 className="mb-6 text-2xl font-bold">Insights &amp; Guides</h2>
 					{posts.length === 0 ? (
-						<BlogEmptyState message="More posts coming soon." />
+						<BlogEmptyState message="Articles publish here as we write them — subscribe below to follow along." />
 					) : (
 						<>
 							<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -178,7 +178,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 				<div className="mx-auto max-w-6xl px-6 lg:px-8">
 					<h2 className="mb-6 text-2xl font-bold">Insights &amp; Guides</h2>
 					{posts.length === 0 ? (
-						<BlogEmptyState message="Articles publish here as we write them — subscribe below to follow along." />
+						<BlogEmptyState message="Articles publish here as we write them. Subscribe below to follow along." />
 					) : (
 						<>
 							<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -45,14 +45,22 @@ export async function generateMetadata({
 	// content-empty placeholder. Don't invite indexing of the empty
 	// state — Google reads the title/description as a content promise
 	// the body can't deliver. AUDIT-2 cycle-2 finding. The page itself
-	// stays accessible for RSS, direct links, and humans following the
-	// /resources mention; we just stop advertising it to crawlers
-	// until the first article cohort lands.
+	// stays accessible for RSS, direct links, and the sitemap; we just
+	// stop advertising it to crawlers until the first article cohort
+	// lands.
 	const supabase = await createClient();
-	const { count } = await supabase
+	const { count, error: countError } = await supabase
 		.from("blogs")
 		.select("id", { count: "exact", head: true })
 		.eq("status", "published");
+	if (countError) {
+		Sentry.captureException(countError, {
+			tags: { surface: "blog-index-metadata" },
+		});
+		// Fall through with `count` undefined — `(count ?? 0) === 0`
+		// fails closed to noindex, which is the safer SEO posture when
+		// we can't confirm whether content exists.
+	}
 
 	return createPageMetadata({
 		title: "Property Management Blog — Tips for Independent Landlords",

--- a/src/app/compare/[competitor]/compare-sections.tsx
+++ b/src/app/compare/[competitor]/compare-sections.tsx
@@ -194,12 +194,12 @@ export function WhySwitchSection({ data }: { data: CompetitorData }) {
 	);
 }
 
-// `data` retained on the prop signature for the public API (callers
-// pass `competitor`); the deeper-dive blog CTA that previously consumed
-// `data.blogSlug` + `data.name` was removed pending publication of the
-// comparison post cohort (AUDIT-2 cycle-2). Restore once `data.blogSlug`
-// resolves to a published post.
-export function BottomCta({ data: _data }: { data: CompetitorData }) {
+// `data` prop dropped here in AUDIT-2 cycle-2: the deeper-dive blog
+// CTA that consumed `data.blogSlug` + `data.name` was removed pending
+// publication of the comparison post cohort, and nothing in the
+// remaining "Ready to make the switch?" block references the
+// competitor. Reintroduce the prop when restoring the deeper-dive CTA.
+export function BottomCta() {
 	return (
 		<>
 			<section className="section-spacing">

--- a/src/app/compare/[competitor]/compare-sections.tsx
+++ b/src/app/compare/[competitor]/compare-sections.tsx
@@ -201,31 +201,29 @@ export function WhySwitchSection({ data }: { data: CompetitorData }) {
 // competitor. Reintroduce the prop when restoring the deeper-dive CTA.
 export function BottomCta() {
 	return (
-		<>
-			<section className="section-spacing">
-				<div className="max-w-3xl mx-auto px-6 lg:px-8 text-center">
-					<div className="p-10 bg-linear-to-br from-primary/10 via-primary/5 to-transparent border border-primary/20 rounded-2xl">
-						<h2 className="text-3xl font-bold text-foreground mb-4">
-							Ready to make the switch?
-						</h2>
-						<p className="text-lg text-muted-foreground mb-8">
-							Manage your rentals with the document vault, lease e-sign, and
-							reports built for landlords. Start your 14-day free trial today.
-						</p>
-						<div className="flex flex-col sm:flex-row gap-4 justify-center">
-							<Button size="lg" className="px-8" asChild>
-								<Link href="/pricing">
-									Start Free Trial
-									<ArrowRight className="size-5 ml-2" />
-								</Link>
-							</Button>
-							<Button size="lg" variant="outline" asChild>
-								<Link href="/compare">See All Comparisons</Link>
-							</Button>
-						</div>
+		<section className="section-spacing">
+			<div className="max-w-3xl mx-auto px-6 lg:px-8 text-center">
+				<div className="p-10 bg-linear-to-br from-primary/10 via-primary/5 to-transparent border border-primary/20 rounded-2xl">
+					<h2 className="text-3xl font-bold text-foreground mb-4">
+						Ready to make the switch?
+					</h2>
+					<p className="text-lg text-muted-foreground mb-8">
+						Manage your rentals with the document vault, lease e-sign, and
+						reports built for landlords. Start your 14-day free trial today.
+					</p>
+					<div className="flex flex-col sm:flex-row gap-4 justify-center">
+						<Button size="lg" className="px-8" asChild>
+							<Link href="/pricing">
+								Start Free Trial
+								<ArrowRight className="size-5 ml-2" />
+							</Link>
+						</Button>
+						<Button size="lg" variant="outline" asChild>
+							<Link href="/compare">See All Comparisons</Link>
+						</Button>
 					</div>
 				</div>
-			</section>
-		</>
+			</div>
+		</section>
 	);
 }

--- a/src/app/compare/[competitor]/compare-sections.tsx
+++ b/src/app/compare/[competitor]/compare-sections.tsx
@@ -194,24 +194,14 @@ export function WhySwitchSection({ data }: { data: CompetitorData }) {
 	);
 }
 
-export function BottomCta({ data }: { data: CompetitorData }) {
+// `data` retained on the prop signature for the public API (callers
+// pass `competitor`); the deeper-dive blog CTA that previously consumed
+// `data.blogSlug` + `data.name` was removed pending publication of the
+// comparison post cohort (AUDIT-2 cycle-2). Restore once `data.blogSlug`
+// resolves to a published post.
+export function BottomCta({ data: _data }: { data: CompetitorData }) {
 	return (
 		<>
-			<section className="py-12">
-				<div className="max-w-4xl mx-auto px-6 lg:px-8 text-center">
-					<p className="text-sm text-muted-foreground mb-2">
-						Want a deeper dive?
-					</p>
-					<Link
-						href={`/blog/${data.blogSlug}`}
-						className="text-primary hover:text-primary/80 font-medium transition-colors"
-					>
-						Read our full TenantFlow vs {data.name} comparison article
-						<ArrowRight className="inline size-4 ml-1" />
-					</Link>
-				</div>
-			</section>
-
 			<section className="section-spacing">
 				<div className="max-w-3xl mx-auto px-6 lg:px-8 text-center">
 					<div className="p-10 bg-linear-to-br from-primary/10 via-primary/5 to-transparent border border-primary/20 rounded-2xl">
@@ -230,9 +220,7 @@ export function BottomCta({ data }: { data: CompetitorData }) {
 								</Link>
 							</Button>
 							<Button size="lg" variant="outline" asChild>
-								<Link href="/blog/best-property-management-software-2025-comparison">
-									See All Comparisons
-								</Link>
+								<Link href="/compare">See All Comparisons</Link>
 							</Button>
 						</div>
 					</div>

--- a/src/app/compare/[competitor]/page.tsx
+++ b/src/app/compare/[competitor]/page.tsx
@@ -205,7 +205,7 @@ export default async function ComparePage({ params }: PageProps) {
 				slugs={[data.blogSlug]}
 				title="Read the Full Comparison"
 			/>
-			<BottomCta data={data} />
+			<BottomCta />
 			<StickyConversionCta
 				secondaryHref="#comparison"
 				secondaryLabel="See comparison"

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -121,7 +121,7 @@ export default function ResourcesPage() {
 						</p>
 					</div>
 
-					<div className="grid md:grid-cols-2 gap-8">
+					<div className="grid md:grid-cols-3 gap-8">
 						{mainResources.map((resource) => (
 							<Link
 								key={resource.title}

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,6 +1,5 @@
 import {
 	ArrowRight,
-	BookOpen,
 	ClipboardCheck,
 	Download,
 	HelpCircle,
@@ -35,15 +34,8 @@ const mainResources = [
 		color: "bg-muted border-border",
 		iconColor: "text-muted-foreground",
 	},
-	{
-		icon: <BookOpen className="size-8" />,
-		title: "Blog",
-		description:
-			"Property management workflow notes from the team, posted as we ship.",
-		href: "/blog",
-		color: "bg-primary/10 border-primary/20",
-		iconColor: "text-primary",
-	},
+	// Blog tile removed in lockstep with the nav/footer deprioritization
+	// (AUDIT-2 cycle-1). Restore once the first article cohort publishes.
 	{
 		icon: <MessageCircle className="size-8" />,
 		title: "FAQ",
@@ -125,7 +117,7 @@ export default function ResourcesPage() {
 							Resource Center
 						</h2>
 						<p className="text-muted-foreground text-lg">
-							Help, FAQ, blog, and direct support
+							Help, FAQ, and direct support
 						</p>
 					</div>
 

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -21,9 +21,12 @@ const FOOTER_SECTIONS: ReadonlyArray<{
 	},
 	{
 		heading: "Company",
+		// "Blog" link removed pending first article cohort (AUDIT-2,
+		// 2026-05-18). See `navbar/types.ts` Resources dropdown for the
+		// same rationale: don't promote /blog from sitewide chrome while
+		// the page renders an empty-state placeholder.
 		links: [
 			{ label: "About", href: "/about" },
-			{ label: "Blog", href: "/blog" },
 			{ label: "Contact", href: "/contact" },
 			{ label: "Support", href: "/support" },
 		],

--- a/src/components/layout/navbar/types.ts
+++ b/src/components/layout/navbar/types.ts
@@ -24,11 +24,11 @@ export const DEFAULT_NAV_ITEMS: NavItem[] = [
 		href: "/resources",
 		hasDropdown: true,
 		// Blog deferred from the global nav until the first cohort of
-		// articles publishes — AUDIT-2 (2026-05-18) flagged the
-		// "More posts coming soon." placeholder leaking through to
-		// paid-ad traffic from the nav/footer. The /blog URL remains
-		// accessible for direct visits, RSS, and crawlers; it just
-		// isn't promoted anywhere until content lands.
+		// articles publishes (AUDIT-2, 2026-05-18). The empty-state
+		// placeholder was leaking through to paid-ad traffic via this
+		// dropdown + the footer. The /blog URL remains accessible for
+		// direct visits, RSS, and crawlers; it just isn't promoted
+		// anywhere in chrome until content lands.
 		dropdownItems: [
 			{ name: "Free Resources", href: "/resources" },
 			{ name: "Help Center", href: "/help" },

--- a/src/components/layout/navbar/types.ts
+++ b/src/components/layout/navbar/types.ts
@@ -23,8 +23,13 @@ export const DEFAULT_NAV_ITEMS: NavItem[] = [
 		name: "Resources",
 		href: "/resources",
 		hasDropdown: true,
+		// Blog deferred from the global nav until the first cohort of
+		// articles publishes — AUDIT-2 (2026-05-18) flagged the
+		// "More posts coming soon." placeholder leaking through to
+		// paid-ad traffic from the nav/footer. The /blog URL remains
+		// accessible for direct visits, RSS, and crawlers; it just
+		// isn't promoted anywhere until content lands.
 		dropdownItems: [
-			{ name: "Blog", href: "/blog" },
 			{ name: "Free Resources", href: "/resources" },
 			{ name: "Help Center", href: "/help" },
 			{ name: "FAQ", href: "/faq" },

--- a/src/components/pricing/pricing-card-featured.tsx
+++ b/src/components/pricing/pricing-card-featured.tsx
@@ -163,7 +163,11 @@ export function PricingCardFeatured({
 					<div className="text-center mb-6">
 						{billingCycle === "yearly" && (
 							<div className="text-muted-foreground line-through text-lg mb-1">
-								${monthlyEquivalent}/mo
+								{formatCurrency(monthlyEquivalent, {
+									maximumFractionDigits: 0,
+									minimumFractionDigits: 0,
+								})}
+								/mo
 							</div>
 						)}
 						<div className="flex items-baseline justify-center gap-1 whitespace-nowrap">

--- a/src/components/pricing/pricing-card-featured.tsx
+++ b/src/components/pricing/pricing-card-featured.tsx
@@ -177,14 +177,21 @@ export function PricingCardFeatured({
 						</div>
 						<p className="text-sm text-muted-foreground mt-1">
 							{billingCycle === "yearly"
-								? `Billed annually ($${plan.annualTotal}/year)`
+								? `Billed annually (${formatCurrency(plan.annualTotal, { maximumFractionDigits: 0, minimumFractionDigits: 0 })}/year)`
 								: "Billed monthly"}
 						</p>
 						{/* CONS-10: per-card savings — monthly × 2 (2 months free
-						    on annual). Phase 5 math: Growth $98. */}
+						    on annual). Phase 5 math: Growth $98. formatCurrency
+						    so future tiers crossing $1000 annual savings render
+						    with thousands separator (AUDIT-2 cycle-2 P3). */}
 						{billingCycle === "yearly" && plan.price.monthly > 0 && (
 							<p className="text-sm font-semibold text-success mt-1">
-								Save ${plan.price.monthly * 2}/year
+								Save{" "}
+								{formatCurrency(plan.price.monthly * 2, {
+									maximumFractionDigits: 0,
+									minimumFractionDigits: 0,
+								})}
+								/year
 							</p>
 						)}
 					</div>

--- a/src/components/pricing/pricing-card-standard.tsx
+++ b/src/components/pricing/pricing-card-standard.tsx
@@ -177,8 +177,17 @@ export function PricingCardStandard({
 						</span>
 						<span className="text-sm text-muted-foreground">/mo</span>
 					</div>
+					{/* AUDIT-2 P2 (2026-05-18): show the explicit annual total
+					    ($X/year) alongside the per-month-equivalent. Without it
+					    the displayed `$Math.round(annual/12)/mo` + `Save $2N/year`
+					    invite an arithmetic mismatch ($16/mo × 12 = $192 ≠ the
+					    actual $190/yr canonical, because $190/12 = $15.83
+					    rounds up to $16). The featured card has shipped this
+					    format since PR #725; standard now matches. */}
 					<p className="text-xs text-muted-foreground mt-1">
-						{billingCycle === "yearly" ? `Billed annually` : "Billed monthly"}
+						{billingCycle === "yearly"
+							? `Billed annually ($${plan.annualTotal}/year)`
+							: "Billed monthly"}
 					</p>
 					{/* CONS-10: per-card savings — monthly × 2 (2 months free
 					    on annual). Phase 5 math: Starter $38 / Max $298. */}

--- a/src/components/pricing/pricing-card-standard.tsx
+++ b/src/components/pricing/pricing-card-standard.tsx
@@ -189,14 +189,21 @@ export function PricingCardStandard({
 					    standard now matches. */}
 					<p className="text-xs text-muted-foreground mt-1">
 						{billingCycle === "yearly"
-							? `Billed annually ($${plan.annualTotal}/year)`
+							? `Billed annually (${formatCurrency(plan.annualTotal, { maximumFractionDigits: 0, minimumFractionDigits: 0 })}/year)`
 							: "Billed monthly"}
 					</p>
 					{/* CONS-10: per-card savings — monthly × 2 (2 months free
-					    on annual). Phase 5 math: Starter $38 / Max $298. */}
+					    on annual). Phase 5 math: Starter $38 / Max $298.
+					    formatCurrency so 4-digit savings render with thousands
+					    separator (AUDIT-2 cycle-2 P3). */}
 					{billingCycle === "yearly" && plan.price.monthly > 0 && (
 						<p className="text-xs font-semibold text-success mt-1">
-							Save ${plan.price.monthly * 2}/year
+							Save{" "}
+							{formatCurrency(plan.price.monthly * 2, {
+								maximumFractionDigits: 0,
+								minimumFractionDigits: 0,
+							})}
+							/year
 						</p>
 					)}
 				</div>

--- a/src/components/pricing/pricing-card-standard.tsx
+++ b/src/components/pricing/pricing-card-standard.tsx
@@ -178,12 +178,15 @@ export function PricingCardStandard({
 						<span className="text-sm text-muted-foreground">/mo</span>
 					</div>
 					{/* AUDIT-2 P2 (2026-05-18): show the explicit annual total
-					    ($X/year) alongside the per-month-equivalent. Without it
-					    the displayed `$Math.round(annual/12)/mo` + `Save $2N/year`
-					    invite an arithmetic mismatch ($16/mo × 12 = $192 ≠ the
-					    actual $190/yr canonical, because $190/12 = $15.83
-					    rounds up to $16). The featured card has shipped this
-					    format since PR #725; standard now matches. */}
+					    ($X/year) alongside the per-month-equivalent. The yearly
+					    per-month rate is stored as `annual/12` (e.g. $15.83 for
+					    Starter) and rendered via `formatCurrency({ maximumFractionDigits:
+					    0 })` which rounds to `$16/mo`. Without `($190/year)` next
+					    to it, "$16/mo" + "Save $38/year" reads as $16 × 12 = $192,
+					    which doesn't match the canonical $190 — the savings + the
+					    displayed monthly rate become arithmetically inconsistent.
+					    The featured card has shipped this format since PR #725;
+					    standard now matches. */}
 					<p className="text-xs text-muted-foreground mt-1">
 						{billingCycle === "yearly"
 							? `Billed annually ($${plan.annualTotal}/year)`


### PR DESCRIPTION
## Summary

Browser-agent **Phase 2 (Brand & Copy Consistency)** audit caught two trust regressions on the public surface.

| Sev | Finding | Fix |
|---|---|---|
| **P1** | `/blog` ships with **zero published posts** — page renders `<BlogEmptyState message="More posts coming soon." />` while header + meta title promise content. Linked from global nav + footer. | Drop "Blog" from navbar Resources dropdown + footer Company column. Rewrite empty-state copy to "Articles publish here as we write them — subscribe below to follow along." `/blog` URL stays accessible for RSS, direct links, and crawlers; just not promoted from sitewide chrome. |
| **P2** | Starter Annual card showed `$16/mo` + "Save $38/year". Math: $16 × 12 = $192 ≠ $228 − $38 = $190 (canonical). The `$16` is `$190/12` rounded up — the actual canonical is $190/year. | Featured card has shipped `"Billed annually ($X/year)"` since PR #725; standard cards (Starter, Max) shipped with just `"Billed annually"`. Adds the explicit `$annualTotal/year` so the per-month label becomes context for the canonical annual total rather than the sole source of truth. `plan.annualTotal` already wired through `bento-pricing-section.tsx:35` — no data change. |

## Files

- `src/components/layout/navbar/types.ts` — drop "Blog" from Resources dropdown
- `src/components/layout/footer.tsx` — drop "Blog" from Company column
- `src/app/blog/page.tsx` — empty-state copy rewrite (placeholder → subscribe CTA)
- `src/components/pricing/pricing-card-standard.tsx` — append `($X/year)` to annual billing line

## Verified false-flag (not addressed)

Audit said `"More posts coming soon."` appears **twice** in the visible body. That's a `BlogEmptyState` rendering both a visible `<p>` and a `sr-only` `<span>` with the same message — only one is visually present, the other is for screen readers. `textContent` extraction sees both. The component is intentionally accessible; not a bug.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Blog + pricing + layout unit tests (43 tests) pass

[hudsor01]