### PR TITLE
fix(dashboard): react-compiler reactivity + flex-cell layout on the portfolio table

### DIFF
--- a/src/components/dashboard/components/__tests__/portfolio-data-table.test.tsx
+++ b/src/components/dashboard/components/__tests__/portfolio-data-table.test.tsx
@@ -246,8 +246,8 @@ describe("PortfolioDataTableToolbar", () => {
 	});
 });
 
-// Stub window.matchMedia so the mobile query (max-width: 375px) reports `matches`
-// per the `shouldMatch` predicate; `useMediaQuery` reads this on mount.
+// Stub window.matchMedia so the force-grid query (max-width: 1023px) reports
+// `matches` per the `shouldMatch` predicate; `useMediaQuery` reads this on mount.
 function stubMatchMedia(shouldMatch: (query: string) => boolean) {
 	const original = window.matchMedia;
 	window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -341,31 +341,39 @@ describe("PortfolioDataTable", () => {
 			// measureElement is wired via data-index (dynamic two-line-row sizing).
 			expect(firstRow.getAttribute("data-index")).toBe("0");
 
-			// Body cells carry role="cell" and an EXPLICIT pixel width matching the
-			// ColumnDef size — the canonical alignment source of truth.
+			// Body cells carry role="cell" and a flex basis matching the ColumnDef
+			// size — columns grow/shrink from getSize() so the table FILLS its
+			// container (no fixed-width overflow) while header + body share the
+			// identical flex math, keeping them aligned.
 			const cells = firstRow.querySelectorAll('td[role="cell"]');
 			expect(cells.length).toBe(portfolioColumns.length);
-			const bodyWidths = Array.from(cells).map(
-				(cell) => (cell as HTMLElement).style.width,
+			const bodyFlex = Array.from(cells).map(
+				(cell) => (cell as HTMLElement).style.flex,
 			);
-			expect(bodyWidths).toEqual([
-				"240px",
-				"90px",
-				"140px",
-				"120px",
-				"120px",
-				"110px",
-				"80px",
+			expect(bodyFlex).toEqual([
+				"1 1 240px",
+				"1 1 90px",
+				"1 1 140px",
+				"1 1 120px",
+				"1 1 120px",
+				"1 1 110px",
+				"1 1 80px",
 			]);
 
+			// Numeric columns (rent idx 4, maintenance idx 5) right-align via
+			// justify-content (text-align is inert inside a flex cell); others left.
+			expect((cells[4] as HTMLElement).style.justifyContent).toBe("flex-end");
+			expect((cells[5] as HTMLElement).style.justifyContent).toBe("flex-end");
+			expect((cells[0] as HTMLElement).style.justifyContent).toBe("flex-start");
+
 			// Header column count equals body column count, and each header <th
-			// role="columnheader"> carries the SAME explicit width as its body cell.
+			// role="columnheader"> carries the SAME flex basis as its body cell.
 			const headers = document.querySelectorAll('th[role="columnheader"]');
 			expect(headers.length).toBe(cells.length);
-			const headerWidths = Array.from(headers).map(
-				(header) => (header as HTMLElement).style.width,
+			const headerFlex = Array.from(headers).map(
+				(header) => (header as HTMLElement).style.flex,
 			);
-			expect(headerWidths).toEqual(bodyWidths);
+			expect(headerFlex).toEqual(bodyFlex);
 
 			// aria-sort still lands on the columnheader (B-1), not the inner button.
 			const propertyHeader = screen.getByRole("columnheader", {
@@ -660,8 +668,8 @@ describe("PortfolioDataTable", () => {
 		expect(screen.queryByText("Vacant Two")).toBeNull();
 	});
 
-	it("forces the grid view at <=375px regardless of viewMode (W-4)", async () => {
-		const restore = stubMatchMedia((q) => q === "(max-width: 375px)");
+	it("forces the grid view below lg (<=1023px) regardless of viewMode (W-4)", async () => {
+		const restore = stubMatchMedia((q) => q === "(max-width: 1023px)");
 		try {
 			await act(async () => {
 				render(

--- a/src/components/dashboard/components/lease-status-badge.tsx
+++ b/src/components/dashboard/components/lease-status-badge.tsx
@@ -1,0 +1,36 @@
+import { cn } from "#lib/utils";
+import type { PortfolioRow } from "../dashboard-types";
+
+type LeaseStatus = PortfolioRow["leaseStatus"];
+
+const LABEL: Record<LeaseStatus, string> = {
+	active: "Active",
+	expiring: "Expiring",
+	vacant: "Vacant",
+};
+
+const CHIP: Record<LeaseStatus, string> = {
+	active:
+		"bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+	expiring:
+		"bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+	vacant: "bg-muted text-muted-foreground",
+};
+
+/**
+ * Shared lease-status pill rendered identically in the portfolio table cell and
+ * the portfolio grid card (DT-01 parity). One chip definition, so the two views
+ * can never drift apart.
+ */
+export function LeaseStatusBadge({ status }: { status: LeaseStatus }) {
+	return (
+		<span
+			className={cn(
+				"inline-flex items-center rounded px-2 py-0.5 font-medium text-xs",
+				CHIP[status],
+			)}
+		>
+			{LABEL[status]}
+		</span>
+	);
+}

--- a/src/components/dashboard/components/portfolio-columns.tsx
+++ b/src/components/dashboard/components/portfolio-columns.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 import Link from "next/link";
-
+import { LeaseStatusBadge } from "#components/dashboard/components/lease-status-badge";
 import { DataTableColumnHeader } from "#components/data-table/data-table-column-header";
 import { formatCurrency } from "#lib/utils/currency";
 import type { PortfolioRow } from "../dashboard-types";
@@ -16,21 +16,6 @@ const STATUS_OPTIONS = [
 	{ label: "Expiring Soon", value: "expiring" },
 	{ label: "Vacant", value: "vacant" },
 ] as const;
-
-/** Lease-status cell: amber treatment for "expiring", muted for "vacant". */
-function LeaseStatusCell({ status }: { status: PortfolioRow["leaseStatus"] }) {
-	if (status === "active") {
-		return <span className="text-sm font-medium text-foreground">Active</span>;
-	}
-	if (status === "expiring") {
-		return (
-			<span className="text-sm font-medium text-amber-600 dark:text-amber-500">
-				Expiring Soon
-			</span>
-		);
-	}
-	return <span className="text-sm text-muted-foreground">Vacant</span>;
-}
 
 /** Open-maintenance cell: red count when > 0, muted "--" otherwise. */
 function MaintenanceCell({ openCount }: { openCount: number }) {
@@ -91,9 +76,9 @@ export const portfolioColumns: ColumnDef<PortfolioRow>[] = [
 			return name.includes(query) || address.includes(query);
 		},
 		cell: ({ row }) => (
-			<div>
-				<div className="font-medium">{row.original.property}</div>
-				<div className="text-xs text-muted-foreground">
+			<div className="min-w-0">
+				<div className="truncate font-medium">{row.original.property}</div>
+				<div className="truncate text-muted-foreground text-xs">
 					{row.original.address}
 				</div>
 			</div>
@@ -163,18 +148,16 @@ export const portfolioColumns: ColumnDef<PortfolioRow>[] = [
 			if (!Array.isArray(value) || value.length === 0) return true;
 			return (value as string[]).includes(row.original.leaseStatus);
 		},
-		cell: ({ row }) => <LeaseStatusCell status={row.original.leaseStatus} />,
+		cell: ({ row }) => <LeaseStatusBadge status={row.original.leaseStatus} />,
 	},
 	{
 		id: "rent",
 		accessorKey: "rent",
 		size: 120,
 		header: ({ column }) => (
-			<div className="text-right">
-				<DataTableColumnHeader column={column} label="Monthly Rent" />
-			</div>
+			<DataTableColumnHeader column={column} label="Monthly Rent" />
 		),
-		meta: { label: "Monthly Rent" },
+		meta: { label: "Monthly Rent", align: "right" },
 		enableSorting: true,
 		cell: ({ row }) => (
 			<div className="text-right tabular-nums">
@@ -192,12 +175,10 @@ export const portfolioColumns: ColumnDef<PortfolioRow>[] = [
 		header: ({ column }) => (
 			<DataTableColumnHeader column={column} label="Maintenance" />
 		),
-		meta: { label: "Maintenance" },
+		meta: { label: "Maintenance", align: "right" },
 		enableSorting: false,
 		cell: ({ row }) => (
-			<div className="text-right">
-				<MaintenanceCell openCount={row.original.maintenanceOpen} />
-			</div>
+			<MaintenanceCell openCount={row.original.maintenanceOpen} />
 		),
 	},
 	{

--- a/src/components/dashboard/components/portfolio-data-table-toolbar.tsx
+++ b/src/components/dashboard/components/portfolio-data-table-toolbar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+"use no memo";
+
 import type { Table } from "@tanstack/react-table";
 import { LayoutGrid, List, Search, X } from "lucide-react";
 

--- a/src/components/dashboard/components/portfolio-data-table.tsx
+++ b/src/components/dashboard/components/portfolio-data-table.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+"use no memo";
+
 import {
 	flexRender,
 	type OnChangeFn,
@@ -32,8 +34,10 @@ type ViewMode = "table" | "grid";
 // Portfolio rows render ~56px (two text lines + py-2.5), so estimate to 56 while
 // never dropping below the 48px touch-target floor.
 const ESTIMATED_ROW_HEIGHT = 56;
-// ≤375px forces the grid (card) view per the UI-SPEC mobile rule (W-4 / D-5).
-const MOBILE_QUERY = "(max-width: 375px)";
+// Below `lg` (1024px) force the grid (card) view: the 7-column table needs the
+// desktop width to stay readable (and the column-visibility control is itself
+// lg-only), so the table view only makes sense at >=lg (W-4 / D-5).
+const FORCE_GRID_QUERY = "(max-width: 1023px)";
 
 interface PortfolioDataTableProps {
 	data: PortfolioRow[];
@@ -85,7 +89,7 @@ export function PortfolioDataTable({
 	// W-4: at ≤375px force grid regardless of the toggle; the table path is never
 	// rendered at that width (no horizontal scroll). The toggle still reflects and
 	// sets `viewMode`; only the render mode is overridden here.
-	const forceGridMobile = useMediaQuery(MOBILE_QUERY);
+	const forceGridMobile = useMediaQuery(FORCE_GRID_QUERY);
 	const effectiveView: ViewMode = forceGridMobile ? "grid" : viewMode;
 
 	const pageRows = table.getRowModel().rows;
@@ -238,7 +242,18 @@ function PortfolioVirtualizedTable({
 									colSpan={header.colSpan}
 									role="columnheader"
 									aria-sort={getAriaSort(header.column)}
-									style={{ display: "flex", width: header.getSize() }}
+									style={{
+										display: "flex",
+										// Grow/shrink from getSize() as the basis so columns FILL the
+										// container (no fixed-width overflow) while header + body share
+										// the identical flex math, keeping them aligned.
+										flex: `1 1 ${header.getSize()}px`,
+										minWidth: 0,
+										justifyContent:
+											header.column.columnDef.meta?.align === "right"
+												? "flex-end"
+												: "flex-start",
+									}}
 								>
 									{header.isPlaceholder
 										? null
@@ -281,11 +296,16 @@ function PortfolioVirtualizedTable({
 									<TableCell
 										key={cell.id}
 										role="cell"
-										className="py-2.5"
+										className="overflow-hidden py-2.5"
 										style={{
 											display: "flex",
-											width: cell.column.getSize(),
+											flex: `1 1 ${cell.column.getSize()}px`,
+											minWidth: 0,
 											alignItems: "center",
+											justifyContent:
+												cell.column.columnDef.meta?.align === "right"
+													? "flex-end"
+													: "flex-start",
 										}}
 									>
 										{flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/components/dashboard/components/portfolio-grid.tsx
+++ b/src/components/dashboard/components/portfolio-grid.tsx
@@ -1,3 +1,4 @@
+import { LeaseStatusBadge } from "#components/dashboard/components/lease-status-badge";
 import { formatCurrency } from "#lib/utils/currency";
 import type { PortfolioRow } from "../dashboard-types";
 
@@ -18,19 +19,7 @@ export function PortfolioGrid({ data }: PortfolioGridProps) {
 							<div className="font-medium">{row.property}</div>
 							<div className="text-xs text-muted-foreground">{row.address}</div>
 						</div>
-						<span
-							className={`text-xs font-medium px-2 py-0.5 rounded ${
-								row.leaseStatus === "active"
-									? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
-									: row.leaseStatus === "expiring"
-										? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
-										: "bg-muted text-muted-foreground"
-							}`}
-						>
-							{row.leaseStatus === "active" && "Active"}
-							{row.leaseStatus === "expiring" && "Expiring"}
-							{row.leaseStatus === "vacant" && "Vacant"}
-						</span>
+						<LeaseStatusBadge status={row.leaseStatus} />
 					</div>
 					<div className="grid grid-cols-2 gap-3 text-sm">
 						<div>

--- a/src/components/dashboard/components/portfolio-preset-menu.tsx
+++ b/src/components/dashboard/components/portfolio-preset-menu.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+"use no memo";
+
 import type { SortingState } from "@tanstack/react-table";
 import { Bookmark, Save, Trash2 } from "lucide-react";
 import {

--- a/src/components/data-table/data-table-column-header.tsx
+++ b/src/components/data-table/data-table-column-header.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+"use no memo";
+
 import type { Column } from "@tanstack/react-table";
 import {
 	ChevronDown,

--- a/src/components/data-table/data-table-faceted-filter.tsx
+++ b/src/components/data-table/data-table-faceted-filter.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+"use no memo";
+
 import type { Column } from "@tanstack/react-table";
 import { Check, PlusCircle, XCircle } from "lucide-react";
 import type { MouseEvent } from "react";

--- a/src/components/data-table/data-table-pagination.tsx
+++ b/src/components/data-table/data-table-pagination.tsx
@@ -1,3 +1,5 @@
+"use no memo";
+
 import type { Table } from "@tanstack/react-table";
 import {
 	ChevronLeft,

--- a/src/components/data-table/data-table-view-options.tsx
+++ b/src/components/data-table/data-table-view-options.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+"use no memo";
+
 import type { Table } from "@tanstack/react-table";
 import { Check, Settings2 } from "lucide-react";
 

--- a/src/types/data-table.ts
+++ b/src/types/data-table.ts
@@ -16,6 +16,8 @@ declare module "@tanstack/react-table" {
 		label?: string;
 		placeholder?: string;
 		variant?: FilterVariant;
+		/** Horizontal alignment for the cell + header in flex-cell tables (numeric -> "right"). */
+		align?: "left" | "right";
 		options?: Option[];
 		range?: [number, number];
 		unit?: string;


### PR DESCRIPTION
## Why

A live Chrome audit of `/dashboard` (post-#763) found the Phase-5 portfolio DataTable's **UI was decoupled from its state**: search dropped all but the last keystroke, the sort caret/`aria-sort` stuck on the default column, the status checkbox never filled, Reset / Clear-filters / preset-delete left stale UI — every case fixed only by a full reload, plus several CSS-layout bugs.

**The 8-cycle perfect-PR gate could not catch these**, and that's the important lesson: unit tests run in jsdom **without the React Compiler transform and without a layout engine**, and code review reasons about source, not built/rendered behavior. Only a live browser audit could surface them.

## Root cause (the blocker)

React Compiler is enabled repo-wide (`next.config.ts: reactCompiler: true`). It auto-memoizes the components that consume TanStack Table's **mutable, stable-reference** `table`/`column` instances, so they never re-render when the table's internal state mutates. The repo already hit this once — `src/components/ui/tour.tsx` carries `"use no memo"` — but the Phase-5 table-consuming components lacked it.

## Fix

**Reactivity (audit #1–#7, #17):** add `"use no memo"` (the existing `tour.tsx` pattern) to every table-consuming component — `portfolio-data-table`, its toolbar, the preset menu, and the shared `data-table` column-header / faceted-filter / view-options / pagination. Confirmed `next build` (which *does* run the compiler) compiles cleanly.

**Layout (flex-cell virtualization bugs jsdom can't see):**
- **#11** numeric columns were left-aligned (`text-align` is inert inside a `display:flex` cell) → `ColumnMeta.align` + flex `justify-content` (rent/maintenance → right).
- **#12** the table overflowed its container by 8px (fixed widths summed > card) → cells now `flex: 1 1 <size>` (grow/shrink to fill) + `min-width:0` + truncation, so it fits exactly and stays aligned.
- **#8** one shared `LeaseStatusBadge` now renders in **both** the table cell and the grid card (can't drift).
- **#9 / #13 / #15** raised the force-grid breakpoint from `≤375px` to below `lg` (1024px): the 7-column table needs desktop width to stay readable and column-visibility is itself `lg`-only, so the table view only renders where it fits.

## Verification

- `next build`: **✓ compiled successfully** (the only step that runs the React Compiler).
- Unit suite: **106,315 pass**; typecheck + lint clean; the flex-change + breakpoint tests were updated.
- **Definitive check is a re-audit:** unit tests cannot see the compiler or CSS layout, so the real confirmation is re-running the Chrome audit against the rebuilt `/dashboard` (search types live, sort caret moves, status checkbox fills, Clear/Reset/preset-delete update without reload, columns align + right-align, no overflow, grid kicks in below `lg`).

## Not in this PR (lower-severity audit items, follow-ups)
Revenue chart mobile overflow (#10, a Phase-4 chart), the persistent Recharts `width(-1)` empty-state warning (#16 console), the status-chip colors being raw palette utilities vs design tokens, and assorted P3 nits (sparkline asymmetry, KPI load flash, onboarding overlay re-appearing).

[hudsor01]