### PR TITLE
Phase 13: Performance & Conversion Polish

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -123,10 +123,10 @@ Replaces the narrow CRIT-01 fix with a full data + UI + automation + content reb
 
 ### Performance & Conversion Polish (PERF)
 
-- [ ] **PERF-01**: `/blog` index server-renders post list — eliminate the ~3-second client-side "Loading TenantFlow…" state. Already covered by BLOG-02; this REQ tracks the perf outcome.
-- [ ] **PERF-02**: Marketing pages use static generation + explicit cache headers where eligible — reduce TTI on `/`, `/pricing`, `/features`, `/about`, `/compare/[competitor]`.
-- [ ] **PERF-03**: Sticky / floating CTA on long pages (`/pricing` comparison, `/faq`, `/features`) — visible after scrolling past primary CTA so users don't scroll back up to convert.
-- [ ] **PERF-04**: Exit-intent or scroll-depth lead-capture component on top marketing pages for paid-traffic optimization (gated behind a feature flag if A/B testing is desired).
+- [x] **PERF-01**: `/blog` index server-renders post list — eliminate the ~3-second client-side "Loading TenantFlow…" state. Already covered by BLOG-02; this REQ tracks the perf outcome.
+- [x] **PERF-02**: Marketing pages use static generation + explicit cache headers where eligible — reduce TTI on `/`, `/pricing`, `/features`, `/about`, `/compare/[competitor]`.
+- [x] **PERF-03**: Sticky / floating CTA on long pages (`/pricing` comparison, `/faq`, `/features`) — visible after scrolling past primary CTA so users don't scroll back up to convert.
+- [x] **PERF-04**: Exit-intent or scroll-depth lead-capture component on top marketing pages for paid-traffic optimization (gated behind a feature flag if A/B testing is desired).
 
 ## v2 Requirements
 
@@ -212,10 +212,10 @@ Updated by `gsd-roadmapper` during roadmap creation. See ROADMAP.md for canonica
 | SEO-05 | Phase 12 | Complete |
 | SEO-06 | Phase 12 | Complete |
 | SEO-07 | Phase 12 | Complete |
-| PERF-01 | Phase 13 | Pending |
-| PERF-02 | Phase 13 | Pending |
-| PERF-03 | Phase 13 | Pending |
-| PERF-04 | Phase 13 | Pending |
+| PERF-01 | Phase 13 | Complete |
+| PERF-02 | Phase 13 | Complete |
+| PERF-03 | Phase 13 | Complete |
+| PERF-04 | Phase 13 | Complete |
 
 **Coverage:**
 - v1 requirements: 55 total (after CONS-12 removed; PRICE-* and BLOG-* added)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -22,7 +22,7 @@ TenantFlow is a mature Next.js 16 + Supabase landlord-only SaaS (v2.6 shipped Ap
 - [x] **Phase 10: CTA & Conversion Standardization** — Canonical "Contact Sales" labels + styles, neutral compare-page framing, fix `/contact` default, testimonials (no headshots) + review badges + monitored inboxes
 - [x] **Phase 11: Design-Token Alignment & Resources Page** — `/resources` neon-pink + decorative cards → tokens; codify no-hex/no-bg-white/no-inline-ms lint rule (completed 2026-05-21)
 - [x] **Phase 12: SEO Metadata, Schema & Content Cleanup** — Meta separator, per-page OG images, Organization + SoftwareApplication schema, blog slugs (post-Phase 6), breadcrumbs, footer sitemap link, sitewide `aria-current` audit
-- [ ] **Phase 13: Performance & Conversion Polish** — Static export + cache headers, sticky CTA on long pages, exit-intent / scroll-depth lead capture (PERF-01 server-render `/blog` already covered in Phase 6)
+- [x] **Phase 13: Performance & Conversion Polish** — Static export + cache headers, sticky CTA on long pages, exit-intent / scroll-depth lead capture (PERF-01 server-render `/blog` already covered in Phase 6) (completed 2026-05-21)
 
 ## Phase Details
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: ready_to_plan
-last_updated: 2026-05-21T20:42:48.706Z
+last_updated: 2026-05-21T22:07:04.417Z
 last_activity: 2026-05-21 -- Phase 12 Plan 03 complete (SEO-03/04/05/06 verify-and-pin + SEO-07 audit)
 progress:
   total_phases: 14
   completed_phases: 11
   total_plans: 28
-  completed_plans: 25
+  completed_plans: 26
   percent: 79
-stopped_at: Phase 12 complete (3/3) — ready to discuss Phase 14
+stopped_at: Phase 13 complete (1/0) — ready to discuss Phase 14
 ---
 
 # Project State

--- a/.planning/phases/13-performance-conversion-polish/13-01-SUMMARY.md
+++ b/.planning/phases/13-performance-conversion-polish/13-01-SUMMARY.md
@@ -1,0 +1,58 @@
+---
+phase: 13-performance-conversion-polish
+plan: 01
+status: complete
+completed: 2026-05-21
+requirements_addressed: [PERF-01, PERF-02, PERF-03, PERF-04]
+key-files:
+  created:
+    - src/app/__tests__/performance-policy.test.ts
+  modified:
+    - src/app/about/page.tsx
+key-decisions:
+  - "PERF-01/03/04 already shipped (Phase 6 server-rendered /blog; StickyConversionCta mounted on conversion-critical pages; LeadCaptureModal gated by NEXT_PUBLIC_LEAD_CAPTURE_MODAL env flag) — verify-and-pin only."
+  - "PERF-02 had one gap: /about/page.tsx lacked explicit cache config. Adding `export const revalidate = 3600` matches all sibling marketing pages and closes the requirement."
+  - "Feature flag mechanism is the existing NEXT_PUBLIC_LEAD_CAPTURE_MODAL env var (default off, operators flip on via Vercel env config). No separate flag system added — this is the canonical v1.0 approach."
+  - "Phase 13 executed inline rather than via the full discuss/plan/check pipeline given the tiny scope (1 production line + 1 test file, ~115 insertions)."
+patterns-established:
+  - "Performance policy pin: a single test file with source-text scans (readFileSync) across all marketing pages asserting their cache-config exports — analog to Phase 12's drift-guards."
+---
+
+# Plan 13-01 — Performance & Conversion Polish — COMPLETE
+
+## What shipped
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| PERF-01 | shipped (Phase 6) — pinned | `/blog/page.tsx` is a server component, no `'use client'`, no `force-dynamic` |
+| PERF-02 | one gap closed, all pinned | `/about/page.tsx` now exports `revalidate = 3600`; all 5 ROADMAP-named pages export static-gen or ISR |
+| PERF-03 | shipped — pinned | `<StickyConversionCta />` mounted on `/pricing`, `/faq`, `/features` |
+| PERF-04 | shipped — pinned | `<LeadCaptureModal />` gated by `NEXT_PUBLIC_LEAD_CAPTURE_MODAL === "on"` (default off); mounted on `/pricing`, `/compare/[competitor]` |
+
+## Files
+
+- **Modified:** `src/app/about/page.tsx` — added `export const revalidate = 3600` (closes the only PERF-02 gap)
+- **Created:** `src/app/__tests__/performance-policy.test.ts` — 12-test consolidated PERF-01..04 regression pin
+
+## Verification
+
+- `bunx vitest --run --project unit src/app/__tests__/performance-policy.test.ts` → **12/12 pass**
+- Full pre-commit gate (`gitleaks`, `lockfile-verify`, `lint` Biome, `typecheck`, `unit-tests` w/ coverage) passed
+- Manual: confirmed every cache-config export by reading source
+
+## Commits
+
+- `2ede899ba`: feat(13): close PERF-02 gap + pin all 4 PERF requirements
+
+## Notes
+
+- This is the smallest v1.0 phase by net production change (1 line of code + a test file).
+- Lighthouse TTI baseline measurement is documented as deferred (not in CI test scope; manual).
+- A/B testing infrastructure for lead-capture variants is documented as deferred to v2.0+.
+
+## Self-Check: PASSED
+
+- `src/app/about/page.tsx` carries `export const revalidate = 3600`
+- All 5 ROADMAP-named marketing pages declare static gen or ISR
+- `src/app/__tests__/performance-policy.test.ts` exists with 12 passing tests
+- Commit `2ede899ba` present on `gsd/phase-13-performance-polish`

--- a/.planning/phases/13-performance-conversion-polish/13-CONTEXT.md
+++ b/.planning/phases/13-performance-conversion-polish/13-CONTEXT.md
@@ -1,0 +1,82 @@
+# Phase 13: Performance & Conversion Polish - Context
+
+**Gathered:** 2026-05-21 (via /gsd-discuss-phase 13 --auto)
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Performance + conversion polish, scoped by ROADMAP Phase 13 (requirements PERF-01..04):
+
+1. **PERF-01** — `/blog` server-rendered (verified outcome of Phase 6 BLOG-02).
+2. **PERF-02** — `/`, `/pricing`, `/features`, `/about`, `/compare/[competitor]` use static generation + explicit cache headers.
+3. **PERF-03** — Sticky CTA bar visible on `/pricing`, `/faq`, `/features`.
+4. **PERF-04** — Exit-intent OR scroll-depth lead-capture component active on top marketing pages, gated behind a feature flag (default off for v1.0).
+
+Pre-scout findings (2026-05-21):
+- `/` — `export const dynamic = "force-static"` ✓
+- `/pricing` — `export const revalidate = 3600` ✓
+- `/features` — `export const revalidate = 3600` ✓
+- `/compare/[competitor]` — `export const revalidate = 3600` ✓
+- `/about` — **gap: no `revalidate`/`dynamic` export** (uses Next.js default; needs explicit cache)
+- `/faq` — `export const revalidate = 3600` ✓ (bonus — not in ROADMAP success criterion but mounted with StickyConversionCta)
+- `/blog/page.tsx` — server component (no `'use client'`); Phase 6 verify-only
+- `StickyConversionCta` mounted on `/pricing`, `/faq`, `/features`, `/compare/[competitor]` ✓
+- `LeadCaptureModal` exists, gated by `NEXT_PUBLIC_LEAD_CAPTURE_MODAL === "on"` env flag (default off), mounted on `/pricing` + `/compare/[competitor]` ✓
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Per-requirement classification (shipped vs remaining)
+- **D-01 PERF-01 — verify-only.** `/blog/page.tsx` is a server component. Phase 6 BLOG-02 owns the rebuild; this phase just confirms server-rendering (no `'use client'` directive, no `dynamic = "force-dynamic"`) and regression-pins it.
+- **D-02 PERF-02 — real work + verify.** 4 of 5 ROADMAP-named pages already have static gen / ISR. `/about` is the one gap. Add `export const revalidate = 3600` to `/about/page.tsx` matching the sibling marketing pages (about is static brand copy — same 1h-revalidate semantics as features/pricing). Regression-pin all 5 pages.
+- **D-03 PERF-03 — verify-only.** `StickyConversionCta` already mounted on all 3 ROADMAP-named pages (`/pricing`, `/faq`, `/features`). Regression-pin the mount sites.
+- **D-04 PERF-04 — verify-only.** `LeadCaptureModal` exists, gated by `NEXT_PUBLIC_LEAD_CAPTURE_MODAL === "on"` env flag (default off), mounted on top marketing pages. Regression-pin the gate behavior + mount sites.
+
+### Feature flag mechanism (LOCKED)
+- **D-05** The lead-capture gate uses `process.env.NEXT_PUBLIC_LEAD_CAPTURE_MODAL` — a `NEXT_PUBLIC_*` env var read in client components. This IS the project's feature flag for v1.0; no separate flag system needs to be added. Default off (env var unset → modal disabled). Operators flip on by setting `NEXT_PUBLIC_LEAD_CAPTURE_MODAL=on` in Vercel env config.
+
+### Claude's Discretion
+- Whether the `/about` `revalidate` should be `3600` (1h, matches siblings) or longer (`/about` content is more static). Default to `3600` for consistency with sibling pages.
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Phase 6 BLOG-02 owns server-rendered `/blog`. Confirm via source inspection — do not re-edit blog code.
+- Phase 12's drift-guard test pattern (`src/app/sitemap.test.ts`, `marketing-copy-landlord-only.test.ts`) is the analog for the regression-pin tests this phase adds.
+- v1.0 is the smallest phase by net production change — 1 line (`export const revalidate = 3600` on `/about`) plus regression-pin tests.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Code touchpoints (verify during research)
+- `src/app/about/page.tsx` — add `revalidate` (PERF-02 only gap)
+- `src/app/page.tsx`, `src/app/pricing/page.tsx`, `src/app/features/page.tsx`, `src/app/compare/[competitor]/page.tsx`, `src/app/faq/page.tsx` — PERF-02/03 regression-pin targets
+- `src/app/blog/page.tsx` — PERF-01 server-rendered verify (no edit)
+- `src/components/marketing/sticky-conversion-cta.tsx` (+ `__tests__/`) — PERF-03 component
+- `src/components/marketing/lead-capture-modal.tsx` (+ `__tests__/`) — PERF-04 component + env gate
+
+### Project rules
+- `CLAUDE.md` — zero-tolerance rules; Vitest 4 + jsdom; Biome lint
+
+</canonical_refs>
+
+<deferred>
+## Deferred Ideas
+
+- A/B testing infrastructure for the lead-capture variants — v2.0+; v1.0 just ships the env-flag default-off gate.
+- Lighthouse TTI baseline measurement — outside CI test scope; manual verification.
+
+</deferred>
+
+---
+
+*Phase: 13-performance-conversion-polish*
+*Context gathered: 2026-05-21 via /gsd-discuss-phase 13 --auto*

--- a/.planning/phases/13-performance-conversion-polish/13-REVIEW.md
+++ b/.planning/phases/13-performance-conversion-polish/13-REVIEW.md
@@ -1,0 +1,106 @@
+---
+phase: 13-performance-conversion-polish
+reviewed: 2026-05-21T00:00:00Z
+depth: deep
+files_reviewed: 2
+files_reviewed_list:
+  - src/app/about/page.tsx
+  - src/app/__tests__/performance-policy.test.ts
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+---
+
+# Phase 13: Code Review Report
+
+**Reviewed:** 2026-05-21T00:00:00Z
+**Depth:** deep
+**Files Reviewed:** 2
+**Status:** clean
+
+## Summary
+
+Independently re-verified both files at deep depth with fresh eyes, treating the prior cycle's verdict as untrusted. No findings.
+
+The PR scope is a 1-line production edit (`export const revalidate = 3600` on `/about/page.tsx`) plus a new consolidated regression-pin suite (`performance-policy.test.ts`, 12 tests covering PERF-01..04). Both files cleanly meet the project's zero-tolerance conventions in `CLAUDE.md`: no `any`, no `as unknown as`, no string-literal query keys, no emojis, no commented-out code, no inline styles, no barrel/re-export, no duplicate types.
+
+## Cross-File Verification (deep-pass)
+
+I cross-referenced every assertion in `performance-policy.test.ts` against the actual shipped source via direct grep:
+
+| Assertion | Reality | Match |
+|-----------|---------|-------|
+| `/blog/page.tsx` is not a client component | Line 1 is `import * as Sentry from "@sentry/nextjs";`; zero `"use client"` occurrences in file | yes |
+| `/blog/page.tsx` does not opt out via `dynamic = 'force-dynamic'` | No `force-dynamic`, no `noStore`, no `revalidate = 0` | yes |
+| `/page.tsx` declares static-gen | `export const dynamic = "force-static"` line 10 | yes |
+| `/pricing/page.tsx` declares ISR | `export const revalidate = 3600` line 24 | yes |
+| `/features/page.tsx` declares ISR | `export const revalidate = 3600` line 10 | yes |
+| `/about/page.tsx` declares ISR | `export const revalidate = 3600` line 46 (this PR) | yes |
+| `/compare/[competitor]/page.tsx` declares ISR | `export const revalidate = 3600` line 24 | yes |
+| `<StickyConversionCta />` mounted on `/pricing` | line 101, import line 5 | yes |
+| `<StickyConversionCta />` mounted on `/faq` | line 99, import line 6 | yes |
+| `<StickyConversionCta />` mounted on `/features` | line 26, import line 2 | yes |
+| `LeadCaptureModal` gated on `NEXT_PUBLIC_LEAD_CAPTURE_MODAL !== "on"` | `lead-capture-modal.tsx` line 50 | yes |
+| `<LeadCaptureModal />` mounted on `/pricing` | line 102, import line 4 | yes |
+| `<LeadCaptureModal />` mounted on `/compare/[competitor]` | line 213, import line 8 | yes |
+
+## Mutation Testing of the Regression Pins
+
+Verified each assertion fails on its corresponding regression vector:
+
+- **PERF-02 — remove `revalidate = 3600` from `/about/page.tsx`** → CACHE_PATTERN regex (`/export\s+const\s+(revalidate\s*=\s*\d+|dynamic\s*=\s*["']force-static["'])/`) has no other match in that file. `toMatch` fails. Pin works.
+- **PERF-01 — add `"use client"` to line 1 of `/blog/page.tsx`** → `src.startsWith('"use client"')` returns `true`; expectation is `false`. Fails. Pin works.
+- **PERF-03 — unmount `<StickyConversionCta />` from `/pricing/page.tsx`** → `/<StickyConversionCta\b/` regex no longer matches. Fails. Pin works.
+- **PERF-04 — remove env-flag gate from `LeadCaptureModal`** → `/process\.env\.NEXT_PUBLIC_LEAD_CAPTURE_MODAL\s*!==\s*["']on["']/` no longer matches. Fails. Pin works.
+
+## about/page.tsx Specifics
+
+- `revalidate = 3600` matches the sibling cadence of `/pricing`, `/features`, `/compare/[competitor]`. The 4-line preceding comment cites Phase 13 / PERF-02 and the design intent (edits land without redeploy) — appropriate scope, not commented-out code.
+- `PageLayout` wraps the entire page; no duplicate `page-offset-navbar` added in children (per CLAUDE.md marketing-page rule).
+- All sections use `section-spacing`, `max-w-7xl mx-auto px-6 lg:px-8`, and `bg-card` / `bg-muted/20` per the marketing-page conventions. No bare `bg-white`, no bare `text-muted`.
+- Stats array uses Lucide icons with `aria-hidden` on the decorative renders. Icon component property capitalized as `Icon` to satisfy React's component-tag rule when destructured (`stat.Icon`).
+- CTAs use `<Button asChild><Link>` — proper Next.js routing, no `<a>` for internal nav.
+- JSON-LD breadcrumb script via the shared helper; `createPageMetadata` for consistent title/description/path generation.
+- No conflicts with route-segment directives — no pre-existing `dynamic`, `dynamicParams`, or `fetchCache` in the file.
+
+## Test-File Specifics
+
+- Located at `src/app/__tests__/performance-policy.test.ts`, alongside seven sibling source-text-scan tests (`cta-label-canonical.test.ts`, `marketing-copy-landlord-only.test.ts`, `seo-title-separator-drift.test.ts`, `design-token-drift.test.ts`, etc.). Convention match.
+- Uses `node:fs` + `node:path` reads anchored at `resolve(__dirname, "..", "..", "..")` — that resolves to the repo root (`src/app/__tests__/` → `src/app/` → `src/` → repo root). Verified the relative paths each `read()` consumes are valid against the live tree.
+- The PERF-01 first test asserts both double-quoted and single-quoted `'use client'` directives are absent — defends against Biome reformatting between the two quote styles.
+- The PERF-02 `CACHE_PATTERN` regex accepts either `revalidate = N` (digits) or `dynamic = "force-static"` (also `'force-static'`). Both shipped variants are covered.
+- The PERF-03 mount check requires BOTH the import-from path AND the JSX usage — defends against half-mounts (import without render, or render without import).
+- The PERF-04 env-gate regex tolerates whitespace variation around `!==` and either quote style around `"on"` — Biome-format-stable.
+- No mocks needed; no Vitest 4 / chai 6 footguns triggered (no `.rejects.toThrow`).
+- No `any`, no `as unknown as`, no `@ts-expect-error`. Pure string assertions.
+
+## Edge Cases Probed but Not Flagged
+
+- **PERF-01 only catches `"use client"` at line 1.** A regression that puts `'use client'` after a comment would slip past `startsWith`. The Next.js compiler still recognizes that as client-tagged. However: (a) Biome formats the directive to file-top per directive-ordering rules, (b) the test header explicitly frames itself as a regression-pin against the shipped source, and (c) the secondary check on `force-dynamic` covers the most common opt-out vector. Acceptable scope for a pin.
+- **PERF-02 won't match `revalidate = false` (the Next.js "cache forever" literal).** None of the listed pages use `false`. A regression to `false` is semantically static (the intent of PERF-02) but would fail the test — that's a conservative false-positive direction, not a real defect.
+- **PERF-04 mount check is text-only — wrapping `<LeadCaptureModal />` in `{false && ...}` would still pass.** Test header explicitly frames itself as source-text scan. Out of scope.
+
+None of the above are project-convention violations or correctness defects. They are deliberate scope-of-pin trade-offs consistent with the file's own header framing ("source-text scans, analog: `sitemap.test.ts`, `marketing-copy-landlord-only.test.ts`").
+
+## Project Convention Compliance
+
+- No `any` types in either file (confirmed via grep — the only "any" match in `/about/page.tsx` is the literal marketing string "Cancel anytime").
+- No `as unknown as` assertions.
+- No barrel imports — every import resolves to the defining module via `#`-prefixed subpath aliases.
+- No emojis in code; Lucide icons throughout.
+- No string-literal query keys (page is not data-fetching at module scope).
+- File sizes within limits: test file 108 lines; production edit is a single line in a 288-line file (well under the 300-line component cap).
+- Vitest 4 + jsdom inherited from project default — test correctly relies on this without re-declaring the environment.
+- `__dirname` available in test files under Vitest CJS interop (same usage as `vitest.config.ts`); `REPO_ROOT` resolution is correct.
+- Test imports `describe`, `expect`, `it` explicitly despite `globals: true` — matches the convention used by the other tests in `src/app/__tests__/`.
+
+All reviewed files meet quality standards. No issues found.
+
+---
+
+_Reviewed: 2026-05-21T00:00:00Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: deep_

--- a/.planning/phases/13-performance-conversion-polish/13-VERIFICATION.md
+++ b/.planning/phases/13-performance-conversion-polish/13-VERIFICATION.md
@@ -1,0 +1,90 @@
+---
+phase: 13-performance-conversion-polish
+verified: 2026-05-21T17:04:55Z
+status: passed
+score: 4/4 must-haves verified
+overrides_applied: 0
+---
+
+# Phase 13: Performance & Conversion Polish Verification Report
+
+**Phase Goal:** Marketing pages use static generation + cache headers where eligible; sticky CTA on long pages; exit-intent / scroll-depth lead capture (gated behind feature flag for A/B testing).
+**Verified:** 2026-05-21T17:04:55Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | PERF-01: `/blog` index is server-rendered (no client-side loading state) | VERIFIED | `src/app/blog/page.tsx` has no `'use client'` directive and no `dynamic = "force-dynamic"` |
+| 2 | PERF-02: All 5 ROADMAP-named marketing pages declare static gen or ISR | VERIFIED | `/` → `dynamic = "force-static"`; `/pricing`, `/features`, `/compare/[competitor]`, `/about` → `revalidate = 3600` |
+| 3 | PERF-03: `<StickyConversionCta />` mounted on `/pricing`, `/faq`, `/features` | VERIFIED | Imported from `#components/marketing/sticky-conversion-cta` and rendered in JSX in all 3 pages |
+| 4 | PERF-04: `<LeadCaptureModal />` gated by `NEXT_PUBLIC_LEAD_CAPTURE_MODAL === "on"` (default off), mounted on `/pricing` + `/compare/[competitor]` | VERIFIED | `process.env.NEXT_PUBLIC_LEAD_CAPTURE_MODAL !== "on"` early-return in component; mounted in both page files |
+
+**Score:** 4/4 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `src/app/about/page.tsx` | `export const revalidate = 3600` | VERIFIED | Line 46: `export const revalidate = 3600` — closes the only PERF-02 gap |
+| `src/app/__tests__/performance-policy.test.ts` | 12-test regression-pin file | VERIFIED | 12 tests, 12 pass — `bunx vitest --run` confirmed |
+| `src/components/marketing/lead-capture-modal.tsx` | Feature-flag gate `NEXT_PUBLIC_LEAD_CAPTURE_MODAL` | VERIFIED | Line 50: `if (process.env.NEXT_PUBLIC_LEAD_CAPTURE_MODAL !== "on") return;` |
+| `src/components/marketing/sticky-conversion-cta.tsx` | Component exists and is mountable | VERIFIED | Imported and used in `/pricing`, `/faq`, `/features` |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `pricing/page.tsx` | `sticky-conversion-cta.tsx` | `import` + JSX render | WIRED | Import line 5; `<StickyConversionCta />` line 101 |
+| `faq/page.tsx` | `sticky-conversion-cta.tsx` | `import` + JSX render | WIRED | Import line 6; `<StickyConversionCta />` line 99 |
+| `features/page.tsx` | `sticky-conversion-cta.tsx` | `import` + JSX render | WIRED | Import line 2; `<StickyConversionCta />` line 26 |
+| `pricing/page.tsx` | `lead-capture-modal.tsx` | `import` + JSX render | WIRED | Import line 4; `<LeadCaptureModal />` line 102 |
+| `compare/[competitor]/page.tsx` | `lead-capture-modal.tsx` | `import` + JSX render | WIRED | Import line 8; `<LeadCaptureModal />` line 213 |
+| `lead-capture-modal.tsx` | `NEXT_PUBLIC_LEAD_CAPTURE_MODAL` env flag | `process.env` gate | WIRED | Line 50: early-return when not `"on"` — default off |
+
+### Data-Flow Trace (Level 4)
+
+Not applicable. This phase delivers static generation config (not dynamic data), a UI overlay component with an env gate, and a regression-pin test file. No dynamic data flows to verify.
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| 12 PERF regression-pin tests pass | `bunx vitest --run --project unit src/app/__tests__/performance-policy.test.ts` | 12 passed, 0 failed, duration 323ms | PASS |
+
+### Requirements Coverage
+
+| Requirement | Description | Status | Evidence |
+|-------------|-------------|--------|---------|
+| PERF-01 | `/blog` server-renders post list | SATISFIED | No `'use client'`, no `force-dynamic`; test pins this |
+| PERF-02 | Marketing pages use static gen + explicit cache headers | SATISFIED | All 5 ROADMAP pages have `revalidate` or `force-static`; `/about` gap closed; test pins all 5 |
+| PERF-03 | Sticky CTA on long pages (`/pricing`, `/faq`, `/features`) | SATISFIED | `<StickyConversionCta />` mounted and imported in all 3; test pins all 3 |
+| PERF-04 | Exit-intent/scroll-depth lead capture, feature-flag gated | SATISFIED | `LeadCaptureModal` gates on `NEXT_PUBLIC_LEAD_CAPTURE_MODAL === "on"` (default off); mounted on `/pricing` + `/compare/[competitor]`; test pins gate + mounts |
+
+### Anti-Patterns Found
+
+None. The single `placeholder` grep match in `lead-capture-modal.tsx` is an HTML `<input placeholder="...">` attribute — not a code stub.
+
+### Human Verification Required
+
+None.
+
+### Gaps Summary
+
+No gaps. All 4 PERF requirements are satisfied by the actual codebase:
+
+- PERF-01: `/blog/page.tsx` confirmed server component, regression-pinned.
+- PERF-02: All 5 ROADMAP-named pages carry explicit cache config (`revalidate = 3600` or `dynamic = "force-static"`). The `/about` gap was closed by adding `export const revalidate = 3600`; regression-pinned.
+- PERF-03: `<StickyConversionCta />` is imported and rendered in `/pricing`, `/faq`, `/features`; regression-pinned.
+- PERF-04: `<LeadCaptureModal />` has a working env-flag gate (`process.env.NEXT_PUBLIC_LEAD_CAPTURE_MODAL !== "on"` early-return) and is mounted on `/pricing` + `/compare/[competitor]`; regression-pinned.
+
+The 12-test regression-pin file runs clean. Commit `2ede899ba` contains all changes.
+
+---
+
+_Verified: 2026-05-21T17:04:55Z_
+_Verifier: Claude (gsd-verifier)_

--- a/src/app/__tests__/performance-policy.test.ts
+++ b/src/app/__tests__/performance-policy.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Phase 13 PERF-01..04 regression pins.
+ *
+ * Source-text scans (analog: `sitemap.test.ts`, `marketing-copy-landlord-only.test.ts`).
+ * Each requirement is pinned against the actual shipped source so that
+ * future edits which silently regress one of:
+ *   - PERF-01: /blog is server-rendered
+ *   - PERF-02: every ROADMAP-named marketing page has explicit cache config
+ *   - PERF-03: StickyConversionCta is mounted on /pricing, /faq, /features
+ *   - PERF-04: LeadCaptureModal is gated by the NEXT_PUBLIC_LEAD_CAPTURE_MODAL
+ *             env flag and mounted on top marketing pages
+ * fails this suite before the regression lands.
+ */
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+function read(rel: string): string {
+	return readFileSync(resolve(REPO_ROOT, rel), "utf8");
+}
+
+describe("Phase 13 PERF-01 — /blog is server-rendered", () => {
+	it("blog/page.tsx is a server component (no 'use client' directive)", () => {
+		const src = read("src/app/blog/page.tsx");
+		expect(src.startsWith('"use client"'), "blog page must not be client").toBe(
+			false,
+		);
+		expect(src.startsWith("'use client'"), "blog page must not be client").toBe(
+			false,
+		);
+	});
+
+	it("blog/page.tsx does not opt out of server rendering via dynamic = 'force-dynamic'", () => {
+		const src = read("src/app/blog/page.tsx");
+		expect(src).not.toMatch(/dynamic\s*=\s*["']force-dynamic["']/);
+	});
+});
+
+describe("Phase 13 PERF-02 — marketing pages have explicit cache config", () => {
+	const CACHE_PATTERN =
+		/export\s+const\s+(revalidate\s*=\s*\d+|dynamic\s*=\s*["']force-static["'])/;
+
+	const pages: Array<{ label: string; path: string }> = [
+		{ label: "homepage", path: "src/app/page.tsx" },
+		{ label: "/pricing", path: "src/app/pricing/page.tsx" },
+		{ label: "/features", path: "src/app/features/page.tsx" },
+		{ label: "/about", path: "src/app/about/page.tsx" },
+		{
+			label: "/compare/[competitor]",
+			path: "src/app/compare/[competitor]/page.tsx",
+		},
+	];
+
+	for (const { label, path } of pages) {
+		it(`${label} (${path}) declares static gen or ISR`, () => {
+			const src = read(path);
+			expect(
+				src,
+				`${path} must export either \`const revalidate = N\` or \`const dynamic = "force-static"\``,
+			).toMatch(CACHE_PATTERN);
+		});
+	}
+});
+
+describe("Phase 13 PERF-03 — StickyConversionCta mounted on conversion-critical pages", () => {
+	const mountSites: Array<{ label: string; path: string }> = [
+		{ label: "/pricing", path: "src/app/pricing/page.tsx" },
+		{ label: "/faq", path: "src/app/faq/page.tsx" },
+		{ label: "/features", path: "src/app/features/page.tsx" },
+	];
+
+	for (const { label, path } of mountSites) {
+		it(`${label} mounts <StickyConversionCta />`, () => {
+			const src = read(path);
+			expect(src).toMatch(/<StickyConversionCta\b/);
+			expect(src).toMatch(
+				/from\s+["']#components\/marketing\/sticky-conversion-cta["']/,
+			);
+		});
+	}
+});
+
+describe("Phase 13 PERF-04 — LeadCaptureModal is feature-flag gated", () => {
+	it("LeadCaptureModal gates on NEXT_PUBLIC_LEAD_CAPTURE_MODAL === 'on'", () => {
+		const src = read("src/components/marketing/lead-capture-modal.tsx");
+		// The gate must check the env flag and bail when it is not "on".
+		// Match either compact or formatted variants of the comparison.
+		expect(src).toMatch(
+			/process\.env\.NEXT_PUBLIC_LEAD_CAPTURE_MODAL\s*!==\s*["']on["']/,
+		);
+	});
+
+	it("LeadCaptureModal mounts on /pricing and /compare/[competitor]", () => {
+		const targets = [
+			"src/app/pricing/page.tsx",
+			"src/app/compare/[competitor]/page.tsx",
+		];
+		for (const path of targets) {
+			const src = read(path);
+			expect(src, `${path} must mount <LeadCaptureModal />`).toMatch(
+				/<LeadCaptureModal\b/,
+			);
+		}
+	});
+});

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -38,6 +38,13 @@ const stats = [
 	{ number: "14-day", label: "Free trial, no credit card", Icon: LifeBuoy },
 ];
 
+// ISR — about-page copy is static; 1h revalidate matches the sibling
+// marketing pages (/pricing, /features, /compare/[competitor], /faq) so
+// edits land without a full redeploy. Closes PERF-02 (Phase 13): every
+// ROADMAP-named marketing page now uses static generation + explicit
+// cache headers.
+export const revalidate = 3600;
+
 export const metadata: Metadata = createPageMetadata({
 	title: "About | Our Mission",
 	description:


### PR DESCRIPTION
## Summary

**Phase 13: Performance & Conversion Polish**
**Goal:** Marketing pages use static generation + cache headers; sticky CTA on long pages; exit-intent / scroll-depth lead capture (feature-flag gated).
**Status:** Verified (4/4 must-haves)

Closes out the PERF requirements (PERF-01..04). Most of the work was already shipped across earlier phases (server-rendered `/blog` in Phase 6, `StickyConversionCta` + `LeadCaptureModal` components already mounted, env-flag gating in place); this phase closes the one remaining gap (`/about` cache config) and locks the entire policy behind a regression-pin test.

## Changes

**Production edit (1 line):**
- `src/app/about/page.tsx` — added `export const revalidate = 3600` (ISR; matches sibling marketing pages). Closes PERF-02's only gap so every ROADMAP-named marketing page now declares static-gen or ISR.

**New regression-pin test (12 tests):**
- `src/app/__tests__/performance-policy.test.ts` — consolidated source-text scan covering all 4 PERF requirements:
  - PERF-01: `/blog/page.tsx` is a server component (no `'use client'`, no `dynamic = "force-dynamic"`)
  - PERF-02: each of `/`, `/pricing`, `/features`, `/about`, `/compare/[competitor]` exports `revalidate = N` or `dynamic = "force-static"`
  - PERF-03: `<StickyConversionCta />` is mounted on `/pricing`, `/faq`, `/features`
  - PERF-04: `<LeadCaptureModal />` gates on `NEXT_PUBLIC_LEAD_CAPTURE_MODAL === "on"` (default off) and is mounted on `/pricing`, `/compare/[competitor]`

## Requirements Addressed

- **PERF-01** — `/blog` server-rendered (Phase 6 ownership; regression-pinned here)
- **PERF-02** — every ROADMAP-named marketing page has explicit cache config (`/about` gap closed)
- **PERF-03** — `<StickyConversionCta />` mounted on conversion-critical pages
- **PERF-04** — `<LeadCaptureModal />` env-flag gated (default off) and mounted on top marketing pages

## Verification

- [x] Automated verification: passed (4/4 must-haves — see `.planning/phases/13-performance-conversion-polish/13-VERIFICATION.md`)
- [x] 12 new tests pass; full unit suite green — no regression
- [x] `typecheck` + Biome `lint` clean
- [ ] Manual: Lighthouse TTI on `/about` vs pre-Phase-13 baseline (deferred — not in CI scope)

## Notes

- A/B testing infrastructure for lead-capture variants documented as deferred to v2.0+.
- Feature flag mechanism is the existing `NEXT_PUBLIC_LEAD_CAPTURE_MODAL` env var (default off; operators flip on via Vercel env config). No separate flag system added — this is the canonical v1.0 approach.

Part of the v1.0 "Marketing Surface Honesty" milestone. Generated via GSD.

[hudsor01]
