### PR TITLE
Phase 7: Verification — /dashboard E2E smoke + token sweep (closes v2.0 34/34)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -74,7 +74,7 @@ Each maps to roadmap phases (1-7). Source: `.planning/MILESTONE-CONTEXT.md` § "
 - [x] **POLISH-09**: E2E smoke for `/dashboard` (synthetic owner; KPI numbers match `get_dashboard_data_v2`; occupancy donut matches `stats.units`; DataTable sort/filter/column-visibility/preset save+restore work; grid/table toggle works).
 - [ ] **POLISH-10**: Phase-2 additive `get_dashboard_data_v2` migration for per-property `open_maintenance` (or ship the column hidden by default if the RPC change is too invasive). RLS owner-isolation test extends the existing dual-client pattern in `tests/integration/rls/`.
 - [ ] **POLISH-11**: `collection_rate` — resolve compute-or-drop in Phase 2 discuss-phase. TenantFlow demolished rent facilitation; the field is likely uncomputable and should be dropped from the KPI set rather than fabricated as `0`. **Never fabricate a metric.**
-- [ ] **POLISH-12**: Final design-token sweep across every new dashboard file — `design-token-drift.test.ts` must stay green.
+- [x] **POLISH-12**: Final design-token sweep across every new dashboard file — `design-token-drift.test.ts` must stay green.
 
 ## Future Requirements
 
@@ -137,7 +137,7 @@ Updated by `gsd-roadmapper` during roadmap creation. See ROADMAP.md for canonica
 | POLISH-09 | Phase 7 | Complete |
 | POLISH-10 | Phase 2 | Complete |
 | POLISH-11 | Phase 2 | Complete |
-| POLISH-12 | Phase 7 | Pending |
+| POLISH-12 | Phase 7 | Complete |
 
 **Coverage:**
 - v2 requirements: 34 total (KPI: 7, CHART: 6, DT: 9, POLISH: 12)

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -71,7 +71,7 @@ Each maps to roadmap phases (1-7). Source: `.planning/MILESTONE-CONTEXT.md` § "
 - [x] **POLISH-06**: 375px responsive — zero horizontal scroll; portfolio table forces grid view at the mobile breakpoint.
 - [x] **POLISH-07**: Skeleton ↔ empty-state mutual exclusion (Phase 14 D-04 pattern: route-scoped `loading.tsx` if streaming is involved; never co-render skeleton + empty state).
 - [x] **POLISH-08**: Reduced-motion guard on every animation (`NumberTicker`, `BlurFade`, chart transitions, any CSS animation).
-- [ ] **POLISH-09**: E2E smoke for `/dashboard` (synthetic owner; KPI numbers match `get_dashboard_data_v2`; occupancy donut matches `stats.units`; DataTable sort/filter/column-visibility/preset save+restore work; grid/table toggle works).
+- [x] **POLISH-09**: E2E smoke for `/dashboard` (synthetic owner; KPI numbers match `get_dashboard_data_v2`; occupancy donut matches `stats.units`; DataTable sort/filter/column-visibility/preset save+restore work; grid/table toggle works).
 - [ ] **POLISH-10**: Phase-2 additive `get_dashboard_data_v2` migration for per-property `open_maintenance` (or ship the column hidden by default if the RPC change is too invasive). RLS owner-isolation test extends the existing dual-client pattern in `tests/integration/rls/`.
 - [ ] **POLISH-11**: `collection_rate` — resolve compute-or-drop in Phase 2 discuss-phase. TenantFlow demolished rent facilitation; the field is likely uncomputable and should be dropped from the KPI set rather than fabricated as `0`. **Never fabricate a metric.**
 - [ ] **POLISH-12**: Final design-token sweep across every new dashboard file — `design-token-drift.test.ts` must stay green.
@@ -134,7 +134,7 @@ Updated by `gsd-roadmapper` during roadmap creation. See ROADMAP.md for canonica
 | POLISH-06 | Phase 6 | Complete |
 | POLISH-07 | Phase 6 | Complete |
 | POLISH-08 | Phase 6 | Complete |
-| POLISH-09 | Phase 7 | Pending |
+| POLISH-09 | Phase 7 | Complete |
 | POLISH-10 | Phase 2 | Complete |
 | POLISH-11 | Phase 2 | Complete |
 | POLISH-12 | Phase 7 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -44,7 +44,7 @@ Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region 
 - [x] **Phase 4: Charts** — `RevenueAreaChart` refresh (30d/6mo toggle) + new `OccupancyDonutChart`. Adds Section C.
 - [x] **Phase 5: Portfolio DataTable** — Replace hand-rolled table with DiceUI DataTable: client hook, column model, faceted filter, column visibility, virtualization, grid/table toggle, saved presets, nuqs URL state.
 - [ ] **Phase 6: Polish & A11y** — Dark-mode audit, keyboard a11y, 375px responsive, skeleton/empty mutual exclusion, reduced-motion.
-- [ ] **Phase 7: Verification** — E2E coverage for `/dashboard` + final design-token sweep.
+- [x] **Phase 7: Verification** — E2E coverage for `/dashboard` + final design-token sweep.
 
 ## Phase Details
 
@@ -160,7 +160,9 @@ Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region 
   4. The merged PR closes the v2.0 milestone with 34/34 requirements satisfied per traceability.
 **Plans:** 2 plans (2 waves)
 - [x] 07-01-PLAN.md — **Wave 1.** POLISH-09 `/dashboard` E2E smoke under the CI-run `owner-axe` project (in-test `loginAsOwner`, no storageState): KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset save+restore + grid/table toggle. New `dashboard-rpc-helpers.ts` derives expected values from the authed RPC; `owner-axe` `testMatch` widened to collect it.
-- [ ] 07-02-PLAN.md — **Wave 2** (depends on 07-01). POLISH-12 design-token sweep verification across every new dashboard file (the drift test already walks `src/components/**` + `src/app/**`) + removal of the stale Phase-1 `dashboard-filters.tsx` exemption; milestone close: flip POLISH-09 + POLISH-12 traceability to satisfied (34/34). Ships as one atomic PR through the perfect-PR gate.
+- [x] 07-02-PLAN.md — **Wave 2** (depends on 07-01). POLISH-12 design-token sweep verification across every new dashboard file (the drift test already walks `src/components/**` + `src/app/**`) + removal of the stale Phase-1 `dashboard-filters.tsx` exemption; milestone close: flip POLISH-09 + POLISH-12 traceability to satisfied (34/34). Ships as one atomic PR through the perfect-PR gate.
+
+Phase 7 ships as one atomic PR through the perfect-PR gate (two consecutive zero-finding deep review cycles), per the milestone's cross-cutting "Independently shippable" constraint, closing v2.0 at 34/34 requirements satisfied.
 
 ## Progress
 
@@ -172,7 +174,7 @@ Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region 
 | 4. Charts | v2.0 | 4/4 | Shipped (PR #748) | 2026-05-28 |
 | 5. Portfolio DataTable | v2.0 | 5/5 | Shipped (PR #763) | 2026-05-31 |
 | 6. Polish & A11y | v2.0 | 4/4 | Complete   | 2026-06-01 |
-| 7. Verification | v2.0 | 1/2 | In Progress|  |
+| 7. Verification | v2.0 | 2/2 | Complete   | 2026-06-02 |
 
 ## Coverage Validation
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -158,7 +158,9 @@ Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region 
   2. `bun run test:e2e` passes locally and the GitHub `e2e-smoke` check passes on the Phase 7 PR.
   3. `design-token-drift.test.ts` runs clean over every new dashboard file (no hex, no rgb, no `bg-white`, no inline ms durations).
   4. The merged PR closes the v2.0 milestone with 34/34 requirements satisfied per traceability.
-**Plans:** TBD
+**Plans:** 2 plans (2 waves)
+- [ ] 07-01-PLAN.md — **Wave 1.** POLISH-09 `/dashboard` E2E smoke under the CI-run `owner-axe` project (in-test `loginAsOwner`, no storageState): KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset save+restore + grid/table toggle. New `dashboard-rpc-helpers.ts` derives expected values from the authed RPC; `owner-axe` `testMatch` widened to collect it.
+- [ ] 07-02-PLAN.md — **Wave 2** (depends on 07-01). POLISH-12 design-token sweep verification across every new dashboard file (the drift test already walks `src/components/**` + `src/app/**`) + removal of the stale Phase-1 `dashboard-filters.tsx` exemption; milestone close: flip POLISH-09 + POLISH-12 traceability to satisfied (34/34). Ships as one atomic PR through the perfect-PR gate.
 
 ## Progress
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -159,7 +159,7 @@ Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region 
   3. `design-token-drift.test.ts` runs clean over every new dashboard file (no hex, no rgb, no `bg-white`, no inline ms durations).
   4. The merged PR closes the v2.0 milestone with 34/34 requirements satisfied per traceability.
 **Plans:** 2 plans (2 waves)
-- [ ] 07-01-PLAN.md — **Wave 1.** POLISH-09 `/dashboard` E2E smoke under the CI-run `owner-axe` project (in-test `loginAsOwner`, no storageState): KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset save+restore + grid/table toggle. New `dashboard-rpc-helpers.ts` derives expected values from the authed RPC; `owner-axe` `testMatch` widened to collect it.
+- [x] 07-01-PLAN.md — **Wave 1.** POLISH-09 `/dashboard` E2E smoke under the CI-run `owner-axe` project (in-test `loginAsOwner`, no storageState): KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset save+restore + grid/table toggle. New `dashboard-rpc-helpers.ts` derives expected values from the authed RPC; `owner-axe` `testMatch` widened to collect it.
 - [ ] 07-02-PLAN.md — **Wave 2** (depends on 07-01). POLISH-12 design-token sweep verification across every new dashboard file (the drift test already walks `src/components/**` + `src/app/**`) + removal of the stale Phase-1 `dashboard-filters.tsx` exemption; milestone close: flip POLISH-09 + POLISH-12 traceability to satisfied (34/34). Ships as one atomic PR through the perfect-PR gate.
 
 ## Progress
@@ -172,7 +172,7 @@ Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region 
 | 4. Charts | v2.0 | 4/4 | Shipped (PR #748) | 2026-05-28 |
 | 5. Portfolio DataTable | v2.0 | 5/5 | Shipped (PR #763) | 2026-05-31 |
 | 6. Polish & A11y | v2.0 | 4/4 | Complete   | 2026-06-01 |
-| 7. Verification | v2.0 | 0/0 | Not started | - |
+| 7. Verification | v2.0 | 1/2 | In Progress|  |
 
 ## Coverage Validation
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v2.0
 milestone_name: Dashboard Command Center
 status: "Phase 6 shipped — PR #767"
-last_updated: "2026-06-01T18:20:06.328Z"
+last_updated: "2026-06-02T17:08:00.969Z"
 last_activity: 2026-06-01
 progress:
   total_phases: 7
-  completed_phases: 5
-  total_plans: 22
-  completed_plans: 22
-  percent: 71
+  completed_phases: 6
+  total_plans: 24
+  completed_plans: 23
+  percent: 86
 ---
 
 # Project State
@@ -58,6 +58,7 @@ Last activity: 2026-06-01
 | 7 | TBD | Not started | gsd/phase-7-dashboard-verification | — | — |
 
 Plan-level durations (Phase 6): P01 2min, P02 —, P03 —, P04 4min (3 tasks, 2 files).
+| Phase 07 P01 | 25m | 3 tasks | 3 files |
 
 ## Locked Decisions (see PROJECT.md Key Decisions for full table)
 

--- a/.planning/phases/07-verification/07-01-PLAN.md
+++ b/.planning/phases/07-verification/07-01-PLAN.md
@@ -1,0 +1,229 @@
+---
+phase: 07-verification
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/e2e/dashboard-rpc-helpers.ts
+  - tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts
+  - tests/e2e/playwright.config.ts
+autonomous: true
+requirements: [POLISH-09]
+must_haves:
+  truths:
+    - "The Playwright suite includes a /dashboard smoke spec that authenticates a synthetic owner in-test and asserts KPI numbers match get_dashboard_data_v2, the occupancy donut matches stats.units, DataTable sort/filter/column-visibility/preset-save+restore work, and the grid/table toggle works."
+    - "The new smoke spec is collected by the CI-run owner-axe project (in-test loginAsOwner, no storageState) so it executes on the Phase 7 PR's e2e-smoke check — not the storageState owner project, which CI does not run."
+    - "KPI and donut assertions compare the rendered DOM to live RPC values (data-shape tolerant), not hardcoded numbers, so a zero-data synthetic owner does not produce a false failure."
+  artifacts:
+    - path: "tests/e2e/dashboard-rpc-helpers.ts"
+      provides: "Reusable authed get_dashboard_data_v2 fetch (same Supabase token API as auth-helpers) returning the typed dashboard payload for in-test DOM comparison"
+      min_lines: 40
+    - path: "tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts"
+      provides: "POLISH-09 /dashboard smoke spec under owner-axe (in-test loginAsOwner)"
+      min_lines: 120
+  key_links:
+    - from: "tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts"
+      to: "tests/e2e/auth-helpers.ts"
+      via: "loginAsOwner in-test auth (owner-axe pattern)"
+      pattern: "loginAsOwner"
+    - from: "tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts"
+      to: "tests/e2e/dashboard-rpc-helpers.ts"
+      via: "fetchDashboardDataAsOwner for RPC-vs-DOM comparison"
+      pattern: "fetchDashboardDataAsOwner"
+    - from: "tests/e2e/playwright.config.ts"
+      to: "tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts"
+      via: "owner-axe testMatch collects the smoke spec; owner/firefox/mobile-chrome testIgnore exclude it"
+      pattern: "dashboard-smoke"
+---
+
+<objective>
+Add the POLISH-09 `/dashboard` E2E smoke test for the v2.0 redesigned dashboard against a synthetic owner with real prod data, and wire it into the CI-run Playwright project so it actually executes on the Phase 7 PR.
+
+Purpose: POLISH-09 requires an E2E smoke that proves the v2.0 dashboard surfaces work end to end — KPI numbers match `get_dashboard_data_v2`, the occupancy donut matches `stats.units`, the DataTable sort/filter/column-visibility/preset save+restore work, and the grid/table toggle works. Success criterion #2 requires the GitHub `e2e-smoke` check to pass on this PR, which means the test must run under a CI-executed project.
+
+Output: a reusable authed-RPC fetch helper, a new `dashboard-smoke.e2e.spec.ts`, and a Playwright config change that routes the smoke spec into the `owner-axe` project (the only authed dashboard project CI runs).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/06-polish-a11y/06-04-SUMMARY.md
+
+# Reconciliation decision (READ FIRST — this drives every choice below)
+#
+# DO NOT extend tests/e2e/tests/owner/owner-dashboard.e2e.spec.ts. That spec:
+#   (a) asserts on OLD pre-v2.0 surfaces ("Total Tenants", "Rent Collection",
+#       generic getByRole("table"), the "Quick Create" button) that the v2.0
+#       redesign removed/replaced — it is legacy and out of scope here, and
+#   (b) runs under the storageState `owner` project, which CI's e2e-smoke job
+#       DOES NOT RUN. CI runs only: --project=smoke --project=public
+#       --project=owner-axe  (see .github/workflows/ci-cd.yml "Run E2E smoke
+#       tests" step). A smoke test placed in the `owner` project would pass
+#       locally via `bun run test:e2e` but never gate the PR. POLISH-09 success
+#       criterion #2 explicitly requires the e2e-smoke CHECK to pass.
+#
+# Therefore: add a NEW focused dashboard-smoke.e2e.spec.ts that authenticates
+# in-test via loginAsOwner (the owner-axe pattern, NO storageState) and is
+# collected by the owner-axe project. The existing owner-dashboard spec is left
+# untouched (it still runs in the local `owner`/`firefox`/`mobile-chrome`
+# projects via `bun run test:e2e`, which is fine — it is not a Phase 7 concern).
+
+# Auth + RPC infrastructure to reuse (DO NOT re-implement):
+@tests/e2e/auth-helpers.ts
+@tests/e2e/tests/owner/dashboard-a11y.e2e.spec.ts
+@tests/e2e/playwright.config.ts
+
+# The v2.0 dashboard surfaces under test (selectors + the RPC contract):
+@src/hooks/api/use-owner-dashboard.ts
+@src/components/dashboard/components/kpi-bento-row.tsx
+@src/components/dashboard/components/occupancy-donut-chart.tsx
+@src/components/dashboard/components/portfolio-data-table-toolbar.tsx
+@src/components/dashboard/components/portfolio-preset-menu.tsx
+@src/components/dashboard/components/portfolio-columns.tsx
+
+<interfaces>
+<!-- Contracts the executor needs. Extracted from the codebase — use directly, no exploration. -->
+
+The RPC (src/hooks/api/use-owner-dashboard.ts):
+  supabase.rpc("get_dashboard_data_v2", { p_user_id: user.id })
+  returns: { stats, trends, time_series, property_performance, activities }
+  stats.units: { total, occupied, vacant, occupancyRate, ... }   (src/types/stats.ts UnitStats)
+  stats.revenue: { monthly, yearly, growth }
+  stats.leases: { active, expiringSoon, ... }
+  stats.maintenance: { open, ... }
+  stats.properties: { total, ... }
+
+Auth (tests/e2e/auth-helpers.ts):
+  export async function loginAsOwner(page, options?) — authenticates via the
+    Supabase /auth/v1/token password grant, injects the @supabase/ssr session as
+    cookies onto the context, navigates to /dashboard, and throws an actionable
+    error if redirected to /login (bad session) or /pricing (subscription gate).
+  The synthetic owner email/password come from E2E_OWNER_EMAIL / E2E_OWNER_PASSWORD
+  (the password helper un-escapes `\!` -> `!`); the Supabase URL + publishable key
+  come from TEST_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL and
+  TEST_SUPABASE_PUBLISHABLE_KEY/NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY.
+
+Stable DOM selectors on the v2.0 dashboard (verified in the component source):
+  - Page heading:        getByRole("heading", { level: 1, name: "Dashboard", exact: true })
+  - Empty-data branch:   [data-slot="empty-title"] with text "Welcome to TenantFlow"
+                         (DashboardEmptyState renders when properties.total==0 && tenants.total==0)
+  - KPI section:         [data-testid="kpi-bento-row"] (loading: [data-testid="kpi-bento-row-loading"])
+  - KPI tiles:           role="listitem" inside the row; each tile <Stat> has an
+                         aria-label built by buildTileAriaLabel; the visible value
+                         is inside <StatValue> via NumberTicker. Tile labels:
+                         "Revenue", "Occupancy", "Active leases", "Open maintenance",
+                         "Properties", "Units" (via <StatLabel>).
+  - Donut:               role="img" with aria-label exactly
+                         `Occupancy donut: {pct} percent occupied ({occupied} of {total} units)`
+                         OR the empty branch "No units yet" when units.total==0.
+  - Portfolio search:    getByLabel("Search properties") (aria-label "Search properties")
+  - Status filter:       button "Status" (DataTableFacetedFilter title="Status";
+                         options Active/Expiring Soon/Vacant)
+  - Column-visibility:   DataTableViewOptions trigger (button, look up by its
+                         accessible name in data-table-view-options.tsx)
+  - View toggle:         role="radiogroup" aria-label="View mode" with two
+                         role="radio" buttons "Grid" and "Table" (aria-checked reflects viewMode)
+  - Sortable headers:    DataTableColumnHeader renders a DropdownMenuTrigger button
+                         whose text is the label ("Property","Units","Lease Status",
+                         "Monthly Rent"); Enter/Space on the focused trigger toggles
+                         sort directly; aria-sort lands on the parent <th
+                         role="columnheader"> via getAriaSort ("none"/"ascending"/"descending").
+  - Preset menu:         button "Presets" -> input aria-label "Preset name" +
+                         button aria-label "Save preset"; saved presets appear as
+                         DropdownMenuItems; per-item delete button aria-label
+                         `Delete preset {name}`.
+
+NumberTicker gotcha (project memory live-audit-headless-chrome-gotchas):
+  KPI big-number values animate via NumberTicker, which starts at 0 until its
+  IntersectionObserver fires on a REAL scroll. Tests MUST scroll the KPI row into
+  view (and allow the ~800ms ticker to settle) before reading the rendered value,
+  or the value reads stuck-0. The reduced-motion path renders the final value
+  immediately, so emulating prefers-reduced-motion is the most robust read: set
+  the context to reduced motion for the KPI-read assertions.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Authed get_dashboard_data_v2 fetch helper for in-test DOM comparison</name>
+  <files>tests/e2e/dashboard-rpc-helpers.ts</files>
+  <action>
+Create a reusable helper that authenticates the synthetic owner against the Supabase token API (the SAME endpoint and env-var resolution auth-helpers.ts uses — do not duplicate the cookie-chunking logic, only the token fetch + an RPC POST) and calls the `get_dashboard_data_v2` RPC, returning the typed payload for DOM comparison.
+
+Export `fetchDashboardDataAsOwner(): Promise<{ stats: { units: { total: number; occupied: number; vacant: number }; revenue: { monthly: number }; leases: { active: number; expiringSoon: number }; maintenance: { open: number }; properties: { total: number } } }>`. Resolve the Supabase URL + publishable key + owner credentials from the same env vars auth-helpers reads (TEST_SUPABASE_URL || NEXT_PUBLIC_SUPABASE_URL, TEST_SUPABASE_PUBLISHABLE_KEY || NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY, E2E_OWNER_EMAIL, E2E_OWNER_PASSWORD with the `\!`->`!` un-escape). POST to `${supabaseUrl}/auth/v1/token?grant_type=password` with the apikey + Bearer publishable-key headers to get the access_token, then POST to `${supabaseUrl}/rest/v1/rpc/get_dashboard_data_v2` with body `{ p_user_id: <user.id from the token response> }`, the apikey header, and `Authorization: Bearer <access_token>` so RLS scopes the call to the owner. Parse the JSON and narrow only the fields the smoke spec asserts on (units, revenue.monthly, leases.active/expiringSoon, maintenance.open, properties.total) via a typed mapper that throws on a missing field — NO `any`, NO `as unknown as` (CLAUDE.md). Throw an actionable error if the token call or RPC call returns non-2xx (mirror the auth-helpers "missing session fields" failure style) so a misconfigured run fails loud, not with a confusing assertion mismatch. This helper does NOT touch a Playwright page — it is a pure Node fetch used to derive expected values.
+  </action>
+  <verify>
+    <automated>cd /Users/richard/Developer/tenant-flow && bunx tsc --noEmit -p tests/e2e/tsconfig.json 2>&1 | grep -v "auth-helpers.ts\|_archived" | grep "dashboard-rpc-helpers" || echo "no new TS errors in dashboard-rpc-helpers.ts"</automated>
+  </verify>
+  <done>tests/e2e/dashboard-rpc-helpers.ts exports fetchDashboardDataAsOwner; it TS-compiles with zero new errors; no `any` / `as unknown as`; reads the same env vars and token endpoint as auth-helpers.ts; calls get_dashboard_data_v2 with the owner Bearer token so RLS applies.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: dashboard-smoke.e2e.spec.ts — POLISH-09 smoke under in-test owner auth</name>
+  <files>tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts</files>
+  <action>
+Create the POLISH-09 smoke spec. Authenticate in-test with `loginAsOwner(page)` (the owner-axe pattern — NO storageState), then mark the onboarding tour completed (write the "tenantflow:tour-progress" localStorage key as `{"owner-onboarding":"completed"}`, mirroring dashboard-a11y.e2e.spec.ts gotoAuthedDashboard) and reload so the spotlight never masks elements. In `beforeAll` (or a fixture), call `fetchDashboardDataAsOwner()` once to capture the expected RPC values; reuse across tests.
+
+Tolerate the zero-data synthetic owner: in a `beforeEach`, wait for EITHER the populated dashboard (`getByRole("heading", { level: 1, name: "Dashboard", exact: true })`) OR the empty-state `[data-slot="empty-title"]` "Welcome to TenantFlow" (the `.or()` pattern already established in the a11y spec). For each assertion below, branch on whether the empty-state rendered — when empty, assert the honest empty surface (no KPI row / "No units yet" donut / "No properties yet" table) instead of skipping silently, so the test still proves the empty path is correct rather than vacuously passing.
+
+Write these tests (each its own `test()`), gating data-bearing assertions on the populated branch:
+
+1. KPI numbers match the RPC. Use `test.use({ ... })` or per-test context emulation to set `prefers-reduced-motion: reduce` for this test (renders NumberTicker's final value immediately — avoids the IntersectionObserver stuck-0 read). Locate the Revenue tile and Occupancy tile inside `[data-testid="kpi-bento-row"]` by their `<StatLabel>` text, read the rendered numeric value from the tile, strip `$`/`,`/`%`, and assert it equals the RPC value: Revenue == `stats.revenue.monthly` (rounded, no cents — the tile formats with 0 fraction digits), Occupancy == `stats.units.occupancyRate` (rounded), Active leases == `stats.leases.active`, Open maintenance == `stats.maintenance.open`, Properties == `stats.properties.total`, Units == `stats.units.total`. If reduced-motion emulation is impractical per-test, instead scroll the KPI row into view and `await expect(...).toHaveText(...)` with a generous timeout so the ticker settles — but prefer reduced-motion.
+
+2. Occupancy donut matches stats.units. Read the donut `role="img"` aria-label and assert it equals `Occupancy donut: {pct} percent occupied ({stats.units.occupied} of {stats.units.total} units)` where `pct = Math.round(stats.units.occupied / stats.units.total * 100)` — OR, when `stats.units.total === 0`, assert the donut renders "No units yet" (honesty branch). This is the most robust donut assertion because the component encodes both counts in the label.
+
+3. DataTable sort works. Ensure table view (the default at the desktop 1280px viewport — the config default viewport is desktop and FORCE_GRID_QUERY only forces grid below 1024px; if a prior test left grid mode, click the "Table" radio first). Click the "Monthly Rent" column header trigger to sort; assert the parent `<th role="columnheader">` for that column exposes `aria-sort` of "ascending" or "descending" (read via `getAttribute("aria-sort")`), and that it was "none" before the click. Also exercise keyboard sort on the "Property" header: focus its trigger, press Enter, assert its `<th>` aria-sort flips.
+
+4. Faceted status filter works. Click the "Status" filter button, select "Vacant" (or whichever option the faceted popover renders), close the popover, and assert the URL gains the `status` nuqs param (`page.url()` contains `status=`) AND a Reset control ("Reset filters" button) appears. Then click Reset and assert the `status` param clears.
+
+5. Column-visibility toggle works. Open the DataTableViewOptions menu, toggle off a hideable column (e.g. "Maintenance" — Property/Actions are non-hideable), and assert that column header is no longer in the DOM; re-toggle it on and assert it returns. (Column visibility lives in the presets store, so this also proves the controlled-visibility wiring.)
+
+6. Preset save + restore works. Apply a recognizable filter (e.g. set the search input to a property substring so a `property` nuqs param is set). Open the "Presets" menu, type a preset name into the "Preset name" input, click "Save preset". Then clear the filter (Reset / clear the search) and confirm the URL no longer has the filter param. Re-open the Presets menu, click the saved preset item, and assert the filter is restored (the search input value / URL param returns). Finally reload the page and confirm the saved preset still appears in the menu (localStorage persist via Zustand) — this proves DT-08 save+restore across refresh, which is the precise POLISH-09 wording.
+
+7. Grid/table toggle works. Click the "Grid" radio; assert `aria-checked="true"` on Grid and the grid view renders (PortfolioGrid cards, not the `<table role="table" aria-label="Property portfolio">`). Click "Table"; assert the `<table aria-label="Property portfolio">` returns and Table is `aria-checked`.
+
+Keep selectors resilient: prefer getByRole / getByLabel / data-testid over CSS classes. Allow Playwright's default timeouts; do not add arbitrary fixed `waitForTimeout` except the minimal settle the ticker may need (and prefer reduced-motion to avoid it). Add a file-level doc comment stating this spec runs under owner-axe (in-test loginAsOwner, no storageState) and is the POLISH-09 smoke.
+  </action>
+  <verify>
+    <automated>cd /Users/richard/Developer/tenant-flow && bunx playwright test --config tests/e2e/playwright.config.ts --project=owner-axe --list 2>&1 | grep "dashboard-smoke" | head</automated>
+  </verify>
+  <done>dashboard-smoke.e2e.spec.ts exists, TS-transpiles, and is collected by the owner-axe project's `--list` (after Task 3 wires it). It covers all seven POLISH-09 surfaces (KPI-vs-RPC, donut-vs-units, sort, filter, column-visibility, preset save+restore across refresh, grid/table toggle), authenticates via in-test loginAsOwner, and tolerates the zero-data owner via the empty-state `.or()` branch with honest empty assertions.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Route the smoke spec into the CI-run owner-axe project</name>
+  <files>tests/e2e/playwright.config.ts</files>
+  <action>
+Wire the new smoke spec into the `owner-axe` project so CI's `e2e-smoke` job (which runs `--project=owner-axe`) executes it, and exclude it from the storageState projects so it is not double-collected with stale auth.
+
+In the `owner-axe` project, broaden `testMatch` to collect BOTH the a11y spec and the new smoke spec — change it to `["**/owner/dashboard-a11y.e2e.spec.ts", "**/owner/dashboard-smoke.e2e.spec.ts"]`. In the `owner`, `firefox`, and `mobile-chrome` projects, add `"**/owner/dashboard-smoke.e2e.spec.ts"` to each `testIgnore` array (they already ignore dashboard-a11y for the same reason — the smoke spec self-authenticates via loginAsOwner and must not run under storageState). Do NOT change the CI workflow — `e2e-smoke` already passes `--project=owner-axe`, so widening the project's testMatch is sufficient and keeps the CI command stable. Update the owner-axe project's leading comment to note it now collects the dashboard a11y sweep AND the POLISH-09 smoke (both in-test auth, no storageState).
+  </action>
+  <verify>
+    <automated>cd /Users/richard/Developer/tenant-flow && bunx playwright test --config tests/e2e/playwright.config.ts --project=owner-axe --list 2>&1 | grep -E "dashboard-(a11y|smoke)" | wc -l | grep -qv "^0$" && echo "owner-axe collects both specs" && bunx playwright test --config tests/e2e/playwright.config.ts --project=owner --list 2>&1 | grep -c "dashboard-smoke" | grep -q "^0$" && echo "owner project does NOT collect smoke"</automated>
+  </verify>
+  <done>The owner-axe project collects both dashboard-a11y and dashboard-smoke specs (verified via `--list`); the storageState owner/firefox/mobile-chrome projects do NOT collect the smoke spec. The CI workflow command (`--project=smoke --project=public --project=owner-axe`) is unchanged and now picks up the smoke spec.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bunx playwright test --config tests/e2e/playwright.config.ts --project=owner-axe --list` shows dashboard-a11y AND dashboard-smoke.
+- `bunx tsc --noEmit -p tests/e2e/tsconfig.json` reports no NEW errors attributable to the two new files (pre-existing auth-helpers.ts / _archived errors are out of scope, as in Phase 6).
+- The smoke spec authenticates via loginAsOwner (grep `loginAsOwner` in the new spec) and derives expected values from fetchDashboardDataAsOwner (grep `fetchDashboardDataAsOwner`).
+- Local `bun run test:e2e --project=owner-axe` runs green when the synthetic owner is reachable (prod auth + secrets); the binding run is on CI's e2e-smoke for the PR.
+</verification>
+
+<success_criteria>
+POLISH-09 satisfied: the Playwright suite includes a `/dashboard` smoke test against a synthetic owner asserting KPI numbers match `get_dashboard_data_v2`, the occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset save+restore work, and the grid/table toggle works — AND it runs under the CI-executed owner-axe project so the `e2e-smoke` check exercises it on the Phase 7 PR.
+</success_criteria>
+
+<output>
+Create `.planning/phases/07-verification/07-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/07-verification/07-01-SUMMARY.md
+++ b/.planning/phases/07-verification/07-01-SUMMARY.md
@@ -1,0 +1,119 @@
+---
+phase: 07-verification
+plan: 01
+subsystem: e2e-testing
+tags: [e2e, playwright, smoke, dashboard, POLISH-09]
+requires:
+  - "loginAsOwner (tests/e2e/auth-helpers.ts) — in-test owner auth"
+  - "get_dashboard_data_v2 RPC (prod) — RLS-scoped dashboard payload"
+  - "owner-axe Playwright project — CI-run authed dashboard project"
+provides:
+  - "fetchDashboardDataAsOwner — authed RPC fetch for RPC-vs-DOM smoke assertions"
+  - "dashboard-smoke.e2e.spec.ts — POLISH-09 /dashboard smoke under owner-axe"
+  - "owner-axe collects the smoke spec so CI e2e-smoke gates it"
+affects:
+  - "CI e2e-smoke job (runs --project=owner-axe) now exercises the dashboard smoke"
+tech-stack:
+  added: []
+  patterns:
+    - "RPC-vs-DOM comparison (no hardcoded numbers) for data-shape-tolerant smoke"
+    - "in-test loginAsOwner + reduced-motion contextOptions for deterministic KPI reads"
+    - "empty-state .or() branch with honest empty assertions (no vacuous skips)"
+key-files:
+  created:
+    - tests/e2e/dashboard-rpc-helpers.ts
+    - tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts
+  modified:
+    - tests/e2e/playwright.config.ts
+decisions:
+  - "reducedMotion set via contextOptions (not a top-level use key) for this Playwright 1.60 TestOptions"
+  - "search filter param confirmed as ?property= ; status faceted as ?status= ; sort as ?sort="
+  - "owner-axe (not the storageState owner project) is the only CI-run authed dashboard project"
+metrics:
+  duration: "~25m"
+  completed: 2026-06-02
+  tasks: 3
+  files: 3
+---
+
+# Phase 7 Plan 01: POLISH-09 /dashboard E2E Smoke Summary
+
+Added the POLISH-09 `/dashboard` smoke for the v2.0 redesigned dashboard — KPI numbers and the occupancy donut assert against the live `get_dashboard_data_v2` RPC (RPC-vs-DOM, never hardcoded), DataTable sort/filter/column-visibility/preset-save+restore and the grid/table toggle are exercised — and wired it into the CI-run `owner-axe` Playwright project so the PR's `e2e-smoke` check gates it.
+
+## What Each Task Produced
+
+### Task 1 — `tests/e2e/dashboard-rpc-helpers.ts` (commit `d4757d43f`)
+A reusable, page-less Node fetch helper `fetchDashboardDataAsOwner()`:
+- Resolves Supabase URL/key + owner credentials from the SAME env vars `auth-helpers.ts` reads (`TEST_*` preferred, `NEXT_PUBLIC_*` fallback, `E2E_OWNER_EMAIL`/`E2E_OWNER_PASSWORD` with the `\!`→`!` un-escape).
+- POSTs the password grant to `/auth/v1/token?grant_type=password`, then POSTs `{ p_user_id: <user.id> }` to `/rest/v1/rpc/get_dashboard_data_v2` with the **owner** Bearer token so RLS scopes the call identically to the in-app fetch.
+- Narrows the response through a typed mapper (`mapDashboardSmokeData`) that validates every asserted field (`stats.units.{total,occupied,vacant,occupancyRate}`, `revenue.monthly`, `leases.{active,expiringSoon}`, `maintenance.open`, `properties.total`) and throws an actionable, path-tagged error on any missing/mistyped field. No `any`, no `as unknown as` — `unknown` + `isRecord`/`requireNumber`/`requireObject` type guards.
+- Non-2xx token or RPC responses throw with the status + body, so a misconfigured run fails loud rather than as a confusing DOM mismatch.
+
+### Task 2 — `tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts` (commit `49b303f73`)
+The POLISH-09 smoke spec (7 tests), authenticating in-test via `loginAsOwner` (owner-axe pattern, no storageState), suppressing the onboarding tour, and tolerating the zero-data owner via the empty-state `.or()` branch with honest empty assertions:
+1. **KPI numbers match the RPC** — reads each `[data-slot="stat-value"]` by its `[data-slot="stat-label"]` tile, strips `$`/`,`/`%`, asserts Revenue=`round(revenue.monthly)`, Occupancy=`round(units.occupancyRate)`, Active leases, Open maintenance, Properties, Units. Empty branch asserts the KPI row is absent.
+2. **Occupancy donut matches stats.units** — exact `role="img"` aria-label `Occupancy donut: {pct} percent occupied ({occupied} of {total} units)`; `units.total===0` asserts the "No units yet" honesty branch.
+3. **DataTable sort** — mouse-click "Monthly Rent" header trigger flips its `<th>` `aria-sort` from `none`; keyboard `Enter` on the focused "Property" trigger flips `ascending`→`descending`.
+4. **Faceted status filter** — selecting "Vacant" writes `?status=`, surfaces "Reset filters"; Reset clears `?status=`.
+5. **Column-visibility** — "Toggle columns" combobox toggles the hideable "Maintenance" column off (header removed) and back on.
+6. **Preset save + restore across reload (DT-08)** — sets `?property=a`, saves a uniquely-named preset, clears the filter, re-applies the preset (param + input value restored), reloads, and confirms the persisted preset still appears in the menu.
+7. **Grid/Table toggle** — Grid radio `aria-checked=true` + table removed; Table radio `aria-checked=true` + `aria-label="Property portfolio"` table returns.
+
+Reduced motion is set via `test.use({ contextOptions: { reducedMotion: "reduce" } })` so `useReducedMotion()` returns true and `KpiNumberTicker` renders its final value immediately (avoids the IntersectionObserver stuck-0 read).
+
+### Task 3 — `tests/e2e/playwright.config.ts` (commit `e68b511e1`)
+- `owner-axe` `testMatch` broadened to `["**/owner/dashboard-a11y.e2e.spec.ts", "**/owner/dashboard-smoke.e2e.spec.ts"]`.
+- `owner`, `firefox`, `mobile-chrome` `testIgnore` each add `"**/owner/dashboard-smoke.e2e.spec.ts"` (self-authenticating spec must not run under stale storageState).
+- CI workflow command (`--project=smoke --project=public --project=owner-axe`) unchanged — widening the project testMatch is sufficient.
+
+## `playwright --list` Result (owner-axe collects the smoke)
+
+```
+[owner-axe] › owner/dashboard-a11y.e2e.spec.ts:80  › has zero WCAG 2.1 A/AA violations
+[owner-axe] › owner/dashboard-a11y.e2e.spec.ts:99  › has zero page-level horizontal scroll at 375px
+[owner-axe] › owner/dashboard-smoke.e2e.spec.ts:150 › KPI numbers match get_dashboard_data_v2
+[owner-axe] › owner/dashboard-smoke.e2e.spec.ts:179 › occupancy donut matches stats.units
+[owner-axe] › owner/dashboard-smoke.e2e.spec.ts:204 › DataTable sort works (mouse + keyboard)
+[owner-axe] › owner/dashboard-smoke.e2e.spec.ts:233 › faceted status filter writes the status param and Reset clears it
+[owner-axe] › owner/dashboard-smoke.e2e.spec.ts:256 › column-visibility toggle hides and restores a column
+[owner-axe] › owner/dashboard-smoke.e2e.spec.ts:282 › preset save + restore survives reload (DT-08)
+[owner-axe] › owner/dashboard-smoke.e2e.spec.ts:331 › grid/table view toggle works
+```
+
+Negative checks: `owner`, `firefox`, and `mobile-chrome` each collect **0** `dashboard-smoke` tests.
+
+## Deviations from Plan
+
+**1. [Rule 3 — blocking issue] `reducedMotion` set via `contextOptions`, not a top-level `use` key.**
+- **Found during:** Task 2 typecheck.
+- **Issue:** The plan suggested `test.use({ ... })` reduced-motion emulation. In Playwright 1.60's `TestOptions`, `reducedMotion` is a **context-level** option — `test.use({ reducedMotion: "reduce" })` raised `TS2353` (not in `Fixtures`).
+- **Fix:** Used the documented `test.use({ contextOptions: { reducedMotion: "reduce" } })` form (verified against `node_modules/playwright/types/test.d.ts`, which documents exactly this `contextOptions.reducedMotion: 'reduce'` pattern). Same runtime effect (`prefers-reduced-motion: reduce` on the context), so `useReducedMotion()` returns true. Docstring updated to match.
+- **Files modified:** tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts
+- **Commit:** 49b303f73
+
+No other deviations — the plan executed as written. Selectors were taken verbatim from the component source (kpi-bento-row, occupancy-donut-chart, portfolio toolbar/columns/preset-menu, data-table-view-options, data-table-column-header). nuqs param names (`property`, `status`, `sort`) match the verified facts.
+
+## Authentication Gates
+
+None. The smoke's first BINDING run is on CI (live prod auth + secrets), identical to the Phase 6 a11y sweep. Local verification was `tsc --noEmit` + `playwright --list` (spec confirmed collected by owner-axe) — the full E2E was intentionally not run locally per the plan's constraints.
+
+## Known Stubs
+
+None. The helper and spec contain no hardcoded empty values, placeholder text, or unwired data sources — all expected values derive from the live RPC.
+
+## Verification
+
+- `bunx playwright test --project=owner-axe --list` → dashboard-a11y AND dashboard-smoke (9 matched lines). PASS.
+- `bunx tsc --noEmit -p tests/e2e/tsconfig.json` → no errors attributable to the two new files (pre-existing `auth-helpers.ts` / legacy `owner-*` spec `noUnused*` errors are out of scope, as in Phase 6). PASS.
+- `grep loginAsOwner` (3) and `grep fetchDashboardDataAsOwner` (2) present in the spec. PASS.
+- Storage-state `owner`/`firefox`/`mobile-chrome` collect 0 smoke tests. PASS.
+- lefthook pre-commit (gitleaks, lockfile, lint, typecheck, unit-tests) + commit-msg (commitlint) green on all three commits.
+
+## Self-Check: PASSED
+
+- FOUND: tests/e2e/dashboard-rpc-helpers.ts (233 lines, min 40)
+- FOUND: tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts (349 lines, min 120)
+- FOUND: tests/e2e/playwright.config.ts
+- FOUND commit d4757d43f (Task 1)
+- FOUND commit 49b303f73 (Task 2)
+- FOUND commit e68b511e1 (Task 3)

--- a/.planning/phases/07-verification/07-02-PLAN.md
+++ b/.planning/phases/07-verification/07-02-PLAN.md
@@ -109,7 +109,7 @@ Add a one-line note that Phase 7 ships as one atomic PR through the perfect-PR g
 Do not edit the v1.0 archive section. Keep edits minimal and surgical — these are status flips, not rewrites.
   </action>
   <verify>
-    <automated>cd /Users/richard/Developer/tenant-flow && grep -c "| POLISH-09 | Phase 7 | Complete |\|| POLISH-12 | Phase 7 | Complete |" .planning/REQUIREMENTS.md | grep -q "^2$" && grep -q "07-01-PLAN.md" .planning/ROADMAP.md && grep -q "07-02-PLAN.md" .planning/ROADMAP.md && echo "traceability + roadmap updated"</automated>
+    <automated>cd /Users/richard/Developer/tenant-flow && grep -qF "POLISH-09 | Phase 7 | Complete" .planning/REQUIREMENTS.md && grep -qF "POLISH-12 | Phase 7 | Complete" .planning/REQUIREMENTS.md && grep -qF "07-01-PLAN.md" .planning/ROADMAP.md && grep -qF "07-02-PLAN.md" .planning/ROADMAP.md && echo "traceability + roadmap updated"</automated>
   </verify>
   <done>REQUIREMENTS.md shows POLISH-09 and POLISH-12 as Complete (both checkbox and traceability table); ROADMAP.md marks Phase 7 done with both plans listed and the perfect-PR / 34-of-34 close note; v1.0 archive untouched.</done>
 </task>

--- a/.planning/phases/07-verification/07-02-PLAN.md
+++ b/.planning/phases/07-verification/07-02-PLAN.md
@@ -1,0 +1,131 @@
+---
+phase: 07-verification
+plan: 02
+type: execute
+wave: 2
+depends_on: ["07-01"]
+files_modified:
+  - src/app/__tests__/design-token-drift.test.ts
+  - .planning/REQUIREMENTS.md
+  - .planning/ROADMAP.md
+autonomous: true
+requirements: [POLISH-12, POLISH-09]
+must_haves:
+  truths:
+    - "design-token-drift.test.ts runs clean over every new v2.0 dashboard file (no hex, no rgb, no bg-white, no inline-ms durations) — confirmed by enumerating the dashboard files and the test's recursive walk."
+    - "The stale DRIFT_EXEMPTIONS entry for the Phase-1-deleted src/components/dashboard/dashboard-filters.tsx is removed, so the exemption allowlist contains no dead entries."
+    - "REQUIREMENTS.md and ROADMAP.md traceability mark POLISH-09 and POLISH-12 satisfied, bringing the v2.0 milestone to 34/34, and the phase is recorded as shipping as one atomic PR through the perfect-PR gate."
+  artifacts:
+    - path: "src/app/__tests__/design-token-drift.test.ts"
+      provides: "Token-drift guard with the stale dashboard-filters.tsx exemption removed"
+      contains: "DRIFT_EXEMPTIONS"
+    - path: ".planning/REQUIREMENTS.md"
+      provides: "Traceability table with POLISH-09 + POLISH-12 = satisfied (34/34)"
+      contains: "POLISH-12"
+  key_links:
+    - from: "src/app/__tests__/design-token-drift.test.ts"
+      to: "src/components/dashboard/**"
+      via: "recursive walkSourceFiles over src/components + src/app already covers every dashboard file"
+      pattern: "src/components"
+---
+
+<objective>
+Verify the POLISH-12 design-token sweep is clean over every new v2.0 dashboard file, prune the one stale exemption left behind by Phase 1's dedup deletion, and close the milestone by marking POLISH-09 + POLISH-12 satisfied (34/34) in the traceability docs.
+
+Purpose: POLISH-12 requires `design-token-drift.test.ts` to stay green over every new dashboard file (no hex, no rgb, no `bg-white`, no inline ms durations). The test already walks `src/components/**` and `src/app/**` recursively, so every Phase 3-6 dashboard file is in scope — this is a verification + cleanup task, not new infrastructure. The milestone-close step finalizes the v2.0 traceability to 34/34.
+
+Output: a confirmed-green drift sweep with the dead `dashboard-filters.tsx` exemption removed, and updated REQUIREMENTS.md + ROADMAP.md.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@src/app/__tests__/design-token-drift.test.ts
+
+# Already-confirmed facts (verified during planning — do not re-derive, just act):
+# - The drift test's walkSourceFiles() recurses src/components/** and src/app/**,
+#   so every new dashboard file (src/components/dashboard/**, src/app/(owner)/dashboard/**)
+#   is ALREADY scanned. POLISH-12 needs no glob change.
+# - src/components/dashboard/dashboard-filters.tsx was DELETED in Phase 1 (POLISH-03 /
+#   01-03-PLAN dedup) but still has a `["hex"]` entry in DRIFT_EXEMPTIONS. The test
+#   passes today only because the file is no longer walked — the entry is dead config
+#   that the POLISH-12 sweep must remove (the exemption discipline requires each entry
+#   to map to a real file with a real justification).
+
+# The v2.0 dashboard files the sweep must cover (enumerate, then confirm zero drift):
+#   src/components/dashboard/dashboard.tsx
+#   src/components/dashboard/components/kpi-bento-row.tsx
+#   src/components/dashboard/components/kpi-sparkline.tsx
+#   src/components/dashboard/components/kpi-helpers.ts
+#   src/components/dashboard/components/revenue-area-chart.tsx
+#   src/components/dashboard/components/revenue-area-chart-skeleton.tsx
+#   src/components/dashboard/components/occupancy-donut-chart.tsx
+#   src/components/dashboard/components/occupancy-donut-chart-skeleton.tsx
+#   src/components/dashboard/components/portfolio-data-table.tsx
+#   src/components/dashboard/components/portfolio-data-table-toolbar.tsx
+#   src/components/dashboard/components/portfolio-columns.tsx
+#   src/components/dashboard/components/portfolio-grid.tsx
+#   src/components/dashboard/components/portfolio-preset-menu.tsx
+#   src/components/dashboard/components/lease-status-badge.tsx
+#   src/app/(owner)/dashboard/page.tsx + its components/ subtree
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Confirm POLISH-12 sweep is green over all dashboard files + remove the stale exemption</name>
+  <files>src/app/__tests__/design-token-drift.test.ts</files>
+  <action>
+First confirm the drift guard is green over the dashboard subtree as-is (the test is path-driven, so running it exercises every dashboard file). Then remove the dead exemption.
+
+Delete the `"src/components/dashboard/dashboard-filters.tsx": ["hex"],` line from the `DRIFT_EXEMPTIONS` object — the file was deleted in Phase 1 so the entry can never match a walked file and is dead config. Do NOT touch the other exemption entries (each maps to a real file with a justification) and do NOT change `walkSourceFiles`, `DRIFT_PATTERNS`, or any regex — the recursive `src/components` + `src/app` walk already covers every new dashboard file, so POLISH-12 requires no glob/scan change.
+
+If, when you run the test, ANY dashboard file under `src/components/dashboard/**` or `src/app/(owner)/dashboard/**` reports drift (hex / rgb / bg-white / inline-ms), that is a real POLISH-12 violation: fix it inline in the owning file by swapping to the appropriate globals.css token (`--color-*`, `bg-card`/`bg-background`/`bg-muted`, `--duration-*`) — do NOT add a new exemption for a dashboard file (the milestone constraint forbids drift in dashboard surfaces). Based on the planning review the dashboard subtree was already token-clean (Phase 6 POLISH-04 migrated the raw palette), so the expected outcome is: remove the one stale entry, sweep stays green.
+  </action>
+  <verify>
+    <automated>cd /Users/richard/Developer/tenant-flow && bun run test:unit -- --run src/app/__tests__/design-token-drift.test.ts 2>&1 | tail -20</automated>
+  </verify>
+  <done>`bun run test:unit -- --run src/app/__tests__/design-token-drift.test.ts` passes; the `dashboard-filters.tsx` exemption entry is gone; no dashboard file under src/components/dashboard or src/app/(owner)/dashboard reports any of the four drift patterns; no regex/glob/walk change was made.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Close the milestone — mark POLISH-09 + POLISH-12 satisfied (34/34)</name>
+  <files>.planning/REQUIREMENTS.md, .planning/ROADMAP.md</files>
+  <action>
+Finalize v2.0 traceability now that POLISH-09 (Plan 07-01) and POLISH-12 (Task 1 above) are both delivered.
+
+In `.planning/REQUIREMENTS.md`: change the `- [ ] **POLISH-09**` and `- [ ] **POLISH-12**` checkboxes to `- [x]`, and in the Traceability table flip `| POLISH-09 | Phase 7 | Pending |` and `| POLISH-12 | Phase 7 | Pending |` to `Complete`. Leave the Coverage block (34 total) as-is — it already reads 34 mapped; the milestone is now 34/34 satisfied.
+
+In `.planning/ROADMAP.md`: in the Phases list change `- [ ] **Phase 7: Verification**` to `- [x]`. In the Progress table, update the Phase 7 row from `0/0 | Not started | -` to `2/2 | Complete | 2026-06-02` (or the actual completion date). Update the Phase 7 "Plans:" line under Phase Details from `TBD` to list the two plans:
+  - `07-01-PLAN.md` — POLISH-09 /dashboard E2E smoke under the CI-run owner-axe project (KPI-vs-RPC, donut-vs-units, sort/filter/column-visibility/preset save+restore, grid/table toggle)
+  - `07-02-PLAN.md` — POLISH-12 design-token sweep verification + stale-exemption cleanup + milestone close
+Add a one-line note that Phase 7 ships as one atomic PR through the perfect-PR gate (two consecutive zero-finding deep review cycles), per the milestone's cross-cutting "Independently shippable" constraint, closing v2.0 at 34/34 requirements.
+
+Do not edit the v1.0 archive section. Keep edits minimal and surgical — these are status flips, not rewrites.
+  </action>
+  <verify>
+    <automated>cd /Users/richard/Developer/tenant-flow && grep -c "| POLISH-09 | Phase 7 | Complete |\|| POLISH-12 | Phase 7 | Complete |" .planning/REQUIREMENTS.md | grep -q "^2$" && grep -q "07-01-PLAN.md" .planning/ROADMAP.md && grep -q "07-02-PLAN.md" .planning/ROADMAP.md && echo "traceability + roadmap updated"</automated>
+  </verify>
+  <done>REQUIREMENTS.md shows POLISH-09 and POLISH-12 as Complete (both checkbox and traceability table); ROADMAP.md marks Phase 7 done with both plans listed and the perfect-PR / 34-of-34 close note; v1.0 archive untouched.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run test:unit -- --run src/app/__tests__/design-token-drift.test.ts` passes (POLISH-12 green over the whole dashboard subtree).
+- `grep -n "dashboard-filters" src/app/__tests__/design-token-drift.test.ts` returns nothing (stale exemption removed).
+- REQUIREMENTS.md + ROADMAP.md mark POLISH-09 + POLISH-12 satisfied → v2.0 at 34/34.
+</verification>
+
+<success_criteria>
+POLISH-12 satisfied: `design-token-drift.test.ts` runs clean over every new dashboard file (no hex, no rgb, no `bg-white`, no inline ms durations) and carries no dead exemption. The merged Phase 7 PR closes the v2.0 milestone with 34/34 requirements satisfied per traceability, shipped as one atomic PR through the perfect-PR gate.
+</success_criteria>
+
+<output>
+Create `.planning/phases/07-verification/07-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/07-verification/07-02-SUMMARY.md
+++ b/.planning/phases/07-verification/07-02-SUMMARY.md
@@ -1,0 +1,74 @@
+---
+phase: 07-verification
+plan: 02
+subsystem: verification
+tags: [design-tokens, drift-guard, milestone-close, traceability]
+requires: ["07-01"]
+provides: ["polish-12-satisfied", "v2.0-milestone-closed-34-of-34"]
+affects:
+  - src/app/__tests__/design-token-drift.test.ts
+  - .planning/REQUIREMENTS.md
+  - .planning/ROADMAP.md
+tech-stack:
+  added: []
+  patterns: ["per-pattern DRIFT_EXEMPTIONS allowlist discipline (each entry maps to a real file)"]
+key-files:
+  created: []
+  modified:
+    - src/app/__tests__/design-token-drift.test.ts
+    - .planning/REQUIREMENTS.md
+    - .planning/ROADMAP.md
+decisions:
+  - "POLISH-12 needed no glob/scan change: the drift test's walkSourceFiles() already recurses src/components/** + src/app/**, so every v2.0 dashboard file was already in scope and token-clean (Phase 6 POLISH-04 migrated the raw palette)."
+  - "Removed the dead dashboard-filters.tsx exemption rather than leaving it — the D-03 allowlist discipline requires each entry to map to a real file with a justification; the file was deleted in Phase 1."
+metrics:
+  duration: ~3min
+  completed: 2026-06-02
+  tasks: 2
+  files: 3
+---
+
+# Phase 7 Plan 02: POLISH-12 Design-Token Sweep + v2.0 Milestone Close Summary
+
+POLISH-12 verified green over the entire dashboard subtree with the dead Phase-1 `dashboard-filters.tsx` exemption pruned, then the v2.0 milestone closed at 34/34 (POLISH-09 + POLISH-12 marked Complete, Phase 7 done).
+
+## What Was Built
+
+**Task 1 — POLISH-12 sweep verification + stale-exemption removal (`e552e0372`)**
+- Confirmed `design-token-drift.test.ts` is green over the full `src/components/**` + `src/app/**` recursive walk (2724 tests pass), which already covers every v2.0 dashboard file under `src/components/dashboard/**` and `src/app/(owner)/dashboard/**`. No dashboard file reported any of the four drift patterns (hex / rgb / `bg-white` / inline `[NNN]ms`) — the subtree was already token-clean from Phase 6's POLISH-04 palette migration.
+- Removed the dead `"src/components/dashboard/dashboard-filters.tsx": ["hex"]` entry from `DRIFT_EXEMPTIONS`. That file was deleted in Phase 1 (POLISH-03 dedup), so the entry could never match a walked file — dead config. No regex, glob, or `walkSourceFiles` change was made (none was needed).
+- Test re-run after removal: still 2724 passing. `grep` confirms no `dashboard-filters` reference remains.
+
+**Task 2 — v2.0 milestone close (`41d707662`)**
+- `.planning/REQUIREMENTS.md`: flipped the `POLISH-12` checkbox `[ ]` → `[x]` and its traceability row `Pending` → `Complete`. POLISH-09 was already `[x]` / `Complete` (Plan 07-01 closeout). Coverage block left at 34 total — now 34/34 satisfied.
+- `.planning/ROADMAP.md`: flipped the `Phase 7: Verification` checkbox to `[x]`, the `07-02-PLAN.md` plan checkbox to `[x]`, and the Progress-table Phase 7 row from `1/2 | In Progress` → `2/2 | Complete | 2026-06-02`. Added the perfect-PR / 34-of-34 close note (Phase 7 ships as one atomic PR through two consecutive zero-finding review cycles).
+
+## Verification Results
+
+- `bun run test:unit -- src/app/__tests__/design-token-drift.test.ts` → 1 file, 2724 tests passed (POLISH-12 green over the whole dashboard subtree, exemption removed).
+- `grep -n "dashboard-filters" src/app/__tests__/design-token-drift.test.ts` → no output (stale exemption gone).
+- Task 2 verify (plan-as-written): `grep -qF "POLISH-09 | Phase 7 | Complete"` + `"POLISH-12 | Phase 7 | Complete"` in REQUIREMENTS.md, and `07-01-PLAN.md` + `07-02-PLAN.md` present in ROADMAP.md → all pass ("traceability + roadmap updated").
+- Both per-task commits passed the full lefthook pre-commit gate (gitleaks, lockfile-verify, biome lint, tsc typecheck, full Vitest unit suite with coverage, commitlint).
+
+## Deviations from Plan
+
+**1. [Rule 3 - Blocking issue] Corrected the test invocation to avoid a duplicate `--run` flag**
+- **Found during:** Task 1
+- **Issue:** The plan's verify command `bun run test:unit -- --run <path>` crashes — the `test:unit` package.json script is already `vitest --run --project unit`, so `-- --run` passes `--run` twice and Vitest's CAC parser errors with `Expected a single value for option "--run", received [true, true]`.
+- **Fix:** Ran `bun run test:unit -- src/app/__tests__/design-token-drift.test.ts` (path only, no second `--run`). Same test, same green result. No code change; only the invocation was adjusted.
+- **Files modified:** none.
+
+## Known Stubs
+
+None. No stub patterns introduced — this plan removed dead config and flipped status checkboxes; no UI data sources touched.
+
+## Threat Flags
+
+None. No new network endpoints, auth paths, file access patterns, or schema changes — test-config cleanup + planning-doc status flips only.
+
+## Self-Check: PASSED
+
+- `src/app/__tests__/design-token-drift.test.ts` — FOUND (exists, exemption removed, green).
+- Commit `e552e0372` (Task 1) — FOUND in git log.
+- Commit `41d707662` (Task 2) — FOUND in git log.
+- POLISH-10/11 checkboxes left as `[ ]` (untouched per constraint); v1.0 archive (`Phase 7: Pricing-Card Chrome`) untouched.

--- a/src/app/__tests__/design-token-drift.test.ts
+++ b/src/app/__tests__/design-token-drift.test.ts
@@ -95,7 +95,6 @@ const DRIFT_EXEMPTIONS: Record<string, readonly DriftPattern[]> = {
 		"hex",
 	],
 	"src/app/(owner)/reports/page.tsx": ["hex"],
-	"src/components/dashboard/dashboard-filters.tsx": ["hex"],
 	"src/components/leases/rent-increase-notice-dialog.tsx": ["hex"],
 	"src/components/maintenance/detail/work-order-template.ts": ["hex"],
 	// Third-party brand SVG logos, brand guidelines require exact hex (D-03)

--- a/tests/e2e/dashboard-rpc-helpers.ts
+++ b/tests/e2e/dashboard-rpc-helpers.ts
@@ -1,0 +1,233 @@
+/**
+ * Authed get_dashboard_data_v2 fetch helper for the POLISH-09 dashboard smoke.
+ *
+ * WHY THIS EXISTS:
+ * The dashboard-smoke spec asserts that the rendered KPI numbers and the
+ * occupancy donut match the LIVE RPC values for the synthetic owner — never
+ * hardcoded numbers — so a zero-data (or differently-seeded) owner can never
+ * produce a false failure. This helper derives those expected values by calling
+ * the SAME `get_dashboard_data_v2` RPC the dashboard UI calls
+ * (src/hooks/api/use-owner-dashboard.ts: `rpc("get_dashboard_data_v2",
+ * { p_user_id: user.id })`), scoped to the owner via their Bearer token so RLS
+ * applies identically to the in-app fetch.
+ *
+ * It is a PURE Node fetch — it never touches a Playwright `page`. It reuses the
+ * same env-var resolution and `/auth/v1/token` password-grant endpoint as
+ * `auth-helpers.ts` (intentionally NOT the cookie-chunking path — that is a
+ * browser-context concern; here we only need the access_token + user id to call
+ * the RPC over REST). A non-2xx token or RPC response throws an actionable error
+ * (mirroring the auth-helpers "missing session fields" failure style) so a
+ * misconfigured run fails loud instead of as a confusing assertion mismatch.
+ */
+
+// Resolve the Supabase URL + publishable key from the SAME env vars
+// auth-helpers.ts reads (TEST_* preferred, NEXT_PUBLIC_* fallback).
+function resolveSupabaseConfig(): { supabaseUrl: string; supabaseKey: string } {
+	const supabaseUrl =
+		process.env.TEST_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const supabaseKey =
+		process.env.TEST_SUPABASE_PUBLISHABLE_KEY ||
+		process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+	if (!supabaseUrl) {
+		throw new Error(
+			"Missing Supabase URL. Set TEST_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL environment variable.",
+		);
+	}
+	if (!supabaseKey) {
+		throw new Error(
+			"Missing Supabase key. Set TEST_SUPABASE_PUBLISHABLE_KEY or NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY environment variable.",
+		);
+	}
+	return { supabaseUrl, supabaseKey };
+}
+
+// Resolve the synthetic owner credentials from the SAME env vars auth-helpers
+// reads, including the `\!` -> `!` un-escape (the password is shell-escaped in
+// CI secrets / .env so a literal `!` survives quoting).
+function resolveOwnerCredentials(): { email: string; password: string } {
+	const email = process.env.E2E_OWNER_EMAIL || "test-admin@tenantflow.app";
+	const rawPassword = process.env.E2E_OWNER_PASSWORD;
+	if (!rawPassword) {
+		throw new Error("E2E_OWNER_PASSWORD environment variable is required");
+	}
+	return { email, password: rawPassword.replace(/\\!/g, "!") };
+}
+
+/**
+ * Narrowed dashboard payload — only the fields the smoke spec asserts on. The
+ * mapper below validates every one of these so a contract drift (missing field /
+ * wrong type) throws here, not as a misleading DOM-vs-undefined mismatch.
+ */
+export interface DashboardSmokeData {
+	stats: {
+		units: {
+			total: number;
+			occupied: number;
+			vacant: number;
+			occupancyRate: number;
+		};
+		revenue: { monthly: number };
+		leases: { active: number; expiringSoon: number };
+		maintenance: { open: number };
+		properties: { total: number };
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Read a required finite number off an unknown record, throwing an actionable
+// error on a missing/non-numeric field (defends against silent RPC drift).
+function requireNumber(
+	source: Record<string, unknown>,
+	key: string,
+	path: string,
+): number {
+	const raw = source[key];
+	if (typeof raw !== "number" || !Number.isFinite(raw)) {
+		throw new Error(
+			`get_dashboard_data_v2 returned a missing/invalid number at ${path}.${key} (got: ${JSON.stringify(raw)})`,
+		);
+	}
+	return raw;
+}
+
+// Read a required object off an unknown record, throwing on absence so the
+// downstream field reads fail with a precise path instead of "cannot read of
+// undefined".
+function requireObject(
+	source: Record<string, unknown>,
+	key: string,
+	path: string,
+): Record<string, unknown> {
+	const raw = source[key];
+	if (!isRecord(raw)) {
+		throw new Error(
+			`get_dashboard_data_v2 returned a missing/invalid object at ${path}.${key}`,
+		);
+	}
+	return raw;
+}
+
+/**
+ * Typed mapper at the RPC boundary (CLAUDE.md: NO `any`, NO `as unknown as`).
+ * Narrows the unknown JSON to exactly the fields the smoke spec compares to the
+ * DOM; throws on any missing/mistyped field.
+ */
+function mapDashboardSmokeData(raw: unknown): DashboardSmokeData {
+	if (!isRecord(raw)) {
+		throw new Error(
+			"get_dashboard_data_v2 returned a non-object payload — verify the RPC is deployed and the owner is authenticated",
+		);
+	}
+	const stats = requireObject(raw, "stats", "<root>");
+	const units = requireObject(stats, "units", "stats");
+	const revenue = requireObject(stats, "revenue", "stats");
+	const leases = requireObject(stats, "leases", "stats");
+	const maintenance = requireObject(stats, "maintenance", "stats");
+	const properties = requireObject(stats, "properties", "stats");
+
+	return {
+		stats: {
+			units: {
+				total: requireNumber(units, "total", "stats.units"),
+				occupied: requireNumber(units, "occupied", "stats.units"),
+				vacant: requireNumber(units, "vacant", "stats.units"),
+				occupancyRate: requireNumber(units, "occupancyRate", "stats.units"),
+			},
+			revenue: { monthly: requireNumber(revenue, "monthly", "stats.revenue") },
+			leases: {
+				active: requireNumber(leases, "active", "stats.leases"),
+				expiringSoon: requireNumber(leases, "expiringSoon", "stats.leases"),
+			},
+			maintenance: {
+				open: requireNumber(maintenance, "open", "stats.maintenance"),
+			},
+			properties: {
+				total: requireNumber(properties, "total", "stats.properties"),
+			},
+		},
+	};
+}
+
+interface TokenResponse {
+	access_token: string;
+	user: { id: string };
+}
+
+function isTokenResponse(value: unknown): value is TokenResponse {
+	if (!isRecord(value)) return false;
+	const user = value.user;
+	return (
+		typeof value.access_token === "string" &&
+		isRecord(user) &&
+		typeof user.id === "string"
+	);
+}
+
+/**
+ * Authenticate the synthetic owner against the Supabase password-grant token
+ * endpoint and call `get_dashboard_data_v2` with their Bearer token (so RLS
+ * scopes the call to the owner), returning the narrowed payload for DOM
+ * comparison. Throws an actionable error on any non-2xx response.
+ */
+export async function fetchDashboardDataAsOwner(): Promise<DashboardSmokeData> {
+	const { supabaseUrl, supabaseKey } = resolveSupabaseConfig();
+	const { email, password } = resolveOwnerCredentials();
+
+	// 1) Password-grant token (same endpoint + headers as auth-helpers.ts).
+	const tokenResponse = await fetch(
+		`${supabaseUrl}/auth/v1/token?grant_type=password`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				apikey: supabaseKey,
+				Authorization: `Bearer ${supabaseKey}`,
+			},
+			body: JSON.stringify({ email, password }),
+		},
+	);
+
+	if (!tokenResponse.ok) {
+		const detail = await tokenResponse.text();
+		throw new Error(
+			`fetchDashboardDataAsOwner: Supabase token request failed (${tokenResponse.status}): ${detail}`,
+		);
+	}
+
+	const tokenJson: unknown = await tokenResponse.json();
+	if (!isTokenResponse(tokenJson)) {
+		throw new Error(
+			"fetchDashboardDataAsOwner: Supabase token response missing required fields (access_token / user.id)",
+		);
+	}
+	const { access_token: accessToken, user } = tokenJson;
+
+	// 2) Call the RPC over REST with the OWNER Bearer token (RLS-scoped),
+	//    matching the UI call shape: { p_user_id: user.id }.
+	const rpcResponse = await fetch(
+		`${supabaseUrl}/rest/v1/rpc/get_dashboard_data_v2`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				apikey: supabaseKey,
+				Authorization: `Bearer ${accessToken}`,
+			},
+			body: JSON.stringify({ p_user_id: user.id }),
+		},
+	);
+
+	if (!rpcResponse.ok) {
+		const detail = await rpcResponse.text();
+		throw new Error(
+			`fetchDashboardDataAsOwner: get_dashboard_data_v2 RPC failed (${rpcResponse.status}): ${detail}`,
+		);
+	}
+
+	const rpcJson: unknown = await rpcResponse.json();
+	return mapDashboardSmokeData(rpcJson);
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -151,22 +151,30 @@ export default defineConfig({
 			},
 			dependencies: ["setup-owner"],
 			testMatch: ["**/owner/**/*.spec.ts"],
-			// dashboard-a11y self-authenticates via loginAsOwner (no storageState).
-			testIgnore: ["**/owner/dashboard-a11y.e2e.spec.ts"],
+			// dashboard-a11y + dashboard-smoke self-authenticate via loginAsOwner
+			// (no storageState) and run under owner-axe — exclude them here.
+			testIgnore: [
+				"**/owner/dashboard-a11y.e2e.spec.ts",
+				"**/owner/dashboard-smoke.e2e.spec.ts",
+			],
 		},
 
 		// ─────────────────────────────────────────
-		// OWNER-AXE: dashboard a11y + 375px sweep (CI: --project=owner-axe).
-		// NO storageState — authenticates in-test via loginAsOwner, which injects
-		// the @supabase/ssr session as cookies onto each fresh per-test context
-		// before the first navigation. No setup-owner dependency.
+		// OWNER-AXE: dashboard a11y + 375px sweep (POLISH-05/06) AND the
+		// POLISH-09 /dashboard smoke (CI: --project=owner-axe).
+		// NO storageState — both specs authenticate in-test via loginAsOwner,
+		// which injects the @supabase/ssr session as cookies onto each fresh
+		// per-test context before the first navigation. No setup-owner dependency.
 		// ─────────────────────────────────────────
 		{
 			name: "owner-axe",
 			use: {
 				...devices["Desktop Chrome"],
 			},
-			testMatch: ["**/owner/dashboard-a11y.e2e.spec.ts"],
+			testMatch: [
+				"**/owner/dashboard-a11y.e2e.spec.ts",
+				"**/owner/dashboard-smoke.e2e.spec.ts",
+			],
 		},
 
 		// ─────────────────────────────────────────
@@ -218,8 +226,12 @@ export default defineConfig({
 			},
 			dependencies: ["setup-owner"],
 			testMatch: ["**/owner/**/*.spec.ts"], // Owner tests for cross-browser
-			// dashboard-a11y self-authenticates via loginAsOwner (no storageState).
-			testIgnore: ["**/owner/dashboard-a11y.e2e.spec.ts"],
+			// dashboard-a11y + dashboard-smoke self-authenticate via loginAsOwner
+			// (no storageState) and run under owner-axe — exclude them here.
+			testIgnore: [
+				"**/owner/dashboard-a11y.e2e.spec.ts",
+				"**/owner/dashboard-smoke.e2e.spec.ts",
+			],
 		},
 
 		// ─────────────────────────────────────────
@@ -233,8 +245,12 @@ export default defineConfig({
 			},
 			dependencies: ["setup-owner"],
 			testMatch: ["**/owner/**/*.spec.ts"], // Owner tests for responsive
-			// dashboard-a11y self-authenticates via loginAsOwner (no storageState).
-			testIgnore: ["**/owner/dashboard-a11y.e2e.spec.ts"],
+			// dashboard-a11y + dashboard-smoke self-authenticate via loginAsOwner
+			// (no storageState) and run under owner-axe — exclude them here.
+			testIgnore: [
+				"**/owner/dashboard-a11y.e2e.spec.ts",
+				"**/owner/dashboard-smoke.e2e.spec.ts",
+			],
 		},
 	],
 

--- a/tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts
+++ b/tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts
@@ -206,14 +206,14 @@ test.describe("Dashboard smoke (POLISH-09)", () => {
 		await ensureTableView(page);
 
 		// Mouse sort on "Monthly Rent" (unsorted by default — Property is the
-		// default sort). Its <th> aria-sort starts "none" and flips after the click.
+		// default sort). The header is a DropdownMenuTrigger: a mouse click OPENS
+		// the asc/desc/reset menu (only keyboard Enter/Space fast-sorts directly),
+		// so sort the explicit, contract-correct way — open the menu, pick "Desc".
 		const rentHeader = columnHeader(page, "Monthly Rent");
 		await expect(rentHeader).toHaveAttribute("aria-sort", "none");
 		await rentHeader.getByRole("button", { name: "Monthly Rent" }).click();
-		await expect(rentHeader).toHaveAttribute(
-			"aria-sort",
-			/ascending|descending/,
-		);
+		await page.getByRole("menuitemcheckbox", { name: "Desc" }).click();
+		await expect(rentHeader).toHaveAttribute("aria-sort", "descending");
 
 		// Keyboard sort on "Property" (default-sorted ascending). Enter toggles to
 		// descending directly via the header trigger's onKeyDown fast-sort path.

--- a/tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts
+++ b/tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts
@@ -1,0 +1,349 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { loginAsOwner } from "../../auth-helpers";
+import {
+	type DashboardSmokeData,
+	fetchDashboardDataAsOwner,
+} from "../../dashboard-rpc-helpers";
+
+/**
+ * Dashboard /dashboard smoke E2E (Phase 7, POLISH-09).
+ *
+ * Runs under the dedicated `owner-axe` Playwright project (NO storageState),
+ * which CI invokes via `--project=owner-axe` in the `e2e-smoke` job. The legacy
+ * storageState `owner` project is NOT run in CI, so a smoke placed there would
+ * pass locally but never gate the PR — POLISH-09 success criterion #2 requires
+ * the `e2e-smoke` CHECK to exercise this test. Authentication is performed
+ * in-test by `loginAsOwner`, which injects the `@supabase/ssr` session as
+ * cookies onto each fresh per-test context before the first navigation. The
+ * file is excluded from the storageState `owner` / `firefox` / `mobile-chrome`
+ * projects via their `testIgnore`.
+ *
+ * This is the v2.0-redesigned-dashboard smoke. It does NOT extend the legacy
+ * owner-dashboard.e2e.spec.ts (which asserts on removed pre-v2.0 surfaces).
+ *
+ * Coverage (the seven POLISH-09 surfaces):
+ *   1. KPI numbers match get_dashboard_data_v2 (RPC-vs-DOM, not hardcoded)
+ *   2. Occupancy donut matches stats.units
+ *   3. DataTable sort (mouse + keyboard) flips aria-sort
+ *   4. Faceted status filter writes the `status` nuqs param + Reset clears it
+ *   5. Column-visibility toggle hides/restores a hideable column
+ *   6. Preset save + restore (incl. survival across reload — DT-08)
+ *   7. Grid/Table view toggle (aria-checked + the rendered surface)
+ *
+ * Zero-data tolerance: a `beforeEach` waits for EITHER the populated dashboard
+ * OR the empty-state. Data-bearing assertions branch on `isEmptyState` and, when
+ * empty, assert the HONEST empty surface ("No units yet" donut / "No properties
+ * yet" table / no KPI row) rather than skipping vacuously. The synthetic owner
+ * currently HAS data, so the populated path is the expected path.
+ *
+ * Reduced motion: `test.use({ contextOptions: { reducedMotion: "reduce" } })`
+ * is applied per describe block so `useReducedMotion()` returns true —
+ * KpiNumberTicker renders its final value immediately (avoiding the
+ * NumberTicker IntersectionObserver stuck-0 read) and the donut/chart entrance
+ * animations are off.
+ */
+
+/**
+ * Authenticate in-test, suppress the onboarding tour, and wait for a definitive
+ * loaded marker (populated heading OR empty-state title). Mirrors
+ * dashboard-a11y.e2e.spec.ts gotoAuthedDashboard.
+ */
+async function gotoAuthedDashboard(page: Page): Promise<void> {
+	await loginAsOwner(page);
+	// Mark the owner onboarding tour completed so its spotlight overlay never
+	// auto-opens over the smoke interactions (it would mask the toolbar / table).
+	await page.evaluate(() => {
+		localStorage.setItem(
+			"tenantflow:tour-progress",
+			JSON.stringify({ "owner-onboarding": "completed" }),
+		);
+	});
+	await page.reload();
+	await expect(
+		page.getByRole("heading", { level: 1, name: "Dashboard", exact: true }).or(
+			page.locator('[data-slot="empty-title"]', {
+				hasText: "Welcome to TenantFlow",
+			}),
+		),
+	).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * True when the zero-data empty-state rendered (DashboardEmptyState) instead of
+ * the populated dashboard. Drives the honest empty-branch assertions below.
+ */
+async function isEmptyState(page: Page): Promise<boolean> {
+	const emptyTitle = page.locator('[data-slot="empty-title"]', {
+		hasText: "Welcome to TenantFlow",
+	});
+	return (await emptyTitle.count()) > 0;
+}
+
+/**
+ * Locate the `<StatValue>` text for a KPI tile by its `<StatLabel>` text inside
+ * the bento row, returning the numeric value with `$` / `,` / `%` stripped.
+ */
+async function readKpiTileNumber(page: Page, label: string): Promise<number> {
+	const row = page.getByTestId("kpi-bento-row");
+	const tile = row.locator('[data-slot="stat"]', {
+		has: page.locator('[data-slot="stat-label"]', { hasText: label }),
+	});
+	const valueText = await tile
+		.locator('[data-slot="stat-value"]')
+		.first()
+		.innerText();
+	const cleaned = valueText.replace(/[$,%\s]/g, "");
+	const parsed = Number(cleaned);
+	expect(
+		Number.isFinite(parsed),
+		`KPI tile "${label}" rendered a non-numeric value: "${valueText}"`,
+	).toBe(true);
+	return parsed;
+}
+
+/** The portfolio virtualized table (role=table, aria-label="Property portfolio"). */
+function portfolioTable(page: Page): Locator {
+	return page.getByRole("table", { name: "Property portfolio" });
+}
+
+/**
+ * Ensure the portfolio is in table view at the desktop default (1280px). If a
+ * prior test left grid mode, click the "Table" radio first. No-op at <1024px,
+ * but this project runs at the desktop default viewport.
+ */
+async function ensureTableView(page: Page): Promise<void> {
+	const viewGroup = page.getByRole("radiogroup", { name: "View mode" });
+	const tableRadio = viewGroup.getByRole("radio", { name: "Table" });
+	if ((await tableRadio.getAttribute("aria-checked")) !== "true") {
+		await tableRadio.click();
+	}
+	await expect(portfolioTable(page)).toBeVisible();
+}
+
+/** The `<th role="columnheader">` for a column, located by its header label text. */
+function columnHeader(page: Page, label: string): Locator {
+	return portfolioTable(page)
+		.getByRole("columnheader")
+		.filter({ hasText: label });
+}
+
+let rpc: DashboardSmokeData;
+
+test.beforeAll(async () => {
+	// Derive expected KPI/donut values ONCE from the live RPC (RLS-scoped to the
+	// owner), reused across every test. A misconfigured run fails loud here.
+	rpc = await fetchDashboardDataAsOwner();
+});
+
+test.describe("Dashboard smoke (POLISH-09)", () => {
+	// Reduced motion renders the NumberTicker final value immediately and turns
+	// off the donut/chart entrance animation — robust KPI + donut reads.
+	// `reducedMotion` is a context-level option in this Playwright, so it is set
+	// via `contextOptions` rather than a top-level `use` key.
+	test.use({ contextOptions: { reducedMotion: "reduce" } });
+
+	test.beforeEach(async ({ page }) => {
+		await gotoAuthedDashboard(page);
+	});
+
+	test("KPI numbers match get_dashboard_data_v2", async ({ page }) => {
+		if (await isEmptyState(page)) {
+			// Honest empty branch: the zero-data path renders the empty-state, NOT
+			// the KPI bento row. Assert the row is absent rather than passing vacuously.
+			await expect(page.getByTestId("kpi-bento-row")).toHaveCount(0);
+			return;
+		}
+
+		const { stats } = rpc;
+		// Revenue tile formats with 0 fraction digits; compare the rounded dollars.
+		expect(await readKpiTileNumber(page, "Revenue")).toBe(
+			Math.round(stats.revenue.monthly),
+		);
+		// Occupancy tile renders stats.units.occupancyRate (rounded by safeOccupancy).
+		expect(await readKpiTileNumber(page, "Occupancy")).toBe(
+			Math.round(stats.units.occupancyRate),
+		);
+		expect(await readKpiTileNumber(page, "Active leases")).toBe(
+			stats.leases.active,
+		);
+		expect(await readKpiTileNumber(page, "Open maintenance")).toBe(
+			stats.maintenance.open,
+		);
+		expect(await readKpiTileNumber(page, "Properties")).toBe(
+			stats.properties.total,
+		);
+		expect(await readKpiTileNumber(page, "Units")).toBe(stats.units.total);
+	});
+
+	test("occupancy donut matches stats.units", async ({ page }) => {
+		const { units } = rpc.stats;
+
+		if (units.total === 0) {
+			// Honesty branch (04-CONTEXT D-03/D-08): no fabricated 0% donut.
+			await expect(
+				page.getByText("No units yet", { exact: true }),
+			).toBeVisible();
+			return;
+		}
+		if (await isEmptyState(page)) {
+			// Owner has units per the RPC but the page rendered empty-state — surface
+			// it as a real failure (contract divergence), not a silent skip.
+			throw new Error(
+				"RPC reports units but the dashboard rendered the empty-state — investigate data/render divergence",
+			);
+		}
+
+		const pct = Math.round((units.occupied / units.total) * 100);
+		const expectedLabel = `Occupancy donut: ${pct} percent occupied (${units.occupied} of ${units.total} units)`;
+		await expect(page.getByRole("img", { name: expectedLabel })).toBeVisible();
+	});
+
+	test("DataTable sort works (mouse + keyboard)", async ({ page }) => {
+		if (await isEmptyState(page)) {
+			test.skip(true, "empty-state owner — no portfolio table to sort");
+			return;
+		}
+		await ensureTableView(page);
+
+		// Mouse sort on "Monthly Rent" (unsorted by default — Property is the
+		// default sort). Its <th> aria-sort starts "none" and flips after the click.
+		const rentHeader = columnHeader(page, "Monthly Rent");
+		await expect(rentHeader).toHaveAttribute("aria-sort", "none");
+		await rentHeader.getByRole("button", { name: "Monthly Rent" }).click();
+		await expect(rentHeader).toHaveAttribute(
+			"aria-sort",
+			/ascending|descending/,
+		);
+
+		// Keyboard sort on "Property" (default-sorted ascending). Enter toggles to
+		// descending directly via the header trigger's onKeyDown fast-sort path.
+		const propertyHeader = columnHeader(page, "Property");
+		const propertyTrigger = propertyHeader.getByRole("button", {
+			name: "Property",
+		});
+		await expect(propertyHeader).toHaveAttribute("aria-sort", "ascending");
+		await propertyTrigger.focus();
+		await propertyTrigger.press("Enter");
+		await expect(propertyHeader).toHaveAttribute("aria-sort", "descending");
+	});
+
+	test("faceted status filter writes the status param and Reset clears it", async ({
+		page,
+	}) => {
+		if (await isEmptyState(page)) {
+			test.skip(true, "empty-state owner — no portfolio table to filter");
+			return;
+		}
+		await ensureTableView(page);
+
+		// Open the Status faceted filter and select "Vacant".
+		await page.getByRole("button", { name: "Status" }).click();
+		await page.getByRole("option", { name: "Vacant" }).click();
+		// Close the popover so the URL settles and the toolbar Reset surfaces.
+		await page.keyboard.press("Escape");
+
+		await expect(page).toHaveURL(/[?&]status=/);
+		const reset = page.getByRole("button", { name: "Reset filters" });
+		await expect(reset).toBeVisible();
+
+		await reset.click();
+		await expect(page).not.toHaveURL(/[?&]status=/);
+	});
+
+	test("column-visibility toggle hides and restores a column", async ({
+		page,
+	}) => {
+		if (await isEmptyState(page)) {
+			test.skip(true, "empty-state owner — no portfolio table columns");
+			return;
+		}
+		await ensureTableView(page);
+
+		const maintenanceHeader = columnHeader(page, "Maintenance");
+		await expect(maintenanceHeader).toBeVisible();
+
+		// Open the DataTableViewOptions popover (combobox "Toggle columns").
+		const viewOptions = page.getByRole("combobox", { name: "Toggle columns" });
+		await viewOptions.click();
+		await page.getByRole("option", { name: "Maintenance" }).click();
+		await page.keyboard.press("Escape");
+		await expect(maintenanceHeader).toHaveCount(0);
+
+		// Re-toggle on and confirm it returns.
+		await viewOptions.click();
+		await page.getByRole("option", { name: "Maintenance" }).click();
+		await page.keyboard.press("Escape");
+		await expect(columnHeader(page, "Maintenance")).toBeVisible();
+	});
+
+	test("preset save + restore survives reload (DT-08)", async ({ page }) => {
+		if (await isEmptyState(page)) {
+			test.skip(true, "empty-state owner — no portfolio to snapshot");
+			return;
+		}
+		await ensureTableView(page);
+
+		const search = page.getByLabel("Search properties");
+		// Apply a recognizable filter: a single-char substring sets the `property`
+		// nuqs param without depending on a specific property name existing.
+		await search.fill("a");
+		await expect(page).toHaveURL(/[?&]property=a(?:[&]|$)/);
+
+		// Save a uniquely-named preset.
+		const presetName = `smoke-${Date.now()}`;
+		await page.getByRole("button", { name: "Presets" }).click();
+		await page.getByLabel("Preset name").fill(presetName);
+		await page.getByRole("button", { name: "Save preset" }).click();
+		// Close the menu so the next interactions are unobstructed.
+		await page.keyboard.press("Escape");
+
+		// Clear the filter and confirm the param is gone.
+		await search.fill("");
+		await expect(page).not.toHaveURL(/[?&]property=/);
+
+		// Re-open Presets and apply the saved preset — the filter must restore.
+		await page.getByRole("button", { name: "Presets" }).click();
+		await page.getByRole("menuitem", { name: presetName }).click();
+		await expect(page).toHaveURL(/[?&]property=a(?:[&]|$)/);
+		await expect(search).toHaveValue("a");
+
+		// Reload: the Zustand-persisted preset must still appear in the menu (the
+		// precise POLISH-09 "save+restore across refresh" wording).
+		await page.reload();
+		await expect(
+			page
+				.getByRole("heading", { level: 1, name: "Dashboard", exact: true })
+				.or(
+					page.locator('[data-slot="empty-title"]', {
+						hasText: "Welcome to TenantFlow",
+					}),
+				),
+		).toBeVisible({ timeout: 10000 });
+		await page.getByRole("button", { name: "Presets" }).click();
+		await expect(
+			page.getByRole("menuitem", { name: presetName }),
+		).toBeVisible();
+	});
+
+	test("grid/table view toggle works", async ({ page }) => {
+		if (await isEmptyState(page)) {
+			test.skip(true, "empty-state owner — no portfolio surface to toggle");
+			return;
+		}
+		await ensureTableView(page);
+
+		const viewGroup = page.getByRole("radiogroup", { name: "View mode" });
+		const gridRadio = viewGroup.getByRole("radio", { name: "Grid" });
+		const tableRadio = viewGroup.getByRole("radio", { name: "Table" });
+
+		// Switch to Grid: aria-checked flips and the table is replaced by the grid.
+		await gridRadio.click();
+		await expect(gridRadio).toHaveAttribute("aria-checked", "true");
+		await expect(portfolioTable(page)).toHaveCount(0);
+
+		// Switch back to Table: the table returns and Table is checked.
+		await tableRadio.click();
+		await expect(tableRadio).toHaveAttribute("aria-checked", "true");
+		await expect(portfolioTable(page)).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary

**Phase 7: Verification** — the v2.0 "Dashboard Command Center" milestone-closer. Adds the `/dashboard` functional E2E smoke (POLISH-09) and the final design-token drift sweep (POLISH-12), bringing v2.0 to **34/34 requirements satisfied**.

## POLISH-09 — `/dashboard` E2E smoke

New `tests/e2e/tests/owner/dashboard-smoke.e2e.spec.ts` (7 tests) under the **`owner-axe`** project — the one CI's `e2e-smoke` job actually runs (`ci-cd.yml:162` = `--project=smoke --project=public --project=owner-axe`). In-test `loginAsOwner` (no storageState), tour-suppressed, empty-state `.or()` branch with honest empty assertions.

- **KPI numbers match `get_dashboard_data_v2`** — a new `dashboard-rpc-helpers.ts` calls the RPC with the **owner Bearer token** (RLS-scoped, same `{ p_user_id: user.id }` call shape as the UI), typed-mapper parsed, and the spec compares the rendered DOM to the live RPC values (data-shape tolerant, not hardcoded). `prefers-reduced-motion` emulation handles the NumberTicker stuck-0 gotcha.
- **Occupancy donut matches `stats.units`** via the deterministic `role="img"` aria-label.
- **DataTable**: sort (mouse + keyboard `aria-sort`), `?status=` faceted filter + Reset, column-visibility toggle, preset save+restore across reload (DT-08), grid/table toggle.
- `playwright.config.ts`: `owner-axe` testMatch widened; `owner`/`firefox`/`mobile-chrome` testIgnore the smoke so it does not double-run.

## POLISH-12 — design-token drift sweep

`design-token-drift.test.ts` is **green** (2724 tests) over the recursive `src/components/**` + `src/app/**` walk — every v2.0 dashboard file already in scope, zero drift. Removed one dead `DRIFT_EXEMPTIONS` entry for the Phase-1-deleted `dashboard-filters.tsx`.

## Verification

- `typecheck` + `lint` + full unit suite green (lefthook on every commit). The **binding** check is CI's `e2e-smoke` running the smoke against live prod (synthetic owner has 5 properties / 2 leases → populated path).
- Planned via `gsd-planner`, verified `gsd-plan-checker` (PASS-WITH-FLAGS, all flags resolved: owner has data, params confirmed `property`/`status`/`sort`, traceability grep fixed).
- Closes v2.0 at **34/34** (REQUIREMENTS + ROADMAP traceability flipped).

[hudsor01]
