### PR TITLE
chore: archive v2.0 Dashboard Command Center milestone

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,57 @@
 # Milestones
 
+## v2.0 Dashboard Command Center (Shipped: 2026-06-02)
+
+**Phases:** 7 (1-7) | **Plans:** 24 | **Tasks:** 40 | **Requirements:** 34/34 satisfied
+**Timeline:** 2026-05-22 → 2026-06-02 (11 days) | **Git range:** PR #744 → PR #773
+**Merge commit:** [`3e1a4cc29`](https://github.com/hudsor01/tenant-flow/commit/3e1a4cc29) (PR #773)
+**Archive:** [`milestones/v2.0-ROADMAP.md`](milestones/v2.0-ROADMAP.md) · [`milestones/v2.0-REQUIREMENTS.md`](milestones/v2.0-REQUIREMENTS.md)
+**Known deferred items at close:** 2 (Phase-6 manual focus-ring UAT + verification sign-off — superseded by the automated WCAG 2.1 AA axe sweep that passed in CI; see STATE.md Deferred Items)
+
+### Delivered
+
+The authenticated owner dashboard at `/dashboard` became a restrained, professional B2B command center — KPI bento row above the fold, refreshed charts, a real DataTable with column controls + saved presets, and full keyboard / dark-mode / mobile / reduced-motion a11y — while killing the latent `*100`/`÷100` revenue round-trip so every dollar is handled correctly throughout the data path. 34/34 requirements (KPI-01..07, CHART-01..06, DT-01..09, POLISH-01..12) mapped with no orphans and no double-mapping.
+
+### Key Accomplishments
+
+**Foundation + honest data layer (Phases 1-2, PRs #744/#745):**
+
+- Killed the `*100`/`÷100` revenue round-trip, extracted one shared `transformDashboardData` module, and dedup-deleted 7 stale dashboard files (owner-dashboard, duplicate dashboard-filters, second portfolio-toolbar, skeletons) — zero visible change, correct in-memory values (POLISH-01/02/03)
+- Additive `get_dashboard_data_v2` migration for per-property `open_maintenance`; dropped the fabricated `collection_rate` `0` (TenantFlow facilitates no rent payments, so the data does not exist — never fabricate) with a dual-client (ownerA/ownerB) RLS owner-isolation test green against prod (POLISH-10/11)
+
+**KPI row + charts (Phases 3-4, PRs #746/#748):**
+
+- 6-tile KPI bento row (Revenue, Occupancy, Active Leases, Open Maintenance, Properties, Units) on `Stat` + `NumberTicker` + `StatTrend`, axis-less `KpiSparkline` on Revenue + Occupancy only, `@container` auto-fit grid (not the marketing `bento-grid.tsx`), `BlurFade` staggered reveals (KPI-01..07)
+- Refreshed `RevenueAreaChart` (30d/6mo toggle, no residual `/100`) + brand-new `OccupancyDonutChart` (center label + legend sourced from `stats.units`), both `next/dynamic` `ssr:false` with shape-matching CSS-only skeletons; series colors source exclusively from `--color-chart-{1..5}` (CHART-01..06)
+
+**Portfolio DataTable (Phase 5, PR #763):**
+
+- Replaced the hand-rolled portfolio table with the vendored DiceUI / TanStack-table composition: `useClientDataTable` hook, 7-column model with `aria-sort` + keyboard sort, faceted status filter, column-visibility menu, always-on virtualization, grid/table toggle, full-snapshot saved presets (Zustand `persist`), and live filter/sort/page state in nuqs URL params; the 3 hand-rolled files (table/toolbar/pagination) deleted in the same atomic swap (DT-01..09)
+
+**Polish, a11y + verification (Phases 6-7, PRs #767/#773):**
+
+- Dark-mode token migration with theme-aware `--color-{success,warning,destructive}-text` companions verified ≥4.5:1 in both themes; internal reduced-motion guard on the shared `NumberTicker` rAF primitive (all 16 consumers snap to final value under `prefers-reduced-motion`); skeleton↔empty branch mutual-exclusion regression (POLISH-04/05/06/07/08)
+- `/dashboard` E2E smoke under the CI `owner-axe` project (in-test `loginAsOwner`, no storageState): KPI numbers vs `get_dashboard_data_v2`, donut vs `stats.units`, DataTable sort / status filter / column visibility / preset save+restore / grid-table toggle — plus an automated axe-core WCAG 2.1 AA sweep + 375px zero-horizontal-scroll probe, and a final design-token drift sweep across every new dashboard file (POLISH-09/12)
+
+### Discipline Outcomes
+
+- **Perfect-PR merge gate** (two consecutive zero-finding deep review cycles) enforced on every shipped phase. Cycle counts: Phase 1 → 7 (6+7 zero), Phase 2 → 11 (+ post-merge fix), Phase 4 → 9 (8+9 zero), Phase 5 → 8 (final two independent reviewers both CLEAN), Phase 7 → review APPROVED with one P2 fixed + CI re-verified green.
+- **Binding verification:** Phase 7 (the milestone's verification phase) ran the 7-test `/dashboard` smoke against live prod (synthetic owner with 5 active properties / 2 leases → populated path) in CI `e2e-smoke` and passed (201s). No separate `/gsd:audit-milestone` was run — Phase 7 IS the milestone audit.
+- **CI gates:** branch protection on `main` requires `checks` / `e2e-smoke` / `rls-security`, all run on every PR and fail hard when secrets missing. The first Phase-6 CI axe run surfaced 4 real WCAG violations + a 623px→375px overflow, all fixed before merge.
+- **Cross-cutting hard rule:** no `*100` / `/100` revenue arithmetic anywhere — repo-wide grep zero across the dashboard subtree, gate-enforced.
+
+### Lessons Carried Forward
+
+- The shared-primitive reduced-motion pattern: guard INSIDE the effect (not a component-top early-return) so the `ref` stays attached and the IntersectionObserver keeps firing — a top-level return would unmount the observed node and break the stuck-0 NumberTicker scroll behavior.
+- Vivid brand tokens fail AA as foreground TEXT in one theme each (destructive in dark 3.29:1; success/warning/info in light 2.1–3.3:1) — use `-text` companions for text, keep vivid for icons (3:1). (Carried into the post-milestone app-wide token sweep, PRs #769/#770.)
+- The CI `owner-axe` project (in-test `loginAsOwner` cookie injection) is the CI-runnable authed path; the `owner` storageState project does NOT run in CI. Authed dashboard E2E must target `owner-axe`.
+
+### Naming-Collision Note
+
+The git tag `v2.0` was already in use from a prior project-iteration milestone ("Stripe Integration Excellence", commit `b244f9c25`, 2026-01-17) — the same disjoint legacy tag namespace (`v1.0`–`v4.0`) noted for the v1.0 "Marketing Surface Honesty" milestone. The complete-milestone workflow's pre-check correctly skipped re-tagging to avoid a silent overwrite. This v2.0 "Dashboard Command Center" milestone is authoritative via `.planning/MILESTONES.md` + `.planning/milestones/v2.0-*.md` archive files + the merge commit (`3e1a4cc29`). A dedicated tag pointing at the actual merge commit would need a distinct name (e.g. `v2.0-dashboard`) or an explicit force-update; not done here, matching the v1.0 precedent.
+
+---
+
 ## v1.0 Marketing Surface Honesty (Shipped: 2026-05-22)
 
 **Phases:** 15 (1-15) | **Plans:** 33 | **Audit:** Round 3 — PERFECT BY ALL MEASURES
@@ -13,33 +65,39 @@ Every public claim on tenantflow.app maps to working code, and every visual alig
 ### Key Accomplishments
 
 **Critical stop-bleed (Phases 1-3):**
+
 - Bulk-unpublished 100 broken blog rows + BEFORE-INSERT trigger guard against re-publish (CRIT-01)
 - Fixed homepage NumberTicker animation (5 / 7 / 500 / 14) with one-shot IntersectionObserver (CRIT-02)
 - 375px mobile drawer using shadcn `Sheet` + 44×44 touch targets + 8-test Playwright spec (CRIT-04)
 - 5 redirect aliases (`/signup` → `/pricing` + 4 legal long-form paths → canonical short paths) eliminating the `/signup` → `/login` loop (CRIT-05/06)
 
 **Persona + Pricing (Phases 4-5):**
+
 - Unified "landlord" persona across hero / About / meta / FAQ / blog with `marketing-copy-landlord-only.test.ts` 7-category banlist drift guard (CONS-01 + COPY-01..07)
 - Pricing restructured to **Starter $19 / Growth $49 / Max $149** with `src/config/pricing.ts` single-source-of-truth, 8 consumer files reading via `#config/pricing`, Stripe products + prices repointed via MCP, 3-offer `Product` JSON-LD (PRICE-01..06)
 - Fabricated "Join 500+" replaced with honest "Built for landlords with 1–15 rentals" segment framing (COPY-02)
 
 **Blog rebuild + battle-test remediation (Phases 6, 14):**
+
 - `/blog` index server-rendered, real-404 on unknown slug via `dynamicParams = false`, visible breadcrumbs, canonical URLs, dynamic OG images, n8n flow redesigned with 9-gate defense-in-depth Edge Function (BLOG-01..06)
 - D-03 try/catch around Supabase fetch routes failures through Sentry instead of 5xx
 - D-04 route-scoped `/blog/loading.tsx` resolves streaming/skeleton mutual exclusion
 
 **Visual polish (Phases 7-10):**
+
 - Most-Popular badge sits cleanly on Growth card; per-card "Save $X/year" annual savings backed by `calculateAnnualSavings(plan.price.monthly)` (CONS-05/09/10)
 - Multi-Property Dashboard feature card uses `lucide-react` `LayoutDashboard` (was back-arrow); homepage `aria-current="page"` no longer mis-highlights "Compare"; Resources dropdown navigates to real URLs (CONS-02/03/11)
 - Legal-page "Last Updated" dates honest + drift-guarded against sitemap constants; Trusted Integrations row consistent opacity; duplicate "Why Landlords Choose" table removed from homepage (CONS-04/13/14)
 - Canonical "Contact Sales" CTA label site-wide + neutral `/compare/*` framing (no red ✗ for by-design omissions) + `/contact` "How did you hear" defaults to "Please select" + 2 real testimonials shipped with `length >= 2` regression pin (CONS-06/07/08, TRUST-01/03/04; TRUST-02 deferred — no fabricated badges)
 
 **Tokens, SEO, performance (Phases 11-13):**
+
 - `design-token-drift.test.ts` Vitest scanner over `src/components` + `src/app` for hex/rgb/`bg-white`/inline-ms (TOKEN-01/02/03); `/resources` neon-pink + decorative card backgrounds → canonical tokens
 - Title-separator drift guard + per-page OG images + site-wide Organization + SoftwareApplication JSON-LD + visible breadcrumbs + footer sitemap link + site-wide `aria-current` audit (SEO-01..07)
 - Marketing pages use static gen + ISR (`revalidate=3600` on /, /pricing, /features, /about, /compare/[competitor]) + sticky CTA on `/pricing`, `/faq`, `/features` + feature-flagged lead-capture modal (PERF-01..04)
 
 **v1.0 cleanup (Phase 15):**
+
 - Retroactive `VERIFICATION.md` for Phases 4/5/6/14 (`retroactive: true` + `shipped_pr` frontmatter)
 - `REQUIREMENTS.md` traceability sweep: 35 Pending → 0, 24 body `[ ]` → 0, footer flipped to "Last updated: 2026-05-21"
 - `@stripe/(react-)?stripe-js` dead-dep drift guard (8 tests across 4 dependency roots)

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,19 +1,14 @@
 # TenantFlow
 
-## Current Milestone: v2.0 Dashboard Command Center
+## Current State
 
-**Goal:** Full redesign of the authenticated owner dashboard (`/dashboard`) — restrained B2B aesthetic using already-vendored DiceUI DataTable + Stat / NumberTicker / BlurFade primitives — plus the latent `*100`/`÷100` revenue-path bug fix.
+**Latest shipped milestone:** v2.0 Dashboard Command Center (shipped 2026-06-02, 7 phases / 24 plans / 34/34 requirements). The authenticated owner dashboard at `/dashboard` is now a restrained B2B command center — 6-tile KPI bento row, refreshed `RevenueAreaChart` (30d/6mo) + new `OccupancyDonutChart`, a vendored DiceUI/TanStack-table Portfolio DataTable (sort / faceted filter / column visibility / virtualization / grid-toggle / saved presets / nuqs URL state), full dark-mode + keyboard + 375px + reduced-motion a11y, and an `/dashboard` E2E smoke under CI `owner-axe`. The latent `*100`/`÷100` revenue round-trip is gone — `get_dashboard_data_v2` returns dollars handled correctly end-to-end. Full summary: [MILESTONES.md](MILESTONES.md) · archive: [milestones/v2.0-ROADMAP.md](milestones/v2.0-ROADMAP.md).
 
-**Target features:**
-- 6-tile KPI bento row with sparklines on Revenue + Occupancy
-- Refreshed `RevenueAreaChart` (30d/6mo toggle) + new `OccupancyDonutChart`
-- Portfolio DataTable on `@tanstack/react-table` with sort / column visibility / faceted filter / virtualization / grid-toggle / saved presets
-- Dark-mode + keyboard a11y + 375px responsive + reduced-motion polish, with E2E coverage
-- Drop the `*100`/`÷100` round-trip — `get_dashboard_data_v2` returns dollars; display is accidentally correct because the bug cancels itself
+**No active milestone.** Next milestone unplanned — run `/gsd-new-milestone`.
 
-**Phase numbering:** Reset to 1-7 (major version → fresh sequence). Branch template: `gsd/phase-{phase}-{slug}`.
+### Next Milestone Goals (candidate)
 
-**Source spec:** `.planning/MILESTONE-CONTEXT.md` (copied from the user's parked plan at `/Users/richard/.claude/plans/i-want-to-enhance-hazy-island.md`).
+Queued seed **SEED-001** (`.planning/seeds/SEED-001-supabase-security-advisor-remediation.md`): systematic Supabase Security Advisor remediation — classify + resolve the 46 `authenticated_security_definer_function_executable` WARNs (KEEP-by-design vs TIGHTEN) and the 10 `rls_enabled_no_policy` INFOs, to a documented + test-pinned steady state with zero RLS regressions. `auth_leaked_password_protection` is explicitly out of scope (paid feature). `/gsd-new-milestone` will surface this seed automatically. The user may also pick a different direction at planning time.
 
 ## What This Is
 
@@ -44,48 +39,16 @@ Every public claim on tenantflow.app must map to working code, and every visual 
 - ✓ **Data retention cron jobs (security_events 90d, user_errors 90d, stripe_webhook_events 90d/180d)** — earlier milestone
 - ✓ **RLS on every table; landlord owner isolation enforced via `tests/integration/rls/`** — pre-v1
 - ✓ **Marketing Surface Honesty (56 audit findings closed across CRIT/CONS/COPY/PRICE/BLOG/TOKEN/TRUST/SEO/PERF)** — v1.0 (shipped 2026-05-22, 15 phases, audit round 3 verdict PERFECT BY ALL MEASURES). Highlights: blog DB cleanup + server-render rebuild + n8n redesign; pricing restructured to Starter $19 / Growth $49 / Max $149 with single-source-of-truth `pricing.ts`; unified "landlord" persona across hero/About/meta/FAQ/blog; 5 redirect aliases (`/signup` + 4 legal long-form paths); homepage NumberTicker fix + 375px mobile drawer; design-token drift guard scanning hex/rgb/`bg-white`/inline-ms; canonical "Contact Sales" CTA; 2 real testimonials; SEO meta-separator standardization + per-page OG images + site-wide Organization/SoftwareApplication JSON-LD + visible breadcrumbs; static-gen + sticky CTA + lead-capture modal (feature-flagged); `@stripe/(react-)?stripe-js` dead-dep drift guard; host-derived Vitest worker-pool cap; `/blog` nav suppression regression-pin until content cohort lands.
+- ✓ **Dashboard Command Center — `/dashboard` redesign (34/34 requirements: KPI-01..07, CHART-01..06, DT-01..09, POLISH-01..12)** — v2.0 (shipped 2026-06-02, 7 phases). 6-tile KPI bento row (`Stat` + `NumberTicker` + `StatTrend`, `@container` grid, sparklines on Revenue + Occupancy); refreshed `RevenueAreaChart` (30d/6mo toggle) + new `OccupancyDonutChart` (center label + legend from `stats.units`), series colors from `--color-chart-{1..5}`, `next/dynamic` `ssr:false`; vendored DiceUI/TanStack Portfolio DataTable (`useClientDataTable`, `aria-sort` + keyboard sort, faceted status filter, column visibility, virtualization, grid/table toggle, Zustand-`persist` saved presets, nuqs URL state — 3 hand-rolled files deleted); dark-mode token migration with theme-aware `--color-{success,warning,destructive}-text` companions (≥4.5:1 both themes); `NumberTicker` internal reduced-motion guard (16 consumers); 375px zero-horizontal-scroll + skeleton↔empty mutual-exclusion; `/dashboard` E2E smoke + axe-core WCAG 2.1 AA under CI `owner-axe`; **killed the `*100`/`÷100` revenue round-trip** (`get_dashboard_data_v2` returns dollars, correct end-to-end) + extracted shared `transformDashboardData` + dropped fabricated `collection_rate` (no rent-payment data exists). Deferred at close: 2 Phase-6 manual focus-ring sign-offs (automated axe coverage passed in CI).
 
 ### Active
 
-<!-- v2.0 scope: full dashboard redesign at /dashboard. 4 requirement categories.
-     Source spec: .planning/MILESTONE-CONTEXT.md (copied from the user's parked plan at
-     /Users/richard/.claude/plans/i-want-to-enhance-hazy-island.md). -->
+<!-- No active milestone. v2.0 Dashboard Command Center shipped 2026-06-02 and its
+     requirements moved to Validated above. The next milestone's requirements are defined
+     fresh by /gsd-new-milestone (which creates a new REQUIREMENTS.md). Leading candidate:
+     SEED-001 (Supabase Security Advisor remediation) — see Current State → Next Milestone Goals. -->
 
-**KPI visibility (KPI):**
-- [ ] 6-tile bento row replacing the one-line text header (Revenue, Occupancy, Active Leases, Open Maintenance, Properties, Units)
-- [ ] Each tile renders via `Stat` shell + `NumberTicker` value + `StatTrend` arrow
-- [ ] Sparklines on Revenue + Occupancy tiles only (`KpiSparkline` axis-less Recharts `Area`)
-- [ ] Staggered reveals via `BlurFade` (max ~4, reduced-motion aware)
-- [ ] `@container` CSS grid (NOT `ui/bento-grid.tsx` — that's a marketing component)
-
-**Charts + data-viz (CHART):**
-- [ ] `RevenueAreaChart` — refreshed Recharts area chart, 30d / 6mo toggle, drops `/100`
-- [ ] `OccupancyDonutChart` — new Recharts donut, center label, legend
-- [ ] Chart colors source from `--color-chart-*` design tokens
-- [ ] Dark-mode contrast verified
-- [ ] Updated loading skeletons match chart shape
-
-**Portfolio DataTable (DT):**
-- [ ] Replace hand-rolled portfolio table with vendored DiceUI `@tanstack/react-table` stack
-- [ ] `useClientDataTable` thin variant (client-side equivalent of the server-mode `useDataTable`)
-- [ ] `portfolio-columns.tsx` column model with `aria-sort` on sortable headers
-- [ ] Faceted status filter via `DataTableFacetedFilter`
-- [ ] Column visibility via `DataTableViewOptions`
-- [ ] Row virtualization via `@tanstack/react-virtual`
-- [ ] Grid / table view toggle
-- [ ] Saved filter presets (`localStorage` via Zustand `persist` slice `dashboard-presets-store.ts`)
-- [ ] Live filter / sort / page state in nuqs URL params (replaces bespoke Zustand state)
-
-**Polish + a11y (POLISH):**
-- [ ] **Drop every `*100` / `/100` in the revenue path** — `page.tsx` (lines 71/92/107), `formatDashboardCurrency`, `revenue-overview-chart.tsx:41`. In-memory values currently 100× wrong (display accidentally correct because the bug round-trips).
-- [ ] Dark-mode audit across new dashboard surface (no white-on-white, no invisible badges, no `bg-white`)
-- [ ] Keyboard a11y — `aria-sort`, visible focus rings, icon-button `aria-label`s, skip link reachable
-- [ ] 375px viewport — zero horizontal scroll; table forces grid view at mobile breakpoint
-- [ ] Skeleton ↔ empty-state mutual exclusion (Phase 14 D-04 pattern: route-scoped loading.tsx)
-- [ ] Reduced-motion guard on every animation
-- [ ] E2E smoke for `/dashboard` (synthetic owner; KPI numbers match `get_dashboard_data_v2`; occupancy donut matches `stats.units`; DataTable sort/filter/column-visibility/presets work)
-- [ ] Dedup: delete `owner-dashboard.tsx` duplicate, `chart-area-interactive.tsx`, dashboard-filters duplicates, second `portfolio-toolbar.tsx`, `skeletons.tsx`
-- [ ] Phase-2 additive RPC migration for per-property `open_maintenance` (or ship the column hidden by default); resolve `collection_rate` compute-or-drop in discuss-phase (no fabricated zeros)
+_(none — between milestones; run `/gsd-new-milestone` to define the next set)_
 
 ### Out of Scope
 
@@ -152,6 +115,12 @@ Every public claim on tenantflow.app must map to working code, and every visual 
 | Testimonials (TRUST-01): real names + property counts + quotes, **no headshots**. Avatar fallback uses initials or geometric placeholder. | User explicit: can provide names/counts/quotes, headshots difficult to source. | ✓ Good — v1.0 |
 | Treat audit document as v1.0 spec; locked decisions captured here override audit-default recommendations where they conflict | User input > audit defaults. | ✓ Good — v1.0 |
 | Brownfield framing — Validated section pre-populated from v2.6 capabilities | TenantFlow is mature; PROJECT.md must reflect that to prevent agents from re-deriving stack/architecture. | ✓ Good — v1.0 |
+| v2.0 phase numbering **reset to 1-7** (major-version → fresh sequence; v1.0's phases 1-15 archived independently) | Keeps per-milestone phase numbers small and legible; archives keep history separable. | ✓ Good — v2.0 |
+| KPI grid is a plain `@container` CSS grid of `Stat` tiles — `ui/bento-grid.tsx` is OUT | `bento-grid.tsx` is a marketing-flash component; the dashboard is restrained B2B. | ✓ Good — v2.0 |
+| Drop `collection_rate` from the KPI set rather than fabricate `0` | TenantFlow facilitates no rent payments, so the data does not exist — v1.0 honesty principle (never fabricate). | ✓ Good — v2.0 |
+| No `*100` / `/100` revenue arithmetic anywhere — cross-cutting hard rule, perfect-PR-gate enforced | The latent round-trip made in-memory values 100× wrong while display accidentally cancelled; `get_dashboard_data_v2` returns dollars. | ✓ Good — v2.0 |
+| Authed dashboard E2E runs under the CI **`owner-axe`** project (in-test `loginAsOwner` cookie injection), NOT the storageState `owner` project | The `owner` storageState project does not run in CI; `owner-axe` is the CI-runnable authed path. | ✓ Good — v2.0 |
+| Dark-mode text uses theme-aware `--color-{success,warning,destructive}-text` companions (≥4.5:1); vivid brand tokens stay on icons only (3:1) | Vivid tokens fail AA as foreground text in one theme each; carried into the post-milestone app-wide token sweep (PRs #769/#770). | ✓ Good — v2.0 |
 
 ## Evolution
 
@@ -171,4 +140,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-06-01 — v2.0 "Dashboard Command Center" in progress. Phase 6 (Polish & A11y) complete: POLISH-04..08 satisfied (theme-aware dark-mode contrast tokens, axe-core a11y E2E wired into CI via the `owner-axe` project, 375px responsive probe, skeleton/empty mutual exclusion, NumberTicker reduced-motion guard). Two human-verification items tracked in `06-HUMAN-UAT.md` (live CI axe run + manual focus audit). Next: Phase 7 (Verification). v1.0 "Marketing Surface Honesty" archived 2026-05-22 (15 phases, 56/56 requirements, audit verdict PERFECT BY ALL MEASURES).*
+*Last updated: 2026-06-02 after v2.0 milestone — "Dashboard Command Center" shipped and archived (7 phases, 24 plans, 34/34 requirements; final phase PR #773 → `3e1a4cc29`). All v2.0 requirements moved to Validated. Deferred at close: 2 Phase-6 manual focus-ring sign-offs (automated axe coverage passed in CI; see STATE.md Deferred Items). No active milestone — next is `/gsd-new-milestone` (queued candidate: SEED-001 Supabase Security Advisor remediation). v1.0 "Marketing Surface Honesty" archived 2026-05-22.*

--- a/.planning/RETROSPECTIVE.md
+++ b/.planning/RETROSPECTIVE.md
@@ -1,0 +1,62 @@
+# TenantFlow — Living Retrospective
+
+Cross-milestone reflection. Newest milestone first; cross-milestone trends at the bottom.
+
+## Milestone: v2.0 — Dashboard Command Center
+
+**Shipped:** 2026-06-02
+**Phases:** 7 | **Plans:** 24 | **Tasks:** 40 | **Requirements:** 34/34
+
+### What Was Built
+
+The authenticated owner dashboard at `/dashboard` was rebuilt into a restrained B2B command center: a 6-tile KPI bento row (`Stat` + `NumberTicker` + `StatTrend`, sparklines on Revenue + Occupancy), a refreshed `RevenueAreaChart` (30d/6mo toggle) + a new `OccupancyDonutChart`, and a vendored DiceUI/TanStack Portfolio DataTable (sort with `aria-sort` + keyboard, faceted filter, column visibility, virtualization, grid/table toggle, Zustand-`persist` saved presets, nuqs URL state). Phase 6 layered dark-mode token correctness, a `NumberTicker` reduced-motion guard, 375px zero-scroll, and skeleton↔empty mutual exclusion. Phase 7 locked it with an `/dashboard` E2E smoke + axe-core WCAG 2.1 AA under CI `owner-axe`. The cross-cutting win: the latent `*100`/`÷100` revenue round-trip was deleted so in-memory dollars are correct end-to-end, and the fabricated `collection_rate` `0` was dropped.
+
+### What Worked
+
+- **Foundation-first sequencing (1 → 2 → (3 ∥ 4) → 5 → 6 → 7).** Phases 1-2 were invisible plumbing (dedup + honest data layer) so every visible phase built on correct values. Phases 3 and 4 each *added* a region with no file overlap and could ship in parallel.
+- **Perfect-PR gate held every phase.** Two consecutive zero-finding deep review cycles caught real regressions before merge (Phase 1: 7 cycles, Phase 2: 11, Phase 4: 9, Phase 5: 8). The discipline cost cycles but kept `main` green throughout.
+- **Phase 7 as the binding audit.** Rather than a separate `/gsd:audit-milestone`, the verification phase ran a real 7-test smoke against live prod (populated synthetic owner) in CI — the milestone's truth was an actually-executed E2E, not a checklist.
+- **Atomic swaps.** Phase 5's DataTable replacement (mount new + trim store + delete 3 hand-rolled files) and Phase 4's chart swap landed as single coherent commits, never leaving the dashboard half-migrated.
+
+### What Was Inefficient
+
+- **Phase 2 took 11 review cycles + a post-merge fix** — the most of any phase. RPC/migration boundary work (typed mappers, RLS test shape) surfaced findings serially rather than all at once; a deeper first-pass mapper review would have collapsed cycles.
+- **Phase-6 manual a11y sign-offs never closed** — `06-HUMAN-UAT.md` + `06-VERIFICATION.md` stayed `human_needed`/`partial` because they require a human at a keyboard. Automated axe coverage substantially superseded them, but the artifacts lingered as open items into milestone close (acknowledged + deferred).
+- **CI dual-run confusion.** The `ci-cd.yml` + `ci-cd-doc-only.yml` pair (both named "CI") made `gh pr checks` ambiguous on mixed src+docs PRs; real E2E had to be confirmed via the long-duration check-run entry.
+
+### Patterns Established
+
+- **Shared-primitive reduced-motion guard goes INSIDE the effect**, not as a component-top early-return — keeps the `ref`/IntersectionObserver attached so the scroll-triggered NumberTicker still fires. (Reused for all 16 consumers.)
+- **`-text` token companions for foreground text, vivid brand tokens for icons.** Vivid `--color-{success,warning,destructive,info}` fail AA as text in one theme each; the `-text` companions (≥4.5:1 both themes) are the text path. Became an app-wide sweep post-milestone (PRs #769/#770).
+- **Authed dashboard E2E targets the CI `owner-axe` project** (in-test `loginAsOwner` cookie injection), not the storageState `owner` project (which doesn't run in CI).
+
+### Key Lessons
+
+- An "invisible" bug that visually cancels itself (`*100` then `/100`) is still a correctness liability the moment any consumer reads the in-memory value — fix it at the source even when the display looks fine.
+- Honesty over fabrication: a missing metric (`collection_rate`) is dropped, never zero-filled, when the underlying data does not exist.
+- Manual human-UAT items will not close themselves; scope them as explicit deferred-with-rationale at milestone close when automated coverage makes them low-risk, rather than blocking the milestone on a keyboard session.
+
+### Cost Observations
+
+- Model mix: quality profile (Opus on heavy reasoning per `config.json model_profile: quality`).
+- Mode: YOLO / autonomous, fine granularity (7 phases).
+- Notable: per-phase deep code review + perfect-PR gate is the dominant token cost; it traded tokens for a consistently green `main` and zero post-merge rollbacks across the milestone.
+
+---
+
+## Cross-Milestone Trends
+
+| Milestone | Phases | Plans | Shipped | Verdict |
+|-----------|--------|-------|---------|---------|
+| v1.0 Marketing Surface Honesty | 15 | 33 | 2026-05-22 | Audit Round 3: PERFECT BY ALL MEASURES |
+| v2.0 Dashboard Command Center | 7 | 24 | 2026-06-02 | 34/34 requirements; Phase-7 E2E green in CI |
+
+**Recurring strengths:**
+- Perfect-PR merge gate (two consecutive zero-finding cycles) enforced every phase, both milestones.
+- Drift-guard tests (design-token scanner, dead-dep guards, marketing-copy banlist) turn one-time fixes into permanent regressions-prevented.
+- Honesty principle (no fabricated stats/metrics/testimonials) held across both milestones.
+
+**Recurring frictions:**
+- RPC/migration-boundary phases attract the most review cycles (v1.0 blog data layer; v2.0 Phase 2).
+- Human-in-the-loop verification items tend to linger open until milestone close.
+- The dual "CI" workflow naming repeatedly obscures which run actually executed E2E.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,192 +3,25 @@
 ## Milestones
 
 - ✅ **v1.0 Marketing Surface Honesty** — Phases 1-15 (shipped 2026-05-22) — see [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md)
-- 🚧 **v2.0 Dashboard Command Center** — Phases 1-7 (in planning; major-version phase reset)
-
----
-
-# v2.0 Dashboard Command Center
-
-**Defined:** 2026-05-22
-**Granularity:** fine (7 phases)
-**Branch template:** `gsd/phase-{phase}-{slug}`
-**Numbering:** reset to 1-7 (major-version → fresh sequence; v1.0's phases 1-15 archived)
-**Coverage:** 34/34 requirements mapped ✓
-**Source spec:** `.planning/MILESTONE-CONTEXT.md`
-
-## Core Value
-
-The authenticated owner dashboard at `/dashboard` becomes a restrained, professional B2B command center — KPI visibility above the fold, polished charts, a real DataTable with column controls + saved presets, full keyboard/dark-mode/mobile a11y. Every dollar amount handled correctly throughout the data path (no `*100`/`÷100` round-trip).
-
-## Cross-Cutting Constraints (apply to every phase)
-
-- **Design-token alignment** — `--color-*`, `--spacing-*`, `--radius-*`, `--shadow-*`, `--duration-*`, `--ease-*`, `--color-chart-{1..5}` only. `design-token-drift.test.ts` Vitest guard (v1.0 Phase 11) continues to enforce.
-- **No `*100` / `/100` revenue arithmetic anywhere.** Cross-cutting hard rule; any new file or edit that re-introduces it fails the perfect-PR gate.
-- **Restrained B2B aesthetic.** No `@magicui` / `@aceternity` flash. `ui/bento-grid.tsx` (marketing component) is forbidden for KPI tiles.
-- **Independently shippable.** Each phase ships as one atomic PR through the perfect-PR gate (two consecutive zero-finding deep review cycles). The dashboard must never break mid-milestone.
-- **Zero Tolerance Rules** (CLAUDE.md): no `any`, no barrel files, no duplicate types, no commented-out code, no inline styles, no `as unknown as`, no string-literal query keys, lucide-react only.
-
-## Dependency Order
-
-```
-1 → 2 → (3 ∥ 4) → 5 → 6 → 7
-```
-
-Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region — they can ship in parallel (no file overlap). Phase 5 is the only swap (atomic PR replacing the hand-rolled portfolio table). Phase 6 is polish over already-shipped surfaces. Phase 7 is invisible verification.
+- ✅ **v2.0 Dashboard Command Center** — Phases 1-7 (shipped 2026-06-02, 34/34 requirements) — see [milestones/v2.0-ROADMAP.md](milestones/v2.0-ROADMAP.md)
+- 📋 **Next milestone** — not yet planned. Queued seed: [SEED-001](seeds/SEED-001-supabase-security-advisor-remediation.md) (Supabase Security Advisor remediation). Run `/gsd:new-milestone`.
 
 ## Phases
 
-- [x] **Phase 1: Foundation & Dedup** — Delete duplicates, fix the `*100`/`÷100` revenue bug, extract shared transform, produce milestone-wide UI-SPEC. Zero visible change.
-- [x] **Phase 2: Data Layer & RPC** — Additive RPC migration for per-property `open_maintenance`; resolve compute-or-drop on `collection_rate`; RLS owner-isolation test.
-- [x] **Phase 3: KPI Bento Row** — 6-tile KPI grid with sparklines on Revenue + Occupancy. Adds Section B.
-- [x] **Phase 4: Charts** — `RevenueAreaChart` refresh (30d/6mo toggle) + new `OccupancyDonutChart`. Adds Section C.
-- [x] **Phase 5: Portfolio DataTable** — Replace hand-rolled table with DiceUI DataTable: client hook, column model, faceted filter, column visibility, virtualization, grid/table toggle, saved presets, nuqs URL state.
-- [ ] **Phase 6: Polish & A11y** — Dark-mode audit, keyboard a11y, 375px responsive, skeleton/empty mutual exclusion, reduced-motion.
-- [x] **Phase 7: Verification** — E2E coverage for `/dashboard` + final design-token sweep.
+<details>
+<summary>✅ v2.0 Dashboard Command Center (Phases 1-7) — SHIPPED 2026-06-02</summary>
 
-## Phase Details
+- [x] Phase 1: Foundation & Dedup (3/3 plans) — PR #744 — completed 2026-05-22
+- [x] Phase 2: Data Layer & RPC (3/3 plans) — PR #745 — completed 2026-05-22
+- [x] Phase 3: KPI Bento Row (3/3 plans) — PR #746 — completed 2026-05-26
+- [x] Phase 4: Charts (4/4 plans) — PR #748 — completed 2026-05-28
+- [x] Phase 5: Portfolio DataTable (5/5 plans) — PR #763 — completed 2026-05-31
+- [x] Phase 6: Polish & A11y (4/4 plans) — PR #767 — completed 2026-06-01
+- [x] Phase 7: Verification (2/2 plans) — PR #773 — completed 2026-06-02
 
-### Phase 1: Foundation & Dedup
-**Slug:** `dashboard-foundation-dedup`
-**Goal:** Strip duplicate/dead dashboard code, kill the `*100`/`÷100` revenue round-trip, extract one shared data transform, and produce the milestone-wide UI-SPEC the remaining phases inherit (aesthetic, tokens, dark-mode rules, breakpoints, motion budget).
-**Depends on:** Nothing (first phase)
-**Requirements:** POLISH-01, POLISH-02, POLISH-03
-**Success Criteria** (what must be TRUE):
-  1. Visiting `/dashboard` after the merge shows the same KPI numbers as before (the `*100`/`÷100` bug visually cancelled itself, so display is unchanged — but in-memory values are now correct).
-  2. `src/components/dashboard/owner-dashboard.tsx`, `chart-area-interactive.tsx`, the duplicate `dashboard-filters*.tsx`, the second `portfolio-toolbar.tsx`, and `skeletons.tsx` no longer exist in the repo.
-  3. Repo-wide grep for `* 100` and `/ 100` against currency variables in `src/app/(owner)/dashboard/` and `src/components/dashboard/` returns zero hits.
-  4. `design-token-drift.test.ts` passes; milestone-wide UI-SPEC committed at `.planning/phases/01-dashboard-foundation-dedup/UI-SPEC.md` (aesthetic, tokens, dark-mode rules, breakpoints, motion budget) and inherited by all later phases.
-**Plans:** 3 plans (3 waves — serialized)
-- [ ] 01-01-PLAN.md — **Wave 1.** Bug fix (drop `*100` in page.tsx + `/100` in revenue-overview-chart.tsx) + extract pure `transformDashboardData` module + wire into use-dashboard-hooks selectors (D-12a interpretation #2)
-- [ ] 01-02-PLAN.md — **Wave 2** (depends on 01-01). Currency utility consolidation: delete duplicate `formatDashboardCurrency`; swap 3 callers to canonical `formatCurrency` with no-cents options object (D-09a / RC-7)
-- [ ] 01-03-PLAN.md — **Wave 3** (depends on 01-01 + 01-02). Dedup deletions: 5 files + 1 test (owner-dashboard.tsx + its test, dashboard-filters{,-compact,-utils}, top-level portfolio-toolbar.tsx, skeletons.tsx); chart-area-interactive.tsx PRESERVED per D-13a. Owns the canonical D-03 / UI-SPEC § Appendix A `*100`/`/100` grep sweep (only runnable after Wave 1+2 land + owner-dashboard.tsx is deleted in Task 1).
-**UI hint:** yes
+Closed at 34/34 requirements (KPI-01..07, CHART-01..06, DT-01..09, POLISH-01..12). Full phase detail + success criteria in [milestones/v2.0-ROADMAP.md](milestones/v2.0-ROADMAP.md); milestone summary in [MILESTONES.md](MILESTONES.md).
 
-### Phase 2: Data Layer & RPC
-**Slug:** `dashboard-data-layer-rpc`
-**Goal:** Make the dashboard's data inputs honest — additive migration for per-property `open_maintenance` (locked D-02), and drop `collection_rate` from the KPI set per the v1.0 honesty principle (locked D-01: TenantFlow does not facilitate rent payments, no payment data exists, never fabricate `0`).
-**Depends on:** Phase 1
-**Requirements:** POLISH-10, POLISH-11
-**Success Criteria** (what must be TRUE):
-  1. Querying `get_dashboard_data_v2` as an authenticated owner returns a real per-property `open_maintenance` count for each row (or the column is documented as ship-hidden until Phase 5 wires it).
-  2. The portfolio data model contains no hardcoded `0` for `collectionRate` — either the field is dropped from the KPI set or sourced from a real RPC value (resolution captured in the Phase 2 discuss artifact).
-  3. `tests/integration/rls/` includes a dual-client (ownerA/ownerB) test confirming the migrated RPC respects owner isolation under RLS.
-  4. `bun run test:integration` passes on the new test against prod.
-**Plans:** 3 plans (3 waves — serialized)
-- [ ] 02-01-PLAN.md — **Wave 1.** Additive migration extending `get_dashboard_data_v2` with `perf_open_maintenance` CTE + `open_maintenance` JSON key; MCP `apply_migration` to prod; reconcile filename with prod timestamp; regenerate `src/types/supabase.ts`.
-- [ ] 02-02-PLAN.md — **Wave 2** (depends on 02-01). Frontend wiring: add `open_maintenance: number` to `PropertyPerformance` + `PropertyPerformanceRpcResponse`; drop `collectionRate` from `DashboardMetrics`; update fetcher mapper, page.tsx re-mapper, `transformDashboardData`, and the inline `dashboard.tsx` portfolio transform to source real `open_maintenance` instead of hardcoded `0`.
-- [ ] 02-03-PLAN.md — **Wave 3** (depends on 02-02). Dual-client RLS integration test at `tests/integration/rls/dashboard-rpc-open-maintenance.test.ts` (happy-path + cross-owner isolation); `bun run test:integration` against prod; manual checkpoint confirming portfolio table renders real maintenance counts.
-
-### Phase 3: KPI Bento Row
-**Slug:** `dashboard-kpi-bento-row`
-**Goal:** Replace the one-line text header with a 6-tile KPI bento row (Revenue, Occupancy, Active Leases, Open Maintenance, Properties, Units) using already-vendored `Stat` + `NumberTicker` + `BlurFade` primitives, with sparklines on Revenue + Occupancy only.
-**Depends on:** Phase 1 (UI-SPEC), Phase 2 (real KPI values)
-**Requirements:** KPI-01, KPI-02, KPI-03, KPI-04, KPI-05, KPI-06, KPI-07
-**Success Criteria** (what must be TRUE):
-  1. `/dashboard` renders 6 KPI tiles above the chart row (Revenue, Occupancy, Active Leases, Open Maintenance, Properties, Units).
-  2. Revenue and Occupancy tiles each render an axis-less Recharts `Area` sparkline; the other four tiles do not.
-  3. Each tile's numeric value animates via `NumberTicker`; users with `prefers-reduced-motion: reduce` see the final value with no animation.
-  4. The KPI grid uses an `@container` CSS grid auto-fit layout (not `ui/bento-grid.tsx`); section reveals stagger via `BlurFade` with at most ~4 reveals.
-**Plans:** 3 plans (3 waves — serialized)
-- [x] 03-01-PLAN.md — **Wave 1.** KpiSparkline component (KPI-05) + pure helpers (formatTrendPercent, sparklineConfigForTrend, KpiTileConfig). Axis-less Recharts Area inside ChartContainer; trend-direction color via ChartConfig.theme map; role='img' + aria-label; no animation.
-- [x] 03-02-PLAN.md — **Wave 2** (depends on 03-01). KpiBentoRow orchestrator + 6 tiles (KPI-01/02/03/04/06/07) + shared useReducedMotion hook. 6 Stat-shell tiles in D-01 order with @container grid (auto-fit minmax(180px,1fr)), NumberTicker value animation (KpiNumberTicker reduced-motion wrapper), Lucide trend chips with !text-[var(--color-warning)] down override, BlurFade waves A {0,1,2} + B {4,5,6}, skeleton ↔ data branch, buildTileAriaLabel a11y.
-- [x] 03-03-PLAN.md — **Wave 3** (depends on 03-01 + 03-02). Mount KpiBentoRow into dashboard.tsx (replace legacy <p> header at lines 172-186; preserve <h1> + data-testid). Extend DashboardProps with kpiData: KpiBentoRowProps. Construct kpiData in page.tsx from useDashboardStats() + useDashboardCharts(). Manual visual checkpoint (browser path or MCP RPC inspection alternate).
-**UI hint:** yes
-
-### Phase 4: Charts
-**Slug:** `dashboard-charts`
-**Goal:** Ship the new charts row — `RevenueAreaChart` (refreshed Recharts area with 30d/6mo toggle, no `/100`) and a brand-new `OccupancyDonutChart` (center label + legend, sourcing from `stats.units`).
-**Depends on:** Phase 1 (UI-SPEC)
-**Requirements:** CHART-01, CHART-02, CHART-03, CHART-04, CHART-05, CHART-06
-**Success Criteria** (what must be TRUE):
-  1. `/dashboard` renders a revenue area chart with a 30d / 6mo toggle that updates the visible series; values are correct dollars (no residual `/100`).
-  2. `/dashboard` renders an occupancy donut chart with a center label and legend; the count matches `stats.units` returned by `get_dashboard_data_v2`.
-  3. Chart series colors source exclusively from `--color-chart-{1..5}`; dark-mode contrast is verified (no invisible series, no white-on-white legend swatches).
-  4. Both charts dynamically import via `next/dynamic` with `ssr: false` and shape-matching CSS-only loading skeletons (no skeleton ↔ empty co-render).
-**Plans:** 4 plans (3 waves — 04-01a + 04-01b parallel in Wave 1)
-- [x] 04-01a-PLAN.md — **Wave 1.** Database half of data layer: Recharts test mock Label export (Wave-0 prereq for Plan 04-03 donut tests); additive migration extending get_dashboard_data_v2 with month_series + ts_revenue_6mo CTEs and the monthly_revenue_6mo time_series key (D-01); MCP apply + filename reconcile + bun run db:types regen. Split out from original 04-01 so the ~300-line SECURITY DEFINER CREATE OR REPLACE has its own context window.
-- [x] 04-01b-PLAN.md — **Wave 1** (depends on 04-01a). TS/test half of data layer: MonthlyRevenuePoint type + boundary mapper line emitting monthlyRevenue6mo; dual-client RLS integration test pinning the cycle-10 /access denied/i contract.
-- [x] 04-02-PLAN.md — **Wave 2** (depends on 04-01a + 04-01b). RevenueAreaChart (CHART-01) + colocated RevenueAreaChartSkeleton + 12 Vitest specs. Local useState 30d/6mo toggle, shadcn Tabs in CardHeader right slot, formatCurrency in tooltip, var(--color-chart-1) area stroke + gradient, animationDuration={800} + isAnimationActive={\!useReducedMotion()}, honest empty-state copy. NO mount yet (dashboard.tsx still uses old chart).
-- [x] 04-03-PLAN.md — **Wave 3** (depends on 04-01a + 04-01b + 04-02). OccupancyDonutChart (CHART-02) + colocated OccupancyDonutChartSkeleton + 11 Vitest specs. Atomic swap (single commit): reshape DashboardProps (drop revenueTrend, add monthlyRevenue + monthlyRevenue6mo + units) + drop revenueTrend transform in page.tsx + mount the chart pair in dashboard.tsx via next/dynamic (3-up layout per D-02: Revenue col-span-2 + Donut col-span-1 + Quick Actions col-span-1). Delete revenue-overview-chart.tsx atomically. Drop chartConfig from dashboard-types.ts if no surviving consumers. Manual visual checkpoint (3-up layout + toggle + dark-mode + skeleton ↔ data transition).
-**UI hint:** yes
-
-### Phase 5: Portfolio DataTable
-**Slug:** `dashboard-portfolio-datatable`
-**Goal:** Replace the hand-rolled portfolio table with the vendored DiceUI DataTable composition — new `useClientDataTable` hook, `portfolio-columns.tsx` column model with `aria-sort`, faceted status filter, column visibility, virtualization, grid/table view toggle, saved presets in localStorage, live filter/sort/page state in nuqs URL params.
-**Depends on:** Phase 1 (UI-SPEC), Phase 2 (real per-property values)
-**Requirements:** DT-01, DT-02, DT-03, DT-04, DT-05, DT-06, DT-07, DT-08, DT-09
-**Success Criteria** (what must be TRUE):
-  1. Clicking a sortable column header on the portfolio table sorts the rows and exposes `aria-sort` on that header; keyboard users can sort via Tab + Enter/Space.
-  2. The faceted status filter and column-visibility menu both work; selected filters and sort persist in the URL (refresh restores state) via nuqs.
-  3. The user can save a filter preset, refresh the page, and re-apply that preset from the preset menu (localStorage via Zustand `persist`).
-  4. The grid/table view toggle works; `dashboard-store.ts` is trimmed to `viewMode` only; the table virtualizes long lists via `useVirtualizer`.
-  5. The hand-rolled `portfolio-table.tsx`, `portfolio-toolbar.tsx`, and `portfolio-pagination.tsx` no longer exist in the repo.
-**Plans:** 5 plans (3 waves)
-- [x] 05-01a-PLAN.md — **Wave 1.** `useClientDataTable` hook (DT-02): fork of `use-data-table.ts` with manual flags off + nuqs mirror kept; URL-compatible with the server hook (DT-09 foundation). Hook unit tests (manual-flags / page-count-recompute / nuqs round-trip / URL hydration).
-- [x] 05-01b-PLAN.md — **Wave 1.** `portfolio-columns.tsx` 7-column `ColumnDef<PortfolioRow>[]` (DT-03) + extend `DataTableColumnHeader` to emit `aria-sort` + keyboard sort (DT-03 a11y); status `meta.options` for the faceted filter (DT-04) + per-column `meta.label` (DT-05). Column-model + aria-sort tests.
-- [x] 05-02-PLAN.md — **Wave 2** (depends on 05-01a + 05-01b). Compose `PortfolioDataTable`: vendored shell + faceted status filter (DT-04) + column visibility (DT-05) + always-on virtualized tbody (DT-06, D-2) + grid/table toggle reading the same rows (DT-07, D-5). Controlled component, NO mount. Component tests.
-- [x] 05-03a-PLAN.md — **Wave 3** (depends on 05-01a + 05-02). `dashboard-presets-store.ts` Zustand `persist` slice: full-snapshot presets (DT-08, D-1) + live `columnVisibility` (D-3). Preset round-trip + persistence + SSR-safety tests. (6 tests)
-- [x] 05-03b-PLAN.md — **Wave 3** (depends on 05-02 + 05-03a). Atomic swap: trimmed `dashboard-store.ts` to `viewMode` only + deleted the 3 dead selector hooks (DT-09); rewrote `dashboard.tsx` to mount `PortfolioDataTable` + `PortfolioPresetMenu` (DT-01, DT-08); nuqs URL state (DT-09); DELETED the 3 hand-rolled files (criterion #5). 5 swap-integrity + preset/URL tests; full suite (106,141) green. Perfect-PR gate pending.
-**UI hint:** yes
-
-### Phase 6: Polish & A11y
-**Slug:** `dashboard-polish-a11y`
-**Goal:** Polish over shipped surfaces — dark-mode audit, keyboard a11y, 375px responsive layout, skeleton/empty mutual exclusion, reduced-motion guards.
-**Depends on:** Phases 3, 4, 5 (polishes their output)
-**Requirements:** POLISH-04, POLISH-05, POLISH-06, POLISH-07, POLISH-08
-**Success Criteria** (what must be TRUE):
-  1. Toggling between light and dark mode on `/dashboard` reveals no white-on-white text, no invisible badges, and zero `bg-white` references in the dashboard subtree.
-  2. Tab-navigating through `/dashboard` reveals a visible focus ring on every interactive element; every icon-only button has an `aria-label`; the skip-to-content link works from the dashboard header.
-  3. At 375px viewport width, `/dashboard` has zero horizontal scroll; the portfolio table forces grid view at the mobile breakpoint.
-  4. Loading states never co-render a skeleton AND an empty state; route-scoped `loading.tsx` covers the streaming case (Phase 14 D-04 pattern from v1.0).
-  5. Users with `prefers-reduced-motion: reduce` see no `NumberTicker`, `BlurFade`, or chart-transition animations.
-**Plans:** 4 plans (2 waves)
-- [x] 06-01-PLAN.md — **Wave 1** (autonomous: false; blocking legitimacy checkpoint). Wave-0 prerequisites: install `@axe-core/playwright` into ROOT `package.json` (declared in tests/e2e but not installed; CI resolves from root) + wire `--project=owner` into the CI E2E run so the authed `/dashboard` axe test executes in CI (POLISH-05).
-- [x] 06-02-PLAN.md — **Wave 1.** Dark-mode token migration (POLISH-04 + D-05): `lease-status-badge` → `status-active/-pending/-inactive` utilities; maintenance cells (`portfolio-columns`, `portfolio-grid`) + `StatTrend` (shared `stat.tsx`) + `expiring-leases-widget` raw palette → `--color-{success,destructive,warning}` tokens; full landmine grep returns zero, drift guard stays green.
-- [x] 06-03-PLAN.md — **Wave 1.** Reduced-motion JS guard (POLISH-08 + D-04): make shared `number-ticker.tsx` honor `useReducedMotion()` internally (additive — motion-on path unchanged; 16 consumers) + matchMedia-mock branch test; verify chart `isAnimationActive` + `BlurFade` guards already present.
-- [x] 06-04-PLAN.md — **Wave 2** (depends on 06-01). A11y + responsive + skeleton/empty: new `dashboard-a11y.e2e.spec.ts` axe-core WCAG 2.1 AA assertion under the authed `owner` project (POLISH-05) + 375px zero-horizontal-scroll probe (POLISH-06, `FORCE_GRID_QUERY` LOCK untouched) + `DashboardContent` skeleton↔empty mutual-exclusion unit regression test (POLISH-07; no `dashboard/loading.tsx`).
-
-### Phase 7: Verification
-**Slug:** `dashboard-verification`
-**Goal:** Lock the milestone — Playwright E2E coverage for `/dashboard` (synthetic owner, real prod data) and a final design-token drift sweep across every new dashboard file.
-**Depends on:** Phases 3, 4, 5, 6 (verifies all visible surfaces)
-**Requirements:** POLISH-09, POLISH-12
-**Success Criteria** (what must be TRUE):
-  1. The Playwright E2E suite includes a `/dashboard` smoke test against a synthetic owner: KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset-save+restore work, grid/table toggle works.
-  2. `bun run test:e2e` passes locally and the GitHub `e2e-smoke` check passes on the Phase 7 PR.
-  3. `design-token-drift.test.ts` runs clean over every new dashboard file (no hex, no rgb, no `bg-white`, no inline ms durations).
-  4. The merged PR closes the v2.0 milestone with 34/34 requirements satisfied per traceability.
-**Plans:** 2 plans (2 waves)
-- [x] 07-01-PLAN.md — **Wave 1.** POLISH-09 `/dashboard` E2E smoke under the CI-run `owner-axe` project (in-test `loginAsOwner`, no storageState): KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset save+restore + grid/table toggle. New `dashboard-rpc-helpers.ts` derives expected values from the authed RPC; `owner-axe` `testMatch` widened to collect it.
-- [x] 07-02-PLAN.md — **Wave 2** (depends on 07-01). POLISH-12 design-token sweep verification across every new dashboard file (the drift test already walks `src/components/**` + `src/app/**`) + removal of the stale Phase-1 `dashboard-filters.tsx` exemption; milestone close: flip POLISH-09 + POLISH-12 traceability to satisfied (34/34). Ships as one atomic PR through the perfect-PR gate.
-
-Phase 7 ships as one atomic PR through the perfect-PR gate (two consecutive zero-finding deep review cycles), per the milestone's cross-cutting "Independently shippable" constraint, closing v2.0 at 34/34 requirements satisfied.
-
-## Progress
-
-| Phase | Milestone | Plans | Status | Completed |
-|-------|-----------|-------|--------|-----------|
-| 1. Foundation & Dedup | v2.0 | 3/3 | Shipped (PR #744) | 2026-05-22 |
-| 2. Data Layer & RPC | v2.0 | 3/3 | Shipped (PR #745) | 2026-05-22 |
-| 3. KPI Bento Row | v2.0 | 3/3 | Shipped (PR #746) | 2026-05-26 |
-| 4. Charts | v2.0 | 4/4 | Shipped (PR #748) | 2026-05-28 |
-| 5. Portfolio DataTable | v2.0 | 5/5 | Shipped (PR #763) | 2026-05-31 |
-| 6. Polish & A11y | v2.0 | 4/4 | Complete   | 2026-06-01 |
-| 7. Verification | v2.0 | 2/2 | Complete   | 2026-06-02 |
-
-## Coverage Validation
-
-| Category | Count | Phase(s) |
-|----------|-------|----------|
-| KPI (KPI-01..07) | 7 | Phase 3 |
-| CHART (CHART-01..06) | 6 | Phase 4 |
-| DT (DT-01..09) | 9 | Phase 5 |
-| POLISH (POLISH-01..12) | 12 | Phase 1 (01/02/03), Phase 2 (10/11), Phase 6 (04..08), Phase 7 (09/12) |
-| **Total** | **34** | **All mapped, no orphans, no double-mapping ✓** |
-
----
-
-# v1.0 Archive (Shipped 2026-05-22)
+</details>
 
 <details>
 <summary>✅ v1.0 Marketing Surface Honesty (Phases 1-15) — SHIPPED 2026-05-22</summary>
@@ -209,9 +42,21 @@ Phase 7 ships as one atomic PR through the perfect-PR gate (two consecutive zero
 - [x] Phase 14: Battle Test Findings Remediation (4/4 plans) — PR #705 + #708/#718-#724 followups
 - [x] Phase 15: v1.0 Milestone Cleanup (5/5 plans) — PR #743
 
-Audit round 3 verdict: PERFECT BY ALL MEASURES. Full milestone summary in [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md) and [milestones/v1.0-MILESTONE-AUDIT.md](milestones/v1.0-MILESTONE-AUDIT.md).
+Audit round 3 verdict: PERFECT BY ALL MEASURES. Full detail in [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md) + [milestones/v1.0-MILESTONE-AUDIT.md](milestones/v1.0-MILESTONE-AUDIT.md).
 
 </details>
 
+## Progress
+
+| Phase | Milestone | Plans | Status | Completed |
+|-------|-----------|-------|--------|-----------|
+| 1. Foundation & Dedup | v2.0 | 3/3 | Shipped (PR #744) | 2026-05-22 |
+| 2. Data Layer & RPC | v2.0 | 3/3 | Shipped (PR #745) | 2026-05-22 |
+| 3. KPI Bento Row | v2.0 | 3/3 | Shipped (PR #746) | 2026-05-26 |
+| 4. Charts | v2.0 | 4/4 | Shipped (PR #748) | 2026-05-28 |
+| 5. Portfolio DataTable | v2.0 | 5/5 | Shipped (PR #763) | 2026-05-31 |
+| 6. Polish & A11y | v2.0 | 4/4 | Shipped (PR #767) | 2026-06-01 |
+| 7. Verification | v2.0 | 2/2 | Shipped (PR #773) | 2026-06-02 |
+
 ---
-*Last updated: 2026-05-26 — Phase 4 plans drafted (04-01 data layer + RLS, 04-02 RevenueAreaChart, 04-03 OccupancyDonutChart + mount + cleanup)*
+*Last updated: 2026-06-02 — v2.0 Dashboard Command Center archived (7 phases, 24 plans, 34/34 requirements). Next milestone unplanned; SEED-001 queued.*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,88 +2,43 @@
 gsd_state_version: 1.0
 milestone: v2.0
 milestone_name: Dashboard Command Center
-status: "Phase 6 shipped — PR #767"
-last_updated: "2026-06-02T17:08:00.969Z"
-last_activity: 2026-06-01
+status: Awaiting next milestone
+last_updated: "2026-06-02T18:12:54.374Z"
+last_activity: 2026-06-02 — Milestone v2.0 completed and archived
 progress:
   total_phases: 7
-  completed_phases: 6
+  completed_phases: 7
   total_plans: 24
-  completed_plans: 23
-  percent: 86
+  completed_plans: 24
+  percent: 100
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-05-22)
+See: .planning/PROJECT.md (updated 2026-06-02 after v2.0)
 
-**Core value:** The authenticated owner dashboard at `/dashboard` becomes a restrained, professional B2B command center — KPI visibility above the fold, polished charts, a real DataTable with column controls + saved presets, full keyboard/dark-mode/mobile a11y. Every dollar amount handled correctly throughout the data path (no `*100`/`÷100` round-trip).
-**Current focus:** Phase 7 — verification
+**Core value:** Every public claim on tenantflow.app maps to working code, and every visual aligns to canonical design tokens in `src/app/globals.css`. The authenticated owner dashboard at `/dashboard` is a restrained, professional B2B command center.
+**Current focus:** Planning next milestone (`/gsd-new-milestone`).
 
 ## Current Position
 
-Phase: 7
-Plan: Not started
-Status: Phase 6 shipped — PR #767
-Last activity: 2026-06-01
+Phase: — (no active milestone)
+Plan: —
+Status: v2.0 Dashboard Command Center shipped and archived (7/7 phases, 24 plans, 34/34 requirements)
+Last activity: 2026-06-02 — Milestone v2.0 completed and archived
 
-```
-[█████░░] 71% of v2.0 milestone (5 / 7 phases shipped; Phase 6 implemented, pre-merge)
-```
+## Deferred Items
 
-## Phase Index
+Items acknowledged and deferred at milestone close on 2026-06-02:
 
-| # | Slug | Status | UI-SPEC | Branch |
-|---|------|--------|---------|--------|
-| 1 | foundation-dedup | SHIPPED (PR #744, 7 cycles) | YES (milestone-wide) | gsd/phase-1-foundation-dedup |
-| 2 | data-layer-rpc | SHIPPED (PR #745, 11 cycles + post-merge fix) | No | gsd/phase-2-data-layer-rpc |
-| 3 | kpi-bento-row | SHIPPED (PR #746) | YES (per-phase) | gsd/phase-3-kpi-bento-row |
-| 4 | dashboard-charts | SHIPPED (PR #748, 9 cycles) | YES | gsd/phase-4-dashboard-charts |
-| 5 | dashboard-portfolio-datatable | SHIPPED (PR #763, 8 cycles) | YES | gsd/phase-5-dashboard-portfolio-datatable |
-| 6 | polish-a11y | Plans executed (pre-merge) | No | gsd/phase-6-polish-a11y |
-| 7 | dashboard-verification | Not started | No | gsd/phase-7-dashboard-verification |
+| Category | Item | Status |
+|----------|------|--------|
+| uat_gap | 06-HUMAN-UAT.md — manual tab + focus-ring visual audit on /dashboard | partial (1 pending scenario) |
+| verification_gap | 06-VERIFICATION.md — SC2 manual focus-ring / aria-label review | human_needed |
 
-## Performance Metrics
-
-| Phase | Plans | Status | Branch | PR | Cycles to perfect-PR |
-|-------|-------|--------|--------|----|-----------------------|
-| 1 | 3 | Shipped | gsd/phase-1-foundation-dedup | #744 | 7 (cycles 6+7 both zero) |
-| 2 | 3 | Shipped | gsd/phase-2-data-layer-rpc | #745 | 11 (+ post-merge fix) |
-| 3 | 3 | Shipped | gsd/phase-3-kpi-bento-row | #746 | — |
-| 4 | 4 | Shipped | gsd/phase-4-dashboard-charts | #748 | 9 (cycles 8+9 both zero) |
-| 5 | 5 | Shipped | gsd/phase-5-dashboard-portfolio-datatable | #763 | 8 (final 2 independent reviewers both CLEAN) |
-| 6 | 4 | Plans executed (pre-merge) | gsd/phase-6-polish-a11y | — | — |
-| 7 | TBD | Not started | gsd/phase-7-dashboard-verification | — | — |
-
-Plan-level durations (Phase 6): P01 2min, P02 —, P03 —, P04 4min (3 tasks, 2 files).
-| Phase 07 P01 | 25m | 3 tasks | 3 files |
-
-## Locked Decisions (see PROJECT.md Key Decisions for full table)
-
-- Mode: YOLO / autonomous
-- Granularity: fine (7 phases for v2.0; previous v1.0 was 15 phases at the same granularity setting — work-driven, not template-driven)
-- Models: quality (Opus on heavy reasoning)
-- Per-phase research: ON (every phase)
-- Branching: per-phase (`gsd/phase-{phase}-{slug}`)
-- PR strategy: one PR per phase, perfect-PR gate (2 zero-finding deep review cycles)
-- Code review: deep
-- Phase numbering: reset to 1-7 for v2.0 (major-version reset; v1.0's phases 1-15 are archived independently)
-- Dependency order: 1 → 2 → (3 ∥ 4) → 5 → 6 → 7
-- Phases requiring `/gsd-ui-phase`: 1 (milestone-wide UI-SPEC), 3, 4, 5
-- Phases NOT requiring UI-SPEC: 2, 6, 7
-- `ui/bento-grid.tsx` is OUT — KPI grid is a plain `@container` CSS grid of `Stat` tiles
-- `collection_rate` resolution deferred to Phase 2 discuss-phase (compute-or-drop, never fabricate)
-- No `*100` / `/100` revenue arithmetic anywhere — cross-cutting hard rule; perfect-PR gate enforces
-- Phase 6 Plan 01: `@axe-core/playwright@4.11.3` installed at ROOT (CI runs `bunx playwright test` from repo root → resolves from root node_modules; the `tests/e2e/package.json:25` declaration has no node_modules/lockfile). Dev-only; never ships to client/runtime, CSP unaffected.
-- Phase 6 Plan 01: `--project=owner` wired into the CI E2E run (`ci-cd.yml:162`); `setup-owner` resolved via the owner project's `dependencies` (not manually re-listed); `--project=smoke`/`--project=public` preserved. Unblocks Plan 04's authed `/dashboard` axe spec.
-- Phase 6 Plan 02: dashboard dark-mode color landmines migrated raw Tailwind palette classes → canonical `status-*` utilities / `--color-*` tokens across 5 files (lease-status-badge CHIP → status-active/-pending/-inactive; portfolio-columns + portfolio-grid maintenance cells → `--color-destructive`; stat.tsx StatTrend up/down → `--color-success`/`--color-destructive`; expiring-leases-widget Clock icons + non-urgent days badge → `--color-warning`). POLISH-04 landmine grep returns zero across the dashboard subtree; design-token-drift guard green (2724/2724). The drift guard scans hex/rgb/bg-white/inline-ms only — palette classes are caught by the explicit landmine grep, not the guard.
-- Phase 6 Plan 02: `statIndicatorVariants` (stat.tsx:45-56) left byte-for-byte unchanged — its `green-500`/`blue-500`/`orange-500` palette classes are an app-wide Phase-7 concern, NOT a dashboard render path (KPI tiles use `<StatTrend>`, not `<StatIndicator color=...>`). `StatTrend` shared-primitive blast radius (7 consumers) documented in 06-02-SUMMARY.md.
-- Phase 6 Plan 03 (POLISH-08 / D-04): the shared `NumberTicker` rAF primitive (`number-ticker.tsx:49-52`) now short-circuits to `setDisplayValue(to); return;` under `useReducedMotion()` BEFORE the `hasIntersected` gate, with `reducedMotion` added to the effect dep array (line 93). The motion-on path is byte-for-byte unchanged. Guard applied INSIDE the effect (not a component-top early-return) so the `<span ref={ref}>` stays mounted and the IntersectionObserver ref stays attached. All 16 app-wide consumers inherit the guard for free; the `KpiNumberTicker` defense-in-depth wrapper in kpi-bento-row.tsx is now redundant but kept (CONTEXT D-04 — do not drop a guard). Unit suite 6→7 (added a `matchMedia`-stub reduced-motion branch test).
-- Phase 6 Plan 03: charts (`isAnimationActive={!reducedMotion}` — revenue-area-chart.tsx:240, occupancy-donut-chart.tsx:108), BlurFade (`shouldReduceMotion` — blur-fade.tsx:87/90/116), kpi-bento-row BlurFade bypass (kpi-bento-row.tsx:355-361 renders raw KpiTile under reduced motion), and the CSS `@media (prefers-reduced-motion)` guard (globals.css:1151) all confirmed PRE-EXISTING (verify-only, no edits). Pitfall-4 flag: `portfolio-data-table.tsx:103` `<BlurFade delay={0.4} inView>` does NOT bypass BlurFade under reduced motion but still renders (opacity-100 once inView flips) — flagged for the manual reduced-motion sweep, no code added.
-- Phase 6 Plan 04 (POLISH-05 / POLISH-06): authed `/dashboard` axe-core WCAG 2.1 A/AA E2E (full-subtree sweep, no `.exclude()`) + 375px page-level zero-horizontal-scroll probe co-located in `tests/e2e/tests/owner/dashboard-a11y.e2e.spec.ts` (two `test.describe` blocks; only the 375px block narrows viewport via `test.use`). Auto-collected by the `owner` project (`**/owner/**/*.spec.ts`) and runs in CI via the Plan-01 `--project=owner` wiring. Auth mirrors `owner-dashboard.e2e.spec.ts` (goto OWNER_DASHBOARD + tour-completed + reload + heading visible). The locked `FORCE_GRID_QUERY = "(max-width: 1023px)"` (D-01) is untouched. Verified locally via Playwright `--list` under `--project=owner` + Biome lint + `tsc -p tests/e2e/tsconfig.json` (zero errors attributable to the new file); the actual axe/375px run is CI-deferred (needs live owner storageState). If the first CI run surfaces a dashboard-subtree violation it MUST be fixed inline — only unambiguous global-chrome violations may be `.exclude()`d with a Phase-7 deferral.
-- Phase 6 Plan 04 (POLISH-07): skeleton↔empty branch mutual-exclusion regression in `src/app/(owner)/dashboard/__tests__/dashboard-page-branch.test.tsx` imports the default `DashboardPage` export (`DashboardContent` is unexported), mocks the 3 dashboard query hooks via `vi.hoisted()`, stubs heavy content/chrome leaves (`Dashboard`, `ExpiringLeasesWidget`, onboarding wizard/tour, `ErrorBoundary`) so only the REAL `DashboardLoadingSkeleton` + `DashboardEmptyState` render through the actual early-return chain. Per-branch markers are distinct (skeleton=`[data-slot="skeleton"]`, empty=`'Welcome to TenantFlow'`, error=`'Unable to load dashboard data'`, content=stub testid) because all four branches share `data-testid="dashboard-stats"`. No `dashboard/loading.tsx` created (client-fetched route). 8 tests green; branch logic was already correct (verify-only) so the regression passed GREEN on first run.
+Both are Phase-6 **manual** human-in-the-loop accessibility sign-offs. The automated coverage that substantially supersedes them passed in CI: the `owner-axe` Playwright project runs `AxeBuilder().withTags([wcag2a, wcag2aa, wcag21a, wcag21aa])` over the full `/dashboard` subtree (covers name/role/value, aria-labels, focus order programmatically) and reported zero violations on PR #767 (`e2e-smoke` green, commit `d78bd32ca`) and again on the Phase-7 smoke. The only residual is the human-perceptible focus-ring *visual quality* confirmation, which axe partially covers but cannot fully substitute. Low risk; revisit during the next a11y-touching milestone.
 
 ## Blockers
 
@@ -92,41 +47,21 @@ None.
 ## Roadmap Evolution
 
 - 2026-05-22: v1.0 "Marketing Surface Honesty" archived (15 phases, 56/56 audit findings closed, Round 3 audit verdict PERFECT BY ALL MEASURES).
-- 2026-05-22: v2.0 "Dashboard Command Center" roadmap created — 7 phases, 34/34 requirements mapped, branch template `gsd/phase-{phase}-{slug}`.
-- 2026-05-28: Phases 1-4 all merged (PRs #744/#745/#746/#748). Milestone at 4/7 (57%).
-- 2026-05-31: Phase 5 (Portfolio DataTable) merged via PR #763 — DiceUI DataTable swap; 8 perfect-PR cycles (final two independent reviewers both CLEAN). Milestone at 5/7 (71%).
-- 2026-06-01: Phase 6 (Polish & A11y) execution began — Plan 01 (Wave 0) complete: `@axe-core/playwright@4.11.3` added to root devDeps + `--project=owner` wired into CI E2E. Unblocks downstream `/dashboard` axe testing (Plan 04). 1/4 Phase-6 plans done.
-- 2026-06-01: Phase 6 Plan 02 (Wave 1) complete — dashboard dark-mode color landmines migrated to canonical `status-*` utilities / `--color-*` tokens (5 files). POLISH-04 satisfied: landmine grep zero across the dashboard subtree, design-token-drift guard green (2724/2724). 2/4 Phase-6 plans done.
-- 2026-06-01: Phase 6 Plan 03 (Wave 1) complete — internal JS reduced-motion guard added to the shared `NumberTicker` rAF primitive (POLISH-08 / D-04); all 16 consumers now snap to final value under `prefers-reduced-motion`. Unit suite 6→7. Charts/BlurFade/CSS reduced-motion guards confirmed pre-existing (verify-only). 3/4 Phase-6 plans done.
-- 2026-06-01: Phase 6 Plan 04 (Wave 2) complete — authed `/dashboard` axe-core WCAG 2.1 A/AA + 375px page-level zero-scroll E2E (`dashboard-a11y.e2e.spec.ts`, runs in CI under the `owner` project) + skeleton↔empty branch mutual-exclusion unit regression (`dashboard-page-branch.test.tsx`, 8 tests). POLISH-05/06/07 satisfied. No `dashboard/loading.tsx` added; D-01 `FORCE_GRID_QUERY` untouched. 4/4 Phase-6 plans done — Phase 6 implementation complete, awaiting perfect-PR gate + merge. Milestone still 5/7 phases SHIPPED (71%).
+- 2026-06-02: v2.0 "Dashboard Command Center" shipped and archived (7 phases, 24 plans, 40 tasks, 34/34 requirements). Final phase merged via PR #773 → `3e1a4cc29`. Perfect-PR gate held on every phase. Phase 7 (verification) served as the binding milestone audit — its 7-test `/dashboard` E2E smoke passed in CI against live prod.
 
 ## Next Action
 
-**Phases 1-5 shipped. Phase 6 (Polish & A11y) fully implemented (4/4 plans) — pre-merge.**
+**v2.0 complete.** Start the next milestone:
 
-Merged so far:
+```
+/clear  then  /gsd-new-milestone
+```
 
-- Phase 1 — Foundation & Dedup — PR #744
-- Phase 2 — Data Layer & RPC — PR #745
-- Phase 3 — KPI Bento Row — PR #746
-- Phase 4 — Dashboard Charts — PR #748 (2026-05-28)
-- Phase 5 — Portfolio DataTable — PR #763 (2026-05-31)
-
-Phase 6 (Polish & A11y) — all 4 plans executed on `gsd/phase-6-polish-a11y`:
-
-- P01 (Wave 0): `@axe-core/playwright` root install + `--project=owner` CI wiring (POLISH-05 prereq)
-- P02 (Wave 1): dashboard dark-mode color landmines → tokens (POLISH-04)
-- P03 (Wave 1): `NumberTicker` internal reduced-motion guard (POLISH-08)
-- P04 (Wave 2): axe WCAG 2.1 AA + 375px zero-scroll E2E + skeleton↔empty regression (POLISH-05/06/07)
-
-**Next:**
-
-1. `/gsd-verify-work 6` → perfect-PR gate (2 consecutive zero-finding deep review cycles) → merge → unblock Phase 7 (Verification).
-2. (Audit-trail gap, still open) Phase 4 shipped without a formal `04-VERIFICATION.md`; optionally run `/gsd-verify-work 4` retroactively.
+`/gsd-new-milestone` will surface queued seed **SEED-001** (Supabase Security Advisor remediation — 46 authenticated SECURITY DEFINER WARNs + 10 `rls_enabled_no_policy` INFOs; `auth_leaked_password_protection` explicitly out of scope) via its seed-scan step. A fresh `REQUIREMENTS.md` is created during new-milestone (the v2.0 one was archived to `milestones/v2.0-REQUIREMENTS.md` and removed).
 
 ## Overrides
 
 (none active)
 
 ---
-*Last updated: 2026-06-01 — Phase 6 Plan 04 executed (axe-core WCAG 2.1 AA + 375px zero-scroll E2E under the owner project; skeleton↔empty branch regression; POLISH-05/06/07 satisfied). 4/4 Phase-6 plans done — Phase 6 implementation complete, pre-merge. Milestone still 5/7 phases SHIPPED (71%). Trust `git log main` + `gh pr list --state merged` as source of truth over this cache.*
+*Last updated: 2026-06-02 — v2.0 Dashboard Command Center completed and archived. Trust `git log main` + `gh pr list --state merged` + `.planning/MILESTONES.md` as source of truth over this cache.*

--- a/.planning/milestones/v2.0-REQUIREMENTS.md
+++ b/.planning/milestones/v2.0-REQUIREMENTS.md
@@ -1,3 +1,12 @@
+# Requirements Archive: v2.0 Dashboard Command Center
+
+**Archived:** 2026-06-02
+**Status:** SHIPPED
+
+For current requirements, see `.planning/REQUIREMENTS.md`.
+
+---
+
 # Requirements: TenantFlow v2.0 — Dashboard Command Center
 
 **Defined:** 2026-05-22

--- a/.planning/milestones/v2.0-ROADMAP.md
+++ b/.planning/milestones/v2.0-ROADMAP.md
@@ -1,0 +1,217 @@
+# Roadmap: TenantFlow
+
+## Milestones
+
+- ✅ **v1.0 Marketing Surface Honesty** — Phases 1-15 (shipped 2026-05-22) — see [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md)
+- ✅ **v2.0 Dashboard Command Center** — Phases 1-7 (SHIPPED 2026-06-02; major-version phase reset) — this archive
+
+---
+
+# v2.0 Dashboard Command Center
+
+**Defined:** 2026-05-22
+**Granularity:** fine (7 phases)
+**Branch template:** `gsd/phase-{phase}-{slug}`
+**Numbering:** reset to 1-7 (major-version → fresh sequence; v1.0's phases 1-15 archived)
+**Coverage:** 34/34 requirements mapped ✓
+**Source spec:** `.planning/MILESTONE-CONTEXT.md`
+
+## Core Value
+
+The authenticated owner dashboard at `/dashboard` becomes a restrained, professional B2B command center — KPI visibility above the fold, polished charts, a real DataTable with column controls + saved presets, full keyboard/dark-mode/mobile a11y. Every dollar amount handled correctly throughout the data path (no `*100`/`÷100` round-trip).
+
+## Cross-Cutting Constraints (apply to every phase)
+
+- **Design-token alignment** — `--color-*`, `--spacing-*`, `--radius-*`, `--shadow-*`, `--duration-*`, `--ease-*`, `--color-chart-{1..5}` only. `design-token-drift.test.ts` Vitest guard (v1.0 Phase 11) continues to enforce.
+- **No `*100` / `/100` revenue arithmetic anywhere.** Cross-cutting hard rule; any new file or edit that re-introduces it fails the perfect-PR gate.
+- **Restrained B2B aesthetic.** No `@magicui` / `@aceternity` flash. `ui/bento-grid.tsx` (marketing component) is forbidden for KPI tiles.
+- **Independently shippable.** Each phase ships as one atomic PR through the perfect-PR gate (two consecutive zero-finding deep review cycles). The dashboard must never break mid-milestone.
+- **Zero Tolerance Rules** (CLAUDE.md): no `any`, no barrel files, no duplicate types, no commented-out code, no inline styles, no `as unknown as`, no string-literal query keys, lucide-react only.
+
+## Dependency Order
+
+```
+1 → 2 → (3 ∥ 4) → 5 → 6 → 7
+```
+
+Phases 1 and 2 are invisible foundation. Phases 3 and 4 each *add* a new region — they can ship in parallel (no file overlap). Phase 5 is the only swap (atomic PR replacing the hand-rolled portfolio table). Phase 6 is polish over already-shipped surfaces. Phase 7 is invisible verification.
+
+## Phases
+
+- [x] **Phase 1: Foundation & Dedup** — Delete duplicates, fix the `*100`/`÷100` revenue bug, extract shared transform, produce milestone-wide UI-SPEC. Zero visible change.
+- [x] **Phase 2: Data Layer & RPC** — Additive RPC migration for per-property `open_maintenance`; resolve compute-or-drop on `collection_rate`; RLS owner-isolation test.
+- [x] **Phase 3: KPI Bento Row** — 6-tile KPI grid with sparklines on Revenue + Occupancy. Adds Section B.
+- [x] **Phase 4: Charts** — `RevenueAreaChart` refresh (30d/6mo toggle) + new `OccupancyDonutChart`. Adds Section C.
+- [x] **Phase 5: Portfolio DataTable** — Replace hand-rolled table with DiceUI DataTable: client hook, column model, faceted filter, column visibility, virtualization, grid/table toggle, saved presets, nuqs URL state.
+- [ ] **Phase 6: Polish & A11y** — Dark-mode audit, keyboard a11y, 375px responsive, skeleton/empty mutual exclusion, reduced-motion.
+- [x] **Phase 7: Verification** — E2E coverage for `/dashboard` + final design-token sweep.
+
+## Phase Details
+
+### Phase 1: Foundation & Dedup
+**Slug:** `dashboard-foundation-dedup`
+**Goal:** Strip duplicate/dead dashboard code, kill the `*100`/`÷100` revenue round-trip, extract one shared data transform, and produce the milestone-wide UI-SPEC the remaining phases inherit (aesthetic, tokens, dark-mode rules, breakpoints, motion budget).
+**Depends on:** Nothing (first phase)
+**Requirements:** POLISH-01, POLISH-02, POLISH-03
+**Success Criteria** (what must be TRUE):
+  1. Visiting `/dashboard` after the merge shows the same KPI numbers as before (the `*100`/`÷100` bug visually cancelled itself, so display is unchanged — but in-memory values are now correct).
+  2. `src/components/dashboard/owner-dashboard.tsx`, `chart-area-interactive.tsx`, the duplicate `dashboard-filters*.tsx`, the second `portfolio-toolbar.tsx`, and `skeletons.tsx` no longer exist in the repo.
+  3. Repo-wide grep for `* 100` and `/ 100` against currency variables in `src/app/(owner)/dashboard/` and `src/components/dashboard/` returns zero hits.
+  4. `design-token-drift.test.ts` passes; milestone-wide UI-SPEC committed at `.planning/phases/01-dashboard-foundation-dedup/UI-SPEC.md` (aesthetic, tokens, dark-mode rules, breakpoints, motion budget) and inherited by all later phases.
+**Plans:** 3 plans (3 waves — serialized)
+- [ ] 01-01-PLAN.md — **Wave 1.** Bug fix (drop `*100` in page.tsx + `/100` in revenue-overview-chart.tsx) + extract pure `transformDashboardData` module + wire into use-dashboard-hooks selectors (D-12a interpretation #2)
+- [ ] 01-02-PLAN.md — **Wave 2** (depends on 01-01). Currency utility consolidation: delete duplicate `formatDashboardCurrency`; swap 3 callers to canonical `formatCurrency` with no-cents options object (D-09a / RC-7)
+- [ ] 01-03-PLAN.md — **Wave 3** (depends on 01-01 + 01-02). Dedup deletions: 5 files + 1 test (owner-dashboard.tsx + its test, dashboard-filters{,-compact,-utils}, top-level portfolio-toolbar.tsx, skeletons.tsx); chart-area-interactive.tsx PRESERVED per D-13a. Owns the canonical D-03 / UI-SPEC § Appendix A `*100`/`/100` grep sweep (only runnable after Wave 1+2 land + owner-dashboard.tsx is deleted in Task 1).
+**UI hint:** yes
+
+### Phase 2: Data Layer & RPC
+**Slug:** `dashboard-data-layer-rpc`
+**Goal:** Make the dashboard's data inputs honest — additive migration for per-property `open_maintenance` (locked D-02), and drop `collection_rate` from the KPI set per the v1.0 honesty principle (locked D-01: TenantFlow does not facilitate rent payments, no payment data exists, never fabricate `0`).
+**Depends on:** Phase 1
+**Requirements:** POLISH-10, POLISH-11
+**Success Criteria** (what must be TRUE):
+  1. Querying `get_dashboard_data_v2` as an authenticated owner returns a real per-property `open_maintenance` count for each row (or the column is documented as ship-hidden until Phase 5 wires it).
+  2. The portfolio data model contains no hardcoded `0` for `collectionRate` — either the field is dropped from the KPI set or sourced from a real RPC value (resolution captured in the Phase 2 discuss artifact).
+  3. `tests/integration/rls/` includes a dual-client (ownerA/ownerB) test confirming the migrated RPC respects owner isolation under RLS.
+  4. `bun run test:integration` passes on the new test against prod.
+**Plans:** 3 plans (3 waves — serialized)
+- [ ] 02-01-PLAN.md — **Wave 1.** Additive migration extending `get_dashboard_data_v2` with `perf_open_maintenance` CTE + `open_maintenance` JSON key; MCP `apply_migration` to prod; reconcile filename with prod timestamp; regenerate `src/types/supabase.ts`.
+- [ ] 02-02-PLAN.md — **Wave 2** (depends on 02-01). Frontend wiring: add `open_maintenance: number` to `PropertyPerformance` + `PropertyPerformanceRpcResponse`; drop `collectionRate` from `DashboardMetrics`; update fetcher mapper, page.tsx re-mapper, `transformDashboardData`, and the inline `dashboard.tsx` portfolio transform to source real `open_maintenance` instead of hardcoded `0`.
+- [ ] 02-03-PLAN.md — **Wave 3** (depends on 02-02). Dual-client RLS integration test at `tests/integration/rls/dashboard-rpc-open-maintenance.test.ts` (happy-path + cross-owner isolation); `bun run test:integration` against prod; manual checkpoint confirming portfolio table renders real maintenance counts.
+
+### Phase 3: KPI Bento Row
+**Slug:** `dashboard-kpi-bento-row`
+**Goal:** Replace the one-line text header with a 6-tile KPI bento row (Revenue, Occupancy, Active Leases, Open Maintenance, Properties, Units) using already-vendored `Stat` + `NumberTicker` + `BlurFade` primitives, with sparklines on Revenue + Occupancy only.
+**Depends on:** Phase 1 (UI-SPEC), Phase 2 (real KPI values)
+**Requirements:** KPI-01, KPI-02, KPI-03, KPI-04, KPI-05, KPI-06, KPI-07
+**Success Criteria** (what must be TRUE):
+  1. `/dashboard` renders 6 KPI tiles above the chart row (Revenue, Occupancy, Active Leases, Open Maintenance, Properties, Units).
+  2. Revenue and Occupancy tiles each render an axis-less Recharts `Area` sparkline; the other four tiles do not.
+  3. Each tile's numeric value animates via `NumberTicker`; users with `prefers-reduced-motion: reduce` see the final value with no animation.
+  4. The KPI grid uses an `@container` CSS grid auto-fit layout (not `ui/bento-grid.tsx`); section reveals stagger via `BlurFade` with at most ~4 reveals.
+**Plans:** 3 plans (3 waves — serialized)
+- [x] 03-01-PLAN.md — **Wave 1.** KpiSparkline component (KPI-05) + pure helpers (formatTrendPercent, sparklineConfigForTrend, KpiTileConfig). Axis-less Recharts Area inside ChartContainer; trend-direction color via ChartConfig.theme map; role='img' + aria-label; no animation.
+- [x] 03-02-PLAN.md — **Wave 2** (depends on 03-01). KpiBentoRow orchestrator + 6 tiles (KPI-01/02/03/04/06/07) + shared useReducedMotion hook. 6 Stat-shell tiles in D-01 order with @container grid (auto-fit minmax(180px,1fr)), NumberTicker value animation (KpiNumberTicker reduced-motion wrapper), Lucide trend chips with !text-[var(--color-warning)] down override, BlurFade waves A {0,1,2} + B {4,5,6}, skeleton ↔ data branch, buildTileAriaLabel a11y.
+- [x] 03-03-PLAN.md — **Wave 3** (depends on 03-01 + 03-02). Mount KpiBentoRow into dashboard.tsx (replace legacy <p> header at lines 172-186; preserve <h1> + data-testid). Extend DashboardProps with kpiData: KpiBentoRowProps. Construct kpiData in page.tsx from useDashboardStats() + useDashboardCharts(). Manual visual checkpoint (browser path or MCP RPC inspection alternate).
+**UI hint:** yes
+
+### Phase 4: Charts
+**Slug:** `dashboard-charts`
+**Goal:** Ship the new charts row — `RevenueAreaChart` (refreshed Recharts area with 30d/6mo toggle, no `/100`) and a brand-new `OccupancyDonutChart` (center label + legend, sourcing from `stats.units`).
+**Depends on:** Phase 1 (UI-SPEC)
+**Requirements:** CHART-01, CHART-02, CHART-03, CHART-04, CHART-05, CHART-06
+**Success Criteria** (what must be TRUE):
+  1. `/dashboard` renders a revenue area chart with a 30d / 6mo toggle that updates the visible series; values are correct dollars (no residual `/100`).
+  2. `/dashboard` renders an occupancy donut chart with a center label and legend; the count matches `stats.units` returned by `get_dashboard_data_v2`.
+  3. Chart series colors source exclusively from `--color-chart-{1..5}`; dark-mode contrast is verified (no invisible series, no white-on-white legend swatches).
+  4. Both charts dynamically import via `next/dynamic` with `ssr: false` and shape-matching CSS-only loading skeletons (no skeleton ↔ empty co-render).
+**Plans:** 4 plans (3 waves — 04-01a + 04-01b parallel in Wave 1)
+- [x] 04-01a-PLAN.md — **Wave 1.** Database half of data layer: Recharts test mock Label export (Wave-0 prereq for Plan 04-03 donut tests); additive migration extending get_dashboard_data_v2 with month_series + ts_revenue_6mo CTEs and the monthly_revenue_6mo time_series key (D-01); MCP apply + filename reconcile + bun run db:types regen. Split out from original 04-01 so the ~300-line SECURITY DEFINER CREATE OR REPLACE has its own context window.
+- [x] 04-01b-PLAN.md — **Wave 1** (depends on 04-01a). TS/test half of data layer: MonthlyRevenuePoint type + boundary mapper line emitting monthlyRevenue6mo; dual-client RLS integration test pinning the cycle-10 /access denied/i contract.
+- [x] 04-02-PLAN.md — **Wave 2** (depends on 04-01a + 04-01b). RevenueAreaChart (CHART-01) + colocated RevenueAreaChartSkeleton + 12 Vitest specs. Local useState 30d/6mo toggle, shadcn Tabs in CardHeader right slot, formatCurrency in tooltip, var(--color-chart-1) area stroke + gradient, animationDuration={800} + isAnimationActive={\!useReducedMotion()}, honest empty-state copy. NO mount yet (dashboard.tsx still uses old chart).
+- [x] 04-03-PLAN.md — **Wave 3** (depends on 04-01a + 04-01b + 04-02). OccupancyDonutChart (CHART-02) + colocated OccupancyDonutChartSkeleton + 11 Vitest specs. Atomic swap (single commit): reshape DashboardProps (drop revenueTrend, add monthlyRevenue + monthlyRevenue6mo + units) + drop revenueTrend transform in page.tsx + mount the chart pair in dashboard.tsx via next/dynamic (3-up layout per D-02: Revenue col-span-2 + Donut col-span-1 + Quick Actions col-span-1). Delete revenue-overview-chart.tsx atomically. Drop chartConfig from dashboard-types.ts if no surviving consumers. Manual visual checkpoint (3-up layout + toggle + dark-mode + skeleton ↔ data transition).
+**UI hint:** yes
+
+### Phase 5: Portfolio DataTable
+**Slug:** `dashboard-portfolio-datatable`
+**Goal:** Replace the hand-rolled portfolio table with the vendored DiceUI DataTable composition — new `useClientDataTable` hook, `portfolio-columns.tsx` column model with `aria-sort`, faceted status filter, column visibility, virtualization, grid/table view toggle, saved presets in localStorage, live filter/sort/page state in nuqs URL params.
+**Depends on:** Phase 1 (UI-SPEC), Phase 2 (real per-property values)
+**Requirements:** DT-01, DT-02, DT-03, DT-04, DT-05, DT-06, DT-07, DT-08, DT-09
+**Success Criteria** (what must be TRUE):
+  1. Clicking a sortable column header on the portfolio table sorts the rows and exposes `aria-sort` on that header; keyboard users can sort via Tab + Enter/Space.
+  2. The faceted status filter and column-visibility menu both work; selected filters and sort persist in the URL (refresh restores state) via nuqs.
+  3. The user can save a filter preset, refresh the page, and re-apply that preset from the preset menu (localStorage via Zustand `persist`).
+  4. The grid/table view toggle works; `dashboard-store.ts` is trimmed to `viewMode` only; the table virtualizes long lists via `useVirtualizer`.
+  5. The hand-rolled `portfolio-table.tsx`, `portfolio-toolbar.tsx`, and `portfolio-pagination.tsx` no longer exist in the repo.
+**Plans:** 5 plans (3 waves)
+- [x] 05-01a-PLAN.md — **Wave 1.** `useClientDataTable` hook (DT-02): fork of `use-data-table.ts` with manual flags off + nuqs mirror kept; URL-compatible with the server hook (DT-09 foundation). Hook unit tests (manual-flags / page-count-recompute / nuqs round-trip / URL hydration).
+- [x] 05-01b-PLAN.md — **Wave 1.** `portfolio-columns.tsx` 7-column `ColumnDef<PortfolioRow>[]` (DT-03) + extend `DataTableColumnHeader` to emit `aria-sort` + keyboard sort (DT-03 a11y); status `meta.options` for the faceted filter (DT-04) + per-column `meta.label` (DT-05). Column-model + aria-sort tests.
+- [x] 05-02-PLAN.md — **Wave 2** (depends on 05-01a + 05-01b). Compose `PortfolioDataTable`: vendored shell + faceted status filter (DT-04) + column visibility (DT-05) + always-on virtualized tbody (DT-06, D-2) + grid/table toggle reading the same rows (DT-07, D-5). Controlled component, NO mount. Component tests.
+- [x] 05-03a-PLAN.md — **Wave 3** (depends on 05-01a + 05-02). `dashboard-presets-store.ts` Zustand `persist` slice: full-snapshot presets (DT-08, D-1) + live `columnVisibility` (D-3). Preset round-trip + persistence + SSR-safety tests. (6 tests)
+- [x] 05-03b-PLAN.md — **Wave 3** (depends on 05-02 + 05-03a). Atomic swap: trimmed `dashboard-store.ts` to `viewMode` only + deleted the 3 dead selector hooks (DT-09); rewrote `dashboard.tsx` to mount `PortfolioDataTable` + `PortfolioPresetMenu` (DT-01, DT-08); nuqs URL state (DT-09); DELETED the 3 hand-rolled files (criterion #5). 5 swap-integrity + preset/URL tests; full suite (106,141) green. Perfect-PR gate pending.
+**UI hint:** yes
+
+### Phase 6: Polish & A11y
+**Slug:** `dashboard-polish-a11y`
+**Goal:** Polish over shipped surfaces — dark-mode audit, keyboard a11y, 375px responsive layout, skeleton/empty mutual exclusion, reduced-motion guards.
+**Depends on:** Phases 3, 4, 5 (polishes their output)
+**Requirements:** POLISH-04, POLISH-05, POLISH-06, POLISH-07, POLISH-08
+**Success Criteria** (what must be TRUE):
+  1. Toggling between light and dark mode on `/dashboard` reveals no white-on-white text, no invisible badges, and zero `bg-white` references in the dashboard subtree.
+  2. Tab-navigating through `/dashboard` reveals a visible focus ring on every interactive element; every icon-only button has an `aria-label`; the skip-to-content link works from the dashboard header.
+  3. At 375px viewport width, `/dashboard` has zero horizontal scroll; the portfolio table forces grid view at the mobile breakpoint.
+  4. Loading states never co-render a skeleton AND an empty state; route-scoped `loading.tsx` covers the streaming case (Phase 14 D-04 pattern from v1.0).
+  5. Users with `prefers-reduced-motion: reduce` see no `NumberTicker`, `BlurFade`, or chart-transition animations.
+**Plans:** 4 plans (2 waves)
+- [x] 06-01-PLAN.md — **Wave 1** (autonomous: false; blocking legitimacy checkpoint). Wave-0 prerequisites: install `@axe-core/playwright` into ROOT `package.json` (declared in tests/e2e but not installed; CI resolves from root) + wire `--project=owner` into the CI E2E run so the authed `/dashboard` axe test executes in CI (POLISH-05).
+- [x] 06-02-PLAN.md — **Wave 1.** Dark-mode token migration (POLISH-04 + D-05): `lease-status-badge` → `status-active/-pending/-inactive` utilities; maintenance cells (`portfolio-columns`, `portfolio-grid`) + `StatTrend` (shared `stat.tsx`) + `expiring-leases-widget` raw palette → `--color-{success,destructive,warning}` tokens; full landmine grep returns zero, drift guard stays green.
+- [x] 06-03-PLAN.md — **Wave 1.** Reduced-motion JS guard (POLISH-08 + D-04): make shared `number-ticker.tsx` honor `useReducedMotion()` internally (additive — motion-on path unchanged; 16 consumers) + matchMedia-mock branch test; verify chart `isAnimationActive` + `BlurFade` guards already present.
+- [x] 06-04-PLAN.md — **Wave 2** (depends on 06-01). A11y + responsive + skeleton/empty: new `dashboard-a11y.e2e.spec.ts` axe-core WCAG 2.1 AA assertion under the authed `owner` project (POLISH-05) + 375px zero-horizontal-scroll probe (POLISH-06, `FORCE_GRID_QUERY` LOCK untouched) + `DashboardContent` skeleton↔empty mutual-exclusion unit regression test (POLISH-07; no `dashboard/loading.tsx`).
+
+### Phase 7: Verification
+**Slug:** `dashboard-verification`
+**Goal:** Lock the milestone — Playwright E2E coverage for `/dashboard` (synthetic owner, real prod data) and a final design-token drift sweep across every new dashboard file.
+**Depends on:** Phases 3, 4, 5, 6 (verifies all visible surfaces)
+**Requirements:** POLISH-09, POLISH-12
+**Success Criteria** (what must be TRUE):
+  1. The Playwright E2E suite includes a `/dashboard` smoke test against a synthetic owner: KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset-save+restore work, grid/table toggle works.
+  2. `bun run test:e2e` passes locally and the GitHub `e2e-smoke` check passes on the Phase 7 PR.
+  3. `design-token-drift.test.ts` runs clean over every new dashboard file (no hex, no rgb, no `bg-white`, no inline ms durations).
+  4. The merged PR closes the v2.0 milestone with 34/34 requirements satisfied per traceability.
+**Plans:** 2 plans (2 waves)
+- [x] 07-01-PLAN.md — **Wave 1.** POLISH-09 `/dashboard` E2E smoke under the CI-run `owner-axe` project (in-test `loginAsOwner`, no storageState): KPI numbers match `get_dashboard_data_v2`, occupancy donut matches `stats.units`, DataTable sort/filter/column-visibility/preset save+restore + grid/table toggle. New `dashboard-rpc-helpers.ts` derives expected values from the authed RPC; `owner-axe` `testMatch` widened to collect it.
+- [x] 07-02-PLAN.md — **Wave 2** (depends on 07-01). POLISH-12 design-token sweep verification across every new dashboard file (the drift test already walks `src/components/**` + `src/app/**`) + removal of the stale Phase-1 `dashboard-filters.tsx` exemption; milestone close: flip POLISH-09 + POLISH-12 traceability to satisfied (34/34). Ships as one atomic PR through the perfect-PR gate.
+
+Phase 7 ships as one atomic PR through the perfect-PR gate (two consecutive zero-finding deep review cycles), per the milestone's cross-cutting "Independently shippable" constraint, closing v2.0 at 34/34 requirements satisfied.
+
+## Progress
+
+| Phase | Milestone | Plans | Status | Completed |
+|-------|-----------|-------|--------|-----------|
+| 1. Foundation & Dedup | v2.0 | 3/3 | Shipped (PR #744) | 2026-05-22 |
+| 2. Data Layer & RPC | v2.0 | 3/3 | Shipped (PR #745) | 2026-05-22 |
+| 3. KPI Bento Row | v2.0 | 3/3 | Shipped (PR #746) | 2026-05-26 |
+| 4. Charts | v2.0 | 4/4 | Shipped (PR #748) | 2026-05-28 |
+| 5. Portfolio DataTable | v2.0 | 5/5 | Shipped (PR #763) | 2026-05-31 |
+| 6. Polish & A11y | v2.0 | 4/4 | Complete   | 2026-06-01 |
+| 7. Verification | v2.0 | 2/2 | Complete   | 2026-06-02 |
+
+## Coverage Validation
+
+| Category | Count | Phase(s) |
+|----------|-------|----------|
+| KPI (KPI-01..07) | 7 | Phase 3 |
+| CHART (CHART-01..06) | 6 | Phase 4 |
+| DT (DT-01..09) | 9 | Phase 5 |
+| POLISH (POLISH-01..12) | 12 | Phase 1 (01/02/03), Phase 2 (10/11), Phase 6 (04..08), Phase 7 (09/12) |
+| **Total** | **34** | **All mapped, no orphans, no double-mapping ✓** |
+
+---
+
+# v1.0 Archive (Shipped 2026-05-22)
+
+<details>
+<summary>✅ v1.0 Marketing Surface Honesty (Phases 1-15) — SHIPPED 2026-05-22</summary>
+
+- [x] Phase 1: Critical Stop-Bleed (Blog Unpublish + Pricing Placeholder) (2/2 plans) — PR #686
+- [x] Phase 2: Frontend Correctness (NumberTicker + Mobile) (2/2 plans) — PR #687
+- [x] Phase 3: Routing & Legal-URL Aliases (1/1 plan) — merged inline
+- [x] Phase 4: Persona & Copy Honesty (2/2 plans) — PR #688
+- [x] Phase 5: Pricing Restructure (2/2 plans) — PR #689
+- [x] Phase 6: Blog Rebuild + n8n Redesign (4/4 plans) — PR #690
+- [x] Phase 7: Pricing-Card Chrome (2/2 plans) — PR #735
+- [x] Phase 8: Nav, Active States & Dead Links (1/1 plan) — PR #736
+- [x] Phase 9: Page-Level Cleanup (1/1 plan) — PR #737
+- [x] Phase 10: CTA & Conversion Standardization (2/2 plans) — PR #738 + #739 (followup)
+- [x] Phase 11: Design-Token Alignment & Resources Page (2/2 plans) — PR #740
+- [x] Phase 12: SEO Metadata, Schema & Content Cleanup (3/3 plans) — PR #741
+- [x] Phase 13: Performance & Conversion Polish (1/1 plan) — PR #742
+- [x] Phase 14: Battle Test Findings Remediation (4/4 plans) — PR #705 + #708/#718-#724 followups
+- [x] Phase 15: v1.0 Milestone Cleanup (5/5 plans) — PR #743
+
+Audit round 3 verdict: PERFECT BY ALL MEASURES. Full milestone summary in [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md) and [milestones/v1.0-MILESTONE-AUDIT.md](milestones/v1.0-MILESTONE-AUDIT.md).
+
+</details>
+
+---
+*Last updated: 2026-05-26 — Phase 4 plans drafted (04-01 data layer + RLS, 04-02 RevenueAreaChart, 04-03 OccupancyDonutChart + mount + cleanup)*


### PR DESCRIPTION
Closes out the **v2.0 Dashboard Command Center** milestone (7 phases / 24 plans / 40 tasks / **34/34 requirements**) and archives its planning artifacts. Docs-only — no source changes.

## What this does
- **MILESTONES.md** — clean v2.0 entry (delivered summary, key accomplishments, discipline outcomes, lessons carried forward, naming-collision note). Replaces the SDK's raw-one-liner auto-extract.
- **ROADMAP.md** — collapsed to milestone groupings (v1.0 + v2.0 both archived as `<details>`); full v2.0 phase detail preserved in `milestones/v2.0-ROADMAP.md`.
- **REQUIREMENTS.md** — archived to `milestones/v2.0-REQUIREMENTS.md` and removed (a fresh one is created by `/gsd-new-milestone`).
- **PROJECT.md** — v2.0 requirements moved Active → Validated; new **Current State** + **Next Milestone Goals** (SEED-001 candidate); v2.0 key decisions logged.
- **STATE.md** — between-milestones reset + **Deferred Items** (2 Phase-6 manual focus-ring sign-offs, superseded by the CI axe sweep that passed on PR #767).
- **RETROSPECTIVE.md** — new living retrospective (v2.0 section + cross-milestone trends).

## Tag note
`git tag v2.0` is already taken by a prior legacy milestone (Stripe Integration Excellence, `b244f9c25`, Jan 2026) in a disjoint legacy tag namespace. Per the v1.0 precedent, this milestone is authoritative via MILESTONES.md + archive files + merge commit `3e1a4cc29` (PR #773) — **not** re-tagged (a re-tag would silently overwrite the legacy tag).

## Deferred at close
2 Phase-6 manual human-UAT/verification items (focus-ring visual quality sign-off). The automated WCAG 2.1 AA axe sweep that covers them programmatically passed in CI (PR #767 `e2e-smoke` green + Phase-7 re-run). Documented in STATE.md → Deferred Items.

## Next
After merge: `/clear` then `/gsd-new-milestone` (surfaces queued **SEED-001** — Supabase Security Advisor remediation; `auth_leaked_password_protection` out of scope).

[hudsor01]