### PR TITLE
a11y: migrate resting vivid-token text to AA-safe -text companions (scope C, #768)

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -217,7 +217,7 @@ function LoginPageContent() {
 								<strong className="text-foreground">New to TenantFlow?</strong>{" "}
 								<Link
 									href="/pricing"
-									className="text-primary hover:underline font-medium"
+									className="text-primary-text hover:underline font-medium"
 								>
 									View plans
 								</Link>{" "}

--- a/src/app/(owner)/billing/plans/page.tsx
+++ b/src/app/(owner)/billing/plans/page.tsx
@@ -233,7 +233,7 @@ export default function BillingPlansPage() {
 					Need help choosing a plan?{" "}
 					<Link
 						href="/contact"
-						className="text-primary hover:underline underline-offset-4"
+						className="text-primary-text hover:underline underline-offset-4"
 					>
 						Contact our sales team
 					</Link>

--- a/src/app/(owner)/documents/templates/components/form-builder-panel.tsx
+++ b/src/app/(owner)/documents/templates/components/form-builder-panel.tsx
@@ -176,7 +176,7 @@ export function FormBuilderPanel({
 									className={fieldErrors[index] ? "border-destructive" : ""}
 								/>
 								{fieldErrors[index] ? (
-									<p className="text-xs text-destructive">
+									<p className="text-xs text-destructive-text">
 										{fieldErrors[index]}
 									</p>
 								) : null}

--- a/src/app/(owner)/financials/expenses/_components/expense-table.tsx
+++ b/src/app/(owner)/financials/expenses/_components/expense-table.tsx
@@ -167,7 +167,7 @@ export function ExpenseTable({
 						</p>
 						<button
 							onClick={onClearFilters}
-							className="mt-3 text-sm text-primary hover:underline"
+							className="mt-3 text-sm text-primary-text hover:underline"
 						>
 							Clear filters
 						</button>

--- a/src/app/(owner)/financials/financials-highlights.tsx
+++ b/src/app/(owner)/financials/financials-highlights.tsx
@@ -35,7 +35,7 @@ export function FinancialsHighlights({
 							</p>
 							{highlight.trend !== null && highlight.trend !== undefined && (
 								<p
-									className={`text-xs mt-1 ${highlight.trend >= 0 ? "text-emerald-600" : "text-destructive"}`}
+									className={`text-xs mt-1 ${highlight.trend >= 0 ? "text-emerald-600" : "text-destructive-text"}`}
 								>
 									{highlight.trend >= 0 ? "+" : ""}
 									{highlight.trend.toFixed(1)}%

--- a/src/app/(owner)/financials/income-statement/income-statement-page-net-summary.tsx
+++ b/src/app/(owner)/financials/income-statement/income-statement-page-net-summary.tsx
@@ -79,7 +79,7 @@ export function IncomeStatementPageNetSummary({
 								{formatCents(previousPeriod.netIncome * 100)}
 							</span>
 							<span
-								className={`text-sm font-medium ${previousPeriod.changePercent >= 0 ? "text-emerald-600" : "text-destructive"}`}
+								className={`text-sm font-medium ${previousPeriod.changePercent >= 0 ? "text-emerald-600" : "text-destructive-text"}`}
 							>
 								({previousPeriod.changePercent >= 0 ? "+" : ""}
 								{previousPeriod.changePercent.toFixed(1)}%)

--- a/src/app/(owner)/financials/income-statement/income-statement-page-net-summary.tsx
+++ b/src/app/(owner)/financials/income-statement/income-statement-page-net-summary.tsx
@@ -62,7 +62,7 @@ export function IncomeStatementPageNetSummary({
 				<div className="flex items-center justify-between p-4 mt-4 bg-primary/5 rounded-lg">
 					<span className="font-medium text-foreground">Net Income</span>
 					<span
-						className={`text-xl font-bold tabular-nums ${netIncome >= 0 ? "text-emerald-600" : "text-destructive"}`}
+						className={`text-xl font-bold tabular-nums ${netIncome >= 0 ? "text-emerald-600" : "text-destructive-text"}`}
 					>
 						{netIncome >= 0 ? "+" : ""}
 						{formatCents(netIncome * 100)}

--- a/src/app/(owner)/financials/tax-documents/page.tsx
+++ b/src/app/(owner)/financials/tax-documents/page.tsx
@@ -72,7 +72,7 @@ export default function TaxDocumentsPage() {
 				<div className="rounded-lg border border-destructive/30 bg-destructive/10 p-6 flex flex-col items-center gap-4 text-center">
 					<AlertCircle className="size-10 text-destructive" />
 					<div>
-						<p className="font-medium text-destructive">
+						<p className="font-medium text-destructive-text">
 							Failed to load tax documents
 						</p>
 						<p className="text-sm text-muted-foreground mt-1">

--- a/src/app/(owner)/leases/[id]/edit/page.tsx
+++ b/src/app/(owner)/leases/[id]/edit/page.tsx
@@ -30,7 +30,7 @@ export default function LeaseEditPage({ params }: LeaseEditPageProps) {
 		return (
 			<div className="mx-auto w-full max-w-4xl space-y-10">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-					<h2 className="text-lg font-semibold text-destructive mb-2">
+					<h2 className="text-lg font-semibold text-destructive-text mb-2">
 						Error Loading Lease
 					</h2>
 					<p className="text-muted-foreground">

--- a/src/app/(owner)/leases/page.tsx
+++ b/src/app/(owner)/leases/page.tsx
@@ -163,7 +163,7 @@ export default function LeasesPage() {
 		return (
 			<div className="p-6 lg:p-8 bg-background min-h-full">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-					<h2 className="text-lg font-semibold text-destructive mb-2">
+					<h2 className="text-lg font-semibold text-destructive-text mb-2">
 						Error Loading Leases
 					</h2>
 					<p className="text-muted-foreground">

--- a/src/app/(owner)/maintenance/[id]/edit/page.tsx
+++ b/src/app/(owner)/maintenance/[id]/edit/page.tsx
@@ -36,7 +36,7 @@ export default function MaintenanceEditPage({
 		return (
 			<div className="mx-auto w-full max-w-4xl space-y-10">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-					<h2 className="text-lg font-semibold text-destructive mb-2">
+					<h2 className="text-lg font-semibold text-destructive-text mb-2">
 						Error Loading Request
 					</h2>
 					<p className="text-muted-foreground">

--- a/src/app/(owner)/profile/page.tsx
+++ b/src/app/(owner)/profile/page.tsx
@@ -174,7 +174,7 @@ export default function OwnerProfilePage() {
 		return (
 			<div className="p-6 lg:p-8">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-					<p className="text-destructive">Failed to load profile</p>
+					<p className="text-destructive-text">Failed to load profile</p>
 					<Button
 						variant="outline"
 						size="sm"

--- a/src/app/(owner)/properties/[id]/edit/page.tsx
+++ b/src/app/(owner)/properties/[id]/edit/page.tsx
@@ -41,7 +41,7 @@ export default function EditPropertyPage({
 		return (
 			<div className="space-y-6">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-					<h2 className="text-lg font-semibold text-destructive mb-2">
+					<h2 className="text-lg font-semibold text-destructive-text mb-2">
 						Error Loading Property
 					</h2>
 					<p className="text-muted-foreground">

--- a/src/app/(owner)/properties/page.tsx
+++ b/src/app/(owner)/properties/page.tsx
@@ -168,7 +168,7 @@ export default function PropertiesPage() {
 		return (
 			<div className="p-6 lg:p-8 bg-background min-h-full">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-					<h2 className="text-lg font-semibold text-destructive mb-2">
+					<h2 className="text-lg font-semibold text-destructive-text mb-2">
 						Error Loading Properties
 					</h2>
 					<p className="text-muted-foreground">

--- a/src/app/(owner)/properties/property-details.client.tsx
+++ b/src/app/(owner)/properties/property-details.client.tsx
@@ -57,13 +57,13 @@ export function PropertyDetails({ property }: PropertyDetailsProps) {
 	const getStatusBadgeClass = (status: string | null) => {
 		switch (status?.toLowerCase()) {
 			case "active":
-				return "bg-success/10 text-success";
+				return "bg-success/10 text-success-text";
 			case "inactive":
 				return "bg-muted text-muted-foreground";
 			case "sold":
-				return "bg-info/10 text-info";
+				return "bg-info/10 text-info-text";
 			default:
-				return "bg-success/10 text-success";
+				return "bg-success/10 text-success-text";
 		}
 	};
 

--- a/src/app/(owner)/properties/units/components/unit-actions.tsx
+++ b/src/app/(owner)/properties/units/components/unit-actions.tsx
@@ -161,7 +161,7 @@ export function UnitActions({ unit }: UnitActionsProps) {
 										"mt-4 p-3 border-destructive/20 bg-destructive/5",
 									)}
 								>
-									<div className="flex items-center gap-2 text-destructive">
+									<div className="flex items-center gap-2 text-destructive-text">
 										<AlertTriangle className="size-4" />
 										<span className="font-medium text-sm">
 											This unit is currently occupied and cannot be deleted.

--- a/src/app/(owner)/tenants/page.tsx
+++ b/src/app/(owner)/tenants/page.tsx
@@ -91,7 +91,7 @@ export default function TenantsPage() {
 		return (
 			<div className="p-6 lg:p-8 bg-background min-h-full">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-					<h2 className="text-lg font-semibold text-destructive mb-2">
+					<h2 className="text-lg font-semibold text-destructive-text mb-2">
 						Error Loading Tenants
 					</h2>
 					<p className="text-muted-foreground">

--- a/src/app/(owner)/units/page.tsx
+++ b/src/app/(owner)/units/page.tsx
@@ -221,7 +221,7 @@ export default function UnitsPage() {
 		return (
 			<div className="p-6 lg:p-8">
 				<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4">
-					<h2 className="typography-large text-destructive">
+					<h2 className="typography-large text-destructive-text">
 						Error Loading Units
 					</h2>
 					<p className="text-muted-foreground">

--- a/src/app/auth/confirm-email/confirm-email-states.tsx
+++ b/src/app/auth/confirm-email/confirm-email-states.tsx
@@ -115,7 +115,7 @@ export function ConfirmEmailErrorBanner() {
 		<div className="p-4 rounded-lg border border-destructive/30 bg-destructive/10 flex items-start gap-3">
 			<AlertTriangle className="size-5 text-destructive shrink-0 mt-0.5" />
 			<div className="text-sm">
-				<p className="font-medium text-destructive">
+				<p className="font-medium text-destructive-text">
 					Confirmation link expired or invalid
 				</p>
 				<p className="text-destructive/80 mt-1">
@@ -171,7 +171,7 @@ export function ConfirmEmailInstructions() {
 					},
 				].map((item) => (
 					<li key={item.step} className="flex items-start gap-3">
-						<span className="shrink-0 size-7 bg-primary/20 text-primary rounded-full flex-center text-sm font-bold">
+						<span className="shrink-0 size-7 bg-primary/20 text-primary-text rounded-full flex-center text-sm font-bold">
 							{item.step}
 						</span>
 						<div className="pt-0.5">
@@ -239,7 +239,7 @@ export function ConfirmEmailFooter() {
 					Need help?{" "}
 					<Link
 						href="mailto:support@tenantflow.app"
-						className="text-primary hover:underline font-medium"
+						className="text-primary-text hover:underline font-medium"
 					>
 						Contact Support
 					</Link>

--- a/src/app/auth/confirm-email/confirm-email-states.tsx
+++ b/src/app/auth/confirm-email/confirm-email-states.tsx
@@ -118,7 +118,7 @@ export function ConfirmEmailErrorBanner() {
 				<p className="font-medium text-destructive-text">
 					Confirmation link expired or invalid
 				</p>
-				<p className="text-destructive/80 mt-1">
+				<p className="text-destructive-text/80 mt-1">
 					The confirmation link you clicked is no longer valid. Please request a
 					new one using the button below.
 				</p>

--- a/src/app/auth/post-checkout/page.tsx
+++ b/src/app/auth/post-checkout/page.tsx
@@ -156,7 +156,7 @@ export default function PostCheckoutPage() {
 				<div className="space-y-4">
 					<Alert className="border-success/20 bg-success/5 dark:border-success/30 dark:bg-success/10">
 						<Mail className="size-4 text-success" />
-						<AlertDescription className="text-success dark:text-success">
+						<AlertDescription className="text-success-text dark:text-success-text">
 							A login link has been sent to <strong>{email}</strong>
 						</AlertDescription>
 					</Alert>
@@ -186,12 +186,12 @@ export default function PostCheckoutPage() {
 							)}
 						</Button>
 						{resendSuccess && (
-							<p className="text-xs text-success text-center">
+							<p className="text-xs text-success-text text-center">
 								Login link sent! Check your inbox.
 							</p>
 						)}
 						{isResendError && (
-							<p className="text-xs text-destructive text-center">
+							<p className="text-xs text-destructive-text text-center">
 								Failed to send link. Please try again.
 							</p>
 						)}

--- a/src/app/auth/post-checkout/page.tsx
+++ b/src/app/auth/post-checkout/page.tsx
@@ -156,7 +156,7 @@ export default function PostCheckoutPage() {
 				<div className="space-y-4">
 					<Alert className="border-success/20 bg-success/5 dark:border-success/30 dark:bg-success/10">
 						<Mail className="size-4 text-success" />
-						<AlertDescription className="text-success-text dark:text-success-text">
+						<AlertDescription className="text-success-text">
 							A login link has been sent to <strong>{email}</strong>
 						</AlertDescription>
 					</Alert>

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -243,7 +243,7 @@ export default function UpdatePasswordPage() {
 							Remember your password?{" "}
 							<Link
 								href="/login"
-								className="text-primary hover:underline font-medium"
+								className="text-primary-text hover:underline font-medium"
 							>
 								Sign in
 							</Link>

--- a/src/app/blog/[slug]/blog-post-page.tsx
+++ b/src/app/blog/[slug]/blog-post-page.tsx
@@ -174,7 +174,7 @@ export default function BlogPostPage({ post, slug }: BlogPostProps) {
 						{postCategory && (
 							<Link
 								href={`/blog/category/${categorySlug}`}
-								className="text-primary hover:text-primary/80 transition-colors"
+								className="text-primary-text hover:text-primary/80 transition-colors"
 							>
 								{postCategory}
 							</Link>
@@ -207,7 +207,7 @@ export default function BlogPostPage({ post, slug }: BlogPostProps) {
 						</p>
 						<Link
 							href={`/compare/${competitorSlug}`}
-							className="inline-flex items-center text-primary font-semibold hover:text-primary/80 transition-colors"
+							className="inline-flex items-center text-primary-text font-semibold hover:text-primary/80 transition-colors"
 						>
 							See Full Comparison
 							<ArrowRight className="ml-1.5 size-4" aria-hidden="true" />
@@ -222,7 +222,7 @@ export default function BlogPostPage({ post, slug }: BlogPostProps) {
 						</p>
 						<Link
 							href={`/resources/${resourceSlug}`}
-							className="inline-flex items-center text-primary font-semibold hover:text-primary/80 transition-colors"
+							className="inline-flex items-center text-primary-text font-semibold hover:text-primary/80 transition-colors"
 						>
 							View Resource
 							<ArrowRight className="ml-1.5 size-4" aria-hidden="true" />

--- a/src/app/compare/[competitor]/compare-sections.tsx
+++ b/src/app/compare/[competitor]/compare-sections.tsx
@@ -55,7 +55,9 @@ export function PricingComparison({ data }: { data: CompetitorData }) {
 											</p>
 										)}
 									</div>
-									<p className="text-lg font-bold text-primary">{tier.price}</p>
+									<p className="text-lg font-bold text-primary-text">
+										{tier.price}
+									</p>
 								</div>
 							))}
 						</div>
@@ -110,7 +112,7 @@ export function FeatureTable({ data }: { data: CompetitorData }) {
 								<th className="text-left p-4 font-semibold text-foreground">
 									Feature
 								</th>
-								<th className="text-center p-4 font-semibold text-primary w-40">
+								<th className="text-center p-4 font-semibold text-primary-text w-40">
 									TenantFlow
 								</th>
 								<th className="text-center p-4 font-semibold text-foreground w-40">

--- a/src/app/compare/[competitor]/page.tsx
+++ b/src/app/compare/[competitor]/page.tsx
@@ -107,7 +107,7 @@ export default async function ComparePage({ params }: PageProps) {
 			{/* Hero */}
 			<section className="section-spacing">
 				<div className="max-w-4xl mx-auto px-6 lg:px-8 text-center">
-					<p className="text-sm font-semibold uppercase tracking-wider text-primary mb-4">
+					<p className="text-sm font-semibold uppercase tracking-wider text-primary-text mb-4">
 						{data.tagline}
 					</p>
 					<h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-foreground mb-6 leading-tight">

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -66,7 +66,7 @@ export default function ComparePage() {
 									<p className="mt-4 text-sm text-muted-foreground line-clamp-3">
 										{competitor.description}
 									</p>
-									<span className="mt-auto pt-4 inline-flex items-center text-sm font-medium text-primary">
+									<span className="mt-auto pt-4 inline-flex items-center text-sm font-medium text-primary-text">
 										See comparison
 										<ArrowRight className="ml-1.5 h-4 w-4 transition-transform group-hover:translate-x-0.5" />
 									</span>

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -147,7 +147,7 @@ export default function HelpPage() {
 								description:
 									"Per-entity uploads, custom categories, search, filters, and tax-season zip exports — everything the vault does in one walkthrough",
 								badge: "Most Popular",
-								badgeColor: "bg-primary/10 text-primary",
+								badgeColor: "bg-primary/10 text-primary-text",
 							},
 							{
 								title: "Send a lease for e-signature",
@@ -161,7 +161,7 @@ export default function HelpPage() {
 								description:
 									"Generate CPA-ready financial reports and bulk-download every receipt and tax document by entity",
 								badge: "Tax Time",
-								badgeColor: "bg-primary/10 text-primary",
+								badgeColor: "bg-primary/10 text-primary-text",
 							},
 							{
 								title: "Manage your team and billing",

--- a/src/app/pricing/complete/complete-client.tsx
+++ b/src/app/pricing/complete/complete-client.tsx
@@ -189,7 +189,7 @@ export default function CompleteClient() {
 										id="view-details"
 										rel="noopener noreferrer"
 										target="_blank"
-										className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors"
+										className="inline-flex items-center gap-2 text-primary-text hover:text-primary/80 transition-colors"
 									>
 										View details
 										<ExternalLink className="size-4" aria-hidden="true" />

--- a/src/app/pricing/success/success-client.tsx
+++ b/src/app/pricing/success/success-client.tsx
@@ -100,7 +100,10 @@ export function SuccessClient() {
 					<div className="border-t pt-6">
 						<p className="text-muted-foreground">
 							Need help?{" "}
-							<Link href="/contact" className="text-primary hover:underline">
+							<Link
+								href="/contact"
+								className="text-primary-text hover:underline"
+							>
 								Contact our support team
 							</Link>
 						</p>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -284,7 +284,7 @@ export default function PrivacyPage() {
 							account settings or by contacting us at{" "}
 							<a
 								href="mailto:privacy@tenantflow.app"
-								className="text-primary underline"
+								className="text-primary-text underline"
 							>
 								privacy@tenantflow.app
 							</a>
@@ -408,7 +408,7 @@ export default function PrivacyPage() {
 								<strong>Email:</strong>{" "}
 								<a
 									href="mailto:privacy@tenantflow.app"
-									className="text-primary underline"
+									className="text-primary-text underline"
 								>
 									privacy@tenantflow.app
 								</a>
@@ -417,7 +417,7 @@ export default function PrivacyPage() {
 								<strong>Support:</strong>{" "}
 								<a
 									href="mailto:support@tenantflow.app"
-									className="text-primary underline"
+									className="text-primary-text underline"
 								>
 									support@tenantflow.app
 								</a>
@@ -455,7 +455,7 @@ export default function PrivacyPage() {
 							To exercise these rights, email{" "}
 							<a
 								href="mailto:privacy@tenantflow.app"
-								className="text-primary underline"
+								className="text-primary-text underline"
 							>
 								privacy@tenantflow.app
 							</a>

--- a/src/app/resources/landlord-tax-deduction-tracker/page.tsx
+++ b/src/app/resources/landlord-tax-deduction-tracker/page.tsx
@@ -52,7 +52,7 @@ export default function TaxDeductionTrackerPage() {
 				</div>
 
 				<header className="mb-12 text-center">
-					<p className="text-sm font-semibold uppercase tracking-wider text-primary mb-3">
+					<p className="text-sm font-semibold uppercase tracking-wider text-primary-text mb-3">
 						Free Resource
 					</p>
 					<h1 className="text-4xl font-bold text-foreground mb-4">

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -148,7 +148,7 @@ export default function ResourcesPage() {
 												{resource.description}
 											</p>
 
-											<div className="flex items-center text-primary font-medium group-hover:translate-x-1 transition-transform">
+											<div className="flex items-center text-primary-text font-medium group-hover:translate-x-1 transition-transform">
 												Explore
 												<ArrowRight className="ml-2 size-4" />
 											</div>
@@ -192,7 +192,7 @@ export default function ResourcesPage() {
 								<p className="text-sm text-muted-foreground mb-4">
 									{resource.description}
 								</p>
-								<span className="inline-flex items-center text-sm text-primary font-medium group-hover:translate-x-1 transition-transform">
+								<span className="inline-flex items-center text-sm text-primary-text font-medium group-hover:translate-x-1 transition-transform">
 									<Download className="size-4 mr-1.5" />
 									View &amp; Print
 								</span>

--- a/src/app/resources/seasonal-maintenance-checklist/page.tsx
+++ b/src/app/resources/seasonal-maintenance-checklist/page.tsx
@@ -306,7 +306,7 @@ export default function SeasonalMaintenanceChecklistPage() {
 
 				{/* Header */}
 				<header className="mb-12 text-center">
-					<p className="text-sm font-semibold uppercase tracking-wider text-primary mb-3">
+					<p className="text-sm font-semibold uppercase tracking-wider text-primary-text mb-3">
 						Free Resource
 					</p>
 					<h1 className="text-4xl font-bold text-foreground mb-4">

--- a/src/app/resources/security-deposit-reference-card/page.tsx
+++ b/src/app/resources/security-deposit-reference-card/page.tsx
@@ -524,7 +524,7 @@ export default function SecurityDepositReferenceCardPage() {
 				</div>
 
 				<header className="mb-12 text-center">
-					<p className="text-sm font-semibold uppercase tracking-wider text-primary mb-3">
+					<p className="text-sm font-semibold uppercase tracking-wider text-primary-text mb-3">
 						Free Resource
 					</p>
 					<h1 className="text-4xl font-bold text-foreground mb-4">

--- a/src/app/security-policy/page.tsx
+++ b/src/app/security-policy/page.tsx
@@ -46,7 +46,7 @@ export default function SecurityPolicyPage() {
 								Email:{" "}
 								<a
 									href="mailto:security@tenantflow.app"
-									className="text-primary hover:underline"
+									className="text-primary-text hover:underline"
 								>
 									security@tenantflow.app
 								</a>
@@ -55,7 +55,7 @@ export default function SecurityPolicyPage() {
 								Encrypt sensitive details using our{" "}
 								<a
 									href="/.well-known/pgp-key.txt"
-									className="text-primary hover:underline"
+									className="text-primary-text hover:underline"
 								>
 									PGP public key
 								</a>
@@ -183,7 +183,7 @@ export default function SecurityPolicyPage() {
 							For security-related inquiries, contact us at{" "}
 							<a
 								href="mailto:security@tenantflow.app"
-								className="text-primary hover:underline"
+								className="text-primary-text hover:underline"
 							>
 								security@tenantflow.app
 							</a>
@@ -193,7 +193,7 @@ export default function SecurityPolicyPage() {
 							For sales and product inquiries, contact{" "}
 							<a
 								href="mailto:sales@tenantflow.app"
-								className="text-primary hover:underline"
+								className="text-primary-text hover:underline"
 							>
 								sales@tenantflow.app
 							</a>
@@ -202,13 +202,13 @@ export default function SecurityPolicyPage() {
 						</p>
 						<p>
 							For general support, visit our{" "}
-							<a href="/support" className="text-primary hover:underline">
+							<a href="/support" className="text-primary-text hover:underline">
 								Support Center
 							</a>{" "}
 							or email{" "}
 							<a
 								href="mailto:support@tenantflow.app"
-								className="text-primary hover:underline"
+								className="text-primary-text hover:underline"
 							>
 								support@tenantflow.app
 							</a>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -108,7 +108,7 @@ export default function TermsPage() {
 							features and pricing. Current plans and pricing are available at{" "}
 							<a
 								href="https://tenantflow.app/pricing"
-								className="text-primary underline"
+								className="text-primary-text underline"
 							>
 								tenantflow.app/pricing
 							</a>
@@ -401,7 +401,7 @@ export default function TermsPage() {
 							If you have a dispute with TenantFlow, please contact us at{" "}
 							<a
 								href="mailto:support@tenantflow.app"
-								className="text-primary underline"
+								className="text-primary-text underline"
 							>
 								support@tenantflow.app
 							</a>{" "}
@@ -494,7 +494,7 @@ export default function TermsPage() {
 								<strong>Email:</strong>{" "}
 								<a
 									href="mailto:legal@tenantflow.app"
-									className="text-primary underline"
+									className="text-primary-text underline"
 								>
 									legal@tenantflow.app
 								</a>
@@ -503,7 +503,7 @@ export default function TermsPage() {
 								<strong>Support:</strong>{" "}
 								<a
 									href="mailto:support@tenantflow.app"
-									className="text-primary underline"
+									className="text-primary-text underline"
 								>
 									support@tenantflow.app
 								</a>

--- a/src/components/admin/deliverability-table.tsx
+++ b/src/components/admin/deliverability-table.tsx
@@ -86,7 +86,7 @@ export function DeliverabilityTable({ data }: { data: DeliverabilityStats[] }) {
 								className={cn(
 									"text-right",
 									row.bouncePercent > BOUNCE_WARN_PERCENT
-										? "text-destructive"
+										? "text-destructive-text"
 										: "text-muted-foreground",
 								)}
 							>
@@ -96,7 +96,7 @@ export function DeliverabilityTable({ data }: { data: DeliverabilityStats[] }) {
 								className={cn(
 									"text-right",
 									row.complaintPercent > COMPLAINT_WARN_PERCENT
-										? "text-destructive"
+										? "text-destructive-text"
 										: "text-muted-foreground",
 								)}
 							>

--- a/src/components/admin/funnel-chart.tsx
+++ b/src/components/admin/funnel-chart.tsx
@@ -86,7 +86,7 @@ export function FunnelChartClient({ data }: { data: FunnelStats | null }) {
 								<dd
 									className={
 										low
-											? "text-xs text-destructive"
+											? "text-xs text-destructive-text"
 											: "text-xs text-muted-foreground"
 									}
 								>

--- a/src/components/admin/gate-conversion-table.tsx
+++ b/src/components/admin/gate-conversion-table.tsx
@@ -94,7 +94,7 @@ export function GateConversionTable({ data }: { data: GateConversionStats[] }) {
 									"text-right",
 									row.conversionRate !== null &&
 										row.conversionRate < LOW_CONVERSION_THRESHOLD
-										? "text-destructive"
+										? "text-destructive-text"
 										: "text-muted-foreground",
 								)}
 							>

--- a/src/components/analytics/components/property-performance-table.tsx
+++ b/src/components/analytics/components/property-performance-table.tsx
@@ -27,7 +27,7 @@ export function PropertyPerformanceTable({
 						</div>
 						<button
 							onClick={onViewDetails}
-							className="text-sm text-primary hover:underline"
+							className="text-sm text-primary-text hover:underline"
 						>
 							View All
 						</button>

--- a/src/components/analytics/owner-payment-summary.tsx
+++ b/src/components/analytics/owner-payment-summary.tsx
@@ -24,7 +24,7 @@ export function OwnerPaymentSummary({ summary }: OwnerPaymentSummaryProps) {
 			<Card>
 				<CardHeader>
 					<CardDescription>Late fees cumulative</CardDescription>
-					<CardTitle className="typography-h3 text-destructive">
+					<CardTitle className="typography-h3 text-destructive-text">
 						{formatCents(values.lateFeeTotal)}
 					</CardTitle>
 				</CardHeader>

--- a/src/components/auth/change-password-dialog.tsx
+++ b/src/components/auth/change-password-dialog.tsx
@@ -285,10 +285,10 @@ export function ChangePasswordDialog({
 						{/* Validation Errors */}
 						{validationErrors.length > 0 && (
 							<div className="rounded-[var(--radius-lg)] border border-destructive/50 bg-destructive/10 p-4">
-								<p className="font-semibold text-destructive mb-2">
+								<p className="font-semibold text-destructive-text mb-2">
 									Please fix the following errors:
 								</p>
-								<ul className="list-[disc] list-inside space-y-1 text-xs text-destructive">
+								<ul className="list-[disc] list-inside space-y-1 text-xs text-destructive-text">
 									{validationErrors.map((error) => (
 										<li key={error}>{error}</li>
 									))}

--- a/src/components/auth/mfa-verification-dialog.tsx
+++ b/src/components/auth/mfa-verification-dialog.tsx
@@ -145,7 +145,7 @@ export function MfaVerificationDialog({
 
 					{error && (
 						<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-center">
-							<p className="text-sm text-destructive">{error}</p>
+							<p className="text-sm text-destructive-text">{error}</p>
 						</div>
 					)}
 

--- a/src/components/auth/two-factor-setup-dialog.tsx
+++ b/src/components/auth/two-factor-setup-dialog.tsx
@@ -178,7 +178,7 @@ export function DisableTwoFactorDialog({
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="sm:max-w-[400px]" intent="delete">
 				<DialogHeader>
-					<DialogTitle className="flex items-center gap-2 text-destructive">
+					<DialogTitle className="flex items-center gap-2 text-destructive-text">
 						<ShieldOff className="size-5" />
 						Disable Two-Factor Authentication
 					</DialogTitle>

--- a/src/components/auth/two-factor-setup-steps.tsx
+++ b/src/components/auth/two-factor-setup-steps.tsx
@@ -91,7 +91,7 @@ export function QrStep({
 					</>
 				) : enrollError ? (
 					<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-center">
-						<p className="text-destructive">
+						<p className="text-destructive-text">
 							Failed to start 2FA setup. Please try again.
 						</p>
 					</div>
@@ -171,7 +171,7 @@ export function VerifyStep({
 
 				{verifyError !== null && (
 					<div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-center">
-						<p className="text-sm text-destructive">
+						<p className="text-sm text-destructive-text">
 							Invalid code. Please try again.
 						</p>
 					</div>
@@ -213,7 +213,7 @@ export function SuccessStep({ onComplete }: SuccessStepProps) {
 	return (
 		<>
 			<DialogHeader>
-				<DialogTitle className="flex items-center gap-2 text-success">
+				<DialogTitle className="flex items-center gap-2 text-success-text">
 					<CheckCircle2 className="size-5" />
 					Two-Factor Authentication Enabled
 				</DialogTitle>

--- a/src/components/auth/update-password-form.tsx
+++ b/src/components/auth/update-password-form.tsx
@@ -172,7 +172,7 @@ export function UpdatePasswordForm({
 								{confirmPassword.length > 0 &&
 									password.length > 0 &&
 									password !== confirmPassword && (
-										<p className="text-xs text-destructive flex items-center gap-[var(--spacing-1)]">
+										<p className="text-xs text-destructive-text flex items-center gap-[var(--spacing-1)]">
 											<AlertTriangle className="size-[var(--spacing-3)]" />
 											Passwords do not match
 										</p>
@@ -180,7 +180,7 @@ export function UpdatePasswordForm({
 								{confirmPassword.length > 0 &&
 									password.length > 0 &&
 									password === confirmPassword && (
-										<p className="text-xs text-primary flex items-center gap-[var(--spacing-1)]">
+										<p className="text-xs text-primary-text flex items-center gap-[var(--spacing-1)]">
 											<CheckCircle2 className="size-[var(--spacing-3)]" />
 											Passwords match
 										</p>

--- a/src/components/billing/upgrade-dialog.tsx
+++ b/src/components/billing/upgrade-dialog.tsx
@@ -141,8 +141,8 @@ export function UpgradeDialog({
 								<span
 									className={cn(
 										"text-sm font-medium",
-										priceDifference > 0 && "text-warning",
-										priceDifference < 0 && "text-success",
+										priceDifference > 0 && "text-warning-text",
+										priceDifference < 0 && "text-success-text",
 										priceDifference === 0 && "text-muted-foreground",
 									)}
 								>
@@ -165,7 +165,7 @@ export function UpgradeDialog({
 								{gained.map((feature) => (
 									<li
 										key={feature.name}
-										className="flex items-center gap-2 text-sm text-success"
+										className="flex items-center gap-2 text-sm text-success-text"
 									>
 										<Check className="size-4" />
 										<span>{feature.name}</span>
@@ -185,7 +185,7 @@ export function UpgradeDialog({
 								{lost.map((feature) => (
 									<li
 										key={feature.name}
-										className="flex items-center gap-2 text-sm text-destructive"
+										className="flex items-center gap-2 text-sm text-destructive-text"
 									>
 										<X className="size-4" />
 										<span>{feature.name}</span>

--- a/src/components/blog/blog-inline-cta.tsx
+++ b/src/components/blog/blog-inline-cta.tsx
@@ -12,7 +12,7 @@ export function BlogInlineCta() {
 	return (
 		<div className="not-prose my-12 rounded-2xl border border-primary/20 bg-linear-to-br from-primary/5 via-primary/[0.02] to-transparent p-8">
 			<div className="flex flex-col gap-4">
-				<p className="text-sm font-semibold uppercase tracking-wider text-primary">
+				<p className="text-sm font-semibold uppercase tracking-wider text-primary-text">
 					TenantFlow
 				</p>
 				<h3 className="text-2xl font-bold text-foreground">

--- a/src/components/blog/lead-magnet-cta.tsx
+++ b/src/components/blog/lead-magnet-cta.tsx
@@ -54,7 +54,7 @@ export function LeadMagnetCta({
 			<div className="flex flex-col gap-4">
 				<div className="flex items-center gap-2">
 					<Icon className="size-5 text-primary" />
-					<p className="text-sm font-semibold uppercase tracking-wider text-primary">
+					<p className="text-sm font-semibold uppercase tracking-wider text-primary-text">
 						Free {resourceType}
 					</p>
 				</div>

--- a/src/components/bulk-import/bulk-import-result-error-list.tsx
+++ b/src/components/bulk-import/bulk-import-result-error-list.tsx
@@ -76,7 +76,7 @@ export function ResultErrorList({
 							<span className="font-mono text-muted-foreground shrink-0">
 								{err.row === 0 ? "!" : `#${err.row}`}
 							</span>
-							<span className="text-destructive">{err.error}</span>
+							<span className="text-destructive-text">{err.error}</span>
 						</li>
 					))}
 				</ul>

--- a/src/components/bulk-import/bulk-import-result-panel.tsx
+++ b/src/components/bulk-import/bulk-import-result-panel.tsx
@@ -104,9 +104,9 @@ function ResultHeader({
 				<p
 					className={cn(
 						"text-base font-semibold",
-						tone === "success" && "text-success",
-						tone === "warning" && "text-warning",
-						tone === "destructive" && "text-destructive",
+						tone === "success" && "text-success-text",
+						tone === "warning" && "text-warning-text",
+						tone === "destructive" && "text-destructive-text",
 					)}
 				>
 					{tone === "success" &&
@@ -168,8 +168,8 @@ function StatCard({
 						"text-xl font-bold",
 						active
 							? tone === "success"
-								? "text-success"
-								: "text-destructive"
+								? "text-success-text"
+								: "text-destructive-text"
 							: "text-muted-foreground",
 					)}
 				>

--- a/src/components/bulk-import/bulk-import-validate-step.tsx
+++ b/src/components/bulk-import/bulk-import-validate-step.tsx
@@ -66,7 +66,7 @@ export function BulkImportValidateStep<T>({
 					</div>
 					<Badge
 						variant="outline"
-						className="bg-success/10 text-success border-success/20"
+						className="bg-success/10 text-success-text border-success/20"
 					>
 						Uploaded
 					</Badge>
@@ -80,7 +80,7 @@ export function BulkImportValidateStep<T>({
 				<div className="flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/30">
 					<AlertCircle className="size-4 text-destructive shrink-0 mt-0.5" />
 					<div>
-						<p className="typography-small text-destructive">
+						<p className="typography-small text-destructive-text">
 							Your CSV file is malformed
 						</p>
 						<p className="text-xs text-muted-foreground mt-0.5">
@@ -119,7 +119,7 @@ export function BulkImportValidateStep<T>({
 						<CheckCircle2 className="size-4" />
 					</div>
 					<div>
-						<p className="text-lg font-bold text-success">{validCount}</p>
+						<p className="text-lg font-bold text-success-text">{validCount}</p>
 						<p className="text-xs text-muted-foreground">Valid rows</p>
 					</div>
 				</div>
@@ -145,7 +145,7 @@ export function BulkImportValidateStep<T>({
 						<p
 							className={cn(
 								"text-lg font-bold",
-								hasErrors ? "text-destructive" : "text-muted-foreground",
+								hasErrors ? "text-destructive-text" : "text-muted-foreground",
 							)}
 						>
 							{errorCount}
@@ -160,7 +160,7 @@ export function BulkImportValidateStep<T>({
 				<div className="flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/30">
 					<AlertCircle className="size-4 text-destructive shrink-0 mt-0.5" />
 					<div>
-						<p className="typography-small text-destructive">
+						<p className="typography-small text-destructive-text">
 							{errorCount} row{errorCount > 1 ? "s" : ""} have errors
 						</p>
 						<p className="text-xs text-muted-foreground mt-0.5">
@@ -241,7 +241,7 @@ export function BulkImportValidateStep<T>({
 													{row.errors.map((err, i) => (
 														<div
 															key={i}
-															className="flex items-center gap-1.5 text-xs text-destructive"
+															className="flex items-center gap-1.5 text-xs text-destructive-text"
 														>
 															<X className="size-3 shrink-0" />
 															<span className="font-medium">{err.field}:</span>
@@ -254,7 +254,7 @@ export function BulkImportValidateStep<T>({
 													<div className="icon-container-sm bg-success/10 text-success shrink-0">
 														<CheckCircle2 className="size-3" />
 													</div>
-													<span className="text-xs text-success font-medium">
+													<span className="text-xs text-success-text font-medium">
 														Valid
 													</span>
 												</div>

--- a/src/components/contact/contact-form.tsx
+++ b/src/components/contact/contact-form.tsx
@@ -209,7 +209,7 @@ export function ContactForm({ className = "" }: ContactFormProps) {
 
 					{submitError && (
 						<div className="mb-4 p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-							<p className="text-sm text-destructive">{submitError}</p>
+							<p className="text-sm text-destructive-text">{submitError}</p>
 						</div>
 					)}
 

--- a/src/components/inspections/inspection-list.client.tsx
+++ b/src/components/inspections/inspection-list.client.tsx
@@ -132,7 +132,7 @@ export function InspectionListClient() {
 
 				{error && (
 					<div className="p-8 text-center">
-						<p className="text-sm text-destructive">
+						<p className="text-sm text-destructive-text">
 							Failed to load inspections. Please try again.
 						</p>
 					</div>

--- a/src/components/landing/feature-backgrounds.tsx
+++ b/src/components/landing/feature-backgrounds.tsx
@@ -35,7 +35,7 @@ export function PropertyGrid() {
 							<span className="text-muted-foreground">
 								{property.units} units
 							</span>
-							<span className="text-success font-medium">
+							<span className="text-success-text font-medium">
 								{property.occupancy}
 							</span>
 						</div>

--- a/src/components/landing/feature-backgrounds.tsx
+++ b/src/components/landing/feature-backgrounds.tsx
@@ -35,7 +35,7 @@ export function PropertyGrid() {
 							<span className="text-muted-foreground">
 								{property.units} units
 							</span>
-							<span className="text-success-text font-medium">
+							<span className="text-success font-medium">
 								{property.occupancy}
 							</span>
 						</div>

--- a/src/components/leases/detail/lease-details.client.tsx
+++ b/src/components/leases/detail/lease-details.client.tsx
@@ -69,7 +69,7 @@ export function LeaseDetails({ id }: LeaseDetailsProps) {
 			<Card className="border-destructive/50 bg-destructive/10">
 				<CardContent className="p-6 text-center">
 					<AlertTriangle className="mx-auto h-10 w-10 text-destructive mb-3" />
-					<h3 className="text-lg font-semibold text-destructive mb-2">
+					<h3 className="text-lg font-semibold text-destructive-text mb-2">
 						Unable to load lease
 					</h3>
 					<p className="text-muted-foreground">{errorMessage}</p>

--- a/src/components/leases/dialogs/terminate-lease-dialog.tsx
+++ b/src/components/leases/dialogs/terminate-lease-dialog.tsx
@@ -58,7 +58,7 @@ export function TerminateLeaseDialog({
 						<div className="flex gap-3">
 							<AlertTriangle className="size-5 text-destructive shrink-0" />
 							<div className="space-y-1">
-								<p className="typography-small text-destructive">
+								<p className="typography-small text-destructive-text">
 									Early Termination Warning
 								</p>
 								<p className="text-muted-foreground">

--- a/src/components/leases/lease-form-property-unit-fields.tsx
+++ b/src/components/leases/lease-form-property-unit-fields.tsx
@@ -73,7 +73,7 @@ export function LeaseFormPropertyUnitFields({
 				</Field>
 
 				{propertiesIsError && (
-					<p className="text-sm text-destructive mt-2">
+					<p className="text-sm text-destructive-text mt-2">
 						Failed to load properties
 						{propertiesError ? `: ${propertiesError.message}` : ""}. Please
 						refresh to retry.
@@ -82,7 +82,7 @@ export function LeaseFormPropertyUnitFields({
 			</div>
 
 			{unitsIsError && (
-				<p className="text-sm text-destructive mt-2">
+				<p className="text-sm text-destructive-text mt-2">
 					Failed to load units for the selected property.
 					{unitsError ? ` ${unitsError.message}` : ""} Please retry.
 				</p>

--- a/src/components/leases/lease-signature-status.tsx
+++ b/src/components/leases/lease-signature-status.tsx
@@ -40,7 +40,7 @@ export function LeaseSignatureStatus({
 				data-testid="signature-status-error"
 			>
 				<CardContent className="py-4">
-					<div className="flex items-center gap-2 text-destructive">
+					<div className="flex items-center gap-2 text-destructive-text">
 						<AlertCircle className="h-4 w-4" />
 						<span className="text-sm">
 							{
@@ -240,7 +240,7 @@ function SignatureRow({
 				{signed ? (
 					<>
 						<CheckCircle2 className="h-4 w-4 text-success" />
-						<span className="text-sm text-success">
+						<span className="text-sm text-success-text">
 							Signed {signedAt && new Date(signedAt).toLocaleDateString()}
 						</span>
 					</>

--- a/src/components/leases/lease-template-default-card.tsx
+++ b/src/components/leases/lease-template-default-card.tsx
@@ -34,7 +34,7 @@ export function LeaseTemplateDefaultCard({
 								<div>
 									<div className="flex items-center gap-2">
 										<h3 className="text-lg font-medium">{template.name}</h3>
-										<span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-primary/10 text-primary rounded-full">
+										<span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-primary/10 text-primary-text rounded-full">
 											<Star className="w-3 h-3" />
 											Default
 										</span>

--- a/src/components/leases/send-for-signature-button.tsx
+++ b/src/components/leases/send-for-signature-button.tsx
@@ -223,7 +223,7 @@ export function SendForSignatureButton({
 						<div>
 							<Label htmlFor="landlord-notice-address" className="mb-2 block">
 								Landlord notice address{" "}
-								<span className="text-destructive">*</span>
+								<span className="text-destructive-text">*</span>
 							</Label>
 							<Textarea
 								id="landlord-notice-address"

--- a/src/components/leases/sign-lease-button.tsx
+++ b/src/components/leases/sign-lease-button.tsx
@@ -84,7 +84,7 @@ export function SignLeaseButton({
 				variant="outline"
 				size={size}
 				disabled
-				className={cn("gap-2 text-success border-success/20", className)}
+				className={cn("gap-2 text-success-text border-success/20", className)}
 			>
 				<CheckCircle2 className="h-4 w-4" />
 				Signed
@@ -120,7 +120,7 @@ export function SignLeaseButton({
 							By signing, you acknowledge that you have read and agree to all
 							terms and conditions outlined in the lease agreement.
 						</p>
-						<p className="text-warning font-medium">
+						<p className="text-warning-text font-medium">
 							This action is legally binding and cannot be undone.
 						</p>
 					</AlertDialogDescription>
@@ -194,7 +194,9 @@ export function SignLeaseActions({
 	// If both signed, show completed state
 	if (bothSigned) {
 		return (
-			<div className={cn("flex items-center gap-2 text-success", className)}>
+			<div
+				className={cn("flex items-center gap-2 text-success-text", className)}
+			>
 				<CheckCircle2 className="h-5 w-5" />
 				<span className="font-medium">Lease Fully Signed</span>
 			</div>

--- a/src/components/leases/table/leases-table.tsx
+++ b/src/components/leases/table/leases-table.tsx
@@ -209,7 +209,7 @@ export function LeasesTable({
 						</p>
 						<button
 							onClick={handleClearFilters}
-							className="mt-3 text-sm text-primary hover:underline"
+							className="mt-3 text-sm text-primary-text hover:underline"
 						>
 							Clear filters
 						</button>

--- a/src/components/leases/wizard/selection-step.tsx
+++ b/src/components/leases/wizard/selection-step.tsx
@@ -180,7 +180,7 @@ export function SelectionStep({
 					{propertiesLoading ? (
 						<Skeleton className="h-10 w-full" />
 					) : propertiesError ? (
-						<div className="flex items-center gap-2 text-destructive text-sm p-3 bg-destructive/10 rounded-md">
+						<div className="flex items-center gap-2 text-destructive-text text-sm p-3 bg-destructive/10 rounded-md">
 							<AlertCircle className="h-4 w-4" />
 							Failed to load properties: {propertiesError.message}
 						</div>
@@ -216,7 +216,7 @@ export function SelectionStep({
 					) : unitsLoading ? (
 						<Skeleton className="h-10 w-full" />
 					) : unitsError ? (
-						<div className="flex items-center gap-2 text-destructive text-sm p-3 bg-destructive/10 rounded-md">
+						<div className="flex items-center gap-2 text-destructive-text text-sm p-3 bg-destructive/10 rounded-md">
 							<AlertCircle className="h-4 w-4" />
 							Failed to load units: {unitsError.message}
 						</div>
@@ -264,7 +264,7 @@ export function SelectionStep({
 					) : tenantsLoading ? (
 						<Skeleton className="h-10 w-full" />
 					) : tenantsError ? (
-						<div className="flex items-center gap-2 text-destructive text-sm p-3 bg-destructive/10 rounded-md">
+						<div className="flex items-center gap-2 text-destructive-text text-sm p-3 bg-destructive/10 rounded-md">
 							<AlertCircle className="h-4 w-4" />
 							Failed to load tenants: {tenantsError.message}
 						</div>

--- a/src/components/maintenance/cards/maintenance-card.tsx
+++ b/src/components/maintenance/cards/maintenance-card.tsx
@@ -21,12 +21,12 @@ function getAgingDisplay(timestamp: string | null | undefined) {
 	if (days <= 3) {
 		return {
 			label: days === 0 ? "Today" : days === 1 ? "1 day" : `${days} days`,
-			className: "bg-success/10 text-success",
+			className: "bg-success/10 text-success-text",
 		};
 	} else if (days <= 7) {
 		return {
 			label: `${days} days`,
-			className: "bg-warning/10 text-warning",
+			className: "bg-warning/10 text-warning-text",
 		};
 	} else if (days <= 14) {
 		return {
@@ -37,7 +37,7 @@ function getAgingDisplay(timestamp: string | null | undefined) {
 	} else {
 		return {
 			label: `${days} days`,
-			className: "bg-destructive/10 text-destructive",
+			className: "bg-destructive/10 text-destructive-text",
 		};
 	}
 }
@@ -46,10 +46,10 @@ function getPriorityBadge(priority: MaintenancePriority | string) {
 	const normalizedPriority = priority?.toLowerCase() as MaintenancePriority;
 	const config: Record<string, string> = {
 		low: "bg-muted text-muted-foreground",
-		medium: "bg-primary/10 text-primary",
-		normal: "bg-primary/10 text-primary",
-		high: "bg-warning/10 text-warning",
-		urgent: "bg-destructive/10 text-destructive",
+		medium: "bg-primary/10 text-primary-text",
+		normal: "bg-primary/10 text-primary-text",
+		high: "bg-warning/10 text-warning-text",
+		urgent: "bg-destructive/10 text-destructive-text",
 	};
 
 	return (

--- a/src/components/maintenance/maintenance-view.client.tsx
+++ b/src/components/maintenance/maintenance-view.client.tsx
@@ -182,7 +182,7 @@ export function MaintenanceViewClient() {
 							/>
 						)}
 						<StatLabel>Open</StatLabel>
-						<StatValue className="flex items-baseline text-warning">
+						<StatValue className="flex items-baseline text-warning-text">
 							<NumberTicker value={openCount} duration={800} />
 						</StatValue>
 						<StatIndicator variant="icon" color="warning">
@@ -206,7 +206,7 @@ export function MaintenanceViewClient() {
 				<BlurFade delay={0.25} inView>
 					<Stat className="relative overflow-hidden">
 						<StatLabel>Completed</StatLabel>
-						<StatValue className="flex items-baseline text-success">
+						<StatValue className="flex items-baseline text-success-text">
 							<NumberTicker value={completedCount} duration={800} />
 						</StatValue>
 						<StatIndicator variant="icon" color="success">

--- a/src/components/maintenance/maintenance-view.client.tsx
+++ b/src/components/maintenance/maintenance-view.client.tsx
@@ -182,6 +182,9 @@ export function MaintenanceViewClient() {
 							/>
 						)}
 						<StatLabel>Open</StatLabel>
+						{/* warning/success stat numbers use -text companions: at 32px (typography-stat)
+						    text-warning/text-success measure 2.15/2.59:1 in light, below the AA-large 3:1
+						    bar; the Urgent stat below keeps vivid text-destructive (4.55/3.29:1, clears it). */}
 						<StatValue className="flex items-baseline text-warning-text">
 							<NumberTicker value={openCount} duration={800} />
 						</StatValue>

--- a/src/components/maintenance/table/columns.tsx
+++ b/src/components/maintenance/table/columns.tsx
@@ -32,7 +32,7 @@ function getStatusBadge(status: MaintenanceStatus | string) {
 			label: "Open",
 		},
 		in_progress: {
-			className: "bg-primary/10 text-primary",
+			className: "bg-primary/10 text-primary-text",
 			label: "In Progress",
 		},
 		completed: {
@@ -72,11 +72,11 @@ function getPriorityBadge(priority: MaintenancePriority | string) {
 			label: "Low",
 		},
 		medium: {
-			className: "bg-primary/10 text-primary",
+			className: "bg-primary/10 text-primary-text",
 			label: "Medium",
 		},
 		normal: {
-			className: "bg-primary/10 text-primary",
+			className: "bg-primary/10 text-primary-text",
 			label: "Normal",
 		},
 		high: {
@@ -84,7 +84,7 @@ function getPriorityBadge(priority: MaintenancePriority | string) {
 			label: "High",
 		},
 		urgent: {
-			className: "bg-destructive/10 text-destructive",
+			className: "bg-destructive/10 text-destructive-text",
 			label: "Urgent",
 		},
 	};
@@ -129,7 +129,7 @@ function getAgingBadge(timestamp: string | null | undefined) {
 			"bg-orange-100 text-orange-700 dark:bg-orange-500/20 dark:text-orange-400";
 		label = `${days} days`;
 	} else {
-		className = "bg-destructive/10 text-destructive";
+		className = "bg-destructive/10 text-destructive-text";
 		label = `${days} days`;
 	}
 

--- a/src/components/maintenance/tenant-maintenance-card.tsx
+++ b/src/components/maintenance/tenant-maintenance-card.tsx
@@ -18,10 +18,10 @@ const statusClassMap: Record<string, string> = {
 };
 
 const priorityColorMap: Record<string, string> = {
-	URGENT: "text-destructive",
-	HIGH: "text-warning",
-	MEDIUM: "text-warning",
-	LOW: "text-info",
+	URGENT: "text-destructive-text",
+	HIGH: "text-warning-text",
+	MEDIUM: "text-warning-text",
+	LOW: "text-info-text",
 };
 
 const formatStatus = (status: string) => status.replace("_", " ");

--- a/src/components/pricing/__tests__/bento-pricing-section.test.tsx
+++ b/src/components/pricing/__tests__/bento-pricing-section.test.tsx
@@ -49,7 +49,7 @@ describe("BentoPricingSection", () => {
 		// (Starter $38, Growth $98, Max $298). This fails if any per-card
 		// line goes missing (count drops below 3).
 		const savingsLines = Array.from(
-			container.querySelectorAll("p.text-success.font-semibold"),
+			container.querySelectorAll("p.text-success-text.font-semibold"),
 		).filter((el) => /Save\s+\$[\d,]+\/year/.test(el.textContent ?? ""));
 		expect(savingsLines).toHaveLength(3);
 		expect(savingsLines.map((el) => el.textContent)).toEqual(

--- a/src/components/pricing/__tests__/pricing-card-standard.test.tsx
+++ b/src/components/pricing/__tests__/pricing-card-standard.test.tsx
@@ -113,7 +113,7 @@ describe("PricingCardStandard", () => {
 		expect(screen.queryByText(/Save\s+\$\d/)).toBeNull();
 	});
 
-	it("savings line uses the text-success token (CONS-10)", () => {
+	it("savings line uses the text-success-text token (CONS-10)", () => {
 		const { container } = render(
 			<PricingCardStandard
 				plan={starterPlan}
@@ -121,7 +121,7 @@ describe("PricingCardStandard", () => {
 				variant="starter"
 			/>,
 		);
-		const savings = container.querySelector(".text-success.font-semibold");
+		const savings = container.querySelector(".text-success-text.font-semibold");
 		expect(savings).toBeTruthy();
 		expect(savings?.textContent).toMatch(/Save\s+\$38\/year/);
 	});

--- a/src/components/pricing/pricing-card-featured.tsx
+++ b/src/components/pricing/pricing-card-featured.tsx
@@ -191,7 +191,7 @@ export function PricingCardFeatured({
 						    savings render with thousands separator (AUDIT-2
 						    cycle-2 P3). */}
 						{billingCycle === "yearly" && plan.price.monthly > 0 && (
-							<p className="text-sm font-semibold text-success mt-1">
+							<p className="text-sm font-semibold text-success-text mt-1">
 								Save{" "}
 								{formatCurrency(calculateAnnualSavings(plan.price.monthly), {
 									maximumFractionDigits: 0,

--- a/src/components/pricing/pricing-card-standard.tsx
+++ b/src/components/pricing/pricing-card-standard.tsx
@@ -198,7 +198,7 @@ export function PricingCardStandard({
 					    Max $298. formatCurrency so 4-digit savings render with
 					    thousands separator (AUDIT-2 cycle-2 P3). */}
 					{billingCycle === "yearly" && plan.price.monthly > 0 && (
-						<p className="text-xs font-semibold text-success mt-1">
+						<p className="text-xs font-semibold text-success-text mt-1">
 							Save{" "}
 							{formatCurrency(calculateAnnualSavings(plan.price.monthly), {
 								maximumFractionDigits: 0,
@@ -236,7 +236,7 @@ export function PricingCardStandard({
 						<button
 							type="button"
 							onClick={() => setShowAllFeatures(!showAllFeatures)}
-							className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 pl-6 transition-colors"
+							className="flex items-center gap-1 text-xs text-primary-text hover:text-primary/80 pl-6 transition-colors"
 						>
 							<ChevronDown
 								className={cn(

--- a/src/components/pricing/pricing-comparison-table.tsx
+++ b/src/components/pricing/pricing-comparison-table.tsx
@@ -164,7 +164,7 @@ function FeatureCell({
 		<span
 			className={cn(
 				"text-sm font-medium",
-				highlight ? "text-primary" : "text-foreground",
+				highlight ? "text-primary-text" : "text-foreground",
 			)}
 		>
 			{value}
@@ -253,7 +253,9 @@ export function PricingComparisonTable({
 							<div className="text-xs text-muted-foreground">$19/mo</div>
 						</div>
 						<div className="text-center bg-primary/5 -my-4 py-4 border-x border-primary/10">
-							<div className="text-sm font-semibold text-primary">Growth</div>
+							<div className="text-sm font-semibold text-primary-text">
+								Growth
+							</div>
 							<div className="text-xs text-primary/70">$49/mo</div>
 						</div>
 						<div className="text-center">

--- a/src/components/profiles/owner/personal-info-section.tsx
+++ b/src/components/profiles/owner/personal-info-section.tsx
@@ -49,7 +49,7 @@ export function PersonalInfoSection({
 						<button
 							type="button"
 							onClick={onEditClick}
-							className="flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+							className="flex items-center gap-1 text-sm font-medium text-primary-text hover:underline"
 						>
 							<Edit className="h-4 w-4" />
 							Edit

--- a/src/components/profiles/owner/recent-activity-section.tsx
+++ b/src/components/profiles/owner/recent-activity-section.tsx
@@ -15,7 +15,7 @@ export function RecentActivitySection() {
 					<button
 						type="button"
 						onClick={() => router.push("/activity")}
-						className="text-sm font-medium text-primary hover:underline"
+						className="text-sm font-medium text-primary-text hover:underline"
 					>
 						View All
 					</button>

--- a/src/components/profiles/tenant/account-data-section.tsx
+++ b/src/components/profiles/tenant/account-data-section.tsx
@@ -233,7 +233,7 @@ export function TenantAccountDataSection() {
 						{!showDeleteConfirm ? (
 							<button
 								onClick={() => setShowDeleteConfirm(true)}
-								className="inline-flex items-center gap-2 px-4 py-2 min-h-11 text-sm font-medium text-destructive border border-destructive/30 rounded-lg hover:bg-destructive/10 transition-colors"
+								className="inline-flex items-center gap-2 px-4 py-2 min-h-11 text-sm font-medium text-destructive-text border border-destructive/30 rounded-lg hover:bg-destructive/10 transition-colors"
 							>
 								<Trash2 className="h-4 w-4" aria-hidden="true" />
 								Delete My Account
@@ -246,7 +246,7 @@ export function TenantAccountDataSection() {
 										aria-hidden="true"
 									/>
 									<div>
-										<p className="text-sm font-medium text-destructive">
+										<p className="text-sm font-medium text-destructive-text">
 											This will schedule your account for deletion
 										</p>
 										<p className="text-sm text-muted-foreground mt-1">

--- a/src/components/properties/property-form-fields.tsx
+++ b/src/components/properties/property-form-fields.tsx
@@ -41,7 +41,7 @@ export function AcquisitionDetailsSection({
 								onBlur={field.handleBlur}
 							/>
 							{(field.state.meta.errors?.length ?? 0) > 0 && (
-								<p className="text-xs text-destructive">
+								<p className="text-xs text-destructive-text">
 									{String(field.state.meta.errors[0])}
 								</p>
 							)}
@@ -64,7 +64,7 @@ export function AcquisitionDetailsSection({
 								onBlur={field.handleBlur}
 							/>
 							{(field.state.meta.errors?.length ?? 0) > 0 && (
-								<p className="text-xs text-destructive">
+								<p className="text-xs text-destructive-text">
 									{String(field.state.meta.errors[0])}
 								</p>
 							)}

--- a/src/components/properties/property-form.mobile.tsx
+++ b/src/components/properties/property-form.mobile.tsx
@@ -58,7 +58,7 @@ export function MobilePropertyForm({
 				</CardHeader>
 				<CardContent className="space-y-4">
 					{!isOnline ? (
-						<Alert className="rounded-2xl border-warning/20 bg-warning/10 text-warning">
+						<Alert className="rounded-2xl border-warning/20 bg-warning/10 text-warning-text">
 							<WifiOff className="size-4" aria-hidden />
 							<AlertTitle>Offline mode</AlertTitle>
 							<AlertDescription>

--- a/src/components/properties/property-performance-section.tsx
+++ b/src/components/properties/property-performance-section.tsx
@@ -68,25 +68,28 @@ export function PropertyPerformanceSection({
 			label: "Revenue",
 			value: formatCurrency(data.total_revenue ?? 0),
 			icon: DollarSign,
-			tone: "text-success",
+			tone: "text-success-text",
 		},
 		{
 			label: "Expenses",
 			value: formatCurrency(data.total_expenses ?? 0),
 			icon: Receipt,
-			tone: "text-destructive",
+			tone: "text-destructive-text",
 		},
 		{
 			label: "Net Income",
 			value: formatCurrency(data.net_income ?? 0),
 			icon: TrendingUp,
-			tone: (data.net_income ?? 0) >= 0 ? "text-success" : "text-destructive",
+			tone:
+				(data.net_income ?? 0) >= 0
+					? "text-success-text"
+					: "text-destructive-text",
 		},
 		{
 			label: "Occupancy",
 			value: formatPercentage(data.occupancy_rate ?? 0),
 			icon: Percent,
-			tone: "text-info",
+			tone: "text-info-text",
 		},
 	];
 

--- a/src/components/properties/property-select-card.tsx
+++ b/src/components/properties/property-select-card.tsx
@@ -113,7 +113,7 @@ export function PropertyCard({
 				{/* View Button */}
 				<button
 					onClick={onView}
-					className="w-full mt-4 py-2.5 text-sm font-medium text-primary border border-primary/20 bg-primary/5 hover:bg-primary hover:text-primary-foreground hover:border-primary rounded-sm transition-all duration-200 flex items-center justify-center gap-2 group/btn min-h-11"
+					className="w-full mt-4 py-2.5 text-sm font-medium text-primary-text border border-primary/20 bg-primary/5 hover:bg-primary hover:text-primary-foreground hover:border-primary rounded-sm transition-all duration-200 flex items-center justify-center gap-2 group/btn min-h-11"
 					aria-label={`View details for ${property.name}`}
 				>
 					<Eye className="w-4 h-4 group-hover/btn:scale-110 transition-transform" />

--- a/src/components/properties/property-units-single-view.tsx
+++ b/src/components/properties/property-units-single-view.tsx
@@ -41,7 +41,7 @@ export function SingleUnitNoData({
 						<button
 							type="button"
 							onClick={() => onAddUnitOpenChange(true)}
-							className="text-primary hover:underline"
+							className="text-primary-text hover:underline"
 						>
 							Set up unit details
 						</button>

--- a/src/components/reports/reports-scheduled-list.tsx
+++ b/src/components/reports/reports-scheduled-list.tsx
@@ -40,7 +40,7 @@ export function ReportsScheduledList({
 								Automated recurring reports
 							</p>
 						</div>
-						<button className="text-sm text-primary hover:underline">
+						<button className="text-sm text-primary-text hover:underline">
 							+ Add Schedule
 						</button>
 					</div>

--- a/src/components/reports/reports-type-grid.tsx
+++ b/src/components/reports/reports-type-grid.tsx
@@ -112,7 +112,7 @@ export function ReportsTypeGrid({
 									</div>
 									<button
 										onClick={() => onGenerateReport?.(type.id)}
-										className="text-sm text-primary hover:underline opacity-0 group-hover:opacity-100 transition-opacity"
+										className="text-sm text-primary-text hover:underline opacity-0 group-hover:opacity-100 transition-opacity"
 									>
 										Generate
 									</button>

--- a/src/components/sections/comparison-table.tsx
+++ b/src/components/sections/comparison-table.tsx
@@ -217,7 +217,7 @@ function FeatureCell({
 			<span
 				className={cn(
 					"typography-small",
-					highlight ? "text-primary" : "text-foreground",
+					highlight ? "text-primary-text" : "text-foreground",
 				)}
 			>
 				{value}

--- a/src/components/sections/how-it-works.tsx
+++ b/src/components/sections/how-it-works.tsx
@@ -68,7 +68,7 @@ export function HowItWorks({ className }: HowItWorksProps) {
 			<div className="max-w-7xl mx-auto px-6 lg:px-8 relative z-10">
 				<BlurFade delay={0.1} inView>
 					<div className="text-center mb-16">
-						<p className="typography-small text-primary uppercase tracking-wider mb-3">
+						<p className="typography-small text-primary-text uppercase tracking-wider mb-3">
 							Three Steps to Set Up
 						</p>
 						<h2 className="text-3xl lg:text-4xl xl:text-5xl font-bold tracking-tight text-foreground mb-4">

--- a/src/components/settings/account-data-section.tsx
+++ b/src/components/settings/account-data-section.tsx
@@ -179,7 +179,7 @@ export function AccountDataSection() {
 
 				{/* Delete Account */}
 				<section className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
-					<h3 className="mb-1 text-sm font-medium text-destructive uppercase tracking-wider">
+					<h3 className="mb-1 text-sm font-medium text-destructive-text uppercase tracking-wider">
 						Danger Zone
 					</h3>
 
@@ -240,7 +240,7 @@ export function AccountDataSection() {
 							{!showDeleteConfirm ? (
 								<button
 									onClick={() => setShowDeleteConfirm(true)}
-									className="inline-flex items-center gap-2 px-4 py-2 min-h-11 text-sm font-medium text-destructive border border-destructive/30 rounded-lg hover:bg-destructive/10 transition-colors"
+									className="inline-flex items-center gap-2 px-4 py-2 min-h-11 text-sm font-medium text-destructive-text border border-destructive/30 rounded-lg hover:bg-destructive/10 transition-colors"
 								>
 									<Trash2 className="h-4 w-4" aria-hidden="true" />
 									Delete My Account
@@ -253,7 +253,7 @@ export function AccountDataSection() {
 											aria-hidden="true"
 										/>
 										<div>
-											<p className="text-sm font-medium text-destructive">
+											<p className="text-sm font-medium text-destructive-text">
 												This will schedule your account for deletion
 											</p>
 											<p className="text-sm text-muted-foreground mt-1">

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -252,7 +252,7 @@ export function BillingSettings() {
 								Your session appears to have expired.{" "}
 								<Link
 									href="/login?redirect=%2Fsettings%3Ftab%3Dbilling"
-									className="text-primary hover:underline underline-offset-4"
+									className="text-primary-text hover:underline underline-offset-4"
 								>
 									Sign in again
 								</Link>{" "}
@@ -264,14 +264,14 @@ export function BillingSettings() {
 								<button
 									type="button"
 									onClick={() => refetchStatus()}
-									className="text-primary hover:underline underline-offset-4"
+									className="text-primary-text hover:underline underline-offset-4"
 								>
 									Retry
 								</button>{" "}
 								or{" "}
 								<Link
 									href="/contact"
-									className="text-primary hover:underline underline-offset-4"
+									className="text-primary-text hover:underline underline-offset-4"
 								>
 									contact support
 								</Link>{" "}
@@ -348,7 +348,7 @@ export function BillingSettings() {
 											Billing cycle syncing from Stripe…{" "}
 											<Link
 												href="/contact"
-												className="text-primary hover:underline underline-offset-4"
+												className="text-primary-text hover:underline underline-offset-4"
 											>
 												Contact support
 											</Link>{" "}
@@ -370,7 +370,7 @@ export function BillingSettings() {
 									shortly.{" "}
 									<Link
 										href="/contact"
-										className="text-primary hover:underline underline-offset-4"
+										className="text-primary-text hover:underline underline-offset-4"
 									>
 										Contact support
 									</Link>{" "}
@@ -387,7 +387,7 @@ export function BillingSettings() {
 									Your trial is active.{" "}
 									<Link
 										href="/billing/plans"
-										className="text-primary hover:underline underline-offset-4"
+										className="text-primary-text hover:underline underline-offset-4"
 									>
 										Choose a plan
 									</Link>{" "}
@@ -399,7 +399,7 @@ export function BillingSettings() {
 									Your subscription is {statusVariant.label.toLowerCase()}.{" "}
 									<Link
 										href="/billing/plans"
-										className="text-primary hover:underline underline-offset-4"
+										className="text-primary-text hover:underline underline-offset-4"
 									>
 										Resubscribe
 									</Link>{" "}

--- a/src/components/settings/categories-settings.tsx
+++ b/src/components/settings/categories-settings.tsx
@@ -192,7 +192,7 @@ export function CategoriesSettings() {
 					<CardTitle>Document categories</CardTitle>
 				</CardHeader>
 				<CardContent className="flex flex-col items-start gap-3 text-sm text-muted-foreground">
-					<div className="flex items-center gap-2 text-destructive">
+					<div className="flex items-center gap-2 text-destructive-text">
 						<AlertCircle className="size-4" aria-hidden="true" />
 						<span>We couldn&apos;t load your document categories.</span>
 					</div>

--- a/src/components/settings/category-create-dialog.tsx
+++ b/src/components/settings/category-create-dialog.tsx
@@ -156,7 +156,7 @@ export function CategoryCreateDialog({
 							className={cn(
 								"text-xs",
 								slugError !== null
-									? "text-destructive"
+									? "text-destructive-text"
 									: "text-muted-foreground",
 							)}
 						>

--- a/src/components/settings/gdpr-data-actions.tsx
+++ b/src/components/settings/gdpr-data-actions.tsx
@@ -198,7 +198,7 @@ export function GdprDataActions({
 	const deletionBlock = (
 		<>
 			{variant === "standalone" && (
-				<h3 className="mb-1 text-sm font-medium text-destructive uppercase tracking-wider">
+				<h3 className="mb-1 text-sm font-medium text-destructive-text uppercase tracking-wider">
 					Danger Zone
 				</h3>
 			)}
@@ -269,7 +269,7 @@ export function GdprDataActions({
 									aria-hidden="true"
 								/>
 								<div>
-									<p className="text-sm font-medium text-destructive">
+									<p className="text-sm font-medium text-destructive-text">
 										This will schedule your account for deletion
 									</p>
 									<p className="text-sm text-muted-foreground mt-1">

--- a/src/components/settings/sections/active-sessions-section.tsx
+++ b/src/components/settings/sections/active-sessions-section.tsx
@@ -82,7 +82,7 @@ export function ActiveSessionsSection() {
 						<button
 							onClick={() => setBulkOpen(true)}
 							disabled={bulkPending || revokeSession.isPending}
-							className="text-sm font-medium text-destructive hover:underline disabled:opacity-50 disabled:no-underline disabled:cursor-not-allowed"
+							className="text-sm font-medium text-destructive-text hover:underline disabled:opacity-50 disabled:no-underline disabled:cursor-not-allowed"
 						>
 							Sign Out All Other Devices
 						</button>
@@ -110,7 +110,7 @@ export function ActiveSessionsSection() {
 												<p className="text-sm font-medium flex items-center gap-2">
 													{deviceLabel}
 													{session.is_current && (
-														<span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">
+														<span className="text-xs bg-primary/10 text-primary-text px-2 py-0.5 rounded-full">
 															Current
 														</span>
 													)}

--- a/src/components/settings/sections/billing-history-section.tsx
+++ b/src/components/settings/sections/billing-history-section.tsx
@@ -10,14 +10,14 @@ function getStatusVisual(invoice: BillingHistoryItem) {
 	if (invoice.isSuccessful) {
 		return {
 			Icon: CheckCircle,
-			color: "text-success",
+			color: "text-success-text",
 			label: "Paid",
 		};
 	}
 	if (invoice.status === "failed" || invoice.status === "cancelled") {
 		return {
 			Icon: XCircle,
-			color: "text-destructive",
+			color: "text-destructive-text",
 			label: invoice.status === "failed" ? "Failed" : "Cancelled",
 		};
 	}
@@ -73,7 +73,7 @@ export function BillingHistorySection() {
 														href={downloadHref}
 														target="_blank"
 														rel="noopener noreferrer"
-														className="text-sm text-primary hover:underline"
+														className="text-sm text-primary-text hover:underline"
 													>
 														Download
 													</a>

--- a/src/components/settings/sections/password-section.tsx
+++ b/src/components/settings/sections/password-section.tsx
@@ -142,7 +142,7 @@ export function PasswordSection() {
 							className="h-10 rounded-lg border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
 						/>
 						{confirmPassword && newPassword !== confirmPassword && (
-							<p className="text-xs text-destructive flex items-center gap-1">
+							<p className="text-xs text-destructive-text flex items-center gap-1">
 								<AlertTriangle className="h-3 w-3" />
 								Passwords do not match
 							</p>
@@ -151,7 +151,7 @@ export function PasswordSection() {
 							newPassword === confirmPassword &&
 							newPassword.length >= VALIDATION_LIMITS.PASSWORD_MIN_LENGTH &&
 							PASSWORD_COMPLEXITY_RE.test(newPassword) && (
-								<p className="text-xs text-primary flex items-center gap-1">
+								<p className="text-xs text-primary-text flex items-center gap-1">
 									<CheckCircle className="h-3 w-3" />
 									Passwords match
 								</p>

--- a/src/components/settings/sections/subscription-cancel-section.tsx
+++ b/src/components/settings/sections/subscription-cancel-section.tsx
@@ -215,7 +215,7 @@ export function SubscriptionCancelSection() {
 	return (
 		<BlurFade delay={0.55} inView>
 			<section className="rounded-lg border border-destructive/20 bg-destructive/5 p-6">
-				<h3 className="mb-4 text-sm font-medium text-destructive uppercase tracking-wider flex items-center gap-2">
+				<h3 className="mb-4 text-sm font-medium text-destructive-text uppercase tracking-wider flex items-center gap-2">
 					<AlertTriangle className="h-4 w-4" aria-hidden="true" />
 					Danger Zone
 				</h3>
@@ -232,7 +232,7 @@ export function SubscriptionCancelSection() {
 							<Button
 								variant="outline"
 								aria-label="Cancel my subscription"
-								className="text-destructive border-destructive/20 hover:bg-destructive/10"
+								className="text-destructive-text border-destructive/20 hover:bg-destructive/10"
 							>
 								Cancel Plan
 							</Button>

--- a/src/components/settings/sections/two-factor-section.tsx
+++ b/src/components/settings/sections/two-factor-section.tsx
@@ -51,7 +51,7 @@ export function TwoFactorSection() {
 								</div>
 							</div>
 							<button
-								className="px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 rounded-lg transition-colors"
+								className="px-3 py-1.5 text-sm font-medium text-destructive-text hover:bg-destructive/10 rounded-lg transition-colors"
 								onClick={() => setShow2FADisable(true)}
 							>
 								Disable

--- a/src/components/settings/sections/two-factor-section.tsx
+++ b/src/components/settings/sections/two-factor-section.tsx
@@ -71,7 +71,7 @@ export function TwoFactorSection() {
 								</div>
 							</div>
 							<button
-								className="px-3 py-1.5 text-sm font-medium text-primary border border-primary/20 rounded-lg hover:bg-primary/10 transition-colors"
+								className="px-3 py-1.5 text-sm font-medium text-primary-text border border-primary/20 rounded-lg hover:bg-primary/10 transition-colors"
 								onClick={() => setShow2FASetup(true)}
 							>
 								Enable

--- a/src/components/settings/security-settings.tsx
+++ b/src/components/settings/security-settings.tsx
@@ -51,7 +51,7 @@ export function SecuritySettings() {
 						Account deletion and data export moved to the{" "}
 						<Link
 							href="/settings?tab=data"
-							className="text-primary hover:underline underline-offset-4"
+							className="text-primary-text hover:underline underline-offset-4"
 						>
 							My Data
 						</Link>{" "}

--- a/src/components/tenants/tenant-detail-sheet-tabs.tsx
+++ b/src/components/tenants/tenant-detail-sheet-tabs.tsx
@@ -142,7 +142,7 @@ export function RecentPaymentsSection({
 				</h3>
 				<button
 					onClick={() => onViewPaymentHistory(tenant.id)}
-					className="text-xs text-primary hover:underline"
+					className="text-xs text-primary-text hover:underline"
 				>
 					View all
 				</button>

--- a/src/components/tenants/tenant-table-row.tsx
+++ b/src/components/tenants/tenant-table-row.tsx
@@ -88,7 +88,7 @@ export function TenantTableRow({
 					<Button
 						variant="ghost"
 						size="sm"
-						className="h-auto p-0 text-primary"
+						className="h-auto p-0 text-primary-text"
 						onClick={() => onViewLease(tenant.id)}
 					>
 						<FileText className="mr-1 h-3.5 w-3.5" />

--- a/src/components/tenants/tenants.tsx
+++ b/src/components/tenants/tenants.tsx
@@ -224,7 +224,7 @@ export function Tenants({
 							</p>
 							<button
 								onClick={clearFilters}
-								className="mt-3 text-sm text-primary hover:underline"
+								className="mt-3 text-sm text-primary-text hover:underline"
 							>
 								Clear filters
 							</button>

--- a/src/components/ui/__tests__/animated-trend-indicator.test.tsx
+++ b/src/components/ui/__tests__/animated-trend-indicator.test.tsx
@@ -80,14 +80,14 @@ describe("AnimatedTrendIndicator", () => {
 			const { container } = render(<AnimatedTrendIndicator value={10} />);
 
 			const span = container.querySelector("span");
-			expect(span).toHaveClass("text-success");
+			expect(span).toHaveClass("text-success-text");
 		});
 
 		it("should apply destructive color for negative values", () => {
 			const { container } = render(<AnimatedTrendIndicator value={-10} />);
 
 			const span = container.querySelector("span");
-			expect(span).toHaveClass("text-destructive");
+			expect(span).toHaveClass("text-destructive-text");
 		});
 
 		it("should apply muted-foreground color for zero value", () => {
@@ -223,7 +223,7 @@ describe("AnimatedTrendIndicator", () => {
 
 			const span = container.querySelector("span");
 			expect(span).toHaveClass("my-custom-class");
-			expect(span).toHaveClass("text-success");
+			expect(span).toHaveClass("text-success-text");
 			expect(span).toHaveClass("inline-flex");
 		});
 	});
@@ -234,7 +234,7 @@ describe("AnimatedTrendIndicator", () => {
 
 			expect(screen.getByText("0.0%")).toBeInTheDocument();
 			const element = screen.getByLabelText("Increased by 0.0%");
-			expect(element).toHaveClass("text-success");
+			expect(element).toHaveClass("text-success-text");
 		});
 
 		it("should handle very small negative values", () => {
@@ -242,7 +242,7 @@ describe("AnimatedTrendIndicator", () => {
 
 			expect(screen.getByText("0.0%")).toBeInTheDocument();
 			const element = screen.getByLabelText("Decreased by 0.0%");
-			expect(element).toHaveClass("text-destructive");
+			expect(element).toHaveClass("text-destructive-text");
 		});
 
 		it("should handle large values", () => {

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
 			variant: {
 				default: "bg-card text-card-foreground",
 				destructive:
-					"text-destructive bg-card [&>svg]:text-current [&_.text-muted-foreground]:text-destructive/90",
+					"text-destructive-text bg-card [&>svg]:text-current [&_.text-muted-foreground]:text-destructive/90",
 			},
 		},
 		defaultVariants: {

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
 			variant: {
 				default: "bg-card text-card-foreground",
 				destructive:
-					"text-destructive-text bg-card [&>svg]:text-current [&_.text-muted-foreground]:text-destructive/90",
+					"text-destructive-text bg-card [&>svg]:text-current [&_.text-muted-foreground]:text-destructive-text/90",
 			},
 		},
 		defaultVariants: {

--- a/src/components/ui/animated-trend-indicator.tsx
+++ b/src/components/ui/animated-trend-indicator.tsx
@@ -51,9 +51,9 @@ export function AnimatedTrendIndicator({
 	const Icon = isPositive ? ArrowUpRight : isNegative ? ArrowDownRight : Minus;
 
 	const colorClass = isPositive
-		? "text-success"
+		? "text-success-text"
 		: isNegative
-			? "text-destructive"
+			? "text-destructive-text"
 			: "text-muted-foreground";
 
 	const animationClass = isPositive

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -20,13 +20,13 @@ const badgeVariants = cva(
 					"text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
 				// Semantic status variants
 				success:
-					"border-success/20 bg-success/10 text-success [a&]:hover:bg-success/15",
+					"border-success/20 bg-success/10 text-success-text [a&]:hover:bg-success/15",
 				warning:
-					"border-warning/20 bg-warning/10 text-warning [a&]:hover:bg-warning/15",
-				info: "border-info/20 bg-info/10 text-info [a&]:hover:bg-info/15",
+					"border-warning/20 bg-warning/10 text-warning-text [a&]:hover:bg-warning/15",
+				info: "border-info/20 bg-info/10 text-info-text [a&]:hover:bg-info/15",
 				// Trust indicator variant
 				trustIndicator:
-					"rounded-full border-primary/20 bg-primary/5 text-primary backdrop-blur-sm",
+					"rounded-full border-primary/20 bg-primary/5 text-primary-text backdrop-blur-sm",
 			},
 			size: {
 				default: "rounded-md px-2 py-0.5 text-xs [&>svg]:size-3 gap-1",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
 				secondary:
 					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground",
-				link: "text-primary underline-offset-4 hover:underline",
+				link: "text-primary-text underline-offset-4 hover:underline",
 			},
 			size: {
 				default: "h-10 px-4 py-2 min-h-11",

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -98,7 +98,7 @@ const DropzoneContent = ({ className }: { className?: string }) => {
 				)}
 			>
 				<CheckCircle size={16} className="text-primary" />
-				<p className="text-primary text-sm">
+				<p className="text-primary-text text-sm">
 					Successfully uploaded {files.length} file{files.length > 1 ? "s" : ""}
 				</p>
 			</div>
@@ -135,7 +135,7 @@ const DropzoneContent = ({ className }: { className?: string }) => {
 								{file.name}
 							</p>
 							{file.errors.length > 0 ? (
-								<p className="text-xs text-destructive">
+								<p className="text-xs text-destructive-text">
 									{file.errors
 										.map((e) =>
 											e.message.startsWith("File is larger than")
@@ -147,11 +147,11 @@ const DropzoneContent = ({ className }: { className?: string }) => {
 							) : loading && !isSuccessfullyUploaded ? (
 								<p className="text-caption">Uploading file...</p>
 							) : fileError ? (
-								<p className="text-xs text-destructive">
+								<p className="text-xs text-destructive-text">
 									Failed to upload: {fileError.message}
 								</p>
 							) : isSuccessfullyUploaded ? (
-								<p className="text-xs text-primary">
+								<p className="text-xs text-primary-text">
 									Successfully uploaded file
 								</p>
 							) : (
@@ -174,7 +174,7 @@ const DropzoneContent = ({ className }: { className?: string }) => {
 				);
 			})}
 			{exceedMaxFiles && (
-				<p className="text-sm text-left mt-2 text-destructive">
+				<p className="text-sm text-left mt-2 text-destructive-text">
 					You may upload only up to {maxFiles} files, please remove{" "}
 					{files.length - maxFiles} file
 					{files.length - maxFiles > 1 ? "s" : ""}.

--- a/src/components/ui/file-upload/file-upload-item.tsx
+++ b/src/components/ui/file-upload/file-upload-item.tsx
@@ -118,7 +118,7 @@ export function FileUploadItemMetadata(props: FileUploadItemMetadataProps) {
 					{itemContext.fileState.error && (
 						<span
 							id={itemContext.messageId}
-							className="text-destructive text-xs"
+							className="text-destructive-text text-xs"
 						>
 							{itemContext.fileState.error}
 						</span>

--- a/src/components/ui/global-sync-indicator.tsx
+++ b/src/components/ui/global-sync-indicator.tsx
@@ -96,7 +96,10 @@ export function GlobalSyncIndicator({
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<div
-						className={cn("flex items-center gap-1.5 text-primary", className)}
+						className={cn(
+							"flex items-center gap-1.5 text-primary-text",
+							className,
+						)}
 					>
 						<Loader2 className="h-4 w-4 animate-spin" />
 						<span className="text-xs">


### PR DESCRIPTION
## Summary

Resolves the deferred **scope-C** work from #768: the app-wide **resting-state** vivid-token-as-text migration. Completes the design-token a11y migration started in #767 (now merged to main).

_(Recreated from the auto-closed #769 after #767 merged and deleted its base branch; same head, now targeting main with a clean scope-C-only diff.)_

## What changed

Every bare `text-{primary,success,warning,destructive,info}` coloring **readable text** now uses its AA-safe `-text` companion — **192 sites across 104 files**. Icons, large display/stat numbers (clear AA-large 3:1), and the two decorative dashboard-mockup illustrations keep the vivid token.

Backed by computed WCAG ratios: as small text, `text-destructive` is **3.29:1 in dark**; `text-success`/`text-warning`/`text-info` are **2.1-3.3:1 in light** — all below AA 4.5:1. Shared primitives fixed once app-wide: `alert`, `badge`, `button` (link), `animated-trend-indicator`.

## Verification

- `typecheck` + `lint` clean; no corruption; full unit suite green (106,327 tests); 3 test files reconciled to the `-text` companions.
- Perfect-PR gate: **two consecutive zero-finding review cycles** on the final commit (5 commits total; the review caught + fixed the `alert` destructive-description `/90` opacity case and the per-token AA-large nuance for large success/warning stats).

Closes #768

[hudsor01]
