### PR TITLE
chore(db): drop 4 dead functions referencing dropped rent_payments table

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -2519,8 +2519,6 @@ export type Database = {
 				Args: { p_customer_id: string };
 				Returns: Json;
 			};
-			get_tenant_lease_ids: { Args: never; Returns: string[] };
-			get_tenant_property_ids: { Args: never; Returns: string[] };
 			get_tenants_by_owner: { Args: { p_user_id: string }; Returns: string[] };
 			get_tenants_with_lease_by_owner: {
 				Args: { p_user_id: string };
@@ -2578,7 +2576,6 @@ export type Database = {
 			};
 			health_check: { Args: never; Returns: Json };
 			is_admin: { Args: never; Returns: boolean };
-			ledger_aggregation: { Args: never; Returns: Json };
 			link_stripe_customer_to_user: {
 				Args: { p_email: string; p_stripe_customer_id: string };
 				Returns: string;
@@ -2596,15 +2593,6 @@ export type Database = {
 				Returns: string;
 			};
 			process_account_deletions: { Args: never; Returns: undefined };
-			process_payment_intent_failed: {
-				Args: {
-					p_amount: number;
-					p_failure_reason: string;
-					p_payment_intent_id: string;
-					p_rent_payment_id: string;
-				};
-				Returns: undefined;
-			};
 			process_subscription_status_change: {
 				Args: {
 					p_new_status: string;
@@ -2682,26 +2670,6 @@ export type Database = {
 					both_signed: boolean;
 					error_message: string;
 					success: boolean;
-				}[];
-			};
-			upsert_rent_payment: {
-				Args: {
-					p_amount: number;
-					p_application_fee_amount?: number;
-					p_currency: string;
-					p_due_date: string;
-					p_lease_id: string;
-					p_paid_date?: string;
-					p_payment_method_type?: string;
-					p_period_end?: string;
-					p_period_start?: string;
-					p_status: string;
-					p_stripe_payment_intent_id?: string;
-					p_tenant_id: string;
-				};
-				Returns: {
-					id: string;
-					was_inserted: boolean;
 				}[];
 			};
 			user_is_tenant: { Args: never; Returns: boolean };

--- a/supabase/migrations/20260528204818_drop_dead_rent_payment_functions.sql
+++ b/supabase/migrations/20260528204818_drop_dead_rent_payment_functions.sql
@@ -1,0 +1,49 @@
+-- Drop 4 dead functions whose bodies reference public.rent_payments. The
+-- rent_payments table was demolished in
+-- 20260418140000_demolish_rent_and_tenant_portal (renamed 20260418183608 in
+-- prod history); these 4 functions survived in pg_catalog because LANGUAGE
+-- plpgsql function bodies are lazy-validated. They were unambiguously dead:
+-- zero callers across src/, tests/, supabase/functions/. The only references
+-- in the frontend were the auto-generated entries in src/types/supabase.ts
+-- (regenerated as part of this commit).
+--
+-- Functions dropped:
+--
+--   public.upsert_rent_payment(uuid,uuid,integer,text,text,text,text,text,
+--                              text,text,text,integer)
+--     -> Wrote a row to rent_payments. Zero real callers; only ref was the
+--        auto-gen type entry.
+--
+--   public.process_payment_intent_failed(uuid,text,integer,text)
+--     -> Webhook handler for failed Stripe rent-payment intents. Zero real
+--        callers; only ref was the auto-gen type entry.
+--
+--   public.notify_n8n_payment_reminder()
+--     -> n8n webhook trigger for rent-payment reminders. Zero callers.
+--
+--   public.notify_n8n_rent_payment()
+--     -> n8n webhook trigger for rent-payment notifications. Zero callers.
+--
+-- Not dropped here (separate concern):
+--   The 8 analytics RPCs that reference rent_payments and ARE actively called
+--   from the frontend (get_billing_insights, get_financial_overview,
+--   get_invoice_statistics, get_revenue_trends_optimized,
+--   calculate_monthly_metrics, get_property_performance_analytics/_trends/
+--   _with_trends). These need a body rewrite to drop the rent_payments
+--   dependency without breaking their callers. That's a feature-touching
+--   refactor, not a cleanup -- tracked separately.
+--
+-- Issue #749 root-cause cleanup, part 2 (part 1: drop dead stripe.* schema
+-- in PR #751).
+
+DROP FUNCTION IF EXISTS public.upsert_rent_payment(
+    uuid, uuid, integer, text, text, text, text, text, text, text, text, integer
+);
+
+DROP FUNCTION IF EXISTS public.process_payment_intent_failed(
+    uuid, text, integer, text
+);
+
+DROP FUNCTION IF EXISTS public.notify_n8n_payment_reminder();
+
+DROP FUNCTION IF EXISTS public.notify_n8n_rent_payment();


### PR DESCRIPTION
## Summary

Drops 4 LANGUAGE plpgsql functions whose bodies reference the long-dropped `public.rent_payments` table. Postgres' lazy body validation tolerated the orphan references; the functions were unambiguously dead (zero real callers across src/, tests/, supabase/functions/ — only the auto-gen src/types/supabase.ts entries, regenerated post-drop).

Closes the function-level half of task #19 (Cleanup: 13 prod RPCs reference dropped rent_payments table).

## What was dropped

| Function | Real callers | Disposition |
|----------|--------------|-------------|
| `upsert_rent_payment(uuid,uuid,integer,...)` | 0 (only auto-gen types) | **DROPPED** |
| `process_payment_intent_failed(uuid,text,integer,text)` | 0 (only auto-gen types) | **DROPPED** |
| `notify_n8n_payment_reminder()` | 0 | **DROPPED** |
| `notify_n8n_rent_payment()` | 0 | **DROPPED** |

## What was NOT dropped (explicitly out of scope)

8 actively-called analytics RPCs whose bodies also reference `rent_payments` but have 3-14 real callers each:
- `get_billing_insights` (14)
- `get_revenue_trends_optimized` (13)
- `get_property_performance_analytics` (9)
- `get_property_performance_with_trends` (8)
- `get_financial_overview` (8)
- `calculate_monthly_metrics` (3)
- `get_property_performance_trends` (3)
- `get_invoice_statistics` (3)

These need body rewrites to drop the rent_payments dependency without breaking their callers — that's a feature-touching refactor, not a cleanup PR. They're either silently failing at runtime or returning empty results because of an unreachable code branch; either way the fix is product engineering, not deletion.

## Context: issue #749 part 2

- PR #751: drop dead `stripe.*` schema (part 1)
- This PR: drop 4 dead `rent_payments`-dependent functions (part 2)
- Future PR: rewrite the 8 live-but-damaged analytics RPCs (separate)
- Eventually: canonical baseline reset per documented Supabase workflow

Each scoped cleanup removes a chunk of dead pivot infrastructure, shrinking the surface that needs to land in the eventual baseline.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test:unit` — 105,845 pass
- [x] Audit confirmed zero callers (RLS + triggers + cron + frontend + edge functions)
- [x] Applied to prod via MCP; verified 4 functions gone; 8 analytics functions preserved
- [ ] CI green

[hudsor01]