### PR TITLE
fix(blog): /blog/[slug] SSG 404 enforcement + og:url, n8n-blog-ingest config

### DIFF
--- a/src/app/blog/[slug]/page.test.tsx
+++ b/src/app/blog/[slug]/page.test.tsx
@@ -449,3 +449,76 @@ describe("generateMetadata (server entry)", () => {
 		expect(mockServerNotFound).toHaveBeenCalled();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// generateStaticParams — retry + fail-the-build behavior.
+//
+// The placeholder-env skip branch is exercised on every PR by the CI
+// `checks` job (it runs `next build` with
+// NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co). These tests
+// cover the two branches that job cannot reach: transient-failure recovery,
+// and throw-after-persistent-failure (which fails the build instead of
+// shipping [] — a catalogue-wide 404 under dynamicParams=false).
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock Supabase client whose successive `.from().select().eq()` chains each
+ * resolve to the next entry in `resultSequence` (the last entry repeats, so
+ * a one-element sequence models a persistent failure).
+ */
+function makeEnumClient(
+	resultSequence: Array<{
+		data: Array<{ slug: string }> | null;
+		error: { message: string; code: string } | null;
+	}>,
+) {
+	let attempt = 0;
+	return {
+		from: () => {
+			const result =
+				resultSequence[Math.min(attempt, resultSequence.length - 1)];
+			attempt += 1;
+			const builder = {
+				select: () => builder,
+				eq: () => Promise.resolve(result),
+			};
+			return builder;
+		},
+	};
+}
+
+describe("generateStaticParams (retry + fail-safe)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("recovers when an early attempt fails and a later one succeeds", async () => {
+		mockSupabaseCreateClient.mockReturnValue(
+			makeEnumClient([
+				{ data: null, error: { message: "transient blip", code: "" } },
+				{ data: [{ slug: "recovered-post" }], error: null },
+			]),
+		);
+
+		const { generateStaticParams } = await import("./page");
+		const params = await generateStaticParams();
+
+		expect(params).toEqual([{ slug: "recovered-post" }]);
+	});
+
+	it("throws after the query fails every attempt — fails the build, not []", async () => {
+		mockSupabaseCreateClient.mockReturnValue(
+			makeEnumClient([
+				{
+					data: null,
+					error: { message: "supabase down", code: "PGRST500" },
+				},
+			]),
+		);
+
+		const { generateStaticParams } = await import("./page");
+		await expect(generateStaticParams()).rejects.toMatchObject({
+			message: expect.stringContaining("failed after 3 attempts"),
+		});
+	}, 10000);
+});

--- a/src/app/blog/[slug]/page.test.tsx
+++ b/src/app/blog/[slug]/page.test.tsx
@@ -280,16 +280,22 @@ describe("BlogArticlePage", () => {
 // added in Plan 06-02 Task 2.
 // ---------------------------------------------------------------------------
 
-const mockServerCreateClient = vi.hoisted(() => vi.fn());
+// getBlogPost uses the cookie-less anon client (`@supabase/supabase-js`
+// createClient) — NOT `#lib/supabase/server` — so that `/blog/[slug]`
+// stays a `●` SSG route and `dynamicParams = false` enforces real 404s.
+// The mock therefore targets `@supabase/supabase-js`; `importOriginal`
+// keeps the module's other exports intact.
+const mockSupabaseCreateClient = vi.hoisted(() => vi.fn());
 const mockServerNotFound = vi.hoisted(() =>
 	vi.fn(() => {
 		throw new Error("NEXT_NOT_FOUND");
 	}),
 );
 
-vi.mock("#lib/supabase/server", () => ({
-	createClient: mockServerCreateClient,
-}));
+vi.mock("@supabase/supabase-js", async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>();
+	return { ...actual, createClient: mockSupabaseCreateClient };
+});
 
 vi.mock("next/navigation", () => ({
 	notFound: mockServerNotFound,
@@ -319,7 +325,7 @@ interface BlogRow {
 	canonical_url: string | null;
 }
 
-function makeServerClient(row: BlogRow | null) {
+function makeSupabaseClient(row: BlogRow | null) {
 	const builder = {
 		select: vi.fn(() => builder),
 		eq: vi.fn(() => builder),
@@ -355,7 +361,7 @@ describe("generateMetadata (server entry)", () => {
 			tags: ["comparison"],
 			canonical_url: "/compare/buildium",
 		};
-		mockServerCreateClient.mockResolvedValue(makeServerClient(row));
+		mockSupabaseCreateClient.mockReturnValue(makeSupabaseClient(row));
 
 		const { generateMetadata } = await import("./page");
 		const metadata = await generateMetadata({
@@ -380,7 +386,7 @@ describe("generateMetadata (server entry)", () => {
 			tags: ["guide"],
 			canonical_url: null,
 		};
-		mockServerCreateClient.mockResolvedValue(makeServerClient(row));
+		mockSupabaseCreateClient.mockReturnValue(makeSupabaseClient(row));
 
 		const { generateMetadata } = await import("./page");
 		const metadata = await generateMetadata({
@@ -405,7 +411,7 @@ describe("generateMetadata (server entry)", () => {
 			tags: ["maintenance"],
 			canonical_url: null,
 		};
-		mockServerCreateClient.mockResolvedValue(makeServerClient(row));
+		mockSupabaseCreateClient.mockReturnValue(makeSupabaseClient(row));
 
 		const { generateMetadata } = await import("./page");
 		const metadata = await generateMetadata({
@@ -425,7 +431,7 @@ describe("generateMetadata (server entry)", () => {
 	});
 
 	it("calls notFound() when getBlogPost returns null", async () => {
-		mockServerCreateClient.mockResolvedValue(makeServerClient(null));
+		mockSupabaseCreateClient.mockReturnValue(makeSupabaseClient(null));
 
 		const { generateMetadata } = await import("./page");
 		await expect(

--- a/src/app/blog/[slug]/page.test.tsx
+++ b/src/app/blog/[slug]/page.test.tsx
@@ -369,6 +369,9 @@ describe("generateMetadata (server entry)", () => {
 		});
 
 		expect(metadata.alternates?.canonical).toBe("/compare/buildium");
+		// og:url mirrors the canonical so the OG + <link rel=canonical>
+		// signals agree (seo-smoke.spec.ts "/blog/[slug] has Article schema").
+		expect(metadata.openGraph?.url).toBe("/compare/buildium");
 	});
 
 	it("falls back to /blog/{slug} canonical when post.canonical_url is null", async () => {
@@ -394,6 +397,8 @@ describe("generateMetadata (server entry)", () => {
 		});
 
 		expect(metadata.alternates?.canonical).toBe("/blog/a-generic-post");
+		// og:url falls back to the post's own URL alongside the canonical.
+		expect(metadata.openGraph?.url).toBe("/blog/a-generic-post");
 	});
 
 	it("wires openGraph.images[0].url to /api/og/blog/{slug}", async () => {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,19 +11,18 @@ import { createBreadcrumbJsonLd } from "#lib/seo/breadcrumbs";
 import { createClient as createServerClient } from "#lib/supabase/server";
 import BlogPostPage from "./blog-post-page";
 
-// ISR with on-demand fallback. `generateStaticParams` enumerates known
-// published slugs at build time so they prerender. `dynamicParams = true`
-// lets slugs published AFTER the last build still render — n8n's 2-hour
-// content cron produces posts faster than the Vercel deploy cadence, so
-// `dynamicParams = false` (the original Phase-6 BLOG-02 setting) caused
-// real 404s on every fresh post until the next manual redeploy. The
-// soft-200 risk that motivated `false` is handled instead by the
-// in-component `notFound()` call below: `getBlogPost(slug)` filters
-// `status='published'` (line ~83) and returns null for any unknown or
-// unpublished slug, at which point the page calls `notFound()` and Next
-// returns a real HTTP 404. Known slugs serve from the 5-minute revalidate
-// cache; unknown slugs render once on first request then cache.
-export const dynamicParams = true;
+// Phase 6 (BLOG-02): restore ISR with `generateStaticParams` returning the
+// published slug set. `dynamicParams = false` makes any slug not in the
+// build-time set return a real HTTP 404 — closes the soft-200 path that
+// in-component `notFound()` cannot reliably guarantee (verified: the
+// `seo-smoke.spec.ts` "/blog/<bogus> returns real HTTP 404" test soft-200s
+// under `dynamicParams = true` — `notFound()` from an ISR route returns
+// 200, not 404). Newly-published posts are picked up by a Vercel deploy
+// triggered from the n8n content workflow (HTTP Request → Vercel Deploy
+// Hook after a successful Publish to Supabase), so the static slug set
+// stays current without a soft-200 trade-off. Known slugs serve from the
+// 5-minute revalidate cache for editorial updates.
+export const dynamicParams = false;
 export const revalidate = 300;
 
 const logger = createLogger({ component: "BlogPost" });

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,14 +11,19 @@ import { createBreadcrumbJsonLd } from "#lib/seo/breadcrumbs";
 import { createClient as createServerClient } from "#lib/supabase/server";
 import BlogPostPage from "./blog-post-page";
 
-// Phase 6 (BLOG-02): restore ISR with `generateStaticParams` returning the
-// published slug set. `dynamicParams = false` makes any slug not in the
-// build-time set return a real HTTP 404 — closes the soft-200 path that
-// Phase-1's `force-dynamic` + in-component `notFound()` couldn't reliably
-// guarantee in dev mode. Newly-published posts are picked up on next
-// Vercel build (frequent given content cadence); known slugs serve from
-// the 5-minute revalidate cache for editorial updates.
-export const dynamicParams = false;
+// ISR with on-demand fallback. `generateStaticParams` enumerates known
+// published slugs at build time so they prerender. `dynamicParams = true`
+// lets slugs published AFTER the last build still render — n8n's 2-hour
+// content cron produces posts faster than the Vercel deploy cadence, so
+// `dynamicParams = false` (the original Phase-6 BLOG-02 setting) caused
+// real 404s on every fresh post until the next manual redeploy. The
+// soft-200 risk that motivated `false` is handled instead by the
+// in-component `notFound()` call below: `getBlogPost(slug)` filters
+// `status='published'` (line ~83) and returns null for any unknown or
+// unpublished slug, at which point the page calls `notFound()` and Next
+// returns a real HTTP 404. Known slugs serve from the 5-minute revalidate
+// cache; unknown slugs render once on first request then cache.
+export const dynamicParams = true;
 export const revalidate = 300;
 
 const logger = createLogger({ component: "BlogPost" });

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -52,6 +52,18 @@ interface Props {
  * public reads), so build-time enumeration matches request-time visibility.
  */
 export async function generateStaticParams() {
+	// The CI compile-check build (`checks` job in ci-cd.yml) runs
+	// `next build` with placeholder Supabase env
+	// (`NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co`) to
+	// verify the build COMPILES, decoupled from live services. That host is
+	// unresolvable, so a query would `fetch failed`. Return [] for that
+	// build: it is never deployed, so an empty static set is harmless. The
+	// Vercel deploy build and the e2e build both run with real Supabase env
+	// and fall through to real enumeration below.
+	if (env.NEXT_PUBLIC_SUPABASE_URL.includes("placeholder")) {
+		return [];
+	}
+
 	const supabase = createSupabaseClient(
 		env.NEXT_PUBLIC_SUPABASE_URL,
 		env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -40,8 +40,9 @@ interface Props {
 
 /**
  * Build-time slug enumeration. Returns ONLY published rows so a leaked
- * unpublished slug cannot mint a static page. ISR misses for unknown
- * slugs hit `notFound()` in the page component below.
+ * unpublished slug cannot mint a static page. With `dynamicParams = false`,
+ * any slug outside this set returns a real HTTP 404 at the router level —
+ * the page component never runs for unknown slugs.
  *
  * Uses a cookie-less anon-key client (not the `#lib/supabase/server`
  * cookie-aware client) because `generateStaticParams` runs at build time
@@ -61,12 +62,21 @@ export async function generateStaticParams() {
 		.eq("status", "published");
 
 	if (error) {
+		// Fail the build — do NOT return []. With `dynamicParams = false`,
+		// an empty static set means EVERY /blog/[slug] returns 404, so
+		// shipping that build silently 404s the entire published catalogue
+		// (Google then drops the indexed pages). A thrown error fails
+		// `next build` instead: the broken build never deploys and prod
+		// keeps serving the last-good build. A transient Supabase failure
+		// resolves on CI retry — the build is reproducible.
 		logger.error("generateStaticParams failed", {
 			action: "generateStaticParams",
 			route: "/blog/[slug]",
 			metadata: { error: error.message, code: error.code },
 		});
-		return [];
+		throw new Error(
+			`generateStaticParams: blogs query failed (${error.code}): ${error.message}`,
+		);
 	}
 
 	return (data ?? []).map(({ slug }) => ({ slug }));

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -168,6 +168,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 			title: post.title,
 			description,
 			type: "article",
+			// og:url MUST be set explicitly. Next.js only emits
+			// <meta property="og:url"> when `openGraph.url` is present, and
+			// this page builds `openGraph` by hand rather than via
+			// `createPageMetadata` (which sets it). Mirror
+			// `alternates.canonical` so the OG canonical and the
+			// <link rel="canonical"> agree. Guarded by seo-smoke.spec.ts
+			// "/blog/[slug] has Article schema".
+			url: canonical,
 			publishedTime: post.published_at ?? undefined,
 			modifiedTime: post.updated_at ?? post.published_at ?? undefined,
 			section: post.category ?? undefined,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -56,30 +56,45 @@ export async function generateStaticParams() {
 		env.NEXT_PUBLIC_SUPABASE_URL,
 		env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
 	);
-	const { data, error } = await supabase
-		.from("blogs")
-		.select("slug")
-		.eq("status", "published");
 
-	if (error) {
-		// Fail the build — do NOT return []. With `dynamicParams = false`,
-		// an empty static set means EVERY /blog/[slug] returns 404, so
-		// shipping that build silently 404s the entire published catalogue
-		// (Google then drops the indexed pages). A thrown error fails
-		// `next build` instead: the broken build never deploys and prod
-		// keeps serving the last-good build. A transient Supabase failure
-		// resolves on CI retry — the build is reproducible.
-		logger.error("generateStaticParams failed", {
+	// Build-time enumeration is one network round-trip to Supabase, and CI
+	// build runners occasionally hit a transient `fetch failed`. Retry with
+	// linear backoff (3 attempts) so a single blip doesn't fail the build.
+	// Only a PERSISTENT failure throws — see the rationale below.
+	const MAX_ATTEMPTS = 3;
+	let lastError: { message: string; code?: string } | null = null;
+
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		const { data, error } = await supabase
+			.from("blogs")
+			.select("slug")
+			.eq("status", "published");
+
+		if (!error) {
+			return (data ?? []).map(({ slug }) => ({ slug }));
+		}
+
+		lastError = error;
+		logger.error("generateStaticParams attempt failed", {
 			action: "generateStaticParams",
 			route: "/blog/[slug]",
-			metadata: { error: error.message, code: error.code },
+			metadata: { attempt, error: error.message, code: error.code },
 		});
-		throw new Error(
-			`generateStaticParams: blogs query failed (${error.code}): ${error.message}`,
-		);
+		if (attempt < MAX_ATTEMPTS) {
+			await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+		}
 	}
 
-	return (data ?? []).map(({ slug }) => ({ slug }));
+	// Persistent failure after retries: throw, do NOT return []. With
+	// `dynamicParams = false`, an empty static set means EVERY /blog/[slug]
+	// returns 404 — shipping that build silently 404s the entire published
+	// catalogue (Google then drops the indexed pages). A thrown error fails
+	// `next build` instead: the broken build never deploys and prod keeps
+	// serving the last-good build. The build is reproducible — a CI re-run
+	// clears a genuinely transient outage that outlasted the retries.
+	throw new Error(
+		`generateStaticParams: blogs query failed after ${MAX_ATTEMPTS} attempts (${lastError?.code}): ${lastError?.message}`,
+	);
 }
 
 /**

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,20 +8,27 @@ import { env } from "#env";
 import { createLogger } from "#lib/frontend-logger";
 import { createArticleJsonLd } from "#lib/seo/article-schema";
 import { createBreadcrumbJsonLd } from "#lib/seo/breadcrumbs";
-import { createClient as createServerClient } from "#lib/supabase/server";
 import BlogPostPage from "./blog-post-page";
 
-// Phase 6 (BLOG-02): restore ISR with `generateStaticParams` returning the
-// published slug set. `dynamicParams = false` makes any slug not in the
-// build-time set return a real HTTP 404 — closes the soft-200 path that
-// in-component `notFound()` cannot reliably guarantee (verified: the
-// `seo-smoke.spec.ts` "/blog/<bogus> returns real HTTP 404" test soft-200s
-// under `dynamicParams = true` — `notFound()` from an ISR route returns
-// 200, not 404). Newly-published posts are picked up by a Vercel deploy
-// triggered from the n8n content workflow (HTTP Request → Vercel Deploy
-// Hook after a successful Publish to Supabase), so the static slug set
-// stays current without a soft-200 trade-off. Known slugs serve from the
-// 5-minute revalidate cache for editorial updates.
+// Phase 6 (BLOG-02): ISR with `generateStaticParams` enumerating the
+// published slug set. `dynamicParams = false` makes any slug outside that
+// set return a real HTTP 404 at the ROUTER level — before the page
+// component runs. This is the only reliable 404: in-component `notFound()`
+// soft-200s on a dynamic route (renders the 404 UI but commits HTTP 200
+// first while streaming).
+//
+// CRITICAL: this enforcement only works while `/blog/[slug]` stays a `●`
+// (SSG) route. Any `cookies()` / `headers()` call in the page or its data
+// helpers flips it to `ƒ` (Dynamic), which silently disables the static
+// 404 gate. `getBlogPost` below therefore MUST use the cookie-less client.
+// The `seo-smoke.spec.ts` "/blog/<bogus> returns real HTTP 404" e2e test
+// guards this — it fails if the route regresses to dynamic.
+//
+// Newly-published posts are picked up by a Vercel deploy triggered from the
+// n8n content workflow (HTTP Request → Vercel Deploy Hook after a
+// successful Publish to Supabase), keeping the static slug set current
+// without a soft-200 trade-off. Known slugs serve from the 5-minute
+// revalidate cache for editorial updates.
 export const dynamicParams = false;
 export const revalidate = 300;
 
@@ -65,9 +72,25 @@ export async function generateStaticParams() {
 	return (data ?? []).map(({ slug }) => ({ slug }));
 }
 
-/** Deduplicated blog post query — shared by generateMetadata and Page */
+/**
+ * Deduplicated blog post query — shared by generateMetadata and Page.
+ *
+ * MUST use the cookie-less anon-key client (NOT `#lib/supabase/server`).
+ * The cookie-aware client calls `cookies()` from `next/headers`, a Dynamic
+ * API that opts `/blog/[slug]` out of static generation — turning it into a
+ * `ƒ` (Dynamic) route. That silently defeats the `generateStaticParams` +
+ * `dynamicParams = false` 404 enforcement above: a dynamic route never
+ * builds a static slug set to gate against, so every unknown slug runs the
+ * page component and hits in-component `notFound()`, which soft-200s under
+ * dynamic streaming. The anon-key client keeps the route `●` (SSG) so
+ * unknown slugs 404 at the router level. Blog posts are public —
+ * `status='published'` is the anon RLS gate — so no session is needed.
+ */
 const getBlogPost = cache(async (slug: string) => {
-	const supabase = await createServerClient();
+	const supabase = createSupabaseClient(
+		env.NEXT_PUBLIC_SUPABASE_URL,
+		env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+	);
 
 	// Race against 5s timeout to prevent Supabase cold-start hangs
 	// (80-398s observed in Sentry).

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -341,6 +341,24 @@ verify_jwt = false
 [functions.docuseal]
 entrypoint = "./functions/docuseal/handler.ts"
 
+# n8n content-factory blog ingest — public endpoint, authenticated via
+# HMAC-SHA256 signature in `x-n8n-signature` (verified against
+# `N8N_WEBHOOK_SECRET`), NOT Supabase JWT. Source: comment block at the
+# top of `supabase/functions/n8n-blog-ingest/index.ts` — "HMAC is the
+# auth boundary". Without `verify_jwt = false`, Supabase's platform
+# layer rejects every call with `UNAUTHORIZED_NO_AUTH_HEADER` before
+# the function code runs.
+#
+# `import_map` points at the project-wide map so the function can use
+# bare specifiers like `@supabase/supabase-js`. Without this, deploys
+# fail with "Relative import path not prefixed with / or ./ or ../"
+# unless the CLI is invoked with `--import-map`, which is fragile
+# (anyone redeploying via the dashboard or a different command won't
+# pass the flag).
+[functions.n8n-blog-ingest]
+verify_jwt = false
+import_map = "./functions/deno.json"
+
 [edge_runtime]
 enabled = true
 # Supported request policies: `oneshot`, `per_worker`.


### PR DESCRIPTION
## Summary

Corrects the `/blog/[slug]` route and persists the `n8n-blog-ingest` Edge
Function config. Opened for the config change; grew to fix two latent
`/blog/[slug]` bugs that surfaced once the blog content pipeline went live
and published real posts.

### `supabase/config.toml`
Canonical `[functions.n8n-blog-ingest]` block:
- `verify_jwt = false` — the function authenticates via HMAC-SHA256
  (`x-n8n-signature`), not Supabase JWT. Without this the platform rejects
  every call with `UNAUTHORIZED_NO_AUTH_HEADER` before the code runs.
- `import_map = "./functions/deno.json"` — lets the function use bare
  specifiers (`@supabase/supabase-js`) without a fragile `--import-map`
  CLI flag on every redeploy.

### `/blog/[slug]` — two latent bugs, exposed once posts existed
Both guarding e2e tests skip when 0 posts are published, so these were
invisible until the cron published content.

1. **Soft-404.** `getBlogPost` used the cookie-aware Supabase client; its
   `cookies()` call is a Dynamic API that forced the route to `ƒ`
   (Dynamic), silently disabling the `generateStaticParams` +
   `dynamicParams=false` 404 gate. Unknown slugs ran the page component
   and hit in-component `notFound()`, which soft-200s under dynamic
   streaming (404 UI, HTTP 200). Fix: cookie-less anon client (blog posts
   are public — `status='published'` is the anon RLS gate) → route is `●`
   (SSG) → unknown slugs 404 at the router level.

2. **Missing `og:url`.** The hand-built `openGraph` object omitted `url`;
   Next.js only emits `<meta property="og:url">` when `openGraph.url` is
   set (`createPageMetadata`, used elsewhere, sets it). Fix:
   `openGraph.url = canonical`, mirroring `<link rel="canonical">`.

### Hardening
`generateStaticParams` now throws on a Supabase query error instead of
returning `[]`. With `dynamicParams=false`, an empty static set 404s the
entire published catalogue — a thrown error fails `next build` so the
broken build never deploys and prod keeps the last-good build.

## Test plan
- [x] typecheck + lint clean
- [x] unit tests — `page.test.tsx` mock retargeted to `@supabase/supabase-js`; `openGraph.url` pinned in both canonical branches
- [x] e2e-smoke green — `seo-smoke.spec.ts` bogus-slug-404 + Article-schema/`og:url` tests pass
- [x] local prod build verified: real posts 200 + `og:url`; bogus slugs 404; build is `● /blog/[slug]` SSG

[hudsor01]