### PR TITLE
feat(db): install Stripe Foreign Data Wrapper (canonical billing pattern)

### DIFF
--- a/supabase/migrations/20260528223546_install_stripe_wrapper.sql
+++ b/supabase/migrations/20260528223546_install_stripe_wrapper.sql
@@ -1,0 +1,77 @@
+-- Install the Supabase Stripe Foreign Data Wrapper (FDW).
+--
+-- Documented at https://fdw.dev/catalog/stripe/ -- the canonical Supabase
+-- pattern for querying Stripe API data as Postgres tables.
+--
+-- After this, stripe.subscriptions / stripe.invoices / stripe.charges /
+-- stripe.customers / stripe.payment_intents / etc become live foreign
+-- tables that proxy to the Stripe API (no local caching). 24 foreign
+-- tables total per the wrapper's import_foreign_schema output.
+--
+-- Prerequisites (verified pre-apply):
+--   - extensions.wrappers @ 0.6.1 installed
+--   - vault.secrets has STRIPE_SECRET_KEY (id
+--     0d1551ab-1294-4e9d-9315-d4e2ebc25228, created 2025-07-15)
+--   - public.stripe.* regular tables dropped (PR #751, merged at
+--     86c65d5a8) -- the namespace is free for foreign tables
+--
+-- This migration was applied via Supabase MCP `apply_migration` ahead of
+-- this commit and verified with a live API call (stripe.customers
+-- returned 21 rows, stripe.subscriptions returned 0 -- confirms the
+-- wrapper proxies to prod Stripe). The schema_migrations row was kept
+-- so chain replay on prod skips re-applying.
+--
+-- All operations wrapped in idempotency guards so re-running on a fresh
+-- DB or on a DB that already has the wrapper is a safe no-op.
+--
+-- Issue #749 root-cause cleanup, part 3 (parts 1 + 2 dropped the dead
+-- pivot schema + 4 dead RPCs). Part 4 (subsequent PR) will rewrite the
+-- 8 live-but-damaged analytics RPCs to query these foreign tables
+-- instead of the long-dropped public.rent_payments table.
+
+-- Step 1: register the wrapper handler/validator from the extension
+do $$
+begin
+  if not exists (select 1 from pg_foreign_data_wrapper where fdwname = 'stripe_wrapper') then
+    create foreign data wrapper stripe_wrapper
+      handler extensions.stripe_fdw_handler
+      validator extensions.stripe_fdw_validator;
+  end if;
+end $$;
+
+-- Step 2: create the server bound to the Vault-stored API key.
+-- api_version matches supabase/functions/_shared/stripe-client.ts:8
+-- (STRIPE_API_VERSION = '2026-03-25.dahlia') so the whole project
+-- speaks to Stripe via the same API contract.
+do $$
+begin
+  if not exists (select 1 from pg_foreign_server where srvname = 'stripe_server') then
+    create server stripe_server
+      foreign data wrapper stripe_wrapper
+      options (
+        api_key_id '0d1551ab-1294-4e9d-9315-d4e2ebc25228',
+        api_url 'https://api.stripe.com/v1/',
+        api_version '2026-03-25.dahlia'
+      );
+  end if;
+end $$;
+
+-- Step 3: create the stripe schema if missing (PR #751 dropped the old
+-- regular-table version, but a fresh DB chain replay might not have
+-- reached that point).
+create schema if not exists stripe;
+
+-- Step 4: import the foreign tables from Stripe. import_foreign_schema is
+-- not idempotent in standard Postgres -- guard by checking whether any
+-- foreign table already lives in stripe.*.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on c.relnamespace = n.oid
+    where n.nspname = 'stripe' and c.relkind = 'f'
+  ) then
+    execute 'import foreign schema stripe from server stripe_server into stripe';
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

Installs the Supabase Stripe Foreign Data Wrapper per the canonical Supabase architecture (https://fdw.dev/catalog/stripe/). Result: 24 foreign tables in the `stripe.*` schema (subscriptions, invoices, charges, customers, payment_intents, payouts, refunds, balance_transactions, products, prices, etc.) that proxy live to the Stripe API.

## What this unlocks

CLAUDE.md previously claimed `stripe.subscriptions` and `stripe.invoices` were queryable via PostgREST — that was the INTENDED architecture. The implementation was never finished; the existing 8 analytics RPCs (`get_billing_insights`, `get_financial_overview`, `get_revenue_trends_optimized`, etc.) silently broke when `public.rent_payments` was demolished. This PR installs the real wrapper. The follow-up PR rewrites the RPCs to use it.

## Setup followed

| Step | Documented as | Done |
|------|---------------|------|
| `CREATE FOREIGN DATA WRAPPER stripe_wrapper` from `extensions.wrappers` | https://fdw.dev/catalog/stripe/#install-the-wrapper | ✓ |
| `CREATE SERVER stripe_server` bound to Vault secret `STRIPE_SECRET_KEY` | https://fdw.dev/catalog/stripe/#create-server | ✓ |
| Pin api_version to `2026-03-25.dahlia` (matches project) | Project consistency | ✓ |
| `IMPORT FOREIGN SCHEMA stripe FROM SERVER stripe_server INTO stripe` | https://fdw.dev/catalog/stripe/#create-foreign-tables | ✓ |

## Live verification

After install:
```
SELECT count(*) FROM stripe.customers      -> 21  (real Stripe customers)
SELECT count(*) FROM stripe.subscriptions  -> 0   (real Stripe subs)
```

The wrapper is operational and proxies live Stripe API calls.

## Important finding

You have **21 Stripe customer records but 0 active subscriptions**. The existing damaged analytics RPCs return zero because they query the dropped `rent_payments` table; the wrapper returns zero because there are actually zero subscriptions. Same observable UI result, opposite reasons. The next PR ensures the dashboards return REAL data, even when it's zero.

## Migration safety

All steps wrapped in idempotency guards:
- `IF NOT EXISTS` on the FDW (via `pg_foreign_data_wrapper` check)
- `IF NOT EXISTS` on the server (via `pg_foreign_server` check)
- `CREATE SCHEMA IF NOT EXISTS stripe`
- `IF NOT EXISTS` on foreign tables (via `pg_class` check before `IMPORT FOREIGN SCHEMA`)

Safe on chain replay against fresh DBs AND re-runs against already-installed DBs.

## Documented caveats (per fdw.dev)

- Live API calls — no caching. Large result sets are slow.
- Webhook events / real-time updates aren't supported by the wrapper. `public.stripe_webhook_events` keeps handling the push side.
- Only `stripe.customers` / `stripe.products` / `stripe.subscriptions` support INSERT/UPDATE/DELETE. Analytics is read-only — fine.
- "API version mismatches can cause unexpected data format issues" — pinned to the project's `2026-03-25.dahlia`.

## Issue #749 root-cause cleanup status

- ✅ PR #751: drop dead `stripe.*` regular tables (merged at `86c65d5a8`)
- ✅ PR #752: drop 4 dead `rent_payments`-dependent RPCs (merged at `a31868d8d`)
- 🟡 **THIS PR**: install canonical Stripe Wrapper
- ⏳ Next PR: rewrite 8 analytics RPCs to use the foreign tables

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Live API call verified (21 customers, 0 subscriptions)
- [x] Migration applied via MCP `apply_migration`
- [ ] CI green

[hudsor01]