### PR TITLE
security: pass-3 SECURITY DEFINER lockdown (revoke anon on is_admin + log_lease_signature_activity)

### DIFF
--- a/.planning/anon-exec-audit/CYCLE-1.md
+++ b/.planning/anon-exec-audit/CYCLE-1.md
@@ -33,11 +33,11 @@ Function takes no user-identifying input; reads `(select auth.uid())` directly a
 
 (`log_lease_signature_activity` is a trigger function — `RETURNS trigger`. Trigger execution doesn't go through GRANT/EXECUTE; the grant on a trigger function is moot. Left as-is in passes 1–2 to avoid noise. **Pass 3 (`20260602044104`) revoked its PUBLIC grant anyway** after confirming it is *orphaned* — no trigger is currently attached, and `RETURNS trigger` means PostgREST can't expose it — so the grant was pure advisor noise. Re-granted `service_role` only.)
 
-### ~~INTENTIONALLY_PUBLIC~~ → REVOKED IN PASS 3 — 1 function
+### ~~INTENTIONALLY_PUBLIC~~ → REVOKED IN PASS 3 — `is_admin` (1 of pass 3's 2; `log_lease_signature_activity` is the other, in NO_PARAM above)
 
 | Function | Cycle-1 disposition (superseded) | Pass-3 correction |
 |---|---|---|
-| `is_admin()` | Kept public: "RLS evaluation needs to call this from any role, including anon. Revoking from anon would break every RLS policy that consults it." | **Disproven against the live schema.** All 6 policies that call `is_admin()` are `{authenticated}`-scoped (`blogs_{insert,update,delete}_admin`, `email_deliverability_admin_select`, "admins can read gate_events", `onboarding_funnel_events_admin_select`) — none apply to anon/public, so anon never evaluates `is_admin()`. The 6 SECURITY DEFINER functions that call it internally invoke it as the function owner and are themselves not anon-executable, so the revoke is inert for them. Pass 3 (`20260602044104`) revokes `FROM PUBLIC` and re-grants `authenticated` + `service_role`; signed-in RLS is unaffected. |
+| `is_admin()` | Kept public: "RLS evaluation needs to call this from any role, including anon. Revoking from anon would break every RLS policy that consults it." | **Disproven against the live schema.** All 6 policies that call `is_admin()` are `{authenticated}`-scoped (`blogs_{insert,update,delete}_admin`, `email_deliverability_admin_select`, "admins can read gate_events", `onboarding_funnel_events_admin_select`) — none apply to anon/public, so anon never evaluates `is_admin()`. Every SECURITY DEFINER function that calls it internally invokes it as the function owner and is itself not anon-executable, so the revoke is inert for them. Pass 3 (`20260602044104`) revokes `FROM PUBLIC` and re-grants `authenticated` + `service_role`; signed-in RLS is unaffected. |
 
 ## Migration plan
 
@@ -68,7 +68,7 @@ Match against migration intent: ✓
 ## Regression-pinning test
 
 `tests/integration/rls/anon-rpc-grants.rls.test.ts` — pins the lockdown state of every function:
-- 22 anon-RPC tests assert `error.code ∈ {42501, 42883, PGRST202}` (PostgREST's three flavors of "revoked") — includes `is_admin` after pass 3
+- 22 anon-RPC tests assert `error.code ∈ {42501, 42883, PGRST202}` (PostgREST's three flavors of "revoked") — includes `is_admin` after pass 3. (`log_lease_signature_activity` is the 23rd anon-revoke but is **not** `.rpc`-pinnable — it `RETURNS trigger`, so PostgREST never exposes it regardless of grant; its grant state is enforced by the migration and re-flagged by the Security Advisor on any anon re-grant.)
 - 2 authenticated-RPC tests assert the IDOR fixes
 - 1 positive test asserts `is_admin()` remains executable by **authenticated** (returns `false` for a non-admin owner) — the RLS-policy contract that requires authenticated to keep EXECUTE
 

--- a/.planning/anon-exec-audit/CYCLE-1.md
+++ b/.planning/anon-exec-audit/CYCLE-1.md
@@ -31,13 +31,13 @@ Function takes no user-identifying input; reads `(select auth.uid())` directly a
 
 `cancel_account_deletion`, `get_user_invoices`, `request_account_deletion`, `log_lease_signature_activity`
 
-(`log_lease_signature_activity` is a trigger function — `RETURNS trigger`. Trigger execution doesn't go through GRANT/EXECUTE; the grant on a trigger function is moot. Left as-is to avoid noise in the migration.)
+(`log_lease_signature_activity` is a trigger function — `RETURNS trigger`. Trigger execution doesn't go through GRANT/EXECUTE; the grant on a trigger function is moot. Left as-is in passes 1–2 to avoid noise. **Pass 3 (`20260602044104`) revoked its PUBLIC grant anyway** after confirming it is *orphaned* — no trigger is currently attached, and `RETURNS trigger` means PostgREST can't expose it — so the grant was pure advisor noise. Re-granted `service_role` only.)
 
-### INTENTIONALLY_PUBLIC — 1 function
+### ~~INTENTIONALLY_PUBLIC~~ → REVOKED IN PASS 3 — 1 function
 
-| Function | Why kept public |
-|---|---|
-| `is_admin()` | Used inside RLS policies. RLS evaluation needs to call this from any role, including anon. Returns `false` for anon because `auth.uid()` is null, so the gate fails safely. Revoking from anon would break every RLS policy that consults it. |
+| Function | Cycle-1 disposition (superseded) | Pass-3 correction |
+|---|---|---|
+| `is_admin()` | Kept public: "RLS evaluation needs to call this from any role, including anon. Revoking from anon would break every RLS policy that consults it." | **Disproven against the live schema.** All 6 policies that call `is_admin()` are `{authenticated}`-scoped (`blogs_{insert,update,delete}_admin`, `email_deliverability_admin_select`, "admins can read gate_events", `onboarding_funnel_events_admin_select`) — none apply to anon/public, so anon never evaluates `is_admin()`. The 6 SECURITY DEFINER functions that call it internally invoke it as the function owner and are themselves not anon-executable, so the revoke is inert for them. Pass 3 (`20260602044104`) revokes `FROM PUBLIC` and re-grants `authenticated` + `service_role`; signed-in RLS is unaffected. |
 
 ## Migration plan
 
@@ -45,8 +45,9 @@ Two-pass migration (matches prod's actual apply chain via MCP):
 
 - `20260529224926_revoke_anon_security_definer_rpcs.sql` — IDOR fixes only. Revoke from `PUBLIC` + `anon` + `authenticated`; grant to `service_role`. Belt-and-suspenders form since Postgres auto-grants EXECUTE to `PUBLIC` and `anon` inherits from `PUBLIC`.
 - `20260529225039_revoke_anon_security_definer_rpcs_v2.sql` — defense-in-depth. Revoke from `PUBLIC` on the 19 functions in GATES_INTERNALLY ∪ NO_PARAM (16 + 3, minus the trigger function `log_lease_signature_activity`); re-grant to `authenticated` + `service_role`.
+- `20260602044104_revoke_anon_security_definer_pass3.sql` — **pass 3.** Revoke `FROM PUBLIC` on the two the prior passes skipped: `is_admin` (re-grant `authenticated` + `service_role`) and `log_lease_signature_activity` (re-grant `service_role`). The skip-reasoning was re-verified against the live schema and disproven (see the REVOKED-IN-PASS-3 correction above).
 
-Total: 21 functions locked down (2 IDOR + 19 defense-in-depth). 1 (`is_admin`) intentionally untouched. 1 (`log_lease_signature_activity`) skipped as moot.
+Total: 23 functions revoked from anon (2 IDOR + 19 defense-in-depth + `is_admin` + `log_lease_signature_activity`). `is_admin` and the 19 keep `authenticated`; the 2 IDOR + `log_lease_signature_activity` are `service_role`-only.
 
 ## Verification (cross-checked post-apply)
 
@@ -59,17 +60,17 @@ FROM pg_proc WHERE prosecdef AND pronamespace='public'::regnamespace AND ...
 |---|---|---|---|---|
 | IDOR fixes | 2 | ✗ | ✗ | ✓ |
 | Defense-in-depth (16 gated + 3 no-param) | 19 | ✗ | ✓ | ✓ |
-| `is_admin` (intentionally public) | 1 | ✓ | ✓ | ✓ |
-| `log_lease_signature_activity` (trigger; grant moot) | 1 | n/a | n/a | n/a |
+| `is_admin` (pass 3: revoked from anon; RLS keeps authenticated) | 1 | ✗ | ✓ | ✓ |
+| `log_lease_signature_activity` (pass 3: orphaned trigger fn, locked to service_role) | 1 | ✗ | ✗ | ✓ |
 
 Match against migration intent: ✓
 
 ## Regression-pinning test
 
 `tests/integration/rls/anon-rpc-grants.rls.test.ts` — pins the lockdown state of every function:
-- 21 anon-RPC tests assert `error.code ∈ {42501, 42883, PGRST202}` (PostgREST's three flavors of "revoked")
+- 22 anon-RPC tests assert `error.code ∈ {42501, 42883, PGRST202}` (PostgREST's three flavors of "revoked") — includes `is_admin` after pass 3
 - 2 authenticated-RPC tests assert the IDOR fixes
-- 1 positive test asserts `is_admin()` is still anon-callable and returns `false`
+- 1 positive test asserts `is_admin()` remains executable by **authenticated** (returns `false` for a non-admin owner) — the RLS-policy contract that requires authenticated to keep EXECUTE
 
 Runs against prod under the existing dual-client `rls-security` CI job.
 
@@ -88,6 +89,6 @@ Runs against prod under the existing dual-client `rls-security` CI job.
 2. **`IS DISTINCT FROM` belt-and-suspenders** on the in-body guard pattern. The 16 GATES_INTERNALLY functions use `IF p_id != (select auth.uid())`. NULL-vs-NULL comparison evaluates to NULL, IF doesn't fire. Role-level revoke (this PR) is the primary fix; in-body guard tightening is defense-in-depth. Source: cycle-3 WR-03.
 3. **Extract `REVOKED_CODES` to a shared test helper.** The literal `["42501", "42883", "PGRST202"]` is duplicated across 4 test files. It already drifted once during this PR's cycle-2. Source: cycle-3 INF-01.
 4. **Supabase "Grace period is over" billing banner.** Surfaced by the browser audit agent during the FRONTEND_URL rollout. Functions are serving fine but the project is at/near quota. Needs billing attention before quota actually blocks service. Source: Supabase Claude browser agent report, 2026-05-29.
-5. **Trigger-function grant cleanup** on `log_lease_signature_activity` and similar. Moot for security (triggers don't go through EXECUTE checks) but worth tidying.
+5. ~~**Trigger-function grant cleanup** on `log_lease_signature_activity` and similar.~~ **Done in pass 3** (`20260602044104`) — revoked its PUBLIC grant after confirming it is orphaned (no trigger attached, `RETURNS trigger` so not PostgREST-callable).
 
 Each item is independently scoped and can ship as its own perfect-PR.

--- a/.planning/repo-audit/AUDIT-2026-05-29.md
+++ b/.planning/repo-audit/AUDIT-2026-05-29.md
@@ -117,7 +117,7 @@ Branch `gsd/post-749-cleanup-review`. Synthesized from verified findings; every 
 - ✅ Coverage threshold (80%) real and wired to lefthook pre-commit.
 - ✅ Skip-link, mobile-sidebar Escape+focus-trap, breadcrumb `aria-label` all compliant.
 - ✅ `bg-white` usages intentional (QR-code contrast), documented.
-- ✅ PR #758 anon-EXEC lockdown complete; 2 remaining anon-executable fns (`is_admin`, `log_lease_signature_activity`) intentional + documented.
+- ✅ PR #758 anon-EXEC lockdown complete. **Superseded 2026-06-02:** the 2 then-remaining anon-executable fns (`is_admin`, `log_lease_signature_activity`) were revoked in pass 3 (migration `20260602044104`) after the "intentional" rationale was disproven — all 6 policies calling `is_admin()` are `{authenticated}`-scoped, so anon never needed it.
 - ✅ 11 RLS-enabled-no-policy tables = intentional fail-closed default-deny; suggested "deny-all" fix would re-introduce the rule just removed in `20260527151342`. Don't re-file.
 - Third-party GitHub Actions pinned by mutable tags, not SHA (`claude-code-action@v1` runs `id-token: write`). Pin to commit SHAs.
 - 14 security `overrides` in `package.json:61-91` pin packages not in the tree (dead no-ops). Delete or document.

--- a/supabase/migrations/20260602044104_revoke_anon_security_definer_pass3.sql
+++ b/supabase/migrations/20260602044104_revoke_anon_security_definer_pass3.sql
@@ -11,17 +11,20 @@
 --     policies, all {authenticated}). anon never evaluates an is_admin() policy,
 --     so the PUBLIC grant is pure attack surface: a direct PostgREST /rpc/is_admin
 --     probe that leaks function existence and only ever returns false for anon.
---     The 6 SECURITY DEFINER functions that call is_admin() internally invoke it
---     as the function owner (not the caller) and are themselves not anon-executable,
---     so revoking anon is inert for them. authenticated keeps EXECUTE, so RLS
---     evaluation for signed-in users is unchanged.
+--     Every SECURITY DEFINER function that calls is_admin() internally invokes it
+--     as the function owner (not the caller) and is itself not anon-executable, so
+--     revoking anon is inert for them. authenticated KEEPS EXECUTE so RLS evaluation
+--     for signed-in users is unchanged -- which means is_admin stays flagged as
+--     `authenticated_security_definer_function_executable` BY DESIGN (that lint is
+--     expected for any SECURITY DEFINER function authenticated must reach via RLS).
+--     Pass 3 only clears the *anon*-executable lint, not the authenticated one.
 --
 --   * log_lease_signature_activity(): pass 2 kept it PUBLIC on "trigger function,
 --     EXECUTE is moot." Trigger firing indeed bypasses EXECUTE checks, but the
 --     function has NO trigger currently attached (orphaned) and the PUBLIC grant
 --     still places it on the role surface the Security Advisor flags. It returns
---     `trigger` so PostgREST will not expose it, but the grant is removed for
---     hygiene and to clear the advisor finding.
+--     `trigger` so PostgREST will not expose it. With no anon and no authenticated
+--     grant and no trigger attached, it drops out of the advisor entirely.
 --
 -- REVOKE FROM PUBLIC is load-bearing: Postgres auto-grants EXECUTE to PUBLIC at
 -- function creation and anon inherits it, so a bare REVOKE FROM anon is a no-op

--- a/supabase/migrations/20260602044104_revoke_anon_security_definer_pass3.sql
+++ b/supabase/migrations/20260602044104_revoke_anon_security_definer_pass3.sql
@@ -1,0 +1,35 @@
+-- Pass 3 of the SECURITY DEFINER lockdown -- closes the two functions that
+-- passes 1 (20260529224926) and 2 (20260529225039) intentionally skipped,
+-- after re-verifying the skip-reasoning against the live schema and disproving
+-- both assumptions.
+--
+--   * is_admin(): pass 2 kept it PUBLIC on the assumption "RLS needs to call it
+--     from any role, including anon." Not true here: every policy that calls
+--     is_admin() is scoped to the `authenticated` role only -- blogs_insert_admin,
+--     blogs_update_admin, blogs_delete_admin, email_deliverability_admin_select,
+--     "admins can read gate_events", onboarding_funnel_events_admin_select (6
+--     policies, all {authenticated}). anon never evaluates an is_admin() policy,
+--     so the PUBLIC grant is pure attack surface: a direct PostgREST /rpc/is_admin
+--     probe that leaks function existence and only ever returns false for anon.
+--     The 6 SECURITY DEFINER functions that call is_admin() internally invoke it
+--     as the function owner (not the caller) and are themselves not anon-executable,
+--     so revoking anon is inert for them. authenticated keeps EXECUTE, so RLS
+--     evaluation for signed-in users is unchanged.
+--
+--   * log_lease_signature_activity(): pass 2 kept it PUBLIC on "trigger function,
+--     EXECUTE is moot." Trigger firing indeed bypasses EXECUTE checks, but the
+--     function has NO trigger currently attached (orphaned) and the PUBLIC grant
+--     still places it on the role surface the Security Advisor flags. It returns
+--     `trigger` so PostgREST will not expose it, but the grant is removed for
+--     hygiene and to clear the advisor finding.
+--
+-- REVOKE FROM PUBLIC is load-bearing: Postgres auto-grants EXECUTE to PUBLIC at
+-- function creation and anon inherits it, so a bare REVOKE FROM anon is a no-op
+-- while the PUBLIC grant stands. Each block revokes PUBLIC then re-grants the
+-- roles that legitimately need it.
+
+REVOKE EXECUTE ON FUNCTION public.is_admin() FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.is_admin() TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.log_lease_signature_activity() FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.log_lease_signature_activity() TO service_role;

--- a/tests/integration/rls/anon-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/anon-rpc-grants.rls.test.ts
@@ -156,8 +156,10 @@ const REVOKED_FROM_ANON: Array<{
 // intentionally NOT pinned in this list: it `RETURNS trigger`, so PostgREST never
 // exposes it as an RPC -- an anon `.rpc()` probe returns PGRST202 regardless of the
 // grant (a tautology, not a real assertion). Its grant state (service_role only) is
-// enforced by migration 20260602044104 and re-flagged by the Supabase Security
-// Advisor on any anon/PUBLIC re-grant, which is the actual regression backstop.
+// enforced by migration 20260602044104 and monitored out-of-band by the Supabase
+// Security Advisor (which re-flags any anon/PUBLIC re-grant). Note: no CI job runs
+// the advisor, so this suite would NOT catch such a re-grant -- the advisor is the
+// monitoring backstop, not an in-CI gate.
 
 /** Functions also revoked from authenticated (the two IDOR fixes). */
 const REVOKED_FROM_AUTHENTICATED: Array<{

--- a/tests/integration/rls/anon-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/anon-rpc-grants.rls.test.ts
@@ -156,10 +156,8 @@ const REVOKED_FROM_ANON: Array<{
 // intentionally NOT pinned in this list: it `RETURNS trigger`, so PostgREST never
 // exposes it as an RPC -- an anon `.rpc()` probe returns PGRST202 regardless of the
 // grant (a tautology, not a real assertion). Its grant state (service_role only) is
-// enforced by migration 20260602044104 and monitored out-of-band by the Supabase
-// Security Advisor (which re-flags any anon/PUBLIC re-grant). Note: no CI job runs
-// the advisor, so this suite would NOT catch such a re-grant -- the advisor is the
-// monitoring backstop, not an in-CI gate.
+// enforced by migration 20260602044104 and monitored by the Supabase Security
+// Advisor, which re-flags any anon/PUBLIC re-grant.
 
 /** Functions also revoked from authenticated (the two IDOR fixes). */
 const REVOKED_FROM_AUTHENTICATED: Array<{

--- a/tests/integration/rls/anon-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/anon-rpc-grants.rls.test.ts
@@ -152,6 +152,13 @@ const REVOKED_FROM_ANON: Array<{
 	{ name: "is_admin" },
 ];
 
+// Pass 3 also revoked `log_lease_signature_activity` FROM PUBLIC, but it is
+// intentionally NOT pinned in this list: it `RETURNS trigger`, so PostgREST never
+// exposes it as an RPC -- an anon `.rpc()` probe returns PGRST202 regardless of the
+// grant (a tautology, not a real assertion). Its grant state (service_role only) is
+// enforced by migration 20260602044104 and re-flagged by the Supabase Security
+// Advisor on any anon/PUBLIC re-grant, which is the actual regression backstop.
+
 /** Functions also revoked from authenticated (the two IDOR fixes). */
 const REVOKED_FROM_AUTHENTICATED: Array<{
 	name: string;

--- a/tests/integration/rls/anon-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/anon-rpc-grants.rls.test.ts
@@ -10,20 +10,27 @@
  *   - 20260529225039_revoke_anon_security_definer_rpcs_v2.sql
  *     (defense-in-depth: revoke FROM PUBLIC on 19 functions that gate on
  *      auth.uid() internally; re-grant to authenticated + service_role)
+ *   - 20260602044104_revoke_anon_security_definer_pass3.sql
+ *     (pass 3: revoke FROM PUBLIC on `is_admin` and `log_lease_signature_activity`
+ *      -- the two functions pass 2 deliberately skipped. Every policy calling
+ *      is_admin() is {authenticated}-scoped, so anon never evaluates it;
+ *      authenticated keeps EXECUTE so RLS is unaffected.)
  *
  * Three contracts pinned here:
  *
- *   1. ANON cannot reach any of the 21 revoked functions. PostgREST surfaces
- *      a revoked EXECUTE as 42501 in current versions; older variants
- *      returned 42883 / PGRST202. Accept any of the three so the test pins
- *      "function is unreachable from anon", not a specific error code.
+ *   1. ANON cannot reach any of the 22 revoked functions (incl. is_admin after
+ *      pass 3). PostgREST surfaces a revoked EXECUTE as 42501 in current
+ *      versions; older variants returned 42883 / PGRST202. Accept any of the
+ *      three so the test pins "function is unreachable from anon", not a code.
  *
  *   2. AUTHENTICATED cannot reach the two IDOR functions
  *      (`confirm_lease_subscription`, `get_user_plan_limits`). Same code set.
  *
- *   3. `is_admin()` IS still callable by anon — it lives inside RLS policy
- *      evaluation contexts and MUST remain executable from any role. Returns
- *      false for anon because `auth.uid()` is null.
+ *   3. `is_admin()` remains executable by AUTHENTICATED (the RLS policy
+ *      contract -- 6 {authenticated}-scoped policies call it) and returns false
+ *      for a non-admin owner. anon can no longer call it (contract 1): pass 2's
+ *      assumption that "RLS needs anon to call is_admin" did not hold for this
+ *      schema -- no anon/public policy references it.
  *
  * The classification spreadsheet lives at
  * `.planning/anon-exec-audit/CYCLE-1.md` and is the source of truth for
@@ -45,7 +52,7 @@ if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
 
 const REVOKED_CODES = ["42501", "42883", "PGRST202"];
 
-/** Functions revoked from anon (21 total: 2 IDOR + 19 defense-in-depth). */
+/** Functions revoked from anon (22 total: 2 IDOR + 19 defense-in-depth + is_admin via pass 3). */
 const REVOKED_FROM_ANON: Array<{
 	name: string;
 	args?: Record<string, unknown>;
@@ -140,6 +147,9 @@ const REVOKED_FROM_ANON: Array<{
 		args: { p_user_id: "00000000-0000-0000-0000-000000000000" },
 	},
 	{ name: "request_account_deletion" },
+	// Pass 3: is_admin() takes no args and was revoked FROM PUBLIC. anon now
+	// hits a revoked-EXECUTE code instead of getting `false` back.
+	{ name: "is_admin" },
 ];
 
 /** Functions also revoked from authenticated (the two IDOR fixes). */
@@ -192,9 +202,12 @@ describe("anon-EXEC SECURITY DEFINER lockdown", () => {
 		}
 	});
 
-	describe("is_admin() remains anon-executable (RLS policy contract)", () => {
-		it("anon can call is_admin and gets false (auth.uid() is null)", async () => {
-			const { data, error } = await anonClient.rpc("is_admin");
+	describe("is_admin() pass-3: authenticated retains EXECUTE (RLS policy contract)", () => {
+		it("authenticated can still call is_admin and gets false (non-admin owner)", async () => {
+			// The 6 policies that call is_admin() are all {authenticated}-scoped,
+			// so authenticated MUST keep EXECUTE for RLS to evaluate. ownerA is not
+			// an admin, so it returns false (not an error).
+			const { data, error } = await authnClient.rpc("is_admin");
 			expect(error).toBeNull();
 			expect(data).toBe(false);
 		});


### PR DESCRIPTION
## Summary

Completes the SECURITY DEFINER least-privilege lockdown by revoking anon `EXECUTE` on the **last 2** functions the Security Advisor flagged as `anon_security_definer_function_executable` — `is_admin()` and `log_lease_signature_activity()`. Passes 1 + 2 (`20260529*`) handled 21 functions but **deliberately skipped these 2**; re-verifying against the live schema **disproved both skip-reasons**.

## Why the prior skips were wrong

**`is_admin()`** — pass 2 kept it PUBLIC assuming "RLS needs anon to call it." But all **6** policies that call `is_admin()` are `{authenticated}`-scoped:

```
blogs_insert_admin / blogs_update_admin / blogs_delete_admin
email_deliverability_admin_select
"admins can read gate_events"
onboarding_funnel_events_admin_select
```

anon never evaluates an `is_admin()` policy, so the PUBLIC grant was pure attack surface (a direct `/rpc/is_admin` probe that leaks function existence and only returns `false`). The 6 SECURITY DEFINER functions that call `is_admin()` internally invoke it **as the owner**, not the caller, and are not anon-executable — so revoking anon is inert for them. `authenticated` keeps `EXECUTE`, so RLS for signed-in users is unchanged.

**`log_lease_signature_activity()`** — pass 2 kept it PUBLIC as "trigger fn, EXECUTE moot." Trigger firing does bypass EXECUTE, but the function has **no trigger attached** (orphaned) and returns `trigger` (so PostgREST cannot expose it). The grant is removed for hygiene + to clear the advisor.

## Verification

- Grants after: `is_admin` → anon=`false`, authenticated=`true`, service_role=`true`; `log_lease_signature_activity` → anon/authenticated=`false`, service_role=`true`.
- Security Advisor `anon_security_definer_function_executable`: **2 → 0** (the 46 `authenticated_*` warnings are the legit RPCs + RLS helpers, correctly untouched).
- Migration `20260602044104` applied to prod via MCP (timestamp reconciled per repo convention).
- `anon-rpc-grants.rls.test.ts` updated: `is_admin` moved into the anon-revoked set; the old contract-3 (which pinned the now-disproven anon-executable assumption) replaced with "authenticated retains EXECUTE." `rls-security` CI runs it against prod.

[hudsor01]
