### PR TITLE
ci: add CodeQL SAST + gitleaks secret-scanning workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+# Static application security testing (SAST). Advanced setup via this
+# workflow file (code-scanning default setup is intentionally left
+# `not-configured` so the two don't conflict). Free on this public repo.
+# Analyzes the app source AND the GitHub Actions workflows themselves
+# (catches e.g. unpinned/over-privileged actions). Results land in the
+# repo Security tab; add `CodeQL` to required checks separately if desired.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Weekly Monday 04:27 UTC — re-scans `main` against updated CodeQL queries.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript", "actions"]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,34 @@
+name: gitleaks
+
+# Server-side secret scanning. gitleaks already runs as a lefthook
+# pre-commit hook, but that is local and bypassable (--no-verify, or a
+# contributor without the hooks installed). This job re-runs it in CI so a
+# committed secret fails the PR regardless of local setup. Free for this
+# personal public repo (no GITLEAKS_LICENSE required).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the scan covers every commit on the branch,
+          # not just the tip — a secret introduced and "removed" in an
+          # earlier commit is still in the pack and still leaked.
+          fetch-depth: 0
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Quick-win CI security gate — closes the two confirmed supply-chain gaps from the 2026-05-29 repo audit (Theme A) with no repo-settings change and no GHAS requirement (repo is public).

| Workflow | Closes | Notes |
|----------|--------|-------|
| `.github/workflows/codeql.yml` | **No SAST** — code-scanning was `not-configured` | Advanced-setup CodeQL (free on public repos). Matrix scans `javascript-typescript` **and** `actions` (flags unpinned/over-privileged workflow steps). Default-setup left unconfigured so the two don't conflict. Results → Security tab. |
| `.github/workflows/gitleaks.yml` | **No server-side secret scanning** — gitleaks was a bypassable local pre-commit hook only | CI job with full-history (`fetch-depth: 0`) scan; fails the PR on a committed secret regardless of local hook state. Free for this personal public repo. |

Both trigger on push-to-main + PRs. Neither uses untrusted event input in `run:`/`ref:`.

## Verification
- Both workflows YAML-valid (parsed clean).
- No secrets required; no branch-protection / repo-settings change in this PR.
- Pre-commit gate (gitleaks, lint, typecheck, unit tests, commitlint) passed locally.

## Follow-ups (not in this PR)
- Add `CodeQL` + `gitleaks` to **required status checks** (branch protection) — a repo-settings change, left to you.
- **Edge-function / Stripe-webhook test gating** — the 74 `Deno.test` blocks (incl. webhook signature verification) need `supabase functions serve` + secrets; deferred to the **v4.0 Hardening** milestone.
- CSP nonce + `strict-dynamic`, constant-time secret compare in `auth-email-send`, SHA-pin existing actions — also v4.0.

[hudsor01]
