### PR TITLE
chore(scripts): add edge function deploy script as cli 401 bypass

### DIFF
--- a/scripts/deploy-edge-functions.ts
+++ b/scripts/deploy-edge-functions.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env bun
+// Deploys all Edge Functions via Supabase Management API.
+//
+// Why this exists: the supabase CLI's `functions deploy` returned 401 on
+// 2026-05-29 even with a valid PAT (`supabase projects list` succeeded in the
+// same shell). The MCP server's deploy_edge_function works against the same
+// backend, so the auth path the CLI takes is broken specifically for functions
+// deploy. This script bypasses the CLI and hits the Management API directly.
+//
+// Usage:
+//   SUPABASE_ACCESS_TOKEN=sbp_... bun scripts/deploy-edge-functions.ts
+//
+// Optional: pass function names to deploy a subset, e.g.
+//   bun scripts/deploy-edge-functions.ts newsletter-subscribe resend-webhook
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PROJECT_REF = "bshjmbshupiibfiewpxb";
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const FUNCTIONS_ROOT = resolve(SCRIPT_DIR, "..", "supabase", "functions");
+const DENO_JSON = join(FUNCTIONS_ROOT, "deno.json");
+
+// verify_jwt matrix matches supabase/config.toml at HEAD `665c34cad`.
+// Only download-documents-zip runs with verify_jwt=true.
+const FUNCTIONS: Array<{
+	slug: string;
+	entrypoint: string;
+	verify_jwt: boolean;
+}> = [
+	{ slug: "auth-email-send", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "docuseal", entrypoint: "handler.ts", verify_jwt: false },
+	{ slug: "docuseal-webhook", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "download-documents-zip", entrypoint: "index.ts", verify_jwt: true },
+	{ slug: "export-report", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "export-user-data", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "generate-pdf", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "n8n-blog-ingest", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "newsletter-subscribe", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "resend-webhook", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "stripe-billing-portal", entrypoint: "index.ts", verify_jwt: false },
+	{
+		slug: "stripe-cancel-subscription",
+		entrypoint: "index.ts",
+		verify_jwt: false,
+	},
+	{ slug: "stripe-checkout", entrypoint: "index.ts", verify_jwt: false },
+	{
+		slug: "stripe-checkout-session",
+		entrypoint: "index.ts",
+		verify_jwt: false,
+	},
+	{ slug: "stripe-webhooks", entrypoint: "index.ts", verify_jwt: false },
+];
+
+const token = process.env.SUPABASE_ACCESS_TOKEN;
+if (!token) {
+	console.error("SUPABASE_ACCESS_TOKEN is not set.");
+	process.exit(1);
+}
+
+/**
+ * Walk relative imports starting from a single entry file.
+ * Returns the set of absolute paths reachable from the entry. Does NOT
+ * follow bare specifiers (those resolve through deno.json at runtime).
+ */
+function walkImports(entryAbs: string): Set<string> {
+	const seen = new Set<string>();
+	const stack = [entryAbs];
+	const importRe = /from\s+["']([^"']+)["']/g;
+
+	while (stack.length) {
+		const current = stack.pop();
+		if (!current || seen.has(current)) continue;
+		seen.add(current);
+		const src = readFileSync(current, "utf8");
+		const here = dirname(current);
+		for (const match of src.matchAll(importRe)) {
+			const spec = match[1];
+			if (!spec) continue;
+			if (!spec.startsWith(".") && !spec.startsWith("/")) continue;
+			const resolved = resolve(here, spec);
+			if (existsSync(resolved)) {
+				stack.push(resolved);
+			} else if (existsSync(`${resolved}.ts`)) {
+				// Some imports omit the .ts extension if a tsconfig allows it;
+				// the Edge Function source is always .ts so try appending.
+				stack.push(`${resolved}.ts`);
+			} else {
+				console.warn(`  warn: unresolved import "${spec}" in ${current}`);
+			}
+		}
+	}
+	return seen;
+}
+
+async function deployOne(fn: {
+	slug: string;
+	entrypoint: string;
+	verify_jwt: boolean;
+}): Promise<{ ok: boolean; message: string }> {
+	const fnRoot = join(FUNCTIONS_ROOT, fn.slug);
+	const entryAbs = join(fnRoot, fn.entrypoint);
+	if (!existsSync(entryAbs)) {
+		return { ok: false, message: `entrypoint not found: ${entryAbs}` };
+	}
+
+	const reachable = walkImports(entryAbs);
+	reachable.add(entryAbs);
+	// deno.json is always included so bare specifiers resolve.
+	reachable.add(DENO_JSON);
+
+	const form = new FormData();
+	form.append(
+		"metadata",
+		new Blob(
+			[
+				JSON.stringify({
+					name: fn.slug,
+					entrypoint_path: `source/functions/${fn.slug}/${fn.entrypoint}`,
+					import_map_path: "source/functions/deno.json",
+					verify_jwt: fn.verify_jwt,
+				}),
+			],
+			{ type: "application/json" },
+		),
+		"metadata",
+	);
+
+	for (const abs of reachable) {
+		const rel = relative(FUNCTIONS_ROOT, abs);
+		const apiPath = `source/functions/${rel}`;
+		form.append(
+			"file",
+			new Blob([readFileSync(abs)], { type: "application/typescript" }),
+			apiPath,
+		);
+	}
+
+	const url =
+		`https://api.supabase.com/v1/projects/${PROJECT_REF}` +
+		`/functions/deploy?slug=${encodeURIComponent(fn.slug)}`;
+
+	const res = await fetch(url, {
+		method: "POST",
+		headers: { Authorization: `Bearer ${token}` },
+		body: form,
+	});
+
+	if (res.ok) {
+		const body = (await res.json().catch(() => ({}))) as {
+			version?: number;
+			status?: string;
+		};
+		return {
+			ok: true,
+			message: `v${body.version ?? "?"} ${body.status ?? "DEPLOYED"}`,
+		};
+	}
+	const errText = await res.text().catch(() => res.statusText);
+	return { ok: false, message: `HTTP ${res.status}: ${errText}` };
+}
+
+async function main() {
+	const filter = new Set(process.argv.slice(2));
+	const targets = FUNCTIONS.filter((f) => !filter.size || filter.has(f.slug));
+	if (!targets.length) {
+		console.error("No matching functions to deploy.");
+		process.exit(1);
+	}
+
+	console.log(`Deploying ${targets.length} function(s) to ${PROJECT_REF}\n`);
+
+	const results: Array<{ slug: string; ok: boolean; message: string }> = [];
+	for (const fn of targets) {
+		process.stdout.write(
+			`  ${fn.slug.padEnd(28)} (verify_jwt=${fn.verify_jwt}) ... `,
+		);
+		const r = await deployOne(fn);
+		console.log(r.ok ? `✓ ${r.message}` : `✗ ${r.message}`);
+		results.push({ slug: fn.slug, ...r });
+	}
+
+	const failed = results.filter((r) => !r.ok);
+	console.log(
+		`\n${results.length - failed.length}/${results.length} succeeded`,
+	);
+	if (failed.length) {
+		console.log("\nFailed:");
+		for (const f of failed) console.log(`  ${f.slug}: ${f.message}`);
+		process.exit(1);
+	}
+}
+
+main().catch((err) => {
+	console.error("fatal:", err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Saves the Bun deploy script we built during the FRONTEND_URL → NEXT_PUBLIC_APP_URL Edge Function rollout (PRs #747 + #756) as a documented, repo-tracked fallback for when the supabase CLI returns 401 on functions deploy.

## The problem this solves

The supabase CLI's \`functions deploy\` command has intermittently returned **401** from \`POST /v1/projects/{ref}/functions/deploy?slug=...\` even when \`supabase projects list\` returns 200 with the same PAT. CLI \`--debug\` output is identical between failing and succeeding runs (same endpoint, same Bearer auth, same multipart upload sequence) — meaning the 401 is server-side, not client-side. Project-side authorization cache appears to enter a stuck state.

During the 2026-05-29 rollout: 14 sequential CLI deploys all 401'd. This script deployed all 15 functions cleanly, and the CLI worked on the next attempt with no client-side changes.

## What the script does

- Statically walks each function's relative imports from the entrypoint
- Includes \`supabase/functions/deno.json\` so bare specifiers (\`@sentry/deno\`, \`stripe\`, etc.) resolve
- Builds multipart \`FormData\` with metadata + every reachable source file
- POSTs to \`https://api.supabase.com/v1/projects/{ref}/functions/deploy?slug={slug}\` with the env-var PAT
- Logs version + status per function; exits non-zero if any failed

## verify_jwt matrix

Hardcoded to match \`supabase/config.toml\` exactly:
- 14 functions: \`verify_jwt = false\` (validateBearerAuth internally, HMAC / Stripe signature / Svix / HOOK_SECRET / unauthenticated-by-design)
- 1 function (\`download-documents-zip\`): \`verify_jwt = true\` (defense-in-depth)

Drift between the script's matrix and \`config.toml\` would be a real issue; calling it out so future Edge Function additions update both.

## Usage

\`\`\`
SUPABASE_ACCESS_TOKEN=sbp_... bun scripts/deploy-edge-functions.ts
# Or a subset:
bun scripts/deploy-edge-functions.ts newsletter-subscribe resend-webhook
\`\`\`

## Verified

- Deployed all 15 Edge Functions on 2026-05-29 (\`15/15 succeeded\`)
- Smoke-tested CORS preflight against 5 sampled functions: all returned 200 + \`access-control-allow-origin: https://tenantflow.app\`

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] Successful end-to-end deploy of 15 functions in production
- [x] CORS preflight verified post-deploy

[hudsor01]