### PR TITLE
test(10): land IN-01/IN-02 review fixes missed by PR #738

### DIFF
--- a/.planning/phases/10-cta-conversion/10-REVIEW-followup.md
+++ b/.planning/phases/10-cta-conversion/10-REVIEW-followup.md
@@ -1,0 +1,80 @@
+---
+phase: 10-cta-conversion
+reviewed: 2026-05-21T00:00:00Z
+depth: deep
+files_reviewed: 3
+files_reviewed_list:
+  - src/app/compare/[competitor]/__tests__/compare-neutral-framing.test.tsx
+  - src/components/contact/__tests__/contact-form-fields.test.tsx
+  - src/data/__tests__/testimonials.test.ts
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+---
+
+# Phase 10: Code Review Report (Followup — PR #739)
+
+**Reviewed:** 2026-05-21T00:00:00Z
+**Depth:** deep
+**Files Reviewed:** 3
+**Status:** clean
+
+## Summary
+
+PR #739 is a 4-line followup to PR #738 (Phase 10, cta-conversion) across three Vitest 4 +
+jsdom regression-guard test files. The diff was verified against `main`:
+
+- Removed the redundant `/** @vitest-environment jsdom */` pragma from all three files.
+- Added a 4-line explanatory comment above the defensive `vi.mock("next/link")` in
+  `compare-neutral-framing.test.tsx`.
+
+No production code is touched.
+
+### Pragma removal — environment unchanged (verified)
+
+`vitest.config.ts` defines the `unit` project with `environment: "jsdom"` and
+`include: ["src/**/*.{test,spec}.{ts,tsx}"]`. All three files match that glob and have no
+`*.component.test.tsx` suffix, so they run under the `unit` project and inherit the global
+jsdom environment. The per-file pragma was strictly redundant — removing it does NOT change
+the environment. Each file still depends on jsdom (`@testing-library/react` `render`, DOM
+queries like `container.querySelector`, `toBeEmptyDOMElement`), and that requirement is now
+satisfied by the project-level default. No behavior change.
+
+### Added comment — accurate (verified cross-file)
+
+The new comment in `compare-neutral-framing.test.tsx` claims `compare-sections.tsx` imports
+`next/link` at module scope, consumed by `BottomCta`, while `FeatureTable` itself renders no
+`<Link>`. Confirmed against source: `compare-sections.tsx:2` has `import Link from "next/link"`,
+`BottomCta` (line 202) uses `<Link>` at lines 216/222, and `FeatureTable` (line 99) contains no
+`<Link>`. The "defensive / not load-bearing for the current tree" framing is correct — the mock
+is dead-but-defensive for the current `FeatureTable`-only import surface.
+
+### Other deep-pass cross-file checks (all pass)
+
+- `compare-data.ts` has exactly 4 `tenantflow: "na"` rows (lines 83, 89, 192, 321) — the
+  `toHaveLength(4)` source-text assertion is accurate.
+- `FeatureSupport` union in `src/types/sections/compare.ts` still includes `"na"` — the type
+  assignment test is valid.
+- `compare-sections.tsx` renders the `"na"` case as a `Minus` with `aria-label="Not applicable"`
+  and `text-muted-foreground` (no destructive token) — the render assertions match.
+- `contact-form-fields.tsx` has `placeholder="Please select"` on the `referralSource`
+  `SelectValue` (line 163) under `SelectTrigger id="type"` (line 162); no `placeholder="Sales
+  Outreach"` exists — both source-text assertions hold.
+- `TestimonialsSection` (`src/components/sections/testimonials-section.tsx:59`) gates on
+  `testimonials.length === 0` returning `null` — the empty-gate render test is valid.
+- The `#data` path alias genuinely does not exist in `tsconfig.json` / `package.json`; the
+  comment in `testimonials.test.ts` correctly documents the relative-import rationale.
+- No `any` types, no `as unknown as` assertions, no emojis, no commented-out code, no inline
+  styles. Mock-component prop types are explicitly typed (`React.ReactNode`, `string`).
+  kebab-case file naming and PascalCase type naming hold.
+
+All reviewed files meet quality standards. No issues found.
+
+---
+
+_Reviewed: 2026-05-21T00:00:00Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: deep_

--- a/src/app/compare/[competitor]/__tests__/compare-neutral-framing.test.tsx
+++ b/src/app/compare/[competitor]/__tests__/compare-neutral-framing.test.tsx
@@ -1,4 +1,3 @@
-/** @vitest-environment jsdom */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { render } from "@testing-library/react";
@@ -6,6 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import { FeatureTable } from "#app/compare/[competitor]/compare-sections";
 import type { CompetitorData } from "#types/sections/compare";
 
+// Defensive isolation: FeatureTable renders no <Link>, but compare-sections.tsx
+// imports `next/link` at module scope (consumed by BottomCta). Mocking it here
+// pre-empts any Next router-context requirement that a future compare-sections.tsx
+// change could introduce. Intentional — not load-bearing for the current tree.
 vi.mock("next/link", () => ({
 	default: ({
 		children,

--- a/src/components/contact/__tests__/contact-form-fields.test.tsx
+++ b/src/components/contact/__tests__/contact-form-fields.test.tsx
@@ -1,4 +1,3 @@
-/** @vitest-environment jsdom */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { render } from "@testing-library/react";

--- a/src/data/__tests__/testimonials.test.ts
+++ b/src/data/__tests__/testimonials.test.ts
@@ -1,5 +1,3 @@
-/** @vitest-environment jsdom */
-
 /**
  * Regression pins for TRUST-01 / TRUST-04.
  *


### PR DESCRIPTION
## Summary

Small followup to PR #738 (Phase 10). #738's code review surfaced 2 Info-level findings; the code-fixer applied the edits but did not commit them, so #738 merged the un-fixed test files. This lands the fixes.

## Changes

3 test files (4 insertions, 4 deletions — cosmetic, test-only):

- **IN-01** — removed the redundant `/** @vitest-environment jsdom */` pragma from `compare-neutral-framing.test.tsx`, `contact-form-fields.test.tsx`, `testimonials.test.ts`. The `unit` Vitest project already sets `environment: jsdom` globally for all `src/**/*.test.{ts,tsx}`.
- **IN-02** — added a 4-line explanatory comment to the defensive `vi.mock("next/link")` in `compare-neutral-framing.test.tsx` so a future reader/reviewer understands it is intentional isolation, not load-bearing.

## Verification

- [x] All 12 tests across the 3 affected files pass without the pragmas
- [x] No behavior change — the 25 Phase 10 regression tests are unaffected

These exact file states were deep-reviewed clean in both of PR #738's perfect-PR cycles; the cycles ran against the working tree that had these (uncommitted) edits.

[hudsor01]