### PR TITLE
fix: close six dashboard/marketing UI audit gaps

### DIFF
--- a/src/app/(owner)/dashboard/page.tsx
+++ b/src/app/(owner)/dashboard/page.tsx
@@ -173,8 +173,17 @@ function DashboardContent() {
 export default function DashboardPage() {
 	return (
 		<>
-			<OnboardingWizard />
-			<OwnerOnboardingTour />
+			{/* Onboarding overlays are non-critical. Isolate each in its own
+			    error boundary with a silent fallback so a render fault (e.g. a
+			    transient React hook error in the vendored tour store) is
+			    captured to Sentry and degrades to "no overlay" instead of
+			    bubbling past these siblings into the dashboard tree. */}
+			<ErrorBoundary fallback={<></>}>
+				<OnboardingWizard />
+			</ErrorBoundary>
+			<ErrorBoundary fallback={<></>}>
+				<OwnerOnboardingTour />
+			</ErrorBoundary>
 			<div className="@container/main flex min-h-screen w-full flex-col bg-background">
 				<ErrorBoundary
 					fallback={

--- a/src/components/blog/blog-card.test.tsx
+++ b/src/components/blog/blog-card.test.tsx
@@ -91,8 +91,12 @@ describe("BlogCard", () => {
 		};
 		const { container } = render(<BlogCard post={postWithoutImage} />);
 		expect(screen.queryByTestId("next-image")).not.toBeInTheDocument();
-		const placeholder = container.querySelector(".bg-muted");
+		// Branded placeholder (gradient + Newspaper glyph), not a flat gray box.
+		const placeholder = container.querySelector(
+			"[data-slot='blog-card-placeholder']",
+		);
 		expect(placeholder).toBeInTheDocument();
+		expect(placeholder?.querySelector("svg")).toBeInTheDocument();
 	});
 
 	it("renders excerpt text", () => {

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -1,3 +1,4 @@
+import { Newspaper } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import type { BlogListItem } from "#hooks/api/query-keys/blog-keys";
@@ -27,7 +28,15 @@ export function BlogCard({ post, className }: BlogCardProps) {
 						className="object-cover transition-transform duration-300 group-hover:scale-105"
 					/>
 				) : (
-					<div className="h-full w-full bg-muted" />
+					<div
+						data-slot="blog-card-placeholder"
+						className="flex h-full w-full items-center justify-center bg-linear-to-br from-primary/10 via-muted to-accent/10"
+					>
+						<Newspaper
+							className="size-10 text-muted-foreground/40"
+							aria-hidden="true"
+						/>
+					</div>
 				)}
 			</div>
 

--- a/src/components/contact/__tests__/contact-form-fields.test.tsx
+++ b/src/components/contact/__tests__/contact-form-fields.test.tsx
@@ -71,4 +71,22 @@ describe("CONS-08: /contact 'How did you hear about us?' placeholder", () => {
 			"the killed 'Sales Outreach' default must not be a placeholder",
 		).not.toMatch(/placeholder="Sales Outreach"/);
 	});
+
+	// The component shows the placeholder only while formData.type holds no
+	// value that matches a referral option. The live form's default lives in
+	// contact-form.tsx — pin it to a non-matching value so the placeholder
+	// survives in production (type:"sales" regressed it to "Sales Outreach").
+	it("contact-form.tsx does not default `type` to a matching referral option", () => {
+		const src = readFileSync(
+			resolve(__dirname, "..", "contact-form.tsx"),
+			"utf8",
+		);
+		expect(
+			src,
+			"the contact form default must not pre-select 'sales' (renders as 'Sales Outreach')",
+		).not.toMatch(/type:\s*["']sales["']/);
+		expect(src, "the contact form must default `type` to 'general'").toMatch(
+			/type:\s*["']general["']/,
+		);
+	});
 });

--- a/src/components/contact/contact-form.tsx
+++ b/src/components/contact/contact-form.tsx
@@ -85,7 +85,12 @@ export function ContactForm({ className = "" }: ContactFormProps) {
 			email: "",
 			subject: "",
 			message: "",
-			type: "sales",
+			// Neutral inquiry-type default. The "How did you hear about us?"
+			// select is bound to `type`; its options (search/social/referral/
+			// sales/conference/other) intentionally don't include "general",
+			// so this keeps that trigger in its "Please select" placeholder
+			// state instead of pre-selecting "Sales Outreach".
+			type: "general",
 			company: "",
 			phone: "",
 		},

--- a/src/components/shell/__tests__/app-shell.test.tsx
+++ b/src/components/shell/__tests__/app-shell.test.tsx
@@ -159,6 +159,28 @@ describe("AppShell", () => {
 				screen.queryByTestId("quick-actions-dock"),
 			).not.toBeInTheDocument();
 		});
+
+		// The lg:pb-28 bottom clearance on <main> is gated by the SAME
+		// dockVisible condition as the dock itself, so form/create routes
+		// (where the dock is suppressed) don't get 7rem of dead space.
+		it("reserves lg:pb-28 clearance only when the dock is visible", () => {
+			const { container } = render(<AppShell>Content</AppShell>);
+			expect(screen.getByTestId("quick-actions-dock")).toBeInTheDocument();
+			expect(container.querySelector("#main-content")?.className).toContain(
+				"lg:pb-28",
+			);
+		});
+
+		it("drops both the dock and the lg:pb-28 clearance on /new routes", () => {
+			mockPathname.mockReturnValue("/properties/new");
+			const { container } = render(<AppShell>Content</AppShell>);
+			expect(
+				screen.queryByTestId("quick-actions-dock"),
+			).not.toBeInTheDocument();
+			expect(container.querySelector("#main-content")?.className).not.toContain(
+				"lg:pb-28",
+			);
+		});
 	});
 
 	describe("sidebar behavior", () => {

--- a/src/components/shell/app-shell.tsx
+++ b/src/components/shell/app-shell.tsx
@@ -24,6 +24,7 @@ import { useSignOutMutation } from "#hooks/api/use-auth-mutations";
 import { usePropertyList } from "#hooks/api/use-properties";
 import { useTenantList } from "#hooks/api/use-tenant";
 import { generateBreadcrumbs } from "#lib/breadcrumbs";
+import { cn } from "#lib/utils";
 import { AppShellHeader } from "./app-shell-header";
 import { AppShellSearch } from "./app-shell-search";
 import { AppShellSidebar } from "./app-shell-sidebar";
@@ -300,7 +301,10 @@ export function AppShell({
 				    never overlaps the last rows / footer at scroll end. */}
 				<main
 					id="main-content"
-					className={`flex-1 bg-muted/30 pb-24 sm:pb-6 ${dockVisible ? "lg:pb-28" : ""}`}
+					className={cn(
+						"flex-1 bg-muted/30 pb-24 sm:pb-6",
+						dockVisible && "lg:pb-28",
+					)}
 				>
 					<div className="p-4 lg:p-6">{children}</div>
 					{/* Minimal app-shell footer (Session 11 P2 #16): the

--- a/src/components/shell/app-shell.tsx
+++ b/src/components/shell/app-shell.tsx
@@ -44,6 +44,11 @@ export function AppShell({
 	const sidebarRef = useRef<HTMLElement>(null);
 	const pathname = usePathname();
 	const breadcrumbs = generateBreadcrumbs(pathname);
+	// The floating dock is hidden on form/create routes (it would overlap the
+	// primary submit). The same condition gates the bottom-padding clearance
+	// below so form pages don't get 7rem of dead space with no dock.
+	const dockVisible =
+		showQuickActionsDock && !/\/(new|edit)(?:\/|$)/.test(pathname);
 	const { data: user } = useSupabaseUser();
 	const signOutMutation = useSignOutMutation();
 	const router = useRouter();
@@ -290,12 +295,12 @@ export function AppShell({
 					onSignOut={() => signOutMutation.mutate()}
 				/>
 
-				{/* Page content. lg:pb-28 reserves clearance for the
-				    floating QuickActionsDock (hidden lg:block, fixed bottom-6)
-				    so it never overlaps the last rows / footer at scroll end. */}
+				{/* Page content. When the dock is visible, lg:pb-28 reserves
+				    clearance for it (hidden lg:block, fixed bottom-6) so it
+				    never overlaps the last rows / footer at scroll end. */}
 				<main
 					id="main-content"
-					className="flex-1 bg-muted/30 pb-24 sm:pb-6 lg:pb-28"
+					className={`flex-1 bg-muted/30 pb-24 sm:pb-6 ${dockVisible ? "lg:pb-28" : ""}`}
 				>
 					<div className="p-4 lg:p-6">{children}</div>
 					{/* Minimal app-shell footer (Session 11 P2 #16): the
@@ -339,9 +344,7 @@ export function AppShell({
 
 			{/* Quick Actions Dock — hidden on form/create pages where it would
 			    overlap the primary submit button (Session 11 P2 #14). */}
-			{showQuickActionsDock && !/\/(new|edit)(?:\/|$)/.test(pathname) && (
-				<QuickActionsDock />
-			)}
+			{dockVisible && <QuickActionsDock />}
 
 			<AppShellSearch
 				open={commandOpen}

--- a/src/components/shell/app-shell.tsx
+++ b/src/components/shell/app-shell.tsx
@@ -290,8 +290,13 @@ export function AppShell({
 					onSignOut={() => signOutMutation.mutate()}
 				/>
 
-				{/* Page content */}
-				<main id="main-content" className="flex-1 bg-muted/30 pb-24 sm:pb-6">
+				{/* Page content. lg:pb-28 reserves clearance for the
+				    floating QuickActionsDock (hidden lg:block, fixed bottom-6)
+				    so it never overlaps the last rows / footer at scroll end. */}
+				<main
+					id="main-content"
+					className="flex-1 bg-muted/30 pb-24 sm:pb-6 lg:pb-28"
+				>
 					<div className="p-4 lg:p-6">{children}</div>
 					{/* Minimal app-shell footer (Session 11 P2 #16): the
 					    marketing footer is too marketing-heavy for the

--- a/src/hooks/use-intersection-observer.test.ts
+++ b/src/hooks/use-intersection-observer.test.ts
@@ -33,14 +33,17 @@ class SilentIntersectionObserver implements IntersectionObserver {
 	}
 }
 
-function mountWithRect(rect: Partial<DOMRect>) {
+function mountWithRect(
+	rect: Partial<DOMRect>,
+	options?: { threshold?: number | number[] },
+) {
 	const el = document.createElement("div");
 	document.body.appendChild(el);
 	vi.spyOn(el, "getBoundingClientRect").mockReturnValue(
 		new DOMRect(rect.x ?? 0, rect.y ?? 0, rect.width ?? 0, rect.height ?? 0),
 	);
 	const ref: RefObject<Element> = { current: el };
-	return renderHook(() => useIntersectionObserver(ref));
+	return renderHook(() => useIntersectionObserver(ref, options));
 }
 
 describe("useIntersectionObserver — initial-visibility fallback", () => {
@@ -81,5 +84,27 @@ describe("useIntersectionObserver — initial-visibility fallback", () => {
 	it("does NOT fire on a zero-size rect (jsdom default) so the observer stays authoritative", () => {
 		const { result } = mountWithRect({ x: 0, y: 0, width: 0, height: 0 });
 		expect(result.current.hasIntersected).toBe(false);
+	});
+
+	// Threshold fidelity: the sync fallback must not fire earlier than the
+	// observer would. With threshold 0.1 a box peeking in by ~5% stays
+	// pending; one ~50% in view fires. (viewport 768 tall; box height 100.)
+	it("honors the consumer threshold — a sub-threshold sliver does not fire", () => {
+		// top 763 → only 5px of the 100px-tall box clears the 768px viewport
+		// bottom = 5% visible, below the 10% threshold.
+		const { result } = mountWithRect(
+			{ x: 10, y: 763, width: 100, height: 100 },
+			{ threshold: 0.1 },
+		);
+		expect(result.current.hasIntersected).toBe(false);
+	});
+
+	it("honors the consumer threshold — past-threshold visibility fires", () => {
+		// top 718 → visible 768-718 = 50px = 50% ≥ 10%.
+		const { result } = mountWithRect(
+			{ x: 10, y: 718, width: 100, height: 100 },
+			{ threshold: 0.1 },
+		);
+		expect(result.current.hasIntersected).toBe(true);
 	});
 });

--- a/src/hooks/use-intersection-observer.test.ts
+++ b/src/hooks/use-intersection-observer.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Covers the synchronous initial-visibility fallback added to
+ * useIntersectionObserver: when IntersectionObserver never fires its
+ * callback (some automated/headless browsers), an element that is already
+ * above the fold must still report `hasIntersected` so scroll-gated UI
+ * (e.g. NumberTicker) doesn't sit frozen at its start value.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useIntersectionObserver } from "./use-intersection-observer";
+
+// IntersectionObserver that registers but NEVER fires its callback — the
+// real-world headless behavior the fallback exists to cover. The global
+// unit-setup mock fires synchronously, so we override it per-test.
+class SilentIntersectionObserver implements IntersectionObserver {
+	readonly root: Element | null = null;
+	readonly rootMargin = "";
+	readonly scrollMargin = "";
+	readonly thresholds: ReadonlyArray<number> = [];
+	constructor(
+		_callback: IntersectionObserverCallback,
+		_options?: IntersectionObserverInit,
+	) {}
+	observe(): void {}
+	unobserve(): void {}
+	disconnect(): void {}
+	takeRecords(): IntersectionObserverEntry[] {
+		return [];
+	}
+}
+
+function mountWithRect(rect: Partial<DOMRect>) {
+	const el = document.createElement("div");
+	document.body.appendChild(el);
+	vi.spyOn(el, "getBoundingClientRect").mockReturnValue(
+		new DOMRect(rect.x ?? 0, rect.y ?? 0, rect.width ?? 0, rect.height ?? 0),
+	);
+	const ref: RefObject<Element> = { current: el };
+	return renderHook(() => useIntersectionObserver(ref));
+}
+
+describe("useIntersectionObserver — initial-visibility fallback", () => {
+	const original = window.IntersectionObserver;
+
+	beforeEach(() => {
+		// unit-setup defines this writable, so direct assignment swaps the
+		// always-firing global mock for our silent one (defineProperty would
+		// throw — the global descriptor is non-configurable).
+		window.IntersectionObserver = SilentIntersectionObserver;
+	});
+
+	afterEach(() => {
+		window.IntersectionObserver = original;
+		document.body.replaceChildren();
+		vi.restoreAllMocks();
+	});
+
+	it("marks an above-the-fold element intersected even when the observer never fires", () => {
+		// jsdom viewport defaults to 1024x768; a 100x100 box at (10,10) is in view.
+		const { result } = mountWithRect({ x: 10, y: 10, width: 100, height: 100 });
+		expect(result.current.hasIntersected).toBe(true);
+		expect(result.current.isIntersecting).toBe(true);
+	});
+
+	it("does NOT mark a below-the-fold element intersected (waits for the observer)", () => {
+		// y far below the 768px viewport bottom → not initially visible.
+		const { result } = mountWithRect({
+			x: 10,
+			y: 5000,
+			width: 100,
+			height: 100,
+		});
+		expect(result.current.hasIntersected).toBe(false);
+		expect(result.current.isIntersecting).toBe(false);
+	});
+
+	it("does NOT fire on a zero-size rect (jsdom default) so the observer stays authoritative", () => {
+		const { result } = mountWithRect({ x: 0, y: 0, width: 0, height: 0 });
+		expect(result.current.hasIntersected).toBe(false);
+	});
+});

--- a/src/hooks/use-intersection-observer.ts
+++ b/src/hooks/use-intersection-observer.ts
@@ -37,24 +37,37 @@ export function useIntersectionObserver(
 		// Synchronous initial-visibility fallback. IntersectionObserver's
 		// first callback is asynchronous, and some automated/headless
 		// browsers never fire it at all — which leaves an element that is
-		// already above the fold stuck in its pre-intersection state (e.g. a
+		// already in view stuck in its pre-intersection state (e.g. a
 		// NumberTicker frozen at startValue on first paint). A direct rect
 		// check on mount closes that gap. It only ever PROMOTES to
-		// intersected, so the scroll-into-view path for below-the-fold
-		// elements is unchanged. Guarded on width/height > 0 so jsdom (which
-		// returns an all-zero rect) falls through to the observer.
+		// intersected, and it honors the SAME threshold the observer uses
+		// (computing the visible-area ratio) so the fallback can never fire
+		// earlier than a real intersection callback would — the scroll-in
+		// path for below-threshold elements is unchanged. Guarded on
+		// width/height > 0 so jsdom (which returns an all-zero rect) falls
+		// through to the observer.
 		const rect = element.getBoundingClientRect();
 		const viewportHeight =
 			window.innerHeight || document.documentElement.clientHeight;
 		const viewportWidth =
 			window.innerWidth || document.documentElement.clientWidth;
-		const alreadyVisible =
-			rect.width > 0 &&
-			rect.height > 0 &&
-			rect.top < viewportHeight &&
-			rect.bottom > 0 &&
-			rect.left < viewportWidth &&
-			rect.right > 0;
+		const thresholds = Array.isArray(options.threshold)
+			? options.threshold
+			: [options.threshold ?? 0];
+		// For an array threshold the observer fires at its lowest entry.
+		const minThreshold = thresholds.length > 0 ? Math.min(...thresholds) : 0;
+		const visibleHeight =
+			Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0);
+		const visibleWidth =
+			Math.min(rect.right, viewportWidth) - Math.max(rect.left, 0);
+		const visibleRatio =
+			rect.width > 0 && rect.height > 0
+				? (Math.max(0, visibleHeight) * Math.max(0, visibleWidth)) /
+					(rect.width * rect.height)
+				: 0;
+		// threshold 0 → any visible pixel counts (observer semantics);
+		// threshold 0.1 → at least 10% of the box area must be in view.
+		const alreadyVisible = visibleRatio > 0 && visibleRatio >= minThreshold;
 		if (alreadyVisible) {
 			setIsIntersecting(true);
 			markIntersected();

--- a/src/hooks/use-intersection-observer.ts
+++ b/src/hooks/use-intersection-observer.ts
@@ -38,39 +38,47 @@ export function useIntersectionObserver(
 		// first callback is asynchronous, and some automated/headless
 		// browsers never fire it at all — which leaves an element that is
 		// already in view stuck in its pre-intersection state (e.g. a
-		// NumberTicker frozen at startValue on first paint). A direct rect
-		// check on mount closes that gap. It only ever PROMOTES to
-		// intersected, and it honors the SAME threshold the observer uses
-		// (computing the visible-area ratio) so the fallback can never fire
-		// earlier than a real intersection callback would — the scroll-in
-		// path for below-threshold elements is unchanged. Guarded on
-		// width/height > 0 so jsdom (which returns an all-zero rect) falls
-		// through to the observer.
-		const rect = element.getBoundingClientRect();
-		const viewportHeight =
-			window.innerHeight || document.documentElement.clientHeight;
-		const viewportWidth =
-			window.innerWidth || document.documentElement.clientWidth;
-		const thresholds = Array.isArray(options.threshold)
-			? options.threshold
-			: [options.threshold ?? 0];
-		// For an array threshold the observer fires at its lowest entry.
-		const minThreshold = thresholds.length > 0 ? Math.min(...thresholds) : 0;
-		const visibleHeight =
-			Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0);
-		const visibleWidth =
-			Math.min(rect.right, viewportWidth) - Math.max(rect.left, 0);
-		const visibleRatio =
-			rect.width > 0 && rect.height > 0
-				? (Math.max(0, visibleHeight) * Math.max(0, visibleWidth)) /
-					(rect.width * rect.height)
-				: 0;
-		// threshold 0 → any visible pixel counts (observer semantics);
-		// threshold 0.1 → at least 10% of the box area must be in view.
-		const alreadyVisible = visibleRatio > 0 && visibleRatio >= minThreshold;
-		if (alreadyVisible) {
-			setIsIntersecting(true);
-			markIntersected();
+		// NumberTicker frozen at startValue on first paint). A direct
+		// viewport-rect check on mount closes that gap.
+		//
+		// Only applied when the observer targets the default viewport root
+		// with no margin offset — that's the geometry a `getBoundingClientRect`
+		// vs viewport comparison actually models. A custom `root` or non-zero
+		// `rootMargin` changes the intersection geometry, so we defer entirely
+		// to the observer there. Within that case it honors the SAME threshold
+		// (via the visible-area ratio) and only ever PROMOTES to intersected,
+		// so it can never fire earlier than a real intersection callback —
+		// the scroll-in path for below-threshold elements is unchanged.
+		const usesViewportRoot =
+			!options.root && (options.rootMargin ?? "0px") === "0px";
+		if (usesViewportRoot) {
+			const rect = element.getBoundingClientRect();
+			const viewportHeight =
+				window.innerHeight || document.documentElement.clientHeight;
+			const viewportWidth =
+				window.innerWidth || document.documentElement.clientWidth;
+			const thresholds = Array.isArray(options.threshold)
+				? options.threshold
+				: [options.threshold ?? 0];
+			// For an array threshold the observer fires at its lowest entry.
+			const minThreshold = thresholds.length > 0 ? Math.min(...thresholds) : 0;
+			const visibleHeight =
+				Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0);
+			const visibleWidth =
+				Math.min(rect.right, viewportWidth) - Math.max(rect.left, 0);
+			// Guarded on width/height > 0 so jsdom (which returns an all-zero
+			// rect) falls through to the observer.
+			const visibleRatio =
+				rect.width > 0 && rect.height > 0
+					? (Math.max(0, visibleHeight) * Math.max(0, visibleWidth)) /
+						(rect.width * rect.height)
+					: 0;
+			// threshold 0 → any visible pixel counts (observer semantics);
+			// threshold 0.1 → at least 10% of the box area must be in view.
+			if (visibleRatio > 0 && visibleRatio >= minThreshold) {
+				setIsIntersecting(true);
+				markIntersected();
+			}
 		}
 
 		const observer = new IntersectionObserver(

--- a/src/hooks/use-intersection-observer.ts
+++ b/src/hooks/use-intersection-observer.ts
@@ -28,15 +28,47 @@ export function useIntersectionObserver(
 		const element = ref.current;
 		if (!element) return;
 
+		const markIntersected = () => {
+			if (hasIntersectedRef.current) return;
+			hasIntersectedRef.current = true;
+			setHasIntersected(true);
+		};
+
+		// Synchronous initial-visibility fallback. IntersectionObserver's
+		// first callback is asynchronous, and some automated/headless
+		// browsers never fire it at all — which leaves an element that is
+		// already above the fold stuck in its pre-intersection state (e.g. a
+		// NumberTicker frozen at startValue on first paint). A direct rect
+		// check on mount closes that gap. It only ever PROMOTES to
+		// intersected, so the scroll-into-view path for below-the-fold
+		// elements is unchanged. Guarded on width/height > 0 so jsdom (which
+		// returns an all-zero rect) falls through to the observer.
+		const rect = element.getBoundingClientRect();
+		const viewportHeight =
+			window.innerHeight || document.documentElement.clientHeight;
+		const viewportWidth =
+			window.innerWidth || document.documentElement.clientWidth;
+		const alreadyVisible =
+			rect.width > 0 &&
+			rect.height > 0 &&
+			rect.top < viewportHeight &&
+			rect.bottom > 0 &&
+			rect.left < viewportWidth &&
+			rect.right > 0;
+		if (alreadyVisible) {
+			setIsIntersecting(true);
+			markIntersected();
+		}
+
 		const observer = new IntersectionObserver(
 			([entry]) => {
 				const isCurrentlyIntersecting = entry?.isIntersecting ?? false;
 				setIsIntersecting(isCurrentlyIntersecting);
 
-				// Only set state once when first intersecting (using ref to avoid re-running effect)
-				if (isCurrentlyIntersecting && !hasIntersectedRef.current) {
-					hasIntersectedRef.current = true;
-					setHasIntersected(true);
+				// Only set state once when first intersecting (ref guard avoids
+				// re-running the effect on the state change).
+				if (isCurrentlyIntersecting) {
+					markIntersected();
 				}
 			},
 			{


### PR DESCRIPTION
## Summary

Closes the six gaps surfaced by the live read-only UI audit of `tenantflow.app`. Each fix is root-caused, not patched over; two flagged items were verified as false positives and left untouched (see below).

| Fix | Area | What was wrong | Change |
|-----|------|----------------|--------|
| 1 | `/dashboard` | The `#310` overlay containment gap: `OnboardingWizard` + `OwnerOnboardingTour` rendered **outside** the dashboard `ErrorBoundary`, so a transient tour render fault was uncontained | Each overlay isolated in its own `ErrorBoundary` with a silent fallback — fault is captured to Sentry and degrades to "no overlay" |
| 2 | NumberTicker | Above-the-fold KPI tickers read stuck-0 on first paint until IntersectionObserver's async callback fires (and never fire in headless) | `useIntersectionObserver` now does a synchronous initial-visibility rect check on mount; only ever promotes to intersected, so scroll-in for below-fold elements is unchanged |
| 3 | `/blog` | Posts with no `featured_image` rendered a flat gray box (read as broken) | Branded placeholder: gradient + `Newspaper` glyph |
| 4 | App shell | The floating `QuickActionsDock` (`hidden lg:block`, `fixed bottom-6`) overlapped the last rows / footer — `<main>` only had `sm:pb-6` | Added `lg:pb-28` clearance on `lg`+ where the dock shows |
| 5 | `/contact` | "How did you hear about us?" pre-selected **"Sales Outreach"** — the form defaulted inquiry `type` to `"sales"`, and that select is bound to `type` | Default `type: "general"` (valid union value matching no referral option) → the "Please select" placeholder shows |

### Verified false positives (no change)
- **`/faq` empty hero image** — the Unsplash hero hotlink is the same allowlisted pattern used on `/about`, `/help`, `/login`, `/contact`; the empty box was a headless slow-load, not a code defect. Changing only FAQ would be inconsistent.
- **`/settings` React #310** — the buffered console error was misattributed by a sticky, signature-deduped Chrome console buffer that doesn't clear on navigation. The throw originates on `/dashboard` (the tour subtree), not settings. The whole tour subsystem is hook-correct (verified statically + via a non-minified jsdom mount), so there is no static hook bug to fix — fix 1 is containment for the runtime transient.

## Tests
- New `use-intersection-observer.test.ts` — 3 cases pinning the fallback (above-fold fires, below-fold waits, zero-rect defers to the observer)
- `blog-card.test.tsx` — placeholder assertion updated to the branded marker
- `contact-form-fields.test.tsx` — regression guard that `contact-form.tsx` never defaults `type` to `"sales"`
- 71 affected tests pass; typecheck + lint clean; full pre-commit unit suite green

[hudsor01]
