### PR TITLE
chore(db): drop dead stripe.* schema — orphaned from rent-payment pivot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,8 +203,7 @@ Deno runtime, `supabase/functions/<name>/index.ts`.
 - Auth decisions: always `getUser()` (server-validated). `getSession()` only to read the access_token string for Bearer.
 - Single auth query key factory: `authKeys` from `src/hooks/api/use-auth.ts`. No other auth key definitions.
 - Pagination: use `count` from Supabase response. Never `data.length`.
-- Stripe schema: `stripe.*` tables (subscriptions, invoices, etc.) are queryable via PostgREST under existing RLS. Use for billing display — don't call Stripe API for reads.
-- Subscription status: query `stripe.subscriptions` for real status. Don't infer from `users.stripe_customer_id` existence.
+- Billing storage: `public.users` carries the denormalized billing fields (`stripe_customer_id`, `subscription_status`, `subscription_id`, `subscription_plan`, `subscription_current_period_end`, `subscription_cancel_at_period_end`, `subscription_source`, `trial_ends_at`). Subscription status reads from `users.subscription_status` directly. Webhooks land in `public.stripe_webhook_events` (90d retention, then archived). There is no `stripe.*` schema — the Stripe Sync direction was abandoned with the rent-payment pivot.
 - `next/image` does NOT support `blob:` URLs — use `<img>` for `URL.createObjectURL()` previews
 - Edge Function tests need `supabase functions serve` running locally
 - `SKIP_ENV_VALIDATION=true` required for `next build` in CI

--- a/supabase/migrations/20260528202741_drop_dead_stripe_schema.sql
+++ b/supabase/migrations/20260528202741_drop_dead_stripe_schema.sql
@@ -1,0 +1,31 @@
+-- Drop the entire `stripe` schema. It is leftover infrastructure from the
+-- abandoned Stripe Connect / Stripe Sync direction (Q1-Q2 2026). The product
+-- has since pivoted to landlord-only property management without rent payment
+-- facilitation -- see CLAUDE.md "Project" paragraph.
+--
+-- Audited 2026-05-28 before this drop:
+--   - 0 RLS policies on stripe.* tables
+--   - 0 functions reference stripe.* in their bodies (pg_proc.prosrc scan)
+--   - 0 foreign keys from public.* to stripe.* (internal stripe-to-stripe
+--     FKs handled by CASCADE)
+--   - 0 views in public depend on stripe.*
+--   - 0 pg_cron jobs reference stripe.*
+--   - 0 foreign data wrappers reference stripe.*
+--   - 0 frontend references (grep src/ tests/)
+--   - 0 Edge Function references (grep supabase/functions/)
+--   - All 6 stripe.* tables empty except `stripe._migrations` (1 row of
+--     internal Stripe Sync migration tracking — also dead)
+--
+-- The current product's billing storage lives entirely in `public`:
+--   - `public.users.subscription_*` columns (denormalized from webhooks)
+--   - `public.stripe_webhook_events` (16 live rows) + archive
+--
+-- `stripe.subscriptions` and `stripe.invoices` referenced in CLAUDE.md never
+-- existed -- that section is documentation of an architecture that was
+-- planned but never built. Updated CLAUDE.md in the same commit.
+--
+-- Issue #749 root-cause cleanup: the migration chain has accumulated 5+
+-- months of dead infrastructure from the pivot. This drop removes one
+-- chunk of it.
+
+DROP SCHEMA IF EXISTS stripe CASCADE;


### PR DESCRIPTION
## Summary

The `stripe.*` schema is leftover infrastructure from the abandoned Stripe Connect / Stripe Sync direction. The product pivoted to landlord-only property management without rent payment facilitation; this schema was never repurposed. Six tables + two views + their indexes/triggers, all empty except for one row of Stripe Sync's own migration tracking.

## Pre-drop audit (verified against live prod)

| Surface | Stripe.* references |
|---------|---------------------|
| RLS policies | 0 |
| Function bodies (`pg_proc.prosrc`) | 0 |
| FKs from public.* to stripe.* | 0 |
| Views in public depending on stripe.* | 0 |
| pg_cron jobs | 0 |
| Foreign data wrappers / servers | 0 |
| Frontend code (`src/`, `tests/`) | 0 |
| Edge Functions (`supabase/functions/`) | 0 |
| Internal stripe→stripe FKs | 3 (handled by CASCADE) |

## What current product actually uses

Billing storage lives entirely in `public`:
- `public.users.subscription_status`, `subscription_id`, `subscription_plan`, `subscription_current_period_end`, `subscription_cancel_at_period_end`, `subscription_source`, `trial_ends_at`
- `public.users.stripe_customer_id` (Stripe customer ID, not Connect)
- `public.stripe_webhook_events` (16 live rows — actual webhook intake)
- `public.stripe_webhook_events_archive` (90d retention)

## CLAUDE.md correction

CLAUDE.md previously claimed `stripe.subscriptions` and `stripe.invoices` were queryable via PostgREST. Those tables never existed. Updated to document the actual architecture (denormalized billing columns on `users`).

## Migration safety

Uses `DROP SCHEMA IF EXISTS stripe CASCADE`. On fresh chain replay (where no migration in the chain creates `stripe.*`), this is a no-op. On prod, it drops 6 tables + 2 views + their indexes/triggers/PKs in one transaction.

## Context: part of issue #749 root-cause cleanup

The migration chain has accumulated 5+ months of dead pivot infrastructure. This is one chunk; task #19's 12 plpgsql functions referencing dropped `rent_payments` is the next. Closing all the dead-code accumulation makes the eventual baseline-reset PR canonical and tractable.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Audit confirmed zero callers across all surfaces
- [ ] CI green
- [ ] Apply migration to prod via MCP after merge

[hudsor01]