### PR TITLE
v4.0 Phase 1: Security-CI Hardening (CISEC-01..04)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,15 +36,15 @@ jobs:
       - name: Suppress git default branch hint
         run: git config --global init.defaultBranch main
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
@@ -111,7 +111,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         run: git config --global init.defaultBranch main
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         with:
           fetch-depth: 1
@@ -139,12 +139,12 @@ jobs:
           SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         with:
           bun-version: 1.3.14
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         with:
           node-version: "24"
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure() && (github.event_name != 'pull_request' || github.actor != 'dependabot[bot]')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-${{ github.sha }}
           path: playwright-report/

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,13 +28,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,16 +34,16 @@ jobs:
       matrix:
         language: ["javascript-typescript", "actions"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Full history so the scan covers every commit on the branch,
           # not just the tip — a secret introduced and "removed" in an
@@ -29,6 +29,6 @@ jobs:
           fetch-depth: 0
 
       - name: gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-deploy-sentry-gate.yml
+++ b/.github/workflows/post-deploy-sentry-gate.yml
@@ -390,7 +390,7 @@ jobs:
 
       - name: Upload baseline artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sentry-baseline-${{ steps.release.outputs.sha }}
           path: snapshot.json

--- a/.github/workflows/rls-security-tests.yml
+++ b/.github/workflows/rls-security-tests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Checkout
         if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Fail hard when any required secret is missing. The previous
       # silent-skip pattern made every PR show "rls-security pass" while
@@ -86,13 +86,13 @@ jobs:
 
       - name: Setup Bun
         if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
 
       - name: Setup Node.js
         if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -11,7 +11,7 @@
 
 - [ ] **CISEC-01**: Stripe-webhook signature verification (and the other security-critical edge-function assertions) run in CI as a hard gate — either a `deno test` job wired to `supabase functions serve` + secrets, or the security-critical assertions ported into the vitest integration suite.
 - [ ] **CISEC-02**: The Content-Security-Policy serves a per-request nonce with `strict-dynamic`; `script-src 'unsafe-inline'` is removed from `vercel.json` / `proxy.ts`.
-- [ ] **CISEC-03**: The `auth-email-send` Edge Function compares its hook secret in constant time (`crypto.subtle.timingSafeEqual` / the shared XOR helper), never `token !== hookSecret`.
+- [x] **CISEC-03**: The `auth-email-send` Edge Function compares its hook secret in constant time (`crypto.subtle.timingSafeEqual` / the shared XOR helper), never `token !== hookSecret`.
 - [ ] **CISEC-04**: All third-party GitHub Actions across `.github/workflows/` are pinned to commit SHAs (CodeQL's `actions` scan stays clean).
 
 ### TYPE — typed RPC/PostgREST boundaries (zero-tolerance rule #8)
@@ -73,7 +73,7 @@ Deferred follow-ups (small, optional, non-blocking — fold into a later milesto
 |-------------|-------|--------|
 | CISEC-01 | Phase 1 — Security-CI Hardening | Pending |
 | CISEC-02 | Phase 1 — Security-CI Hardening | Pending |
-| CISEC-03 | Phase 1 — Security-CI Hardening | Pending |
+| CISEC-03 | Phase 1 — Security-CI Hardening | Complete |
 | CISEC-04 | Phase 1 — Security-CI Hardening | Pending |
 | TYPE-01 | Phase 2 — Typed RPC Boundaries | Pending |
 | TYPE-02 | Phase 2 — Typed RPC Boundaries | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -64,7 +64,11 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   2. The deployed Content-Security-Policy serves a per-request nonce with `strict-dynamic` and no `script-src 'unsafe-inline'` remains in `vercel.json` / `proxy.ts`.
   3. `auth-email-send` compares its hook secret in constant time (`crypto.subtle.timingSafeEqual` / shared XOR helper); a grep/test confirms no `token !== hookSecret` short-circuit compare remains.
   4. Every third-party action under `.github/workflows/` is pinned to a commit SHA, and CodeQL's `actions` scan stays clean.
-**Plans**: TBD
+**Plans**: 4 plans (all Wave 1 — parallel, zero file overlap)
+- [ ] 01-01-PLAN.md — CISEC-01: Stripe-webhook signature accept/reject Vitest gate
+- [ ] 01-02-PLAN.md — CISEC-02: route-scoped per-request nonce CSP + drop script-src 'unsafe-inline'
+- [ ] 01-03-PLAN.md — CISEC-03: shared timing-safe helper + constant-time auth-email-send compare
+- [ ] 01-04-PLAN.md — CISEC-04: SHA-pin all workflow actions + drift-guard test
 
 ### Phase 2: Typed RPC Boundaries
 **Goal**: Every RPC/PostgREST boundary under `src/hooks/api/` returns through a typed mapper with Zod validation — zero `as unknown as` casts — enforced by a drift guard so the violation cannot silently return.
@@ -145,7 +149,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 
 | Phase | Milestone | Plans | Status | Completed |
 |-------|-----------|-------|--------|-----------|
-| 1. Security-CI Hardening | v4.0 | 0/? | Not started | - |
+| 1. Security-CI Hardening | v4.0 | 0/4 | Planned | - |
 | 2. Typed RPC Boundaries | v4.0 | 0/? | Not started | - |
 | 3. Stats RPC Consolidation | v4.0 | 0/? | Not started | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -65,10 +65,10 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   3. `auth-email-send` compares its hook secret in constant time (`crypto.subtle.timingSafeEqual` / shared XOR helper); a grep/test confirms no `token !== hookSecret` short-circuit compare remains.
   4. Every third-party action under `.github/workflows/` is pinned to a commit SHA, and CodeQL's `actions` scan stays clean.
 **Plans**: 4 plans (all Wave 1 — parallel, zero file overlap)
-- [ ] 01-01-PLAN.md — CISEC-01: Stripe-webhook signature accept/reject Vitest gate
+- [x] 01-01-PLAN.md — CISEC-01: Stripe-webhook signature accept/reject Vitest gate
 - [ ] 01-02-PLAN.md — CISEC-02: route-scoped per-request nonce CSP + drop script-src 'unsafe-inline'
-- [ ] 01-03-PLAN.md — CISEC-03: shared timing-safe helper + constant-time auth-email-send compare
-- [ ] 01-04-PLAN.md — CISEC-04: SHA-pin all workflow actions + drift-guard test
+- [x] 01-03-PLAN.md — CISEC-03: shared timing-safe helper + constant-time auth-email-send compare
+- [x] 01-04-PLAN.md — CISEC-04: SHA-pin all workflow actions + drift-guard test
 
 ### Phase 2: Typed RPC Boundaries
 **Goal**: Every RPC/PostgREST boundary under `src/hooks/api/` returns through a typed mapper with Zod validation — zero `as unknown as` casts — enforced by a drift guard so the violation cannot silently return.
@@ -149,7 +149,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 
 | Phase | Milestone | Plans | Status | Completed |
 |-------|-----------|-------|--------|-----------|
-| 1. Security-CI Hardening | v4.0 | 0/4 | Planned | - |
+| 1. Security-CI Hardening | v4.0 | 3/4 | In Progress|  |
 | 2. Typed RPC Boundaries | v4.0 | 0/? | Not started | - |
 | 3. Stats RPC Consolidation | v4.0 | 0/? | Not started | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v4.0
 milestone_name: Hardening & Hygiene
-status: in_progress
-last_updated: "2026-06-04T15:30:00.000Z"
-last_activity: 2026-06-04
+status: planning
+last_updated: "2026-06-04T18:16:25.570Z"
+last_activity: 2026-06-04 — v4.0 roadmap created (8 phases, 21/21 requirements mapped)
 progress:
   total_phases: 8
   completed_phases: 0
-  total_plans: 0
-  completed_plans: 0
+  total_plans: 4
+  completed_plans: 3
   percent: 0
 ---
 
@@ -27,7 +27,7 @@ See: .planning/PROJECT.md (updated 2026-06-04 — v4.0 Hardening & Hygiene activ
 Phase: 1 of 8 (Security-CI Hardening) — v4.0
 Plan: — (not yet planned)
 Status: Roadmap created; ready to plan Phase 1
-Progress: [        ] 0/8 phases (0%)
+Progress: [████████░░] 75%
 Last activity: 2026-06-04 — v4.0 roadmap created (8 phases, 21/21 requirements mapped)
 
 ## Roadmap Summary (v4.0)

--- a/.planning/phases/01-security-ci-hardening/01-01-PLAN.md
+++ b/.planning/phases/01-security-ci-hardening/01-01-PLAN.md
@@ -1,0 +1,117 @@
+---
+phase: 01-security-ci-hardening
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/lib/__tests__/stripe-webhook-signature.test.ts
+autonomous: true
+requirements: [CISEC-01]
+must_haves:
+  truths:
+    - "A correctly-signed Stripe webhook payload is accepted by constructEvent (accept path gated)"
+    - "A tampered body, a wrong secret, and a stale timestamp are each rejected (reject paths gated)"
+    - "The assertion runs inside the already-green checks gate on every PR with no server, no prod secret, no supabase functions serve"
+  artifacts:
+    - path: "src/lib/__tests__/stripe-webhook-signature.test.ts"
+      provides: "Vitest unit test pinning the Stripe webhook-signature accept/reject contract"
+      min_lines: 40
+  key_links:
+    - from: "src/lib/__tests__/stripe-webhook-signature.test.ts"
+      to: "stripe SDK webhooks.generateTestHeaderString + constructEvent"
+      via: "import Stripe from 'stripe'"
+      pattern: "generateTestHeaderString|constructEvent"
+---
+
+<objective>
+Close CISEC-01: pin the Stripe-webhook signature accept/reject contract as a hard CI gate via a pure Vitest unit test, satisfying the user's locked decision that this is a Vitest unit test (NOT a deno test + supabase functions serve CI job).
+
+Purpose: The `stripe-webhooks` Edge Function delegates 100% of signature verification to the Stripe SDK (`constructEventAsync` at `stripe-webhooks/index.ts:65-72`). No test exercises that contract in any CI workflow today. The Node `stripe` SDK (`22.1.1`, already in package.json) exposes `webhooks.generateTestHeaderString()`, which mints a genuine HMAC signature locally — letting a unit test gate BOTH the accept path (valid sig) and every reject path (tampered/wrong-secret/stale) inside the already-green `checks` gate.
+Output: `src/lib/__tests__/stripe-webhook-signature.test.ts`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/01-security-ci-hardening/01-RESEARCH.md
+@.planning/phases/01-security-ci-hardening/01-VALIDATION.md
+
+<interfaces>
+<!-- Stripe SDK contract the Edge Function depends on (Node SDK 22.1.1, verified via `node -e require('stripe')`). -->
+<!-- generateTestHeaderString mints a real HMAC-SHA256 over `${timestamp}.${payload}` in the `t=…,v1=…` scheme. -->
+<!-- DO NOT hand-roll the t=…,v1=… header — that re-introduces the bug class this test guards. -->
+
+From the `stripe` package (already a dependency):
+  Stripe.webhooks.generateTestHeaderString(options: { payload: string; secret: string; timestamp?: number }): string
+  Stripe.webhooks.constructEvent(payload: string, header: string, secret: string, tolerance?: number): Stripe.Event   // throws Stripe.errors.StripeSignatureVerificationError on mismatch
+
+Edge Function under guard (do NOT import — it uses npm:/jsr: specifiers Vite cannot resolve):
+  supabase/functions/stripe-webhooks/index.ts:65 — `await stripe.webhooks.constructEventAsync(body, signature, env.STRIPE_WEBHOOK_SECRET)`
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Write the Stripe webhook-signature accept/reject unit test</name>
+  <files>src/lib/__tests__/stripe-webhook-signature.test.ts</files>
+  <read_first>
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-01 — "Concrete Implementation Steps" steps 1-9 and "Gotchas / Landmines")
+    - supabase/functions/stripe-webhooks/index.ts (lines 60-97 — the constructEventAsync contract being guarded)
+    - vitest.config.ts (lines 60-114 — the `unit` project globs `src/**/*.{test,spec}.{ts,tsx}`; this is why the file MUST live under src/)
+  </read_first>
+  <behavior>
+    - Accept: a payload signed with `generateTestHeaderString({ payload, secret })` passes `constructEvent(payload, header, secret)` and returns the parsed event (assert the event `type` / `id` round-trips).
+    - Reject (tampered body): `constructEvent(payload + " ", header, secret)` throws.
+    - Reject (wrong secret): `constructEvent(payload, header, "whsec_wrong…")` throws.
+    - Reject (stale timestamp): a header built with `timestamp: Math.floor(Date.now()/1000) - 10_000` is rejected when a `tolerance` (e.g. 300s) is passed to `constructEvent`.
+  </behavior>
+  <action>
+    Create the file under `src/lib/__tests__/` (required — the `unit` vitest project only globs `src/**`, so a path outside src would silently not run in the `checks` gate). `import Stripe from "stripe"` (the Node SDK already in package.json — do NOT import the Deno Edge Function file). Construct `const stripe = new Stripe("sk_test_x")` and a throwaway `const secret = "whsec_test_" + "x".repeat(24)`. Build a minimal event JSON string (an object with `id` and `type` fields, JSON.stringify'd). Use `stripe.webhooks.generateTestHeaderString({ payload, secret })` to mint the valid header — never hand-build the `t=…,v1=…` string. Write four assertions matching the four `<behavior>` cases above: use the sync `constructEvent` (the Node SDK supports sync; the Edge Function uses `constructEventAsync` only because Deno needs the Web-Crypto async variant — note this distinction in a comment so nobody "fixes" the test to match). For the stale-timestamp case, pass a positive `tolerance` argument so the SDK enforces the timestamp window. Use `.toThrow()` for the reject paths. Add a header comment linking the test to `supabase/functions/stripe-webhooks/index.ts:65` so a future reader knows it guards the Edge Function verification contract. Respect `exactOptionalPropertyTypes`: pass a fully-populated options object to `generateTestHeaderString` (no `undefined` properties). No `any` — if a typed event field is read, narrow via the SDK's `Stripe.Event` type.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/lib/__tests__/stripe-webhook-signature.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `bun run test:unit -- --run src/lib/__tests__/stripe-webhook-signature.test.ts` exits 0 with 4 passing assertions (accept + 3 reject).
+    - `grep -c "generateTestHeaderString" src/lib/__tests__/stripe-webhook-signature.test.ts` ≥ 1 (a real SDK signature is minted, not a hand-rolled `t=…,v1=…` string).
+    - `grep -cE "t=.*v1=" src/lib/__tests__/stripe-webhook-signature.test.ts` returns 0 (no hand-rolled header string literal).
+    - `bun run typecheck` passes with no new errors (no `any`, exactOptionalPropertyTypes satisfied).
+  </acceptance_criteria>
+  <done>Valid signature accepted; tampered body, wrong secret, and stale timestamp each rejected; test runs green in the `checks` gate.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Stripe → stripe-webhooks Edge Function | Untrusted external POST crosses here; the `Stripe-Signature` header is the only proof of authenticity |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-01-01 | Spoofing | stripe-webhooks signature verification (`index.ts:65`) | mitigate | SDK `constructEventAsync` verifies the HMAC; this plan adds a CI-gated regression test (CISEC-01) that fails the PR if a valid signature stops being accepted OR a forged/tampered/stale one stops being rejected |
+| T-01-02 | Tampering | webhook payload body in transit | mitigate | The accept-vs-tampered assertion pins that any mutation of the signed body fails verification |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- --run src/lib/__tests__/stripe-webhook-signature.test.ts` green.
+- `bun run validate:quick` green (typecheck + lint + unit).
+- The new test runs inside the `checks` gate on the PR (no new workflow, no new secret, no supabase functions serve).
+</verification>
+
+<success_criteria>
+- Stripe-webhook signature verification fails the CI run when broken: a valid signature is accepted and tampered/wrong-secret/stale signatures are rejected, all asserted in a Vitest unit test inside the existing `checks` gate.
+</success_criteria>
+
+<output>
+Create `.planning/phases/01-security-ci-hardening/01-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/01-security-ci-hardening/01-01-PLAN.md
+++ b/.planning/phases/01-security-ci-hardening/01-01-PLAN.md
@@ -27,7 +27,7 @@ must_haves:
 <objective>
 Close CISEC-01: pin the Stripe-webhook signature accept/reject contract as a hard CI gate via a pure Vitest unit test, satisfying the user's locked decision that this is a Vitest unit test (NOT a deno test + supabase functions serve CI job).
 
-Purpose: The `stripe-webhooks` Edge Function delegates 100% of signature verification to the Stripe SDK (`constructEventAsync` at `stripe-webhooks/index.ts:65-72`). No test exercises that contract in any CI workflow today. The Node `stripe` SDK (`22.1.1`, already in package.json) exposes `webhooks.generateTestHeaderString()`, which mints a genuine HMAC signature locally — letting a unit test gate BOTH the accept path (valid sig) and every reject path (tampered/wrong-secret/stale) inside the already-green `checks` gate.
+Purpose: The `stripe-webhooks` Edge Function delegates 100% of signature verification to the Stripe SDK (`constructEventAsync` at `stripe-webhooks/index.ts:73-80`). No test exercises that contract in any CI workflow today. The Node `stripe` SDK (`22.1.1`, already in package.json) exposes `webhooks.generateTestHeaderString()`, which mints a genuine HMAC signature locally — letting a unit test gate BOTH the accept path (valid sig) and every reject path (tampered/wrong-secret/stale) inside the already-green `checks` gate.
 Output: `src/lib/__tests__/stripe-webhook-signature.test.ts`.
 </objective>
 
@@ -50,7 +50,7 @@ From the `stripe` package (already a dependency):
   Stripe.webhooks.constructEvent(payload: string, header: string, secret: string, tolerance?: number): Stripe.Event   // throws Stripe.errors.StripeSignatureVerificationError on mismatch
 
 Edge Function under guard (do NOT import — it uses npm:/jsr: specifiers Vite cannot resolve):
-  supabase/functions/stripe-webhooks/index.ts:65 — `await stripe.webhooks.constructEventAsync(body, signature, env.STRIPE_WEBHOOK_SECRET)`
+  supabase/functions/stripe-webhooks/index.ts:73 — `await stripe.webhooks.constructEventAsync(body, signature, env.STRIPE_WEBHOOK_SECRET)`
 </interfaces>
 </context>
 
@@ -71,7 +71,7 @@ Edge Function under guard (do NOT import — it uses npm:/jsr: specifiers Vite c
     - Reject (stale timestamp): a header built with `timestamp: Math.floor(Date.now()/1000) - 10_000` is rejected when a `tolerance` (e.g. 300s) is passed to `constructEvent`.
   </behavior>
   <action>
-    Create the file under `src/lib/__tests__/` (required — the `unit` vitest project only globs `src/**`, so a path outside src would silently not run in the `checks` gate). `import Stripe from "stripe"` (the Node SDK already in package.json — do NOT import the Deno Edge Function file). Construct `const stripe = new Stripe("sk_test_x")` and a throwaway `const secret = "whsec_test_" + "x".repeat(24)`. Build a minimal event JSON string (an object with `id` and `type` fields, JSON.stringify'd). Use `stripe.webhooks.generateTestHeaderString({ payload, secret })` to mint the valid header — never hand-build the `t=…,v1=…` string. Write four assertions matching the four `<behavior>` cases above: use the sync `constructEvent` (the Node SDK supports sync; the Edge Function uses `constructEventAsync` only because Deno needs the Web-Crypto async variant — note this distinction in a comment so nobody "fixes" the test to match). For the stale-timestamp case, pass a positive `tolerance` argument so the SDK enforces the timestamp window. Use `.toThrow()` for the reject paths. Add a header comment linking the test to `supabase/functions/stripe-webhooks/index.ts:65` so a future reader knows it guards the Edge Function verification contract. Respect `exactOptionalPropertyTypes`: pass a fully-populated options object to `generateTestHeaderString` (no `undefined` properties). No `any` — if a typed event field is read, narrow via the SDK's `Stripe.Event` type.
+    Create the file under `src/lib/__tests__/` (required — the `unit` vitest project only globs `src/**`, so a path outside src would silently not run in the `checks` gate). `import Stripe from "stripe"` (the Node SDK already in package.json — do NOT import the Deno Edge Function file). Construct `const stripe = new Stripe("sk_test_x")` and a throwaway `const secret = "whsec_test_" + "x".repeat(24)`. Build a minimal event JSON string (an object with `id` and `type` fields, JSON.stringify'd). Use `stripe.webhooks.generateTestHeaderString({ payload, secret })` to mint the valid header — never hand-build the `t=…,v1=…` string. Write four assertions matching the four `<behavior>` cases above: use the sync `constructEvent` (the Node SDK supports sync; the Edge Function uses `constructEventAsync` only because Deno needs the Web-Crypto async variant — note this distinction in a comment so nobody "fixes" the test to match). For the stale-timestamp case, pass a positive `tolerance` argument so the SDK enforces the timestamp window. Use `.toThrow()` for the reject paths. Add a header comment linking the test to `supabase/functions/stripe-webhooks/index.ts:73` so a future reader knows it guards the Edge Function verification contract. Respect `exactOptionalPropertyTypes`: pass a fully-populated options object to `generateTestHeaderString` (no `undefined` properties). No `any` — if a typed event field is read, narrow via the SDK's `Stripe.Event` type.
   </action>
   <verify>
     <automated>bun run test:unit -- --run src/lib/__tests__/stripe-webhook-signature.test.ts</automated>
@@ -98,7 +98,7 @@ Edge Function under guard (do NOT import — it uses npm:/jsr: specifiers Vite c
 
 | Threat ID | Category | Component | Disposition | Mitigation Plan |
 |-----------|----------|-----------|-------------|-----------------|
-| T-01-01 | Spoofing | stripe-webhooks signature verification (`index.ts:65`) | mitigate | SDK `constructEventAsync` verifies the HMAC; this plan adds a CI-gated regression test (CISEC-01) that fails the PR if a valid signature stops being accepted OR a forged/tampered/stale one stops being rejected |
+| T-01-01 | Spoofing | stripe-webhooks signature verification (`index.ts:73`) | mitigate | SDK `constructEventAsync` verifies the HMAC; this plan adds a CI-gated regression test (CISEC-01) that fails the PR if a valid signature stops being accepted OR a forged/tampered/stale one stops being rejected |
 | T-01-02 | Tampering | webhook payload body in transit | mitigate | The accept-vs-tampered assertion pins that any mutation of the signed body fails verification |
 </threat_model>
 

--- a/.planning/phases/01-security-ci-hardening/01-01-SUMMARY.md
+++ b/.planning/phases/01-security-ci-hardening/01-01-SUMMARY.md
@@ -1,0 +1,116 @@
+---
+phase: 01-security-ci-hardening
+plan: 01
+subsystem: testing
+tags: [stripe, webhook, signature, hmac, vitest, ci-gate, security]
+
+# Dependency graph
+requires: []
+provides:
+  - CI-gated Stripe-webhook signature accept/reject contract test (CISEC-01)
+  - Vitest unit test pinning generateTestHeaderString + constructEvent behavior
+affects: [stripe-webhooks, edge-functions, payments-security]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Test the SDK contract an Edge Function depends on, not the Deno function file (avoids npm:/jsr: specifier resolution in Vite)"
+    - "Mint a real HMAC via stripe.webhooks.generateTestHeaderString instead of hand-rolling the Stripe-Signature header"
+
+key-files:
+  created:
+    - src/lib/__tests__/stripe-webhook-signature.test.ts
+  modified: []
+
+key-decisions:
+  - "Used the synchronous constructEvent (Node SDK) as the correct mirror of the Edge Function's constructEventAsync (Deno) — same t=,v1= HMAC-SHA256 scheme"
+  - "Throwaway test secrets only; no prod STRIPE_WEBHOOK_SECRET, no server, no supabase functions serve"
+
+patterns-established:
+  - "Edge-Function signature contracts are gated in the unit vitest project (src/**) so they run in the already-green checks gate without booting the Deno runtime"
+
+requirements-completed: [CISEC-01]
+
+# Metrics
+duration: 12min
+completed: 2026-06-04
+---
+
+# Phase 1 Plan 01: Stripe-Webhook Signature CI Gate Summary
+
+**Vitest unit test that mints a genuine HMAC via the stripe SDK and pins the Stripe-webhook signature accept/reject contract (valid accepted; tampered/wrong-secret/stale rejected) inside the already-green `checks` gate.**
+
+## Performance
+
+- **Duration:** 12 min
+- **Started:** 2026-06-04T12:55:00Z
+- **Completed:** 2026-06-04T13:03:00Z
+- **Tasks:** 1
+- **Files modified:** 1 (created)
+
+## Accomplishments
+- Closed CISEC-01: the Stripe-webhook signature path is now a hard CI gate — a PR breaks if a valid signature stops being accepted OR a forged/tampered/stale one stops being rejected.
+- Test mints a real HMAC via `stripe.webhooks.generateTestHeaderString` (no hand-rolled header literal) and asserts all four contract cases against `constructEvent`.
+- Runs in the `unit` vitest project (`src/**`), so it executes in the existing `checks` gate with no server, no prod secret, no `supabase functions serve`, and no new dependency.
+- Guards the `constructEventAsync` contract at `supabase/functions/stripe-webhooks/index.ts:73` (linked in a header comment for future readers).
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Write the Stripe webhook-signature accept/reject unit test** - `c64d06f54` (test)
+
+_Note: this is a pure test-only artifact (the test IS the deliverable; no production source code), so the RED/GREEN cycle collapses to a single passing test commit — there is no implementation source to add in a separate GREEN commit._
+
+## Files Created/Modified
+- `src/lib/__tests__/stripe-webhook-signature.test.ts` - Vitest unit test minting a valid Stripe signature via the SDK and asserting accept (valid) + reject (tampered body, wrong secret, stale timestamp outside tolerance).
+
+## Decisions Made
+- Used the synchronous `constructEvent` from the Node SDK rather than `constructEventAsync` — the Edge Function only uses the async variant because Deno requires the async Web-Crypto path; both implement the identical signed-header scheme. Documented in a comment so nobody "fixes" the test to match the Edge Function's async call.
+- Used throwaway, internally-consistent test secrets (`whsec_test_…`) shaped like real signing secrets; the wrong-secret case uses a distinct `whsec_wrong_…` value.
+- Passed an explicit `tolerance` (300s) to `constructEvent` only on the stale-timestamp case so the SDK enforces the timestamp window; the other reject paths rely on the default behavior.
+
+## Deviations from Plan
+
+### Adjustments (no rule-class deviation)
+
+**1. Comment wording adjusted to satisfy the `t=.*v1=` grep acceptance guard**
+- **Found during:** Task 1 (acceptance-criteria grep check)
+- **Issue:** My initial header comment explained the Stripe scheme using the literal text `t=<timestamp>,v1=<hmac-sha256>` and `t=…,v1=…` to warn against hand-rolling. The acceptance criterion `grep -cE "t=.*v1=" … returns 0` matched those explanatory comment lines (returned 2), even though no code hand-rolls a header.
+- **Fix:** Reworded the comment to describe the scheme in prose ("an HMAC-SHA256 over the timestamp-and-payload, carried in the Stripe-Signature header") without the literal `t=…,v1=…` pattern. Intent (warn against hand-rolling) preserved.
+- **Files modified:** src/lib/__tests__/stripe-webhook-signature.test.ts
+- **Verification:** `grep -cE "t=.*v1=" …` now returns 0; `grep -c "generateTestHeaderString" …` returns 5; 4 tests still pass.
+- **Committed in:** c64d06f54 (Task 1 commit)
+
+**2. `bun run test:unit -- --run <file>` corrected to `bun run test:unit -- <file>`**
+- **Found during:** Task 1 (running the plan's stated verify command)
+- **Issue:** The `test:unit` package.json script is already `vitest --run --project unit`, so the plan's `bun run test:unit -- --run <file>` passed `--run` twice and vitest 4 errored ("Expected a single value for option --run").
+- **Fix:** Ran `bun run test:unit -- <file>` (the script already injects `--run --project unit`). Also confirmed via the plan's exact `bunx vitest --run --project unit <file>` form, which passes cleanly.
+- **Files modified:** none (command-invocation fix only)
+- **Verification:** Both forms pass — 4/4 tests green.
+- **Committed in:** n/a (no file change)
+
+---
+
+**Total deviations:** 2 minor adjustments (1 comment-wording to satisfy a grep guard, 1 command-invocation fix). No rule-class auto-fixes (no bugs, missing functionality, or blockers in code).
+**Impact on plan:** Plan executed as written. No scope creep, no production code touched, no new dependency.
+
+## Issues Encountered
+- The plan's literal `--run` flag in the verify command duplicated the script's own `--run` (vitest 4 rejects duplicate single-value options). Resolved by dropping the redundant flag; the underlying assertion is unchanged. See Deviation 2.
+
+## User Setup Required
+None - no external service configuration required. The test uses only throwaway in-test secrets and the already-installed `stripe` + `vitest` packages.
+
+## Next Phase Readiness
+- CISEC-01 is closed; the signature contract is gated on every PR via `checks`.
+- Remaining Phase 1 requirements (CISEC-02 CSP nonce, CISEC-03 constant-time hook-secret compare, CISEC-04 SHA-pin GitHub Actions) are independent and untouched by this plan.
+- No blockers introduced.
+
+## Self-Check: PASSED
+- FOUND: src/lib/__tests__/stripe-webhook-signature.test.ts
+- FOUND: commit c64d06f54
+
+---
+*Phase: 01-security-ci-hardening*
+*Completed: 2026-06-04*

--- a/.planning/phases/01-security-ci-hardening/01-02-PLAN.md
+++ b/.planning/phases/01-security-ci-hardening/01-02-PLAN.md
@@ -6,41 +6,45 @@ wave: 1
 depends_on: []
 files_modified:
   - src/proxy.ts
+  - src/lib/supabase/middleware.ts
   - vercel.json
   - src/lib/__tests__/csp-header.test.ts
 autonomous: true
 requirements: [CISEC-02]
 must_haves:
   truths:
-    - "Authenticated app routes (PRIVATE_ROUTE_PREFIXES) serve a per-request nonce CSP with 'strict-dynamic' and no script-src 'unsafe-inline'"
+    - "Authenticated app routes (PRIVATE_ROUTE_PREFIXES) serve a per-request nonce CSP with 'strict-dynamic' and no script-src 'unsafe-inline', AND the same nonce CSP is forwarded on the REQUEST 'Content-Security-Policy' header so Next 16 auto-nonces its hydration scripts"
     - "Marketing/blog/static routes keep their existing vercel.json CSP and stay statically rendered (no nonce forcing them dynamic)"
     - "JSON-LD <script type='application/ld+json'> blocks are NOT noticed/altered (data, not executable — not governed by script-src)"
-    - "A unit test asserts the proxy emits a nonce + strict-dynamic CSP on a private route and that vercel.json script-src no longer contains 'unsafe-inline'"
+    - "A unit test asserts the proxy forwards the nonce CSP on the REQUEST headers passed to NextResponse.next AND on the response header (same nonce both places) on a private route, and that vercel.json script-src no longer contains 'unsafe-inline'"
   artifacts:
     - path: "src/proxy.ts"
-      provides: "Per-request nonce generation + Content-Security-Policy header on private routes via x-nonce forward header"
-      contains: "x-nonce"
+      provides: "Per-request nonce generation + Content-Security-Policy on BOTH the forwarded request headers and the response, scoped to private routes"
+      contains: "Content-Security-Policy"
+    - path: "src/lib/supabase/middleware.ts"
+      provides: "updateSession accepts request-header overrides so its NextResponse.next({ request }) carries the nonce CSP at render time"
+      contains: "Content-Security-Policy"
     - path: "vercel.json"
       provides: "Hardened static CSP for non-private routes with no script-src 'unsafe-inline'"
     - path: "src/lib/__tests__/csp-header.test.ts"
-      provides: "Regression guard: nonce+strict-dynamic on private route; no unsafe-inline in vercel.json script-src"
-      min_lines: 30
+      provides: "Regression guard: request-side nonce propagation == response nonce on a private route; no unsafe-inline in vercel.json script-src"
+      min_lines: 40
   key_links:
     - from: "src/proxy.ts"
-      to: "Next.js framework hydration scripts"
-      via: "x-nonce request header + Content-Security-Policy response header"
-      pattern: "x-nonce|nonce-|strict-dynamic"
+      to: "Next.js framework hydration scripts (getScriptNonceFromHeader, app-render.js:167)"
+      via: "Content-Security-Policy on the forwarded REQUEST headers (NOT x-nonce) + matching response header"
+      pattern: "Content-Security-Policy|nonce-|strict-dynamic"
     - from: "src/lib/__tests__/csp-header.test.ts"
       to: "vercel.json + src/proxy.ts"
-      via: "readFileSync assertion + proxy invocation"
-      pattern: "unsafe-inline|strict-dynamic"
+      via: "readFileSync assertion + proxy invocation asserting request-side == response-side nonce"
+      pattern: "unsafe-inline|strict-dynamic|content-security-policy"
 ---
 
 <objective>
 Close CISEC-02: serve a per-request nonce CSP with `strict-dynamic` on authenticated app routes and drop `script-src 'unsafe-inline'` from those routes, while leaving marketing/blog/static pages on their existing `vercel.json` CSP — satisfying the user's locked route-scoped decision (a nonce forces dynamic rendering and must not de-optimize the SEO pages this milestone is separately recovering).
 
-Purpose: `vercel.json` currently ships `script-src 'self' 'unsafe-inline'` — the largest inline-script XSS hole. The canonical Next 16 fix generates a per-request nonce in `proxy.ts`, forwards it via an `x-nonce` request header, and sets the CSP response header so Next auto-attaches the nonce to framework + page bundles. The locked constraint: apply this ONLY to `PRIVATE_ROUTE_PREFIXES` (the authenticated owner surface) so static marketing/blog pages stay statically rendered.
-Output: nonce CSP wired into `src/proxy.ts`, hardened `vercel.json` static CSP, and `src/lib/__tests__/csp-header.test.ts`.
+Purpose: `vercel.json` currently ships `script-src 'self' 'unsafe-inline'` — the largest inline-script XSS hole. The canonical Next 16 fix generates a per-request nonce in `proxy.ts` and forwards the full CSP string (with `'nonce-<nonce>'`) on the **forwarded request's `Content-Security-Policy` header**. Next 16.2.6 sources the hydration-script nonce by parsing that request header via `getScriptNonceFromHeader` (`node_modules/next/dist/server/app-render/app-render.js:167-168` — `headers['content-security-policy'] → getScriptNonceFromHeader`). It does **NOT** read `x-nonce`. The same CSP is also set on the response so the browser enforces it. The locked constraint: apply this ONLY to `PRIVATE_ROUTE_PREFIXES` (the authenticated owner surface) so static marketing/blog pages stay statically rendered.
+Output: nonce CSP wired into `src/proxy.ts` + `src/lib/supabase/middleware.ts`, hardened `vercel.json` static CSP, and `src/lib/__tests__/csp-header.test.ts`.
 </objective>
 
 <execution_context>
@@ -52,22 +56,34 @@ Output: nonce CSP wired into `src/proxy.ts`, hardened `vercel.json` static CSP, 
 @.planning/phases/01-security-ci-hardening/01-RESEARCH.md
 @.planning/phases/01-security-ci-hardening/01-VALIDATION.md
 @src/proxy.ts
+@src/lib/supabase/middleware.ts
 @vercel.json
 
 <interfaces>
-<!-- Existing proxy contract (src/proxy.ts) the nonce wiring slots into. -->
+<!-- Existing proxy + updateSession contract the nonce wiring slots into. -->
 <!-- isPrivateRoute(pathname) uses PRIVATE_ROUTE_PREFIXES — this is the route-scope gate the user locked. -->
-<!-- updateSession(request) returns { user, supabaseResponse: NextResponse }; the CSP must be applied to the response and the forwarded request headers. -->
+<!-- updateSession(request) builds supabaseResponse via NextResponse.next({ request }); it OWNS the request-header forwarding. -->
 
 From src/proxy.ts:
   const PRIVATE_ROUTE_PREFIXES: string[]   // /admin,/analytics,/billing,/dashboard,/documents,/financials,/inspections,/leases,/maintenance,/profile,/properties,/reports,/settings,/tenants,/units
   function isPrivateRoute(pathname: string): boolean
+  function redirectWithCookies(url: URL, supabaseResponse: NextResponse): NextResponse  // re-copies auth cookies onto a redirect
   export async function proxy(request: NextRequest): Promise<NextResponse>
   export const config = { matcher: [...] }   // already excludes _next/static, _next/image, favicon.ico, image extensions, monitoring, api/
 
+From src/lib/supabase/middleware.ts:
+  export async function updateSession(request: NextRequest): Promise<{ user: User | null; supabaseResponse: NextResponse }>
+  // Internally: `let supabaseResponse = NextResponse.next({ request })`, rebuilt on cookie setAll as `NextResponse.next({ request })`.
+  // This is the ONLY place that constructs the pass-through NextResponse — so the forwarded request headers MUST flow through here.
+
+From node_modules/next/dist/server/app-render/app-render.js (line 167-168), Next 16.2.6:
+  const csp = headers['content-security-policy'] || headers['content-security-policy-report-only'];
+  const nonce = typeof csp === 'string' ? getScriptNonceFromHeader(csp) : undefined;
+  // ==> Next sources the hydration-script nonce from the REQUEST 'content-security-policy' header. NOT from x-nonce.
+
 From the Next 16 CSP guide (nextjs.org/docs/app/guides/content-security-policy, v16.2.7):
   - nonce generated per request: `Buffer.from(crypto.randomUUID()).toString("base64")`
-  - forward via request header `x-nonce`; set response header `Content-Security-Policy`
+  - forward the CSP (with 'nonce-…') on the REQUEST headers via NextResponse.next({ request: { headers } }); set the same CSP on the response
   - 'strict-dynamic' is MANDATORY (App Router has no _document.tsx to manually nonce hydration scripts)
   - 'unsafe-eval' ONLY in dev (process.env.NODE_ENV === 'development')
 </interfaces>
@@ -76,55 +92,80 @@ From the Next 16 CSP guide (nextjs.org/docs/app/guides/content-security-policy, 
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Generate + apply a per-request nonce CSP on private routes in proxy.ts</name>
-  <files>src/proxy.ts</files>
+  <name>Task 1: Forward a per-request nonce CSP on the REQUEST header + response, scoped to private routes</name>
+  <files>src/proxy.ts, src/lib/supabase/middleware.ts</files>
   <read_first>
-    - src/proxy.ts (full file — the nonce wiring must compose with the existing updateSession/auth/subscription gate returns, NOT replace them)
-    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-02 — "Recommended Approach", the canonical proxy snippet, and ALL "Gotchas / Landmines")
+    - src/proxy.ts (full file — the nonce wiring must compose with the existing updateSession/auth/subscription gate returns, NOT replace them; note redirectWithCookies re-copies cookies onto every redirect)
+    - src/lib/supabase/middleware.ts (full file — updateSession OWNS `NextResponse.next({ request })`, both at init line 27 and on cookie setAll line 44; the forwarded request headers MUST flow through this function for Next to see the CSP at render time)
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-02 — "Recommended Approach", the canonical proxy snippet at lines 153-177 which shows `requestHeaders.set("Content-Security-Policy", csp)` threaded into `NextResponse.next({ request: { headers: requestHeaders } })`, and ALL "Gotchas / Landmines")
+    - node_modules/next/dist/server/app-render/app-render.js (lines 156-168 — confirm Next reads `headers['content-security-policy']`, parses the nonce via getScriptNonceFromHeader, and never reads x-nonce)
     - vercel.json (the current CSP value at the Content-Security-Policy key — mirror its directive set into the nonce header so private routes lose nothing except 'unsafe-inline')
   </read_first>
   <action>
-    Add nonce generation + CSP application scoped to private routes. Compute the nonce ONLY when `isPrivateRoute(pathname)` is true (per the user's locked route-scope decision): `const nonce = Buffer.from(crypto.randomUUID()).toString("base64")`. Build the CSP string mirroring the directive set already in `vercel.json` but with `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'` (append `'unsafe-eval'` ONLY when `process.env.NODE_ENV === "development"`), `style-src 'self' 'nonce-${nonce}'` in prod (keep `'unsafe-inline'` for style-src ONLY in dev), and the existing `img-src`/`connect-src`/`font-src`/`frame-ancestors`/`base-uri`/`form-action` directives unchanged (keep the `*.supabase.co *.sentry.io *.stripe.com` host-allowlist in `connect-src`, NOT in `script-src` — strict-dynamic ignores host allowlists in script-src). Forward the nonce to the rendered page by cloning the incoming request headers, setting `x-nonce`, and passing them through the response path that Next reads (the existing `updateSession` flow returns `supabaseResponse`; set both the `x-nonce` on the forwarded request headers and the `Content-Security-Policy` on the response headers). Apply the CSP header to EVERY return path that serves a private route (the authenticated pass-through `return supabaseResponse`, AND the redirect paths via `redirectWithCookies` if a private URL is requested) so an authenticated private-route response always carries the nonce header. Do NOT touch the public-route early return (`if (!isPrivateRoute(pathname)) return supabaseResponse`) — those stay on the vercel.json static CSP. Do NOT add a nonce to JSON-LD: `<script type="application/ld+json">` is inert data, not governed by `script-src` — leave `src/components/seo/json-ld-script.tsx` and `src/components/seo/seo-json-ld.tsx` untouched. Reconcile `config.matcher` only if needed (it already excludes `_next/static`, `_next/image`, `favicon.ico`, image extensions, `monitoring`, `api/`).
+    The load-bearing mechanism is the **REQUEST `Content-Security-Policy` header**, not `x-nonce`. Next 16.2.6 sources the hydration-script nonce by parsing the forwarded request's `content-security-policy` header via `getScriptNonceFromHeader` (`app-render.js:167-168`); it never reads `x-nonce`. Setting CSP only on the response while `updateSession` builds `supabaseResponse` from the original nonce-less request leaves framework scripts un-nonced under `strict-dynamic` → blocked → blank dashboard. Wire it as follows.
+
+    In `src/proxy.ts`: when `isPrivateRoute(pathname)` is true (per the user's locked route-scope decision) AND BEFORE calling `updateSession`, generate the nonce `const nonce = Buffer.from(crypto.randomUUID()).toString("base64")` and build the CSP string mirroring the directive set already in `vercel.json`, but with `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'` (append `'unsafe-eval'` ONLY when `process.env.NODE_ENV === "development"`). For `style-src`, the locked private-route prod policy is `'self' 'unsafe-inline'` (keep `'unsafe-inline'` for style-src in BOTH dev and prod) — RESEARCH A3 flags runtime-injected inline styles as MEDIUM-risk and CISEC-02's success criterion is `script-src`-scoped only; do NOT tighten style-src to nonce/hash in this plan. Keep the existing `img-src 'self' data: blob:` / `connect-src 'self' *.supabase.co *.sentry.io *.stripe.com` / `font-src 'self'` / `frame-ancestors 'none'` / `base-uri 'self'` / `form-action 'self'` / `object-src 'none'` directives unchanged (keep the `*.supabase.co *.sentry.io *.stripe.com` host-allowlist in `connect-src`, NOT in `script-src` — strict-dynamic ignores host allowlists in script-src). Build a `Headers` clone of `request.headers`, set BOTH `requestHeaders.set("Content-Security-Policy", csp)` (the load-bearing render-time header) AND `requestHeaders.set("x-nonce", nonce)` (convenience for app code that reads `headers()`; NOT load-bearing).
+
+    Thread the augmented request headers through to the response Next renders by passing them into `updateSession`. Modify `src/lib/supabase/middleware.ts`: change `updateSession` to accept an optional second parameter `requestHeaders?: Headers` and, when provided, build `supabaseResponse` via `NextResponse.next({ request: { headers: requestHeaders } })` at BOTH construction sites (the initial assignment at line 27 and the rebuild inside the `setAll` cookie callback at line 44) so the forwarded CSP survives the cookie-sync rebuild. When `requestHeaders` is undefined (public-route call), preserve the existing `NextResponse.next({ request })` behavior exactly. Do NOT change the cookie `getAll`/`setAll` pattern, the `getUser()` call, or the Sentry error handling. In `proxy.ts`, call `await updateSession(request, requestHeaders)` on private routes and `await updateSession(request)` on the public path (or pass `undefined`); since `isPrivateRoute` is checked before the public early-return, compute `requestHeaders` only inside the private branch.
+
+    After `updateSession` returns on a private route, ALSO set the same CSP on the response so the browser enforces it: `supabaseResponse.headers.set("Content-Security-Policy", csp)`. Apply this response header to EVERY private-route return path: the authenticated pass-through `return supabaseResponse`, AND the redirect paths built via `redirectWithCookies` (set the CSP on the redirect response before returning, or set it on `supabaseResponse` before `redirectWithCookies` copies — verify the header survives the cookie copy; if `redirectWithCookies` only copies cookies, set `Content-Security-Policy` on the returned redirect response explicitly). Do NOT touch the public-route early return (`if (!isPrivateRoute(pathname)) return supabaseResponse`) — those stay on the vercel.json static CSP. Do NOT add a nonce to JSON-LD: `<script type="application/ld+json">` is inert data, not governed by `script-src` — leave `src/components/seo/json-ld-script.tsx` and `src/components/seo/seo-json-ld.tsx` untouched. `config.matcher` already excludes `_next/static`, `_next/image`, `favicon.ico`, image extensions, `monitoring`, `api/` — leave it unless a private route is unexpectedly excluded.
   </action>
   <verify>
     <automated>bun run typecheck</automated>
   </verify>
   <acceptance_criteria>
-    - `grep -c "x-nonce" src/proxy.ts` ≥ 1 and `grep -c "strict-dynamic" src/proxy.ts` ≥ 1.
-    - `grep -cE "isPrivateRoute" src/proxy.ts` shows the nonce block is gated behind the private-route check (CSP is NOT applied on the public early-return path).
+    - `grep -c "Content-Security-Policy" src/proxy.ts` ≥ 1 and `grep -c "strict-dynamic" src/proxy.ts` ≥ 1.
+    - `grep -c "Content-Security-Policy" src/lib/supabase/middleware.ts` ≥ 1 — confirming the request-header CSP flows through updateSession's `NextResponse.next({ request: { headers } })` (the load-bearing render-time path, not just the response).
+    - `grep -c "NextResponse.next" src/lib/supabase/middleware.ts` shows both construction sites carry the optional `requestHeaders` path (init + setAll rebuild).
+    - `grep -cE "isPrivateRoute" src/proxy.ts` shows the nonce/CSP block is gated behind the private-route check (CSP is NOT applied on the public early-return path).
     - `grep -v '^[[:space:]]*//' src/proxy.ts | grep -c "json-ld\|application/ld+json"` returns 0 (JSON-LD renderers untouched).
-    - `bun run typecheck` passes (no `any`, no `unsafe` removed from style-src in dev).
-    - In the prod CSP branch, `script-src` contains `'nonce-` + `'strict-dynamic'` and does NOT contain `'unsafe-inline'`.
+    - In the prod CSP branch, `script-src` contains `'nonce-` + `'strict-dynamic'` and does NOT contain `'unsafe-inline'`; `style-src` contains `'unsafe-inline'` (locked private-route policy).
+    - `bun run typecheck` passes (no `any`; `requestHeaders` typed as `Headers`).
   </acceptance_criteria>
-  <done>Private routes emit a per-request nonce + strict-dynamic CSP with no script-src 'unsafe-inline'; public routes are untouched; JSON-LD renderers untouched; typecheck green.</done>
+  <done>Private routes generate a per-request nonce, forward the CSP on the REQUEST headers through updateSession's NextResponse.next (so Next auto-nonces hydration scripts), and set the same CSP on every private-route response; public routes untouched; JSON-LD untouched; typecheck green.</done>
 </task>
 
 <task type="auto">
-  <name>Task 2: Harden vercel.json static CSP + add the regression guard test</name>
+  <name>Task 2: Harden vercel.json static CSP + regression test pinning request-side nonce propagation</name>
   <files>vercel.json, src/lib/__tests__/csp-header.test.ts</files>
   <read_first>
     - vercel.json (the Content-Security-Policy header value — currently `script-src 'self' 'unsafe-inline'`)
-    - src/proxy.ts (the nonce CSP from Task 1 — the test invokes the proxy / nonce helper to assert the dynamic header)
+    - src/proxy.ts (the nonce CSP from Task 1 — the test invokes the proxy to assert the request-side AND response-side header)
+    - src/lib/supabase/middleware.ts (the updateSession signature from Task 1 — the test mocks it and asserts it was called with the augmented request headers carrying the CSP)
     - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-02 "Validation Architecture")
     - vitest.config.ts (lines 60-114 — test must live under `src/**` to run in the `unit`/`checks` gate)
   </read_first>
   <behavior>
-    - vercel.json static CSP `script-src` no longer contains `'unsafe-inline'` (assert via readFileSync + parse of the Content-Security-Policy header value).
-    - Invoking the proxy on a private path (e.g. `/dashboard`) produces a response whose `Content-Security-Policy` header contains `'nonce-` and `'strict-dynamic'` and NOT `'unsafe-inline'` in script-src.
-    - Invoking the proxy on a public path (e.g. `/`) does NOT add a per-request nonce CSP (the static vercel.json header governs those).
+    - vercel.json static CSP `script-src` no longer contains `'unsafe-inline'` (assert via readFileSync + parse of the Content-Security-Policy header value). `style-src` may retain `'unsafe-inline'` (out of CISEC-02 scope).
+    - Invoking the proxy on a private path (e.g. `/dashboard`): `updateSession` (mocked) is called with a `requestHeaders`/`Headers` argument that carries a `content-security-policy` value containing `'nonce-` and `'strict-dynamic'` — i.e. the nonce is forwarded on the REQUEST side, not just the response.
+    - The request-side nonce equals the response-side nonce: the `'nonce-XXX'` token in the request-header CSP passed to `updateSession` is byte-for-byte the same as the `'nonce-XXX'` token in the response `Content-Security-Policy` header. (This is the only assertion that pins success criterion 2 and would FAIL under the old response-only wiring.)
+    - The private-route response `Content-Security-Policy` contains `'nonce-` and `'strict-dynamic'` and NOT `'unsafe-inline'` in script-src.
+    - Invoking the proxy on a public path (e.g. `/`): no per-request nonce CSP is forwarded (updateSession called without CSP-bearing request headers) and no per-request CSP added to the response (the static vercel.json header governs those).
   </behavior>
   <action>
-    In `vercel.json`, remove `'unsafe-inline'` from the `script-src` directive of the Content-Security-Policy header value (the static fallback for non-private routes). Keep `style-src` as-is or tighten to `'self'` per CLAUDE.md rule #5 (no inline styles) — verify the marketing pages still render before tightening style-src; if uncertain, leave style-src `'unsafe-inline'` and note it as the documented follow-up (script-src is the CISEC-02 gate). Then create `src/lib/__tests__/csp-header.test.ts` (under src/ so it runs in the `unit`/`checks` gate). The test: (a) `readFileSync` `vercel.json`, JSON.parse, locate the `Content-Security-Policy` header value, split its `script-src` directive, and assert it does NOT include `'unsafe-inline'`; (b) import and invoke the proxy (or a small extracted nonce-CSP helper) against a mock `NextRequest` for `/dashboard`, assert the response `Content-Security-Policy` contains `'nonce-` and `'strict-dynamic'` and that script-src has no `'unsafe-inline'`; (c) invoke against `/` and assert no per-request nonce CSP is added. Mock `updateSession`/Supabase as needed with `vi.hoisted()` for any variable referenced in `vi.mock()` (chai-6: use `.rejects.toMatchObject({ message: expect.stringContaining(...) })` if asserting throws). No `any` — type the mock request via the imported `NextRequest` type.
+    In `vercel.json`, remove `'unsafe-inline'` from the `script-src` directive of the Content-Security-Policy header value (the static fallback for non-private routes). Leave `style-src 'unsafe-inline'` as-is — tightening style-src is explicitly out of CISEC-02 scope (success criterion is script-src-only; RESEARCH A3 flags inline-style risk as MEDIUM, a documented follow-up).
+
+    Create `src/lib/__tests__/csp-header.test.ts` (under src/ so it runs in the `unit`/`checks` gate). Mock `#lib/supabase/middleware` so `updateSession` is a `vi.fn()` (use `vi.hoisted()` for any variable referenced in `vi.mock()`); have the mock return `{ user: { id: "test-user" }, supabaseResponse: NextResponse.next() }` (or a stub `NextResponse`) so the proxy reaches the CSP-setting return path on a private route — and, on private paths, make the user appear subscription-active enough to reach the pass-through return (mock the Supabase `createServerClient` chain to return `{ data: { is_admin: false, subscription_status: "active" }, error: null }` from `.maybeSingle()`, mirroring the gate query in proxy.ts). Capture the `requestHeaders` argument the proxy passes to `updateSession` via `updateSession.mock.calls`.
+
+    The test assertions:
+    (a) `readFileSync` `vercel.json`, JSON.parse, locate the `Content-Security-Policy` header value, isolate the `script-src` directive, and assert it does NOT include `'unsafe-inline'`.
+    (b) Invoke the proxy with a mock `NextRequest` for `/dashboard`; assert `updateSession` was called with a second argument that is a `Headers` instance whose `.get("content-security-policy")` contains `'nonce-` and `'strict-dynamic'` — proving REQUEST-side propagation (this is the assertion that fails under response-only wiring).
+    (c) Extract the nonce token from the request-side CSP (the captured `updateSession` arg) and from the response `Content-Security-Policy` header; assert they are equal (same nonce on both sides).
+    (d) Assert the response `Content-Security-Policy` script-src contains `'nonce-` + `'strict-dynamic'` and no `'unsafe-inline'`.
+    (e) Invoke against `/`; assert `updateSession` was called WITHOUT a CSP-bearing request-headers argument (called with one arg, or a second arg lacking `content-security-policy`) and the response has no per-request nonce CSP.
+
+    Use chai-6-safe patterns: `.rejects.toMatchObject({ message: expect.stringContaining(...) })` if asserting throws. No `any` — type the mock request via the imported `NextRequest` type and the captured arg via `Headers`.
   </action>
   <verify>
     <automated>bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts</automated>
   </verify>
   <acceptance_criteria>
     - `grep -A40 'Content-Security-Policy' vercel.json | grep -o "script-src[^;]*" | grep -c "unsafe-inline"` returns 0 (no unsafe-inline in vercel.json script-src).
-    - `bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts` exits 0 with the three behavior assertions passing.
+    - The test file asserts `updateSession` received a `Headers` argument carrying a `content-security-policy` value with `'nonce-` + `'strict-dynamic'` (request-side propagation), AND that the request-side nonce token equals the response-side nonce token.
+    - `bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts` exits 0 with all five behavior assertions passing.
     - `bun run typecheck` passes.
   </acceptance_criteria>
-  <done>vercel.json script-src has no 'unsafe-inline'; the regression test pins both the static header and the proxy nonce header; suite green in the `checks` gate.</done>
+  <done>vercel.json script-src has no 'unsafe-inline'; the regression test pins the static header AND asserts the proxy forwards the nonce on the request header with request==response nonce parity; suite green in the `checks` gate.</done>
 </task>
 
 </tasks>
@@ -140,19 +181,23 @@ From the Next 16 CSP guide (nextjs.org/docs/app/guides/content-security-policy, 
 
 | Threat ID | Category | Component | Disposition | Mitigation Plan |
 |-----------|----------|-----------|-------------|-----------------|
-| T-01-03 | Tampering | inline-script XSS on authenticated routes | mitigate | Per-request nonce + `strict-dynamic` on private routes (CISEC-02); drop `script-src 'unsafe-inline'` so an injected inline `<script>` without the nonce cannot execute |
+| T-01-03 | Tampering | inline-script XSS on authenticated routes | mitigate | Per-request nonce + `strict-dynamic` on private routes (CISEC-02), forwarded on the REQUEST `Content-Security-Policy` header so Next auto-nonces hydration scripts and an injected inline `<script>` without the nonce cannot execute; drop `script-src 'unsafe-inline'` |
 | T-01-04 | Tampering | static marketing/blog CSP | accept | Marketing pages keep the vercel.json static CSP (route-scoped per locked decision) so they stay statically rendered; the inline-script risk on those pages is lower (no authenticated session, no PII), and the SEO recovery in this milestone forbids forcing them dynamic |
-| T-01-05 | Information Disclosure | nonce reuse / predictability | mitigate | Nonce is regenerated per request via `crypto.randomUUID()` base64 — never reused across requests; `'unsafe-eval'` gated to dev only |
+| T-01-05 | Information Disclosure | nonce reuse / predictability | mitigate | Nonce is regenerated per request via `crypto.randomUUID()` base64 — never reused across requests; the request-side and response-side CSP carry the same per-request nonce; `'unsafe-eval'` gated to dev only |
+| T-01-06 | Tampering | runtime-injected inline styles | accept | `style-src 'unsafe-inline'` retained on private routes per RESEARCH A3 (MEDIUM-risk, out of CISEC-02 script-src scope); documented follow-up for a later style-src hardening pass |
 </threat_model>
 
 <verification>
 - `bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts` green.
 - `bun run validate:quick` green.
-- MANUAL (post-deploy, per VALIDATION.md Manual-Only): load `/dashboard` and `/` (marketing) in a browser, inspect the `Content-Security-Policy` response header (nonce + strict-dynamic on /dashboard, static CSP on /), and confirm zero CSP-violation errors in the console on both — including the next-themes no-flash script in dark mode and the Vercel Analytics beacon + Sentry tunnel.
+- MANUAL (post-deploy, per VALIDATION.md Manual-Only): load `/dashboard` and `/` (marketing) in a browser, inspect the `Content-Security-Policy` response header (nonce + strict-dynamic on /dashboard, static CSP on /), and confirm:
+  - Zero `script-src` CSP-violation errors in the console on both — including the next-themes no-flash script in dark mode and the Vercel Analytics beacon + Sentry tunnel.
+  - The dashboard renders with no `style-src` CSP violations (style-src keeps `'unsafe-inline'` on private routes — verify no console style-src violations and no broken/unstyled regions).
+  - The dashboard fully hydrates (interactive — confirms framework hydration scripts received the nonce from the forwarded request CSP; a blank/non-interactive dashboard would mean the request-side nonce wiring failed).
 </verification>
 
 <success_criteria>
-- The deployed CSP serves a per-request nonce with `strict-dynamic` on authenticated routes and no `script-src 'unsafe-inline'` remains in `vercel.json`/`proxy.ts` for those routes; marketing/blog pages keep their static CSP and stay statically rendered.
+- The deployed CSP serves a per-request nonce with `strict-dynamic` on authenticated routes, the nonce is forwarded on the REQUEST `Content-Security-Policy` header (so Next's hydration scripts are auto-nonced and the dashboard hydrates), and no `script-src 'unsafe-inline'` remains in `vercel.json`/`proxy.ts` for those routes; marketing/blog pages keep their static CSP and stay statically rendered.
 </success_criteria>
 
 <output>

--- a/.planning/phases/01-security-ci-hardening/01-02-PLAN.md
+++ b/.planning/phases/01-security-ci-hardening/01-02-PLAN.md
@@ -1,0 +1,160 @@
+---
+phase: 01-security-ci-hardening
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/proxy.ts
+  - vercel.json
+  - src/lib/__tests__/csp-header.test.ts
+autonomous: true
+requirements: [CISEC-02]
+must_haves:
+  truths:
+    - "Authenticated app routes (PRIVATE_ROUTE_PREFIXES) serve a per-request nonce CSP with 'strict-dynamic' and no script-src 'unsafe-inline'"
+    - "Marketing/blog/static routes keep their existing vercel.json CSP and stay statically rendered (no nonce forcing them dynamic)"
+    - "JSON-LD <script type='application/ld+json'> blocks are NOT noticed/altered (data, not executable — not governed by script-src)"
+    - "A unit test asserts the proxy emits a nonce + strict-dynamic CSP on a private route and that vercel.json script-src no longer contains 'unsafe-inline'"
+  artifacts:
+    - path: "src/proxy.ts"
+      provides: "Per-request nonce generation + Content-Security-Policy header on private routes via x-nonce forward header"
+      contains: "x-nonce"
+    - path: "vercel.json"
+      provides: "Hardened static CSP for non-private routes with no script-src 'unsafe-inline'"
+    - path: "src/lib/__tests__/csp-header.test.ts"
+      provides: "Regression guard: nonce+strict-dynamic on private route; no unsafe-inline in vercel.json script-src"
+      min_lines: 30
+  key_links:
+    - from: "src/proxy.ts"
+      to: "Next.js framework hydration scripts"
+      via: "x-nonce request header + Content-Security-Policy response header"
+      pattern: "x-nonce|nonce-|strict-dynamic"
+    - from: "src/lib/__tests__/csp-header.test.ts"
+      to: "vercel.json + src/proxy.ts"
+      via: "readFileSync assertion + proxy invocation"
+      pattern: "unsafe-inline|strict-dynamic"
+---
+
+<objective>
+Close CISEC-02: serve a per-request nonce CSP with `strict-dynamic` on authenticated app routes and drop `script-src 'unsafe-inline'` from those routes, while leaving marketing/blog/static pages on their existing `vercel.json` CSP — satisfying the user's locked route-scoped decision (a nonce forces dynamic rendering and must not de-optimize the SEO pages this milestone is separately recovering).
+
+Purpose: `vercel.json` currently ships `script-src 'self' 'unsafe-inline'` — the largest inline-script XSS hole. The canonical Next 16 fix generates a per-request nonce in `proxy.ts`, forwards it via an `x-nonce` request header, and sets the CSP response header so Next auto-attaches the nonce to framework + page bundles. The locked constraint: apply this ONLY to `PRIVATE_ROUTE_PREFIXES` (the authenticated owner surface) so static marketing/blog pages stay statically rendered.
+Output: nonce CSP wired into `src/proxy.ts`, hardened `vercel.json` static CSP, and `src/lib/__tests__/csp-header.test.ts`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/01-security-ci-hardening/01-RESEARCH.md
+@.planning/phases/01-security-ci-hardening/01-VALIDATION.md
+@src/proxy.ts
+@vercel.json
+
+<interfaces>
+<!-- Existing proxy contract (src/proxy.ts) the nonce wiring slots into. -->
+<!-- isPrivateRoute(pathname) uses PRIVATE_ROUTE_PREFIXES — this is the route-scope gate the user locked. -->
+<!-- updateSession(request) returns { user, supabaseResponse: NextResponse }; the CSP must be applied to the response and the forwarded request headers. -->
+
+From src/proxy.ts:
+  const PRIVATE_ROUTE_PREFIXES: string[]   // /admin,/analytics,/billing,/dashboard,/documents,/financials,/inspections,/leases,/maintenance,/profile,/properties,/reports,/settings,/tenants,/units
+  function isPrivateRoute(pathname: string): boolean
+  export async function proxy(request: NextRequest): Promise<NextResponse>
+  export const config = { matcher: [...] }   // already excludes _next/static, _next/image, favicon.ico, image extensions, monitoring, api/
+
+From the Next 16 CSP guide (nextjs.org/docs/app/guides/content-security-policy, v16.2.7):
+  - nonce generated per request: `Buffer.from(crypto.randomUUID()).toString("base64")`
+  - forward via request header `x-nonce`; set response header `Content-Security-Policy`
+  - 'strict-dynamic' is MANDATORY (App Router has no _document.tsx to manually nonce hydration scripts)
+  - 'unsafe-eval' ONLY in dev (process.env.NODE_ENV === 'development')
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Generate + apply a per-request nonce CSP on private routes in proxy.ts</name>
+  <files>src/proxy.ts</files>
+  <read_first>
+    - src/proxy.ts (full file — the nonce wiring must compose with the existing updateSession/auth/subscription gate returns, NOT replace them)
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-02 — "Recommended Approach", the canonical proxy snippet, and ALL "Gotchas / Landmines")
+    - vercel.json (the current CSP value at the Content-Security-Policy key — mirror its directive set into the nonce header so private routes lose nothing except 'unsafe-inline')
+  </read_first>
+  <action>
+    Add nonce generation + CSP application scoped to private routes. Compute the nonce ONLY when `isPrivateRoute(pathname)` is true (per the user's locked route-scope decision): `const nonce = Buffer.from(crypto.randomUUID()).toString("base64")`. Build the CSP string mirroring the directive set already in `vercel.json` but with `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'` (append `'unsafe-eval'` ONLY when `process.env.NODE_ENV === "development"`), `style-src 'self' 'nonce-${nonce}'` in prod (keep `'unsafe-inline'` for style-src ONLY in dev), and the existing `img-src`/`connect-src`/`font-src`/`frame-ancestors`/`base-uri`/`form-action` directives unchanged (keep the `*.supabase.co *.sentry.io *.stripe.com` host-allowlist in `connect-src`, NOT in `script-src` — strict-dynamic ignores host allowlists in script-src). Forward the nonce to the rendered page by cloning the incoming request headers, setting `x-nonce`, and passing them through the response path that Next reads (the existing `updateSession` flow returns `supabaseResponse`; set both the `x-nonce` on the forwarded request headers and the `Content-Security-Policy` on the response headers). Apply the CSP header to EVERY return path that serves a private route (the authenticated pass-through `return supabaseResponse`, AND the redirect paths via `redirectWithCookies` if a private URL is requested) so an authenticated private-route response always carries the nonce header. Do NOT touch the public-route early return (`if (!isPrivateRoute(pathname)) return supabaseResponse`) — those stay on the vercel.json static CSP. Do NOT add a nonce to JSON-LD: `<script type="application/ld+json">` is inert data, not governed by `script-src` — leave `src/components/seo/json-ld-script.tsx` and `src/components/seo/seo-json-ld.tsx` untouched. Reconcile `config.matcher` only if needed (it already excludes `_next/static`, `_next/image`, `favicon.ico`, image extensions, `monitoring`, `api/`).
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "x-nonce" src/proxy.ts` ≥ 1 and `grep -c "strict-dynamic" src/proxy.ts` ≥ 1.
+    - `grep -cE "isPrivateRoute" src/proxy.ts` shows the nonce block is gated behind the private-route check (CSP is NOT applied on the public early-return path).
+    - `grep -v '^[[:space:]]*//' src/proxy.ts | grep -c "json-ld\|application/ld+json"` returns 0 (JSON-LD renderers untouched).
+    - `bun run typecheck` passes (no `any`, no `unsafe` removed from style-src in dev).
+    - In the prod CSP branch, `script-src` contains `'nonce-` + `'strict-dynamic'` and does NOT contain `'unsafe-inline'`.
+  </acceptance_criteria>
+  <done>Private routes emit a per-request nonce + strict-dynamic CSP with no script-src 'unsafe-inline'; public routes are untouched; JSON-LD renderers untouched; typecheck green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Harden vercel.json static CSP + add the regression guard test</name>
+  <files>vercel.json, src/lib/__tests__/csp-header.test.ts</files>
+  <read_first>
+    - vercel.json (the Content-Security-Policy header value — currently `script-src 'self' 'unsafe-inline'`)
+    - src/proxy.ts (the nonce CSP from Task 1 — the test invokes the proxy / nonce helper to assert the dynamic header)
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-02 "Validation Architecture")
+    - vitest.config.ts (lines 60-114 — test must live under `src/**` to run in the `unit`/`checks` gate)
+  </read_first>
+  <behavior>
+    - vercel.json static CSP `script-src` no longer contains `'unsafe-inline'` (assert via readFileSync + parse of the Content-Security-Policy header value).
+    - Invoking the proxy on a private path (e.g. `/dashboard`) produces a response whose `Content-Security-Policy` header contains `'nonce-` and `'strict-dynamic'` and NOT `'unsafe-inline'` in script-src.
+    - Invoking the proxy on a public path (e.g. `/`) does NOT add a per-request nonce CSP (the static vercel.json header governs those).
+  </behavior>
+  <action>
+    In `vercel.json`, remove `'unsafe-inline'` from the `script-src` directive of the Content-Security-Policy header value (the static fallback for non-private routes). Keep `style-src` as-is or tighten to `'self'` per CLAUDE.md rule #5 (no inline styles) — verify the marketing pages still render before tightening style-src; if uncertain, leave style-src `'unsafe-inline'` and note it as the documented follow-up (script-src is the CISEC-02 gate). Then create `src/lib/__tests__/csp-header.test.ts` (under src/ so it runs in the `unit`/`checks` gate). The test: (a) `readFileSync` `vercel.json`, JSON.parse, locate the `Content-Security-Policy` header value, split its `script-src` directive, and assert it does NOT include `'unsafe-inline'`; (b) import and invoke the proxy (or a small extracted nonce-CSP helper) against a mock `NextRequest` for `/dashboard`, assert the response `Content-Security-Policy` contains `'nonce-` and `'strict-dynamic'` and that script-src has no `'unsafe-inline'`; (c) invoke against `/` and assert no per-request nonce CSP is added. Mock `updateSession`/Supabase as needed with `vi.hoisted()` for any variable referenced in `vi.mock()` (chai-6: use `.rejects.toMatchObject({ message: expect.stringContaining(...) })` if asserting throws). No `any` — type the mock request via the imported `NextRequest` type.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -A40 'Content-Security-Policy' vercel.json | grep -o "script-src[^;]*" | grep -c "unsafe-inline"` returns 0 (no unsafe-inline in vercel.json script-src).
+    - `bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts` exits 0 with the three behavior assertions passing.
+    - `bun run typecheck` passes.
+  </acceptance_criteria>
+  <done>vercel.json script-src has no 'unsafe-inline'; the regression test pins both the static header and the proxy nonce header; suite green in the `checks` gate.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Browser → authenticated app routes | Rendered HTML may contain attacker-injected markup if any XSS sink exists; CSP is the defense-in-depth that stops injected inline scripts from executing |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-01-03 | Tampering | inline-script XSS on authenticated routes | mitigate | Per-request nonce + `strict-dynamic` on private routes (CISEC-02); drop `script-src 'unsafe-inline'` so an injected inline `<script>` without the nonce cannot execute |
+| T-01-04 | Tampering | static marketing/blog CSP | accept | Marketing pages keep the vercel.json static CSP (route-scoped per locked decision) so they stay statically rendered; the inline-script risk on those pages is lower (no authenticated session, no PII), and the SEO recovery in this milestone forbids forcing them dynamic |
+| T-01-05 | Information Disclosure | nonce reuse / predictability | mitigate | Nonce is regenerated per request via `crypto.randomUUID()` base64 — never reused across requests; `'unsafe-eval'` gated to dev only |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts` green.
+- `bun run validate:quick` green.
+- MANUAL (post-deploy, per VALIDATION.md Manual-Only): load `/dashboard` and `/` (marketing) in a browser, inspect the `Content-Security-Policy` response header (nonce + strict-dynamic on /dashboard, static CSP on /), and confirm zero CSP-violation errors in the console on both — including the next-themes no-flash script in dark mode and the Vercel Analytics beacon + Sentry tunnel.
+</verification>
+
+<success_criteria>
+- The deployed CSP serves a per-request nonce with `strict-dynamic` on authenticated routes and no `script-src 'unsafe-inline'` remains in `vercel.json`/`proxy.ts` for those routes; marketing/blog pages keep their static CSP and stay statically rendered.
+</success_criteria>
+
+<output>
+Create `.planning/phases/01-security-ci-hardening/01-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/01-security-ci-hardening/01-02-SUMMARY.md
+++ b/.planning/phases/01-security-ci-hardening/01-02-SUMMARY.md
@@ -1,0 +1,134 @@
+---
+phase: 01-security-ci-hardening
+plan: 02
+subsystem: frontend-security-headers
+tags: [csp, nonce, strict-dynamic, proxy, middleware, xss]
+requires:
+  - "Next 16 proxy.ts auth/subscription gate (existing)"
+  - "updateSession NextResponse.next cookie-sync pattern (existing)"
+provides:
+  - "Per-request nonce CSP with strict-dynamic on PRIVATE_ROUTE_PREFIXES, forwarded on the REQUEST Content-Security-Policy header so Next 16 auto-nonces hydration scripts"
+  - "Hardened vercel.json static CSP (no script-src 'unsafe-inline') for non-private routes"
+  - "csp-header.test.ts regression guard (request==response nonce parity + vercel.json script-src guard)"
+affects:
+  - "src/proxy.ts"
+  - "src/lib/supabase/middleware.ts"
+  - "vercel.json"
+tech-stack:
+  added: []
+  patterns:
+    - "Route-scoped nonce CSP (private routes dynamic, marketing/static stay static)"
+    - "Nonce CSP threaded through updateSession's NextResponse.next({ request: { headers } }) — the load-bearing render-time path Next parses, not x-nonce"
+key-files:
+  created:
+    - "src/lib/__tests__/csp-header.test.ts"
+  modified:
+    - "src/proxy.ts"
+    - "src/lib/supabase/middleware.ts"
+    - "vercel.json"
+decisions:
+  - "Scope nonce CSP to PRIVATE_ROUTE_PREFIXES only (locked) — a nonce forces dynamic rendering; marketing/blog must stay statically rendered for the SEO recovery"
+  - "style-src keeps 'unsafe-inline' on private routes (CISEC-02 is script-src-scoped; inline-style risk is a MEDIUM follow-up)"
+  - "JSON-LD <script type='application/ld+json'> untouched (data, not governed by script-src)"
+  - "strict-dynamic ignores host allowlists in script-src, so *.supabase.co *.sentry.io *.stripe.com stay in connect-src"
+requirements: [CISEC-02]
+metrics:
+  duration: "~25m"
+  completed: "2026-06-04"
+  tasks: 2
+  files: 4
+---
+
+# Phase 1 Plan 02: CSP Per-Request Nonce + strict-dynamic (CISEC-02) Summary
+
+Per-request nonce CSP with `'strict-dynamic'` on authenticated routes, forwarded on the forwarded REQUEST `Content-Security-Policy` header (the exact string Next 16.2.6 parses via `getScriptNonceFromHeader`) so framework hydration scripts get auto-nonced — and `script-src 'unsafe-inline'` dropped from both the private-route CSP and the `vercel.json` static fallback. Marketing/blog/static pages keep the static `vercel.json` CSP and stay statically rendered.
+
+## What Was Built
+
+### Task 1 — Per-request nonce CSP forwarded on the REQUEST header + response (private routes only)
+- `src/proxy.ts`:
+  - Added `buildNonceCsp(nonce)`: emits `default-src 'self'; script-src 'self' 'nonce-<nonce>' 'strict-dynamic'[ 'unsafe-eval' in dev]; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' *.supabase.co *.sentry.io *.stripe.com; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'`. Host allowlist stays in `connect-src` (strict-dynamic ignores host allowlists in script-src). `'unsafe-eval'` is gated to `process.env.NODE_ENV === "development"`.
+  - On `isPrivateRoute(pathname)` only: generate `const nonce = Buffer.from(crypto.randomUUID()).toString("base64")`, build the CSP, clone `request.headers` into `requestHeaders`, and `requestHeaders.set("Content-Security-Policy", nonceCsp)` (load-bearing) + `requestHeaders.set("x-nonce", nonce)` (convenience only).
+  - Call `updateSession(request, requestHeaders)` on private routes; `updateSession(request, undefined)` on public routes (the `requestHeaders` var is `undefined` there).
+  - Added a `withCsp()` wrapper that sets the same CSP on the response, applied to EVERY private-route return path: the authenticated pass-through, the subscription-allowlist pass-through, the no-user `/login` redirect, the gate-failure `/login` redirect, the non-admin `/dashboard` redirect, and the no-subscription `/pricing` redirect. The public early-return (`if (!privateRoute) return supabaseResponse`) is NOT wrapped — public routes keep the static `vercel.json` CSP.
+  - JSON-LD renderers left untouched (verified via grep — 0 references in proxy.ts).
+- `src/lib/supabase/middleware.ts`:
+  - `updateSession` now takes an optional `requestHeaders?: Headers`. When provided it builds `supabaseResponse` via `NextResponse.next({ request: { headers: requestHeaders } })` at BOTH construction sites (init + the cookie `setAll` rebuild) so the CSP survives the cookie-sync rebuild. When undefined, the original `NextResponse.next({ request })` behavior is preserved exactly.
+  - The existing auth (`getUser()`), `getAll`/`setAll` cookie pattern, and Sentry error handling are unchanged — the nonce wiring is purely additive.
+
+### Task 2 — Harden vercel.json + regression test
+- `vercel.json`: `script-src 'self' 'unsafe-inline'` → `script-src 'self'`. `style-src 'self' 'unsafe-inline'` retained (out of CISEC-02 scope).
+- `src/lib/__tests__/csp-header.test.ts` (5 assertions, uses the REAL `next/server` `NextResponse`, mocks `#lib/supabase/middleware`/`@supabase/ssr`/`@sentry/nextjs`/`#env`):
+  - (a) `vercel.json` static `script-src` has no `'unsafe-inline'`.
+  - (b) On `/dashboard`, `updateSession` receives a `Headers` arg whose `content-security-policy` value contains `'nonce-` + `'strict-dynamic'` (REQUEST-side propagation — fails under response-only wiring).
+  - (c) request-side nonce token == response-side nonce token (the success-criterion-2 pin).
+  - (d) private-route response CSP has `'nonce-` + `'strict-dynamic'`, no `script-src 'unsafe-inline'`, and keeps `style-src 'self' 'unsafe-inline'`.
+  - (e) On `/`, `updateSession` is called WITHOUT a CSP-bearing request-headers arg and the response carries no per-request CSP.
+
+## Verification Results
+
+- `bunx vitest --run --project unit src/lib/__tests__/csp-header.test.ts` → 5 passed.
+- Combined with existing proxy/middleware suites (`middleware-routing.test.ts` + `middleware.test.ts`) → 35 passed, 0 regressions.
+- `bun run typecheck` → clean (no `any`; `requestHeaders` typed as `Headers`).
+- `bun run lint` → pass (one pre-existing Biome version `info` notice unrelated to this change).
+- Full lefthook gate on commit (gitleaks, lockfile-verify, lint, typecheck, unit-tests, commitlint) → all green. Committed without `--no-verify`.
+
+### Acceptance-criteria greps (all satisfied)
+- `grep -c "Content-Security-Policy" src/proxy.ts` = 3; `grep -c "strict-dynamic" src/proxy.ts` = 3.
+- `grep -c "Content-Security-Policy" src/lib/supabase/middleware.ts` = 4 (request-header CSP path documented at the load-bearing `NextResponse.next` site).
+- Both `NextResponse.next` sites carry `nextOptions` (init + setAll rebuild).
+- `grep -cE "isPrivateRoute|privateRoute" src/proxy.ts` = 4 (nonce/CSP block gated behind the private-route check).
+- JSON-LD references in proxy.ts (non-comment) = 0.
+- `vercel.json` script-src `'unsafe-inline'` count = 0; `script-src 'self'` confirmed.
+
+## The Load-Bearing Mechanism (why the plan was revised)
+
+Next 16.2.6 sources the hydration-script nonce by parsing the `content-security-policy` header on the **forwarded request** (`getScriptNonceFromHeader`, `node_modules/next/dist/server/app-render/app-render.js:167-168` — verified by reading the installed source). It does NOT read `x-nonce`. So the nonce CSP string is set on `requestHeaders` and threaded through `updateSession`'s `NextResponse.next({ request: { headers: requestHeaders } })` at BOTH construction sites. `x-nonce` is set only as a non-load-bearing convenience. Test assertion (c) (request-side nonce == response-side nonce, captured off the `updateSession` mock arg) is what pins this — it would fail under a naive response-only wiring.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Cookie-sync correctness when forwarding custom requestHeaders**
+- **Found during:** Task 1 (middleware.ts wiring)
+- **Issue:** The original `setAll` rebuild used `NextResponse.next({ request })`, which forwards the mutated `request` (with refreshed auth cookies). Switching the rebuild to `NextResponse.next({ request: { headers: requestHeaders } })` would forward the proxy's pre-mutation `requestHeaders` snapshot, dropping the refreshed cookies from the request Server Components render against — a session-desync bug.
+- **Fix:** On the `setAll` rebuild, mirror the freshly-updated `cookie` header from `request` back into `requestHeaders` (`requestHeaders.set("cookie", request.headers.get("cookie") ?? "")`) before the rebuild. Next's `RequestCookies.set()` writes through to the underlying `cookie` header, so this captures the refreshed cookies. Only runs when `requestHeaders` is provided (private routes); public-route behavior is byte-for-byte unchanged.
+- **Files modified:** `src/lib/supabase/middleware.ts`
+- **Commit:** 2c878f486
+
+**2. [Rule 3 - Blocking] Plan's test command had a duplicate `--run` flag**
+- **Issue:** `bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts` crashed — the `test:unit` script already passes `--run`, so vitest's CAC parser rejected the duplicate. (`bun run validate:quick` also failed in this shell with an unrelated packaged-Node `Cannot find module 'bun'` resolution quirk on the chained nested `bun run` — not a code issue; the three steps were run individually and all passed.)
+- **Fix:** Ran the test via the direct invocation the task prompt specified: `bunx vitest --run --project unit src/lib/__tests__/csp-header.test.ts`. No code change.
+
+**3. [Rule 1 - Bug] `import.meta.url` not a file: URL under the Vitest transform**
+- **Found during:** Task 2 (test authoring)
+- **Issue:** `fileURLToPath(new URL("../../../vercel.json", import.meta.url))` threw `The URL must be of scheme file` — `import.meta.url` is not a `file:` URL in this Vitest setup.
+- **Fix:** Resolve `vercel.json` from `process.cwd()` (Vitest runs from repo root): `resolve(process.cwd(), "vercel.json")`.
+- **Files modified:** `src/lib/__tests__/csp-header.test.ts`
+
+No architectural changes were required. No package installs.
+
+## Remaining Manual Verification (CANNOT be automated here)
+
+Per `01-VALIDATION.md` Manual-Only, the deployed-browser CSP check is a post-deploy step that this executor cannot run (no deployed environment):
+
+- After deploy, load `/dashboard` (authenticated) and `/` (marketing) in a browser:
+  - Confirm the `/dashboard` response `Content-Security-Policy` header carries `'nonce-<n>'` + `'strict-dynamic'` and `/` serves the static `vercel.json` CSP.
+  - Confirm ZERO `script-src` CSP-violation errors in the console on both — specifically the `next-themes` no-flash inline script (test dark mode for a flash), the Vercel Analytics beacon, and the Sentry tunnel `/monitoring`.
+  - Confirm the dashboard **fully hydrates and is interactive** — a blank/non-interactive dashboard would mean the request-side nonce wiring failed (framework scripts blocked under strict-dynamic).
+  - Confirm no `style-src` CSP violations and no broken/unstyled regions (style-src keeps `'unsafe-inline'` on private routes).
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, file access, or schema changes were introduced beyond the planned CSP header surface.
+
+## Self-Check: PASSED
+- `src/proxy.ts` — present, modified (buildNonceCsp + nonce wiring + withCsp).
+- `src/lib/supabase/middleware.ts` — present, modified (optional requestHeaders).
+- `vercel.json` — present, modified (script-src 'self').
+- `src/lib/__tests__/csp-header.test.ts` — present, created (5 passing assertions).
+- Commit `2c878f486` present on `gsd/phase-1-security-ci-hardening`.

--- a/.planning/phases/01-security-ci-hardening/01-03-PLAN.md
+++ b/.planning/phases/01-security-ci-hardening/01-03-PLAN.md
@@ -1,0 +1,155 @@
+---
+phase: 01-security-ci-hardening
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - supabase/functions/_shared/timing-safe.ts
+  - supabase/functions/auth-email-send/index.ts
+  - src/lib/__tests__/timing-safe.test.ts
+autonomous: true
+requirements: [CISEC-03]
+must_haves:
+  truths:
+    - "auth-email-send compares its hook secret in constant time via the shared timingSafeEqualStr helper"
+    - "No 'token !== hookSecret' short-circuit string compare remains in auth-email-send/index.ts"
+    - "The shared _shared/timing-safe.ts helper lifts the resend-webhook crypto.subtle.timingSafeEqual + XOR-fallback pattern"
+    - "A unit test pins timingSafeEqualStr: equal→true, unequal-same-length→false, different-length→false"
+  artifacts:
+    - path: "supabase/functions/_shared/timing-safe.ts"
+      provides: "Shared constant-time string compare (timingSafeEqualStr) with crypto.subtle.timingSafeEqual + XOR fallback"
+      contains: "timingSafeEqualStr"
+    - path: "supabase/functions/auth-email-send/index.ts"
+      provides: "Hook-secret check via timingSafeEqualStr (no !== compare)"
+      contains: "timingSafeEqualStr"
+    - path: "src/lib/__tests__/timing-safe.test.ts"
+      provides: "Unit test pinning the constant-time compare behavior"
+      min_lines: 20
+  key_links:
+    - from: "supabase/functions/auth-email-send/index.ts"
+      to: "supabase/functions/_shared/timing-safe.ts"
+      via: "import timingSafeEqualStr"
+      pattern: "import.*timingSafeEqualStr.*_shared/timing-safe"
+---
+
+<objective>
+Close CISEC-03: replace the lone non-constant-time `token !== hookSecret` compare in `auth-email-send` with a shared `timingSafeEqualStr` helper, eliminating the timing side-channel on the Auth-Hook secret — satisfying the user's locked decision to extract a shared `supabase/functions/_shared/timing-safe.ts` (lifting the proven `resend-webhook` pattern) and one-line-swap `auth-email-send/index.ts:81`.
+
+Purpose: `auth-email-send/index.ts:81` compares the raw hook secret with `!==`, leaking timing information about how many leading bytes matched. Three other webhooks already use `crypto.subtle.timingSafeEqual` with an XOR fallback but inline the pattern (no shared helper). The user-locked fix extracts one helper and swaps the compare — closing CISEC-03 and removing the triplication ethos violation.
+Output: `supabase/functions/_shared/timing-safe.ts`, the one-line swap in `auth-email-send/index.ts`, and `src/lib/__tests__/timing-safe.test.ts`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/01-security-ci-hardening/01-RESEARCH.md
+@.planning/phases/01-security-ci-hardening/01-VALIDATION.md
+@supabase/functions/auth-email-send/index.ts
+
+<interfaces>
+<!-- Source pattern to lift (resend-webhook/index.ts:145-168) — crypto.subtle.timingSafeEqual + XOR fallback. -->
+<!-- KEY DISTINCTION: resend/docuseal/n8n compare an attacker HMAC digest vs a computed digest. -->
+<!-- auth-email-send compares two RAW secret strings directly (no HMAC) — so the helper is a plain constant-time byte compare, NOT the HMAC machinery. Do NOT HMAC the token. -->
+
+New helper contract:
+  // supabase/functions/_shared/timing-safe.ts
+  export function timingSafeEqualStr(a: string, b: string): boolean
+  // TextEncoder.encode both; early-return false on length mismatch (secret length is not itself secret — all 3 existing helpers do this);
+  // crypto.subtle.timingSafeEqual when available (feature-detected via a runtime shim cast — this `as unknown as` is a feature-detection shim, NOT an RPC boundary, matching resend-webhook:151 and NOT a CLAUDE.md rule #8 violation); XOR-loop fallback otherwise.
+
+Call site (auth-email-send/index.ts:78-89):
+  const hookSecret = env["SUPABASE_AUTH_HOOK_SECRET"];
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+  if (token !== hookSecret) { /* 401 path */ }    // ← replace the condition with !timingSafeEqualStr(token, hookSecret)
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create _shared/timing-safe.ts and pin it with a unit test</name>
+  <files>supabase/functions/_shared/timing-safe.ts, src/lib/__tests__/timing-safe.test.ts</files>
+  <read_first>
+    - supabase/functions/resend-webhook/index.ts (lines 145-168 — the exact crypto.subtle.timingSafeEqual + XOR-fallback pattern to lift; preserve the `?? 0` index guards for noUncheckedIndexedAccess)
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-03 — "Recommended Approach" with the full helper body, and "Gotchas / Landmines")
+    - vitest.config.ts (lines 60-114 — the test lives under `src/**` so it runs in the `unit`/`checks` gate; the helper is pure TS using only `TextEncoder` + `crypto.subtle`, both available in jsdom/node, so a relative import resolves)
+  </read_first>
+  <behavior>
+    - timingSafeEqualStr("abc", "abc") === true (equal strings).
+    - timingSafeEqualStr("abc", "abd") === false (unequal, same length).
+    - timingSafeEqualStr("abc", "abcd") === false (different length).
+    - Empty-string edge: timingSafeEqualStr("", "") === true.
+  </behavior>
+  <action>
+    Create `supabase/functions/_shared/timing-safe.ts` exporting `timingSafeEqualStr(a: string, b: string): boolean`. Body lifted from `resend-webhook/index.ts:145-168`: `TextEncoder().encode` both inputs; early-return `false` on length mismatch (acceptable — secret length is not itself secret, matching all three existing helpers); feature-detect `crypto.subtle.timingSafeEqual` via the same runtime shim cast used at `resend-webhook:151` (`crypto.subtle as unknown as { timingSafeEqual?: (x: Uint8Array, y: Uint8Array) => boolean }`) wrapped in try/catch; XOR-loop fallback with `(ab[i] ?? 0) ^ (bb[i] ?? 0)` to satisfy `noUncheckedIndexedAccess`, returning `d === 0`. Add a doc comment noting this compares RAW secret strings (no HMAC) and that the `as unknown as` is a feature-detection shim, not an RPC-boundary cast (CLAUDE.md rule #8 scopes to PostgREST/RPC returns). Then create `src/lib/__tests__/timing-safe.test.ts` importing `timingSafeEqualStr` from the relative `supabase/functions/_shared/timing-safe.ts` path and assert the four `<behavior>` cases. No `any` (the shim cast is `unknown`-based, allowed here per the documented exception).
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/lib/__tests__/timing-safe.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "export function timingSafeEqualStr" supabase/functions/_shared/timing-safe.ts` === 1.
+    - `grep -c "timingSafeEqual" supabase/functions/_shared/timing-safe.ts` ≥ 1 (uses crypto.subtle.timingSafeEqual, not a naive compare).
+    - `bun run test:unit -- --run src/lib/__tests__/timing-safe.test.ts` exits 0 with 4 passing assertions.
+    - `bun run typecheck` passes.
+  </acceptance_criteria>
+  <done>Shared helper exists with the lifted constant-time pattern; unit test pins equal/unequal/length-mismatch/empty behavior; suite green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Swap auth-email-send to the constant-time compare</name>
+  <files>supabase/functions/auth-email-send/index.ts</files>
+  <read_first>
+    - supabase/functions/auth-email-send/index.ts (lines 11-25 for the import block, lines 78-89 for the compare site)
+    - supabase/functions/_shared/timing-safe.ts (the helper created in Task 1 — confirm the export name)
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-03 "Concrete Implementation Steps" step 2)
+  </read_first>
+  <action>
+    Add `import { timingSafeEqualStr } from "../_shared/timing-safe.ts";` to the `_shared/` import block (lines 11-25, matching the existing relative-path style with the `.ts` extension Deno requires). Replace the condition at line 81 from `if (token !== hookSecret) {` to `if (!timingSafeEqualStr(token, hookSecret)) {` — leave the 401 body, `captureWebhookError`, and the `validateEnv` startup guard unchanged (the contract is byte-for-byte equivalent for rejection, only the compare is now constant-time). Do NOT HMAC the token — `auth-email-send` compares the raw shared secret; adding HMAC would break the Supabase Auth Hook config.
+  </action>
+  <verify>
+    <automated>grep -c "token !== hookSecret" supabase/functions/auth-email-send/index.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "token !== hookSecret" supabase/functions/auth-email-send/index.ts` returns 0 (no short-circuit compare remains).
+    - `grep -c "timingSafeEqualStr" supabase/functions/auth-email-send/index.ts` === 2 (import + call site).
+    - `grep -c 'from "../_shared/timing-safe.ts"' supabase/functions/auth-email-send/index.ts` === 1.
+    - `bun run typecheck` passes.
+  </acceptance_criteria>
+  <done>auth-email-send compares the hook secret via timingSafeEqualStr; no `!== hookSecret` remains; the 401 reject contract is unchanged.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Supabase Auth → auth-email-send Edge Function | Server-to-server POST authenticated solely by the shared `SUPABASE_AUTH_HOOK_SECRET` in the Authorization Bearer header |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-01-06 | Information Disclosure | hook-secret compare (`auth-email-send/index.ts:81`) | mitigate | Replace the `!==` string compare with `timingSafeEqualStr` (constant-time) so the response time no longer leaks how many leading secret bytes matched (CISEC-03) |
+| T-01-07 | Spoofing | forged Auth-Hook POST | mitigate | The constant-time compare hardens the existing secret check; a brute-force attacker can no longer use timing to recover the secret byte-by-byte. The `validateEnv` startup guard (secret required) is unchanged |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- --run src/lib/__tests__/timing-safe.test.ts` green.
+- `grep -n "token !== hookSecret" supabase/functions/auth-email-send/index.ts` returns nothing.
+- `bun run validate:quick` green.
+- POST-MERGE: deploy the Edge Function out-of-band (`bun scripts/deploy-edge-functions.ts` — there is no CI deploy step for Edge Functions). Until deployed, the running prod function keeps the old compare; the merge gate is the source change + tests, deployment is the follow-up step.
+</verification>
+
+<success_criteria>
+- `auth-email-send` compares its hook secret in constant time via the shared XOR/`crypto.subtle.timingSafeEqual` helper; a grep confirms no `token !== hookSecret` short-circuit compare remains.
+</success_criteria>
+
+<output>
+Create `.planning/phases/01-security-ci-hardening/01-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/01-security-ci-hardening/01-03-PLAN.md
+++ b/.planning/phases/01-security-ci-hardening/01-03-PLAN.md
@@ -77,6 +77,7 @@ Call site (auth-email-send/index.ts:78-89):
     - supabase/functions/resend-webhook/index.ts (lines 145-168 — the exact crypto.subtle.timingSafeEqual + XOR-fallback pattern to lift; preserve the `?? 0` index guards for noUncheckedIndexedAccess)
     - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-03 — "Recommended Approach" with the full helper body, and "Gotchas / Landmines")
     - vitest.config.ts (lines 60-114 — the test lives under `src/**` so it runs in the `unit`/`checks` gate; the helper is pure TS using only `TextEncoder` + `crypto.subtle`, both available in jsdom/node, so a relative import resolves)
+    - NOTE: this is the FIRST `src/` test to import from `supabase/functions/` — typecheck this cross-boundary import early (see the EXECUTOR NOTE in <action> for the Deno-only fallback if the Node tsconfig rejects the Deno helper)
   </read_first>
   <behavior>
     - timingSafeEqualStr("abc", "abc") === true (equal strings).
@@ -86,6 +87,8 @@ Call site (auth-email-send/index.ts:78-89):
   </behavior>
   <action>
     Create `supabase/functions/_shared/timing-safe.ts` exporting `timingSafeEqualStr(a: string, b: string): boolean`. Body lifted from `resend-webhook/index.ts:145-168`: `TextEncoder().encode` both inputs; early-return `false` on length mismatch (acceptable — secret length is not itself secret, matching all three existing helpers); feature-detect `crypto.subtle.timingSafeEqual` via the same runtime shim cast used at `resend-webhook:151` (`crypto.subtle as unknown as { timingSafeEqual?: (x: Uint8Array, y: Uint8Array) => boolean }`) wrapped in try/catch; XOR-loop fallback with `(ab[i] ?? 0) ^ (bb[i] ?? 0)` to satisfy `noUncheckedIndexedAccess`, returning `d === 0`. Add a doc comment noting this compares RAW secret strings (no HMAC) and that the `as unknown as` is a feature-detection shim, not an RPC-boundary cast (CLAUDE.md rule #8 scopes to PostgREST/RPC returns). Then create `src/lib/__tests__/timing-safe.test.ts` importing `timingSafeEqualStr` from the relative `supabase/functions/_shared/timing-safe.ts` path and assert the four `<behavior>` cases. No `any` (the shim cast is `unknown`-based, allowed here per the documented exception).
+
+    EXECUTOR NOTE (first-of-its-kind cross-boundary import): this `src/` test importing `supabase/functions/_shared/timing-safe.ts` is the first `src/` test to pull a Deno helper across the boundary — no existing `src/` test imports `supabase/functions/`. Run `bun run typecheck` EARLY (right after creating both files, before fleshing out assertions). If pulling the Deno helper into the Node tsconfig trips type errors (`checkJs`, `bundler` module resolution, or Deno-only globals leaking), do NOT fight the boundary: fall back to a Deno-only test under `supabase/functions/tests/timing-safe.test.ts` (run via `deno test` with `supabase functions serve`) and drop the `src/lib/__tests__/timing-safe.test.ts` artifact. The CISEC-03 success criterion is the constant-time compare living in `auth-email-send` (Task 2) — it does NOT depend on the test residing under `src/`. If you take the Deno-fallback path, update `files_modified` in your SUMMARY accordingly and note the `src/`-test artifact was relocated.
   </action>
   <verify>
     <automated>bun run test:unit -- --run src/lib/__tests__/timing-safe.test.ts</automated>

--- a/.planning/phases/01-security-ci-hardening/01-03-SUMMARY.md
+++ b/.planning/phases/01-security-ci-hardening/01-03-SUMMARY.md
@@ -1,0 +1,111 @@
+---
+phase: 01-security-ci-hardening
+plan: 03
+subsystem: edge-functions
+tags: [timing-safe, constant-time, auth-hook, hook-secret, edge-functions, security, vitest]
+
+# Dependency graph
+requires: []
+provides:
+  - Shared constant-time string compare helper (timingSafeEqualStr) in supabase/functions/_shared/
+  - auth-email-send hook-secret check is now constant-time (CISEC-03)
+  - CI-gated unit test pinning timingSafeEqualStr equal/unequal/length-mismatch/empty behavior
+affects: [auth-email-send, edge-functions, auth-hooks, supabase-auth]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Extract one _shared/timing-safe.ts helper instead of inlining a fourth copy of the crypto.subtle.timingSafeEqual + XOR-fallback pattern (no-duplicate ethos)"
+    - "src/ unit test importing a supabase/functions/_shared/ helper across the Deno/Node boundary — typechecks clean under bundler resolution + noEmit; runs in the checks gate"
+    - "Feature-detect crypto.subtle.timingSafeEqual via an `as unknown as` runtime shim (feature-detection, NOT an RPC boundary — outside CLAUDE.md rule #8 scope)"
+
+key-files:
+  created:
+    - supabase/functions/_shared/timing-safe.ts
+    - src/lib/__tests__/timing-safe.test.ts
+  modified:
+    - supabase/functions/auth-email-send/index.ts
+
+key-decisions:
+  - "Took the src/ test path (NOT the Deno fallback): the cross-boundary import typechecked clean on the FIRST `bun run typecheck`, so the test lives under src/lib/__tests__/ and runs in the checks/unit gate as planned"
+  - "Imported the helper in the test WITHOUT the `.ts` extension (../../../supabase/functions/_shared/timing-safe) so Vite/tsc bundler resolution resolves it; the Edge Function import keeps the `.ts` extension Deno requires"
+  - "Raw-secret compare only — did NOT HMAC the token (auth-email-send compares the shared secret directly; HMAC would break the Supabase Auth Hook config)"
+  - "Length early-return on mismatch is intentional and acceptable (secret length is not itself secret; matches all three existing inline helpers)"
+
+patterns-established:
+  - "Constant-time secret comparisons in Edge Functions go through _shared/timing-safe.ts timingSafeEqualStr; new shared-secret checks should reuse it rather than inlining"
+
+requirements-completed: [CISEC-03]
+
+# Metrics
+duration: 8min
+completed: 2026-06-04
+---
+
+# Phase 1 Plan 03: Constant-Time Hook-Secret Compare Summary
+
+**Extracted a shared `timingSafeEqualStr` helper (lifting the resend-webhook `crypto.subtle.timingSafeEqual` + XOR-fallback pattern) and swapped `auth-email-send`'s `token !== hookSecret` short-circuit compare for `!timingSafeEqualStr(token, hookSecret)`, closing the timing side-channel on `SUPABASE_AUTH_HOOK_SECRET` while preserving the byte-for-byte 401-on-mismatch contract.**
+
+## Performance
+
+- **Duration:** ~8 min
+- **Started:** 2026-06-04T13:08:00Z
+- **Completed:** 2026-06-04T13:16:00Z
+- **Tasks:** 2
+- **Files:** 2 created, 1 modified
+
+## Accomplishments
+- Closed CISEC-03: `auth-email-send` now compares the Auth-Hook secret in constant time, so response timing no longer leaks how many leading secret bytes matched (mitigates T-01-06 Information Disclosure and hardens T-01-07 forged-POST spoofing).
+- Created `supabase/functions/_shared/timing-safe.ts` exporting `timingSafeEqualStr(a, b)` — lifts the proven `resend-webhook/index.ts:145-168` pattern: `TextEncoder` encode, length-mismatch early-return, `crypto.subtle.timingSafeEqual` when available (feature-detected via a runtime shim), XOR-loop fallback with `?? 0` index guards.
+- One-line swap in `auth-email-send/index.ts`: condition `token !== hookSecret` → `!timingSafeEqualStr(token, hookSecret)` plus the `../_shared/timing-safe.ts` import. The 401 body, `captureWebhookError`, and the `validateEnv` startup guard are unchanged.
+- Pinned the helper behavior in `src/lib/__tests__/timing-safe.test.ts` (6 cases: equal, unequal-same-length, different-length, empty-equal, longer-secret-equal, final-byte-differs) — runs in the `checks`/`unit` gate.
+
+## Test-Location Decision: `src/` path (NOT the Deno fallback)
+
+The plan flagged this as the first `src/` test importing a `supabase/functions/` Deno helper and instructed running `bun run typecheck` EARLY, falling back to a Deno-only test if the Node tsconfig rejected the cross-boundary import.
+
+**Outcome: the `src/` path held.** The first `bun run typecheck` after writing both files passed clean — the Deno helper imports nothing Deno-specific (only `TextEncoder` + `crypto.subtle`, both present in Node/jsdom), and the project's `bundler` moduleResolution + `noEmit: true` accept the cross-boundary import. The test imports the helper WITHOUT the `.ts` extension (`../../../supabase/functions/_shared/timing-safe`) so Vite/tsc resolve it; the Edge Function keeps the `.ts` extension Deno requires. No Deno-only fallback test was created; `files_modified` matches the plan as written.
+
+## Verification
+
+- `bun run test:unit src/lib/__tests__/timing-safe.test.ts` → 6 passed (1 file).
+- `grep -n "token !== hookSecret" supabase/functions/auth-email-send/index.ts` → no match (regression guard satisfied).
+- `grep -c "timingSafeEqualStr" supabase/functions/auth-email-send/index.ts` → 2 (import + call site).
+- `grep -c 'from "../_shared/timing-safe.ts"' supabase/functions/auth-email-send/index.ts` → 1.
+- `grep -c "export function timingSafeEqualStr" supabase/functions/_shared/timing-safe.ts` → 1.
+- `bun run typecheck` → clean (rc=0).
+- `bun run lint` → clean (rc=0; the single biome `migrate` info is pre-existing/out-of-scope).
+- Full lefthook pre-commit gate (gitleaks, lockfile-verify, typecheck, unit-tests w/ 80% coverage threshold, lint, commitlint) ran on both commits — NEVER `--no-verify`.
+
+## Deviations from Plan
+
+**1. [Rule 3 - Blocking] `bun run test:unit -- --run <file>` crashed (duplicate `--run`)**
+- **Found during:** Task 1 verification.
+- **Issue:** The plan's verify command `bun run test:unit -- --run <file>` failed because the `test:unit` package script already injects `--run`; vitest's CAC parser rejects the duplicated flag ("Expected a single value for option `--run`").
+- **Fix:** Invoked as `bun run test:unit <file>` (no second `--run`). Behavior-equivalent — vitest still runs once, non-watch. No source change.
+- **Files modified:** none.
+
+**2. [Rule 1 - Format] Biome formatting on the test's multi-line `expect(...).toBe(false)`**
+- **Found during:** Task 1 commit (lefthook `lint` step aborted the first commit).
+- **Issue:** The hand-written multi-line `expect(timingSafeEqualStr(...)).toBe(\n  false,\n)` block did not match biome's preferred wrap.
+- **Fix:** Ran `biome check --write` on the new test file; re-staged and committed. Auto-format only, no semantic change.
+- **Files modified:** src/lib/__tests__/timing-safe.test.ts (formatting).
+- **Commit:** 2dc4c07ac (final committed form).
+
+## Post-Merge Follow-Up (not part of the merge gate)
+
+The Edge Function must be redeployed out-of-band after merge (`bun scripts/deploy-edge-functions.ts`) — there is no CI deploy step for Edge Functions. Until then, the running prod `auth-email-send` keeps the old `!==` compare. The merge gate is the source change + tests; deployment is the documented follow-up dance.
+
+## Commits
+
+- `2dc4c07ac` feat(01-03): add shared timingSafeEqualStr constant-time compare helper
+- `3a779e516` fix(01-03): constant-time hook-secret compare in auth-email-send (CISEC-03)
+
+## Self-Check: PASSED
+
+- FOUND: supabase/functions/_shared/timing-safe.ts
+- FOUND: src/lib/__tests__/timing-safe.test.ts
+- FOUND: supabase/functions/auth-email-send/index.ts (modified)
+- FOUND commit: 2dc4c07ac
+- FOUND commit: 3a779e516

--- a/.planning/phases/01-security-ci-hardening/01-04-PLAN.md
+++ b/.planning/phases/01-security-ci-hardening/01-04-PLAN.md
@@ -1,0 +1,152 @@
+---
+phase: 01-security-ci-hardening
+plan: 04
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .github/workflows/ci-cd.yml
+  - .github/workflows/rls-security-tests.yml
+  - .github/workflows/claude.yml
+  - .github/workflows/codeql.yml
+  - .github/workflows/gitleaks.yml
+  - .github/workflows/post-deploy-sentry-gate.yml
+  - src/lib/__tests__/workflow-pins.test.ts
+autonomous: true
+requirements: [CISEC-04]
+must_haves:
+  truths:
+    - "Every third-party `uses:` across .github/workflows/*.yml is pinned to a 40-char commit SHA with a trailing version comment"
+    - "First-party actions/* and github/codeql-action/* are pinned uniformly too (a 40-char SHA + version comment)"
+    - "A drift-guard test fails if any third-party `uses:` is not a 40-char SHA"
+    - "The existing CodeQL Analyze (actions) scan stays clean"
+  artifacts:
+    - path: "src/lib/__tests__/workflow-pins.test.ts"
+      provides: "Drift guard: scans .github/workflows/*.yml and fails on any non-SHA third-party uses:"
+      min_lines: 25
+  key_links:
+    - from: "src/lib/__tests__/workflow-pins.test.ts"
+      to: ".github/workflows/*.yml"
+      via: "readdirSync + readFileSync + regex over uses: lines"
+      pattern: "uses:.*@[0-9a-f]{40}"
+---
+
+<objective>
+Close CISEC-04: pin every third-party `uses:` across `.github/workflows/*.yml` to a 40-char commit SHA with a trailing version comment, AND pin first-party `actions/*` + `github/codeql-action/*` uniformly — plus add a drift-guard test that fails if any third-party `uses:` is not a SHA. Satisfies the user's locked uniform-pinning decision and defeats action-tag repointing supply-chain attacks.
+
+Purpose: A mutable action tag (`@v2`, `@v6`) can be repointed by a repo compromise to a malicious commit. Only the immutable commit SHA defends against this. The highest-blast-radius action is `anthropics/claude-code-action` (requests `id-token: write` OIDC). The CodeQL + gitleaks workflows shipped via PR #781 must have their actions SHA-pinned too. The RESEARCH §CISEC-04 table already resolved each action to its commit SHA (annotated tags dereferenced) on 2026-06-04.
+Output: SHA-pinned `uses:` lines across 6 workflow files + `src/lib/__tests__/workflow-pins.test.ts`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/01-security-ci-hardening/01-RESEARCH.md
+@.planning/phases/01-security-ci-hardening/01-VALIDATION.md
+
+<interfaces>
+<!-- RESEARCH §CISEC-04 resolved SHA table (live GitHub API, 2026-06-04, annotated tags dereferenced to commit SHAs). -->
+<!-- These are the pin targets. Re-verify each via `gh api repos/<owner>/<repo>/commits/<tag>` at execution time per RESEARCH "Valid until" note; if a SHA drifted, pin the freshly-resolved commit and keep the version comment accurate. -->
+
+  oven-sh/setup-bun@v2          → 0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0   (ci-cd.yml:43,142; rls-security-tests.yml:89)
+  gitleaks/gitleaks-action@v2   → ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9   (gitleaks.yml:32)  — pin v2 SHA; do NOT jump to v3 in this PR
+  anthropics/claude-code-action@v1 → 70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135 (claude.yml:37) — PRIORITY: id-token: write
+  actions/checkout@v6           → df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3  (ci-cd.yml:39,114; rls-security-tests.yml:56; claude.yml:31; codeql.yml:37; gitleaks.yml:24)
+  actions/setup-node@v6         → 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0  (ci-cd.yml:47,147; rls-security-tests.yml:95)
+  actions/upload-artifact@v7    → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1  (ci-cd.yml:172; post-deploy-sentry-gate.yml:393)
+  github/codeql-action/init@v3  → dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3     (codeql.yml:42)
+  github/codeql-action/analyze@v3 → dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3   (codeql.yml:47)
+
+Already pinned (leave as-is): dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0 (dependabot-auto-merge.yml:40)
+ci-cd-doc-only.yml has no third-party uses: to pin (verify with grep).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: SHA-pin every uses: across the 6 workflow files</name>
+  <files>.github/workflows/ci-cd.yml, .github/workflows/rls-security-tests.yml, .github/workflows/claude.yml, .github/workflows/codeql.yml, .github/workflows/gitleaks.yml, .github/workflows/post-deploy-sentry-gate.yml</files>
+  <read_first>
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-04 — the full resolved SHA table and ALL "Gotchas / Landmines", especially annotated-tag dereferencing and gitleaks v2-vs-v3)
+    - .github/workflows/ci-cd.yml, rls-security-tests.yml, claude.yml, codeql.yml, gitleaks.yml, post-deploy-sentry-gate.yml (read the `uses:` lines to confirm current refs match the RESEARCH table before editing)
+  </read_first>
+  <action>
+    For each `uses:` line listed in the `<interfaces>` SHA table, replace the `@vX` ref with `@<sha> # vX.Y.Z` using the exact SHAs from the table. Re-verify each SHA at execution time via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` (RESEARCH "Valid until" 2026-07-04 but SHAs drift — if a freshly-resolved SHA differs, pin the new commit and update the version comment). Pin uniformly: third-party (`oven-sh/setup-bun`, `gitleaks/gitleaks-action`, `anthropics/claude-code-action`) AND first-party (`actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `github/codeql-action/init`, `github/codeql-action/analyze`). Keep `dependabot/fetch-metadata` as-is (already a SHA). For `gitleaks/gitleaks-action`, pin the v2 SHA `ff98106…` — do NOT silently jump to v3 (v3 may change config; let Dependabot propose it separately). For the annotated tags (`codeql-action@v3`, `gitleaks-action@v2`, `claude-code-action@v1`), the table already shows the dereferenced COMMIT SHA (not the tag-object SHA) — pin those. Every pin MUST carry a trailing `# vX.Y.Z` comment so Dependabot recognizes and bumps it. Confirm `ci-cd-doc-only.yml` has no third-party `uses:` needing a pin (grep it).
+  </action>
+  <verify>
+    <automated>grep -rn "uses:" .github/workflows/ | grep -vE "@[0-9a-f]{40}" | grep -vE "ci-cd-doc-only"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -rn "uses:" .github/workflows/ | grep -vE "@[0-9a-f]{40}"` returns NOTHING (every uses: is a 40-hex SHA).
+    - `grep -rE "uses: (oven-sh|gitleaks|anthropics)/" .github/workflows/ | grep -vE "@[0-9a-f]{40}"` returns NOTHING (all third-party pinned).
+    - `grep -c "# v" .github/workflows/ci-cd.yml` shows each pinned uses: carries a trailing version comment (Dependabot bump anchor).
+    - `grep -c "ff98106e4c7b2bc287b24eaf42907196329070c7" .github/workflows/gitleaks.yml` === 1 (gitleaks pinned to the v2 SHA, not v3).
+    - `grep -c "70a6e5256e9e2366a1ed5c041904a982ba3a328f" .github/workflows/claude.yml` === 1 (the id-token: write action is pinned).
+  </acceptance_criteria>
+  <done>Every uses: across the 6 workflow files is a 40-char commit SHA with a version comment; gitleaks stays on v2; the OIDC claude action is pinned; dependabot/fetch-metadata unchanged.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add the workflow-pin drift-guard test</name>
+  <files>src/lib/__tests__/workflow-pins.test.ts</files>
+  <read_first>
+    - .github/workflows/ (the pinned files from Task 1 — the test reads them)
+    - .planning/phases/01-security-ci-hardening/01-RESEARCH.md (§CISEC-04 "Validation Architecture" — the grep assertion to encode)
+    - vitest.config.ts (lines 60-114 — test under `src/**` so it runs in the `unit`/`checks` gate)
+  </read_first>
+  <behavior>
+    - The test enumerates every `.github/workflows/*.yml` file, extracts every `uses:` line, and fails if ANY third-party `uses:` (owner not `actions` and not `github`) is not pinned to a 40-char SHA.
+    - The stricter assertion (per the locked uniform decision): EVERY `uses:` line (including `actions/*` and `github/codeql-action/*`) is a 40-char SHA — assert this too so a future un-pinned first-party action also trips the guard.
+    - The test lists the offending file:line in the failure message so a regression is actionable.
+  </behavior>
+  <action>
+    Create `src/lib/__tests__/workflow-pins.test.ts` (under src/ so it runs in the `unit`/`checks` gate). Use `readdirSync` over `.github/workflows/` filtered to `.yml`, `readFileSync` each, split into lines, and collect lines matching a `uses:` pattern. For each `uses:` line, parse the action ref after the `@`; assert it matches `/@[0-9a-f]{40}( |$)/` (a 40-hex SHA, optionally followed by a space + comment). Build a list of violators as `file:lineNumber → ref` strings and assert the list is empty with the joined violators in the failure message (so the message is actionable, not "looks correct"). Encode both checks: (a) third-party (owner ∉ {actions, github}) MUST be a SHA; (b) the stricter all-uses: SHA assertion per the uniform decision. Skip blank/comment lines. No `any` — type the parsed entries via an explicit interface or string tuples.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/lib/__tests__/workflow-pins.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `bun run test:unit -- --run src/lib/__tests__/workflow-pins.test.ts` exits 0 (all uses: are SHA-pinned).
+    - The test fails with an actionable `file:line → ref` message if a non-SHA `uses:` is introduced (verify by temporarily reverting one pin locally, confirming red, then restoring — do not commit the revert).
+    - `bun run typecheck` passes.
+  </acceptance_criteria>
+  <done>The drift-guard test passes against the pinned workflows and fails loudly (with file:line) on any future non-SHA uses:.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| GitHub Actions runner → third-party action code | Each `uses:` pulls and executes code from an external repo at the resolved ref; a mutable tag lets the action author (or a repo-compromiser) change what runs |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-01-08 | Tampering / Elevation | `anthropics/claude-code-action@v1` (`id-token: write`, `contents: read`) | mitigate | Pin to commit SHA `70a6e525…` — highest blast radius (OIDC token write); a repointed mutable tag here could exfiltrate an OIDC token |
+| T-01-09 | Tampering | all other third-party actions (setup-bun, gitleaks) | mitigate | Pin to immutable commit SHAs with version comments; Dependabot bumps via the trailing comment |
+| T-01-10 | Tampering | first-party actions/* + github/codeql-action/* | mitigate | Pinned uniformly per the locked decision (lower risk but zero-cost; removes the "is this one trusted?" judgment) |
+| T-01-SC | Tampering | npm/pip/cargo installs | accept | No package installs in this phase — all four requirements use already-present deps (per RESEARCH "Package Legitimacy Audit"); no slopcheck applicable |
+</threat_model>
+
+<verification>
+- `grep -rn "uses:" .github/workflows/ | grep -vE "@[0-9a-f]{40}"` returns nothing.
+- `bun run test:unit -- --run src/lib/__tests__/workflow-pins.test.ts` green.
+- `bun run validate:quick` green.
+- On the PR: the existing CodeQL `Analyze (actions)` matrix job runs green with zero new findings (a wrong/nonexistent SHA fails the workflow immediately — that is the self-validating gate).
+</verification>
+
+<success_criteria>
+- Every third-party action under `.github/workflows/` is pinned to a commit SHA (with first-party actions pinned uniformly), a drift-guard test fails on any non-SHA `uses:`, and CodeQL's `actions` scan stays clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/01-security-ci-hardening/01-04-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/01-security-ci-hardening/01-04-SUMMARY.md
+++ b/.planning/phases/01-security-ci-hardening/01-04-SUMMARY.md
@@ -1,0 +1,98 @@
+---
+phase: 01-security-ci-hardening
+plan: 04
+subsystem: ci-supply-chain
+tags: [github-actions, supply-chain, sha-pinning, drift-guard, CISEC-04]
+requires: []
+provides:
+  - "SHA-pinned uses: across all .github/workflows/*.yml"
+  - "src/lib/__tests__/workflow-pins.test.ts drift guard"
+affects:
+  - .github/workflows/ci-cd.yml
+  - .github/workflows/rls-security-tests.yml
+  - .github/workflows/claude.yml
+  - .github/workflows/codeql.yml
+  - .github/workflows/gitleaks.yml
+  - .github/workflows/post-deploy-sentry-gate.yml
+tech-stack:
+  added: []
+  patterns:
+    - "GitHub Actions pinned to immutable commit SHA + trailing # vX.Y.Z Dependabot anchor"
+    - "Vitest filesystem drift guard (readdirSync + readFileSync + regex)"
+key-files:
+  created:
+    - src/lib/__tests__/workflow-pins.test.ts
+  modified:
+    - .github/workflows/ci-cd.yml
+    - .github/workflows/rls-security-tests.yml
+    - .github/workflows/claude.yml
+    - .github/workflows/codeql.yml
+    - .github/workflows/gitleaks.yml
+    - .github/workflows/post-deploy-sentry-gate.yml
+decisions:
+  - "Pin first-party actions/* + github/codeql-action/* uniformly (zero-cost, removes the trusted-or-not judgment) per the locked decision"
+  - "gitleaks stays on the v2 SHA — no silent v3 jump; let Dependabot propose v3 separately"
+  - "github/codeql-action pinned to SHA for uniformity (option a) rather than tracking @v3"
+metrics:
+  duration: ~12m
+  completed: 2026-06-04
+requirements: [CISEC-04]
+---
+
+# Phase 1 Plan 04: SHA-pin GitHub Actions (CISEC-04) Summary
+
+Pinned every `uses:` across the six `.github/workflows/*.yml` files to an immutable 40-char commit SHA with a trailing `# vX.Y.Z` Dependabot anchor, and added a Vitest drift guard that fails on any non-SHA `uses:` — defeating action-tag repointing supply-chain attacks.
+
+## What Was Built
+
+**Task 1 — SHA-pin every `uses:`** (`c4d6ce8`)
+Re-resolved each action tag to its dereferenced commit SHA at execution time (live GitHub API, annotated tags `gitleaks@v2`, `claude-code-action@v1`, `codeql-action@v3` dereferenced through the tag object to the underlying commit). All re-resolved SHAs matched the RESEARCH §CISEC-04 table — no drift since 2026-06-04. 18 `uses:` lines pinned across 6 files (19 total including the pre-existing `dependabot/fetch-metadata` pin, left untouched):
+
+| Action | SHA | Version | Owner |
+|--------|-----|---------|-------|
+| anthropics/claude-code-action | `70a6e525…` | v1.0.135 | third-party (id-token: write — highest blast radius) |
+| oven-sh/setup-bun | `0c5077e5…` | v2.2.0 | third-party |
+| gitleaks/gitleaks-action | `ff98106e…` | v2.3.9 | third-party (stays v2) |
+| actions/checkout | `df4cb1c0…` | v6.0.3 | first-party |
+| actions/setup-node | `48b55a01…` | v6.4.0 | first-party |
+| actions/upload-artifact | `043fb46d…` | v7.0.1 | first-party |
+| github/codeql-action/{init,analyze} | `dd903d2e…` | v3 | first-party |
+
+`ci-cd-doc-only.yml` confirmed to have zero `uses:` lines (nothing to pin). `dependabot/fetch-metadata@25dd0e34… # v3.1.0` left as-is (already correctly pinned).
+
+**Task 2 — drift-guard test** (`28cb9a2c6`)
+`src/lib/__tests__/workflow-pins.test.ts` (102 lines): enumerates `.github/workflows/*.yml`, extracts every `uses:` line, and runs two assertions — (a) every third-party action (owner ∉ {actions, github}) MUST be a 40-hex SHA, (b) the stricter uniform check that EVERY `uses:` is a 40-hex SHA. Violations are reported as `file:line → ref` strings so a regression is actionable. Skips blank/comment lines and local/composite (`./`, `docker://`) refs. No `any` — parsed entries typed via an explicit `UsesEntry` interface. Runs in the `unit`/`checks` gate via the `src/**` glob.
+
+## Verification
+
+- `grep -rn "uses:" .github/workflows/ | grep -vE "@[0-9a-f]{40}"` (excl. ci-cd-doc-only) → nothing. PASS.
+- `grep -rE "uses: (oven-sh|gitleaks|anthropics)/" … | grep -vE "@[0-9a-f]{40}"` → nothing. PASS.
+- gitleaks v2 SHA count in gitleaks.yml === 1. PASS.
+- claude OIDC action SHA count in claude.yml === 1. PASS.
+- All 8 workflow files parse as valid YAML (`ruby -ryaml YAML.load_file`). PASS.
+- `bunx vitest --run --project unit src/lib/__tests__/workflow-pins.test.ts` → 3 tests passed. PASS.
+- Red-on-revert verified: temporarily reverting the gitleaks pin to `@v2` turned both assertions red with the actionable `gitleaks.yml:32 → gitleaks/gitleaks-action@v2` message, then restored. PASS.
+- `bunx tsc --noEmit` → exit 0. PASS.
+- lefthook pre-commit gate (gitleaks, lockfile, lint, typecheck, unit-tests) ran green on both commits — NEVER `--no-verify`.
+
+## Deviations from Plan
+
+None affecting scope. Two execution-mechanics notes:
+
+1. **[Rule 3 — blocking] `bun run test:unit -- --run <file>` double-injects `--run`.** The `test:unit` npm script already passes `--run`, so the plan's literal command crashed with `Expected a single value for option "--run"`. Used the plan's alternative form `bunx vitest --run --project unit <file>` instead. Test outcome unaffected.
+2. **`bun run validate:quick` fails to launch in this environment** — the chained `bun run typecheck && bun run lint && bun run test:unit` script resolves `bun` as a missing CJS module path under the bundled-node prelude (a `pkg`/node interop quirk, unrelated to the changes). Each constituent gate was verified independently green: lefthook pre-commit (typecheck + lint + unit-tests) on both commits, plus `bunx tsc --noEmit` exit 0 and the targeted drift-guard test passing. No code-level issue.
+3. **commitlint subject-case** rejected the first Task-1 subject ("SHA-pin…" read as upper-case); reworded to "pin every GitHub Actions uses to commit SHA". Lowercase-start subject, no content change.
+
+## Threat Surface
+
+No new security surface introduced — this plan removes surface (mutable tag → immutable SHA). Threat register dispositions T-01-08/09/10 (`mitigate`) all satisfied: the OIDC `claude-code-action`, all other third-party actions, and first-party actions are now SHA-pinned.
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+- src/lib/__tests__/workflow-pins.test.ts — FOUND
+- .github/workflows/{ci-cd,rls-security-tests,claude,codeql,gitleaks,post-deploy-sentry-gate}.yml — all modified, FOUND
+- Commit c4d6ce8 (Task 1) — FOUND
+- Commit 28cb9a2c6 (Task 2) — FOUND

--- a/.planning/phases/01-security-ci-hardening/01-RESEARCH.md
+++ b/.planning/phases/01-security-ci-hardening/01-RESEARCH.md
@@ -1,0 +1,521 @@
+# Phase 1: Security-CI Hardening - Research
+
+**Researched:** 2026-06-04
+**Domain:** CI supply-chain hardening, Next.js 16 CSP, Deno Edge Function security, GitHub Actions pinning
+**Confidence:** HIGH (all four requirements verified against current source + official docs + live GitHub API)
+
+## Summary
+
+Phase 1 closes four independent hardening gaps surfaced by the 2026-05-29 audit. None requires a new npm/Deno package — every fix is pure code/config against already-installed tooling (`stripe@22.1.1`, `vitest@4.1.6`, Next 16.2.6, Deno Web Crypto). The work splits cleanly: one CI/test gate (CISEC-01), one frontend security-header change (CISEC-02), one one-line Edge Function fix (CISEC-03), and a mechanical workflow-pinning sweep (CISEC-04).
+
+The two non-trivial items are CISEC-01 and CISEC-02. For **CISEC-01**, the decisive finding is that the Node `stripe` SDK already installed in `package.json` exposes `stripe.webhooks.generateTestHeaderString()` and `stripe.webhooks.constructEvent()` — `[VERIFIED: node -e require('stripe')]`. This makes the Stripe-webhook signature path **unit-testable in isolation in Vitest** with zero server, zero prod secrets, and zero `supabase functions serve` — so the security-critical assertion can run inside the already-green `unit`/`checks` gate. For **CISEC-02**, the canonical Next 16 nonce pattern is documented and matches the repo's `proxy.ts`, but nonce-based CSP **forces every page into dynamic rendering** — a direct conflict with the dozens of statically-generated marketing/blog pages this SEO-sensitive app depends on. That tradeoff is the central risk of the phase and must be a locked decision before planning.
+
+**Primary recommendation:** CISEC-01 → port the Stripe signature assertions to a Vitest unit test (option B). CISEC-02 → adopt the Next-16 proxy nonce pattern but **scope it to authenticated/dynamic routes only**, or accept full-dynamic with explicit owner sign-off (locked decision required). CISEC-03 → introduce one `_shared/timing-safe.ts` helper and replace the `!==` compare. CISEC-04 → pin all third-party actions to the commit SHAs resolved below.
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Stripe-webhook signature verification | API / Edge Function | CI (test gate) | Signature check runs in the Deno Edge Function; the *assertion* runs in Vitest CI |
+| Constant-time secret compare | API / Edge Function | — | Hook-secret check is server-to-server inside `auth-email-send` |
+| CSP nonce generation | Frontend Server (proxy) | CDN/static headers | Per-request nonce must be generated in `proxy.ts` at request time; the static fallback header lives in `vercel.json` |
+| GitHub Actions pinning | CI / build infra | — | Workflow files are CI-only; never ship to prod artifacts |
+
+## User Constraints
+
+> No CONTEXT.md exists for this phase yet (`/gsd:discuss-phase 1` not run). The constraints below are extracted from CLAUDE.md + REQUIREMENTS.md "Out of Scope" and are treated with locked-decision authority.
+
+### Project Constraints (from CLAUDE.md)
+- **No `--no-verify`** ever. All commits pass lefthook (gitleaks, lint, typecheck, unit-tests).
+- **Perfect-PR merge gate**: two consecutive zero-finding review cycles. Not "passing CI".
+- **Never push to main**: feature branch → push → `gh pr create`; owner reviews + merges.
+- **Never change repo settings / branch protection / secrets** without explicit per-change permission (`feedback_never_change_repo_settings`). This rules out the "enable GitHub secret-scanning toggle" approach — code-PR solutions only.
+- **Edge Functions**: Deno runtime, `_shared/` utilities, `validateEnv` inside the handler, `errorResponse()` never leaks `err.message`.
+- **CSP enforced via `vercel.json`** (current home of the header).
+- **No `any`**, no barrel files, no `as unknown as` at RPC boundaries (not in scope here but the timing-safe helper must respect it).
+- Every change keeps `checks` / `e2e-smoke` / `rls-security` green.
+
+### Out of Scope (from REQUIREMENTS.md — do NOT re-do)
+- CodeQL SAST + gitleaks CI secret-scanning — **already shipped via PR #781** (`codeql.yml` + `gitleaks.yml` exist on disk). CISEC-04 only *pins* their actions; it does not add the workflows.
+- Enabling GitHub secret-scanning / push-protection / CodeQL default-setup / branch-protection required-checks — repo-settings toggles, owner's action.
+- `auth_leaked_password_protection` — paid feature, intentionally disabled.
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| CISEC-01 | Stripe-webhook signature verification runs in CI as a hard gate | §CISEC-01 — Stripe SDK `generateTestHeaderString` enables a pure Vitest unit test in the `checks` gate |
+| CISEC-02 | CSP serves per-request nonce + `strict-dynamic`; `unsafe-inline` removed | §CISEC-02 — Next-16 proxy nonce pattern; dynamic-rendering tradeoff documented |
+| CISEC-03 | `auth-email-send` compares hook secret in constant time | §CISEC-03 — exact `timingSafeEqual` replacement + new `_shared/timing-safe.ts` |
+| CISEC-04 | All third-party GitHub Actions pinned to commit SHAs | §CISEC-04 — every `uses:` enumerated with resolved SHA |
+
+---
+
+## CISEC-01 — Stripe-webhook signature test gate in CI
+
+### Current State
+
+The Stripe webhook function delegates 100% of signature verification to the Stripe SDK — it owns no hand-rolled crypto:
+
+`supabase/functions/stripe-webhooks/index.ts:70-97`
+```ts
+const body = await req.text();
+let event: Stripe.Event;
+try {
+    event = await stripe.webhooks.constructEventAsync(
+        body, signature, env.STRIPE_WEBHOOK_SECRET,
+    );
+} catch (err) {
+    captureWebhookError(err, { action: "verify_signature", reason: "verification_failed", ... });
+    return new Response(JSON.stringify({ error: "Webhook signature verification failed" }),
+        { status: 400, ... });
+}
+```
+
+The existing test `supabase/functions/tests/stripe-webhooks-test.ts` is a **Deno integration test** that calls `client.functions.invoke("stripe-webhooks", ...)` — it requires a served function and is asserted loosely (`error !== null || data !== null`). Header comment line 13: *"Requires: local Supabase instance (`supabase functions serve`)"*. `[VERIFIED: file read]` This suite runs in **zero workflows** today (audit §4 tests). `grep "uses:" .github/workflows/` confirms no `deno test` step exists. `[VERIFIED: grep]`
+
+**Decisive capability finding** — the Node `stripe` SDK already in `package.json` (`stripe@22.1.1`) exposes the test-signing API:
+```
+$ node -e "const s=new (require('stripe'))('sk_test_x'); console.log(typeof s.webhooks.generateTestHeaderString, typeof s.webhooks.constructEvent)"
+function function
+```
+`[VERIFIED: node -e require('stripe')]` The Deno function uses `stripe@20` (`deno.json`); the Node SDK's signature algorithm (HMAC-SHA256 over `${timestamp}.${payload}`, the `t=...,v1=...` scheme) is identical and stable across both major versions — the same Stripe webhook protocol. `[CITED: stripe.com/docs/webhooks/signatures]`
+
+### Recommended Approach: Option B — port signature assertions to Vitest
+
+**Write a pure Vitest unit test** at `src/lib/__tests__/stripe-webhook-signature.test.ts` (the `unit` vitest project globs `src/**/*.test.ts`, runs in the `checks` gate). The test imports the Node `stripe` SDK, signs a payload with a throwaway test secret via `generateTestHeaderString`, and asserts `constructEvent` (a) **accepts** a correctly-signed payload, (b) **rejects** a tampered body, (c) **rejects** a wrong secret, (d) **rejects** a stale timestamp outside tolerance. This pins the exact security contract the Edge Function relies on, runs in <50ms with no network, no secrets, no server.
+
+**Rationale (why B over A):**
+- **Lower CI risk.** Option A (a `deno test` job wired to `supabase functions serve` + injected secrets) requires booting the Supabase CLI runtime in CI, mirroring `STRIPE_WEBHOOK_SECRET`/`SUPABASE_*` into the Actions scope, and tolerating serve-startup flakiness. The existing integration test asserts only "responded without crashing" — it cannot assert a *valid* signature is accepted because no test can mint a real Stripe signature against the prod secret. Option A therefore gates the *reject* path but never the *accept* path.
+- **Gates the full contract.** Because `generateTestHeaderString` lets us mint a valid signature locally, the Vitest test gates BOTH accept and reject — strictly more coverage than A.
+- **Already-green gate.** Lands in `checks` (PR-required), no new secrets, no new job, no Dependabot-scope mirroring.
+- **No new dependency.** `stripe` and `vitest` are already installed. `[VERIFIED: package.json]`
+
+**Rejected alternative (Option A):** A `deno test` CI job. Higher complexity (CLI serve in CI), higher flakiness, more secrets to mirror, and weaker assertions (reject-only). Keep the existing Deno integration test as a local/manual smoke test (it still documents the deployed-function behavior) but do **not** make it the CI gate. *Optionally* the planner may add a non-blocking `deno test` job later — out of scope for closing CISEC-01.
+
+### Concrete Implementation Steps
+1. Create `src/lib/__tests__/stripe-webhook-signature.test.ts`.
+2. `import Stripe from "stripe"` (Node SDK already a dep).
+3. In the test: `const secret = "whsec_test_" + "x".repeat(24); const stripe = new Stripe("sk_test_x");`
+4. Build a minimal event JSON string; `const header = stripe.webhooks.generateTestHeaderString({ payload, secret });`
+5. Assert `stripe.webhooks.constructEvent(payload, header, secret)` returns the parsed event (accept path).
+6. Assert `constructEvent(payload + " ", header, secret)` throws (tampered body).
+7. Assert `constructEvent(payload, header, "whsec_wrong")` throws (wrong secret).
+8. Assert a header built with `timestamp: Math.floor(Date.now()/1000) - 10_000` is rejected when passing `tolerance` (stale timestamp).
+9. Add a short comment linking the test to `stripe-webhooks/index.ts:73` so a future reader knows it guards the Edge Function's verification contract.
+
+### Gotchas / Landmines
+- **Async vs sync.** The Edge Function uses `constructEventAsync` (Deno needs the async/Web Crypto variant); the Node test can use the sync `constructEvent` — both implement the same scheme. Note this in a comment so nobody "fixes" the test to match.
+- **`generateTestHeaderString` is a real SDK method**, not a mock — it produces a genuine HMAC. Don't hand-roll the `t=...,v1=...` string; that re-introduces the exact bug class the test guards against.
+- **Don't import the Deno function file** into the Vitest test — it imports `npm:`/`jsr:` specifiers Vite can't resolve. Test the *SDK contract*, which is what the function depends on.
+- **`exactOptionalPropertyTypes`** is on — `generateTestHeaderString` options are all required-or-omitted; pass a fully-populated options object.
+
+### Validation Architecture (CISEC-01)
+- **Test command:** `bun run test:unit -- --run src/lib/__tests__/stripe-webhook-signature.test.ts`
+- **CI gate:** runs inside `checks` (the `unit` vitest project) on every PR — already required by branch protection.
+- **Grep assertion (regression guard):** the file's existence + the four assertions ARE the gate; no extra grep needed.
+
+### Risk Note
+**LOW.** Self-contained new test file, no production code touched, no new dependency, no new CI secret. Worst case is a flaky-free deterministic unit test. The only judgment call (keep vs. delete the Deno integration test) is non-blocking — recommend *keep* as documentation.
+
+---
+
+## CISEC-02 — CSP per-request nonce + strict-dynamic, drop unsafe-inline
+
+### Current State
+
+CSP lives in `vercel.json` (a static response header), with `'unsafe-inline'` on both `script-src` and `style-src`:
+
+`vercel.json:100-103`
+```json
+{
+  "key": "Content-Security-Policy",
+  "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' *.supabase.co *.sentry.io *.stripe.com; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+}
+```
+`[VERIFIED: file read]` `proxy.ts` currently sets **no** CSP header — it only does auth/subscription gating. `[VERIFIED: file read]`
+
+**Every inline-script source that `'unsafe-inline'` currently covers** `[VERIFIED: grep + file reads]`:
+| Inline script source | File | How it gets a nonce under strict-dynamic |
+|----------------------|------|------------------------------------------|
+| Next.js framework hydration (`self.__next_f.push(...)`) | framework-injected | Next.js auto-attaches the nonce when it parses `'nonce-…'` from the request CSP header (no manual work) — but only on **dynamically rendered** pages |
+| `next-themes` no-flash inline `<script>` | `src/providers/theme-provider.tsx` (uses `next-themes@0.4.6`) | `next-themes` injects an inline script; relies on `'strict-dynamic'` trust OR the `nonce` prop (see gotchas) |
+| JSON-LD `<script type="application/ld+json">` (×2 renderers, 8+ pages) | `src/components/seo/json-ld-script.tsx:26`, `src/components/seo/seo-json-ld.tsx` | **`type="application/ld+json"` is data, not executable JS — CSP `script-src` does NOT block it.** No nonce needed (see gotchas) |
+| Vercel Analytics + Speed Insights | `src/app/layout.tsx:113-118` (`@vercel/analytics`, `@vercel/speed-insights`) | Loaded as external `<script src>` from Vercel's injected runtime; covered by `'strict-dynamic'` once the bootstrap is nonced, plus `connect-src` for the beacon |
+| Sentry tunnel `/monitoring` + SDK | `next.config.ts:140` (`tunnelRoute`), `@sentry/nextjs@10` | Tunnel is a same-origin POST endpoint (already in `connect-src 'self'`); the SDK loads via Next bundles covered by strict-dynamic |
+
+There is **no** `next/script` usage and **no** Google Tag Manager / Partytown in the tree. `[VERIFIED: grep "from \"next/script\"" → empty]`
+
+### Recommended Approach: Next-16 proxy nonce pattern, dynamic-route-scoped
+
+The canonical Next.js 16 pattern (docs version 16.2.7, matching `next@16.2.6`) generates the nonce in `proxy.ts`, forwards it via an `x-nonce` request header AND sets the `Content-Security-Policy` response header per request. Next.js auto-applies the nonce to framework + page bundles during SSR. `[CITED: nextjs.org/docs/app/guides/content-security-policy]`
+
+**Canonical proxy snippet (adapt into the existing `proxy.ts`):**
+```ts
+// Source: nextjs.org/docs/app/guides/content-security-policy (v16.2.7)
+const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+const isDev = process.env.NODE_ENV === "development";
+const csp = `
+  default-src 'self';
+  script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""};
+  style-src 'self' ${isDev ? "'unsafe-inline'" : `'nonce-${nonce}'`};
+  img-src 'self' data: blob:;
+  connect-src 'self' *.supabase.co *.sentry.io *.stripe.com;
+  font-src 'self';
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+`.replace(/\s{2,}/g, " ").trim();
+
+const requestHeaders = new Headers(request.headers);
+requestHeaders.set("x-nonce", nonce);
+requestHeaders.set("Content-Security-Policy", csp);
+// existing updateSession()/gate logic uses NextResponse.next({ request: { headers: requestHeaders } })
+response.headers.set("Content-Security-Policy", csp);
+```
+
+**THE central tradeoff (locked-decision territory):** Per the official docs, *"When you use nonces in your CSP, **all pages must be dynamically rendered**… Static optimization and ISR are disabled… Pages cannot be cached by CDNs."* `[CITED: nextjs.org CSP guide]` This app is **SEO-sensitive** with many statically-generated marketing/blog pages (`MEMORY.md`: SEO recovery, sitemap honesty, static blog rendering). Forcing every page dynamic would regress crawl performance and hosting cost.
+
+**Recommended resolution (pick ONE — needs owner decision in discuss-phase):**
+1. **Scope nonce CSP to dynamic/authenticated routes** (the existing `PRIVATE_ROUTE_PREFIXES` set in `proxy.ts`) and keep a strict static header (no `unsafe-inline`, hash-based or `'self'`-only) in `vercel.json` for static marketing pages. Best balance: removes `unsafe-inline` from the high-value authenticated surface without de-optimizing SEO pages. **Recommended.**
+2. **Full-dynamic everywhere** — simplest header logic, but accepts the SEO/perf/cost regression. Only if owner explicitly accepts.
+3. **Experimental SRI** (`experimental.sri.algorithm`) — keeps static generation, hash-pins scripts, no nonce. But it's flagged experimental + App-Router-only and doesn't cover the `next-themes` inline script. Higher uncertainty; **rejected for now**.
+
+**Rejected alternative:** Generating the nonce in `vercel.json` — impossible; `vercel.json` headers are static strings with no per-request execution. The nonce MUST come from `proxy.ts`. The `vercel.json` CSP becomes either a static-page fallback (option 1) or is removed entirely (option 2).
+
+### Concrete Implementation Steps
+1. **Decide scope** (option 1 vs 2) in discuss-phase — this gates everything below.
+2. Add nonce generation + CSP header set to `proxy.ts`. Reconcile the `config.matcher` (current matcher already excludes `_next/static`, `_next/image`, `favicon.ico`, `monitoring`, `api/` — close to the docs' recommended matcher; verify prefetch-skip is desired).
+3. Remove `'unsafe-inline'` from `script-src` in `vercel.json` (and from `style-src` — but verify Tailwind/inline-style needs; the app forbids inline styles per CLAUDE.md rule #5, so `style-src 'self'` + nonce should hold).
+4. For `next-themes`: confirm whether `'strict-dynamic'` trust covers its injected script, or thread `nonce` via `headers()` into the provider. Test the no-flash behavior in dark mode (MEMORY notes `bg-white` breaks dark mode — a CSP-blocked theme script would flash light).
+5. If option 1: keep a hardened static CSP in `vercel.json` for non-private routes; ensure the two don't both emit (proxy header wins on dynamic routes).
+6. Add a regression test (see Validation Architecture).
+7. **Browser-verify** in a real deploy: open dashboard + a marketing page, check DevTools console for zero CSP violations, confirm Vercel Analytics beacon + Sentry tunnel still fire (`connect-src`).
+
+### Gotchas / Landmines
+- **JSON-LD is NOT blocked by `script-src`.** `<script type="application/ld+json">` is parsed as data, never executed, so CSP `script-src` does not apply. **Do not** add a nonce to the JSON-LD renderers — it's unnecessary and the existing `.replace(/</g, "\\u003c")` XSS-escaping is the correct guard. `[CITED: MDN CSP script-src — type-restricted scripts]` Confirm in a browser to refute the temptation to "nonce everything."
+- **Nonce forces dynamic rendering.** This is the #1 landmine — static blog/marketing pages will break or silently become dynamic. Pages that read `headers()` for the nonce become dynamic; pages that don't but are served with a per-request nonce CSP can still hit a build/runtime mismatch. The Next docs warn: pages "build successfully but may encounter runtime errors if not properly configured." `[CITED: nextjs.org CSP guide]`
+- **`'strict-dynamic'` ignores `'self'` and host-allowlists in `script-src`.** Once `strict-dynamic` is present, the browser ignores `'self'` and any `https://…` host in `script-src` — only nonced/hashed scripts and their descendants load. Keep host-allowlists in `connect-src`/`img-src`, not `script-src`. `[CITED: WebSearch verified w/ MDN + Next docs]`
+- **Sentry tunnel** (`/monitoring`) is same-origin POST → already covered by `connect-src 'self'`. No `script-src` change needed for it. `[VERIFIED: next.config.ts tunnelRoute]`
+- **Next.js App Router cannot manually nonce its hydration scripts** — `strict-dynamic` is the *only* supported way to trust them (no `_document.tsx` in App Router). `[CITED: vercel/next.js discussion #81703]` So `strict-dynamic` is mandatory, not optional.
+- **`'unsafe-eval'` only in dev** (React's eval-based debugging). Production must not include it. `[CITED: nextjs.org CSP guide]`
+- **PPR / cacheComponents incompatible with nonce.** The repo does NOT currently enable PPR or `cacheComponents` (`next.config.ts` has only `reactCompiler: true` + `optimizePackageImports`) `[VERIFIED: file read]`, so this is latent — but a future PPR adoption would conflict. Document it.
+
+### Validation Architecture (CISEC-02)
+- **Grep assertion (regression guard):** a test asserting `vercel.json`'s `script-src` no longer contains `'unsafe-inline'`:
+  `grep -q "unsafe-inline" vercel.json && echo FAIL` — wire into a vitest test that `readFileSync`s `vercel.json` and asserts `!csp.includes("'unsafe-inline'")` for `script-src`.
+- **Proxy unit test:** a vitest test that invokes the `proxy()` (or the nonce helper) and asserts the response carries a `Content-Security-Policy` header containing `'nonce-` and `'strict-dynamic'` and NOT `'unsafe-inline'` in `script-src`.
+- **E2E check:** the existing `owner-axe` Playwright project loads the dashboard; extend a smoke assertion that the response CSP header contains a nonce (or add a console-error assertion that no CSP violation fires).
+- **Manual browser verify:** DevTools console clean on dashboard + one marketing page post-deploy.
+
+### Risk Note
+**MEDIUM-HIGH.** The dynamic-rendering tradeoff can regress SEO/perf if applied app-wide without scoping. Mitigation: option-1 scoping + browser verification + the `owner-axe` E2E gate. This requires a locked owner decision before planning. The `next-themes` no-flash script and Vercel Analytics beacon are the two things most likely to break silently — both must be browser-verified, not just assumed-covered by `strict-dynamic`.
+
+---
+
+## CISEC-03 — Constant-time hook-secret compare in auth-email-send
+
+### Current State
+
+`supabase/functions/auth-email-send/index.ts:78-89`
+```ts
+const hookSecret = env["SUPABASE_AUTH_HOOK_SECRET"];
+const authHeader = req.headers.get("authorization") ?? "";
+const token = authHeader.replace(/^Bearer\s+/i, "");
+if (token !== hookSecret) {            // ← non-constant-time string compare (timing side-channel)
+    captureWebhookError(new Error("Unauthorized: invalid hook secret"), { ... });
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401, headers: jsonHeaders });
+}
+```
+`[VERIFIED: file read]` This is the lone `!==` secret compare; every other webhook uses a constant-time path. `[VERIFIED: grep]`
+
+**Existing constant-time patterns (three inlined copies, NO shared `_shared/` helper):** `[VERIFIED: grep]`
+- `resend-webhook/index.ts:145-168` — `crypto.subtle.timingSafeEqual` with an XOR fallback for runtimes lacking it (compares HMAC base64 strings).
+- `docuseal-webhook/index.ts:295-301` — length-check then `crypto.subtle.timingSafeEqual` (compares hex HMAC strings).
+- `n8n-blog-ingest/index.ts:131-150` (`verifyHmac`) — length-check then manual XOR loop.
+
+**Key distinction:** the other three compare an attacker-supplied **HMAC digest** against a **computed digest**. `auth-email-send` compares two **raw secret strings** directly (no HMAC). So it needs a plain constant-time byte compare of `token` vs `hookSecret`, not the HMAC machinery.
+
+### Recommended Approach: extract one `_shared/timing-safe.ts`, use it here
+
+Create `supabase/functions/_shared/timing-safe.ts` with a single exported `timingSafeEqualStr(a: string, b: string): boolean` that does a length-check (intentional early return on length mismatch is acceptable — secret length is not itself secret) then `crypto.subtle.timingSafeEqual` with the proven XOR fallback (lifted verbatim from `resend-webhook`). Then replace the `auth-email-send` compare:
+
+```ts
+// supabase/functions/_shared/timing-safe.ts
+export function timingSafeEqualStr(a: string, b: string): boolean {
+    const enc = new TextEncoder();
+    const ab = enc.encode(a);
+    const bb = enc.encode(b);
+    if (ab.length !== bb.length) return false;
+    const subtle = crypto.subtle as unknown as {
+        timingSafeEqual?: (x: Uint8Array, y: Uint8Array) => boolean;
+    };
+    if (typeof subtle.timingSafeEqual === "function") {
+        try { return subtle.timingSafeEqual(ab, bb); } catch { /* fall through */ }
+    }
+    let d = 0;
+    for (let i = 0; i < ab.length; i++) d |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+    return d === 0;
+}
+```
+```ts
+// auth-email-send/index.ts — replace line 81
+import { timingSafeEqualStr } from "../_shared/timing-safe.ts";
+// ...
+if (!timingSafeEqualStr(token, hookSecret)) { /* unchanged 401 path */ }
+```
+
+**Rationale:** The audit explicitly recommends *"Reuse the resend-webhook XOR-fallback helper."* Three functions already inline the same pattern — extracting one helper closes CISEC-03 AND removes the triplication (matches CLAUDE.md "no duplicate" ethos). The XOR fallback keeps Deno-runtime portability if `crypto.subtle.timingSafeEqual` is unavailable. **The `as unknown as` here is a runtime-feature-detection shim, not an RPC boundary** — it matches the existing pattern in `resend-webhook:151` and is NOT a CLAUDE.md rule #8 violation (rule #8 scopes to PostgREST/RPC return casts).
+
+**Rejected alternative:** A one-line inline fix in `auth-email-send` only (no shared helper). Closes CISEC-03 but leaves three duplicated copies and adds a fourth — worse hygiene. The shared helper is barely more work and is the audit's intent.
+
+### Concrete Implementation Steps
+1. Create `supabase/functions/_shared/timing-safe.ts` with `timingSafeEqualStr`.
+2. Replace `auth-email-send/index.ts:81` `token !== hookSecret` → `!timingSafeEqualStr(token, hookSecret)`; add the import.
+3. *(Optional, in-scope cleanup)* refactor `resend-webhook`/`docuseal-webhook`/`n8n-blog-ingest` to import the shared helper — but those compare HMAC digests, so only if the helper also fits their string-compare shape; otherwise leave them and note the follow-up. **Recommend: scope CISEC-03 to `auth-email-send` + the new helper; defer the other three refactors** to avoid widening the PR.
+4. Deploy the Edge Function out-of-band post-merge (`bun scripts/deploy-edge-functions.ts`) — there is no CI deploy step for Edge Functions (`MEMORY.md`).
+
+### Gotchas / Landmines
+- **Length early-return is fine.** Returning early on length mismatch leaks only that the lengths differ, not the secret bytes. All three existing helpers do this. Don't over-engineer a length-padding scheme.
+- **Don't HMAC the token.** `auth-email-send` compares the raw shared secret, not a signature. Adding HMAC would change the auth contract and break the Supabase Auth Hook config.
+- **Deno Web Crypto `timingSafeEqual`** is available in current Deno runtimes but the XOR fallback is the portability guarantee — keep it. `[VERIFIED: resend-webhook uses the same guard in prod]`
+- **No test exists for `auth-email-send`** (`ls supabase/functions/tests/ | grep auth` → none) `[VERIFIED]`. The helper itself is trivially unit-testable in Vitest (it's pure TS — but it's a Deno-path `.ts` importing nothing Deno-specific except `crypto`, which Node also has). Consider a Vitest test for `timingSafeEqualStr` (equal → true, unequal-same-length → false, different-length → false).
+
+### Validation Architecture (CISEC-03)
+- **Grep assertion (regression guard):** `grep -n "token !== hookSecret" supabase/functions/auth-email-send/index.ts` must return nothing after the fix. Wire into a vitest `readFileSync` test that asserts the file imports `timingSafeEqualStr` and does NOT contain `!== hookSecret`.
+- **Unit test:** `bun run test:unit -- --run` on a new `timing-safe` test (equal/unequal/length-mismatch cases). Runs in `checks`.
+- **Deno test (optional/local):** add to `supabase/functions/tests/` if a fuller Edge Function test is desired (not the CI gate).
+
+### Risk Note
+**LOW.** One-line behavioral-equivalent swap (rejects the same inputs, in constant time) plus a pure new helper. The only operational step is the manual Edge Function redeploy post-merge — a known, documented dance.
+
+---
+
+## CISEC-04 — SHA-pin all third-party GitHub Actions
+
+### Current State
+
+`grep "uses:" .github/workflows/*` — full enumeration `[VERIFIED: grep + live GitHub API resolution 2026-06-04]`:
+
+| Action (current ref) | File(s) | Owner | Resolve-to SHA (pin target) | Notes |
+|----------------------|---------|-------|-----------------------------|-------|
+| `oven-sh/setup-bun@v2` | ci-cd.yml:43,142; rls-security-tests.yml:89 | **third-party** | `0c5077e51419868618aeaa5fe8019c62421857d6` # v2.2.0 | **must pin** |
+| `gitleaks/gitleaks-action@v2` | gitleaks.yml:32 | **third-party** | `ff98106e4c7b2bc287b24eaf42907196329070c7` # v2.3.9 | **must pin** (v2 tag → annotated tag → this commit) |
+| `anthropics/claude-code-action@v1` | claude.yml:37 | **third-party** (runs `id-token: write`) | `70a6e5256e9e2366a1ed5c041904a982ba3a328f` # v1 (v1.0.135) | **must pin** — highest priority (audit called it out: `id-token: write`) |
+| `dependabot/fetch-metadata@25dd0e34…` | dependabot-auto-merge.yml:40 | third-party | already `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` # v3.1.0 | **already pinned** ✅ (comment says v3.1.0; the v3 tag resolves to the same commit) |
+| `actions/checkout@v6` | ci-cd.yml:39,114; rls-security-tests.yml:56; claude.yml:31; codeql.yml:37; gitleaks.yml:24 | GitHub-owned | `df4cb1c069e1874edd31b4311f1884172cec0e10` # v6.0.3 | recommend pin (consistency) |
+| `actions/setup-node@v6` | ci-cd.yml:47,147; rls-security-tests.yml:95 | GitHub-owned | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` # v6.4.0 | recommend pin |
+| `actions/upload-artifact@v7` | ci-cd.yml:172; post-deploy-sentry-gate.yml:393 | GitHub-owned | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` # v7.0.1 | recommend pin |
+| `github/codeql-action/init@v3` | codeql.yml:42 | GitHub-owned | `dd903d2e4f5405488e5ef1422510ee31c8b32357` # v3 (v3 tag→commit) | GitHub recommends keeping `@v3` for CodeQL; see note |
+| `github/codeql-action/analyze@v3` | codeql.yml:47 | GitHub-owned | `dd903d2e4f5405488e5ef1422510ee31c8b32357` # v3 | same as init |
+
+> All SHAs resolved via `gh api repos/<owner>/<repo>/{git/refs/tags,git/tags,tags}` on 2026-06-04. Annotated-tag objects (codeql `v3`, gitleaks `v2`, claude `v1`) were dereferenced to their underlying commit. `[VERIFIED: live GitHub API]`
+
+### Recommended Approach
+
+**Pin every third-party action to its commit SHA with a trailing `# vX.Y.Z` comment** — the format Dependabot understands and bumps. `[CITED: docs.github.com/actions/security-guides/security-hardening-for-github-actions]` Format:
+```yaml
+uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+```
+
+**First-party `actions/*` and `github/codeql-action/*`:** GitHub-owned, lower risk (a compromise of GitHub-owned action repos is a platform-level event). The CodeQL `actions`-language scan (already running in `codeql.yml`) flags *unpinned third-party* actions specifically; GitHub-owned ones are typically not flagged. **Recommendation: pin them too** for a clean, uniform policy and to satisfy the strictest reading of the audit ("All third-party GitHub Actions… pinned"). Pinning `actions/*` costs nothing (Dependabot maintains them via the trailing comment) and removes the "is this one trusted?" judgment call. CodeQL's `actions` scan stays clean either way; pinning guarantees zero findings.
+
+**Special-case `github/codeql-action`:** GitHub's own guidance is to track `@v3` (the major tag) for CodeQL so security-query updates flow automatically; pinning to a SHA freezes the query suite until Dependabot bumps. Two valid options — (a) pin to SHA with comment (uniform policy, Dependabot bumps weekly) or (b) leave `@v3` and document the exception (GitHub-owned + GitHub-recommended). **Recommend (a) for uniformity** but flag (b) as acceptable; the planner/owner can choose.
+
+**Rejected alternative:** Pinning to a *version tag* (`@v2.3.9` instead of the SHA). Tags are mutable — an attacker who compromises the action repo can re-point `v2.3.9` to a malicious commit. Only the immutable SHA defends against tag-repointing. `[CITED: GitHub security-hardening guide]`
+
+### Concrete Implementation Steps
+1. For each `uses:` line in the table, replace `@vX` with `@<sha> # vX.Y.Z`.
+2. Ensure `dependabot.yml` has the `github-actions` ecosystem enabled (it does — `dependabot-auto-merge.yml` exists and auto-merges non-major GHA bumps) so pins stay current.
+3. Keep the existing `dependabot/fetch-metadata` pin as-is (already correct).
+4. Run the `actions` CodeQL scan locally-equivalent: push to a branch, confirm the CodeQL `Analyze (actions)` job is green with zero new findings.
+5. Verify CI still passes (a wrong SHA fails the workflow immediately — that's the test).
+
+### Gotchas / Landmines
+- **Annotated vs lightweight tags.** `codeql-action@v3`, `gitleaks-action@v2`, `claude-code-action@v1` are **annotated tags** — `git/refs/tags/<tag>` returns a tag OBJECT, not a commit. You must dereference (`git/tags/<sha>` → `.object.sha`) to get the COMMIT SHA to pin. Pinning the tag-object SHA would break the workflow. The table above already shows the dereferenced commit SHAs. `[VERIFIED: API dereference]`
+- **`setup-bun@v2` mutable tag currently == v2.2.0** (`0c5077e…`). Pin the SHA, comment `# v2.2.0`. If a `v2.3.0` ships, Dependabot bumps both.
+- **`claude-code-action` is the priority pin** — it requests `id-token: write` (OIDC) and `contents: read`; a compromised mutable tag there is the highest-blast-radius action in the repo. The audit explicitly named it. `[CITED: AUDIT §5]`
+- **`gitleaks-action` v2 vs v3.** v3.0.0 exists (`e0c47f4…`) but `gitleaks.yml` pins `@v2`. **Pin to the v2 SHA the workflow currently resolves (`ff98106…`)** — do NOT silently jump to v3 in the same PR (v3 may change config/behavior; keep the version bump separate). Let Dependabot propose v3 later.
+- **Don't pin `actions/*` to a SHA without the comment** — Dependabot needs the `# vX.Y.Z` trailing comment to recognize and bump the pin.
+
+### Validation Architecture (CISEC-04)
+- **Grep assertion (regression guard):** every third-party `uses:` line must match a 40-hex SHA. A test/script:
+  `grep -rE "uses: (oven-sh|gitleaks|anthropics|dependabot)/" .github/workflows/ | grep -vE "@[0-9a-f]{40}" && echo FAIL` — must return nothing.
+- **CI gate:** the existing `codeql.yml` `Analyze (actions)` matrix job IS the gate — it flags unpinned third-party actions. A clean run after pinning closes the loop. `[VERIFIED: codeql.yml analyzes "actions" language]`
+- **Self-validating:** a wrong/nonexistent SHA fails the workflow on next run.
+
+### Risk Note
+**LOW.** Mechanical text change; the only error mode (wrong SHA) fails loudly and immediately in CI. The one judgment call (pin GitHub-owned `actions/*` + `codeql-action` or not) is a policy preference, not a correctness risk — recommend pinning all for uniformity.
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Stripe signature verify (test) | A hand-built `t=…,v1=…` HMAC string | `stripe.webhooks.generateTestHeaderString()` + `constructEvent()` | Hand-rolling re-introduces the exact bug class; SDK is the source of truth |
+| Constant-time compare | A naive `===` or early-returning loop | `crypto.subtle.timingSafeEqual` + XOR fallback (`_shared/timing-safe.ts`) | Timing side-channels are subtle; reuse the proven `resend-webhook` pattern |
+| CSP nonce propagation | Manually nonce-ing every Next hydration script | `'strict-dynamic'` + Next's auto-nonce on dynamic pages | App Router has no `_document.tsx`; strict-dynamic is the only supported path |
+| Action-version trust | Pinning to `@vX.Y.Z` tags | Immutable commit SHA + `# vX.Y.Z` comment | Tags are mutable and repointable by a repo compromise |
+
+**Key insight:** Three of four requirements close by *reusing an existing pattern already in this repo* (Stripe SDK, the resend-webhook timing-safe path, the dependabot/fetch-metadata SHA pin). The only genuinely new ground is the Next-16 CSP nonce — and even there the framework does the heavy lifting; the risk is the dynamic-rendering tradeoff, not the mechanics.
+
+## Common Pitfalls
+
+### Pitfall 1: Nonce-ing JSON-LD scripts
+**What goes wrong:** Adding a nonce to `<script type="application/ld+json">` because "it's a script tag."
+**Why it happens:** Looks like a script; isn't executed.
+**How to avoid:** CSP `script-src` only governs executable JS. `type="application/ld+json"` is inert data. Leave the existing `<` escaping; add no nonce.
+**Warning signs:** A PR diff that touches `json-ld-script.tsx`/`seo-json-ld.tsx` for CSP reasons.
+
+### Pitfall 2: App-wide nonce CSP silently de-optimizing SEO pages
+**What goes wrong:** Every marketing/blog page becomes dynamic; ISR/CDN caching disabled; crawl perf + hosting cost regress.
+**Why it happens:** Nonce CSP forces dynamic rendering (official docs).
+**How to avoid:** Scope nonce CSP to authenticated/dynamic routes (option 1) OR get explicit owner sign-off for full-dynamic.
+**Warning signs:** Build output shows previously-static routes now `ƒ (Dynamic)`; Vercel function-invocation count jumps.
+
+### Pitfall 3: Pinning an annotated-tag object SHA instead of the commit SHA
+**What goes wrong:** Workflow fails with "unable to resolve action" because the pinned SHA is a tag object, not a commit.
+**Why it happens:** `git/refs/tags/v3` returns a tag object for annotated tags.
+**How to avoid:** Dereference via `git/tags/<sha>` → `.object.sha`. (Table above is pre-dereferenced.)
+**Warning signs:** `gh api …/git/refs/tags/<tag> --jq '.object.type'` returns `tag` not `commit`.
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| `stripe` (Node SDK) | CISEC-01 unit test | ✓ | 22.1.1 | — |
+| `vitest` | CISEC-01/-03 tests | ✓ | 4.1.6 | — |
+| Next.js | CISEC-02 proxy nonce | ✓ | 16.2.6 | — |
+| Deno Web Crypto (`crypto.subtle`) | CISEC-03 | ✓ (runtime) | — | XOR fallback (already in helper) |
+| `gh` CLI / GitHub API | CISEC-04 SHA resolution | ✓ | (resolved this session) | — |
+| `supabase` CLI (functions serve) | only if Option A chosen for CISEC-01 | n/a | — | **Option B avoids it entirely** |
+
+**Missing dependencies with no fallback:** none.
+**Missing dependencies with fallback:** Deno `crypto.subtle.timingSafeEqual` (XOR fallback covers it).
+
+## Package Legitimacy Audit
+
+**No external packages are installed by this phase.** All four requirements use already-present dependencies (`stripe@22.1.1`, `vitest@4.1.6`, `next@16.2.6`, `next-themes@0.4.6`) verified in `package.json`, plus runtime `crypto.subtle` and the `gh` CLI. slopcheck/registry verification is **not applicable** — no `npm install` / `deno add` occurs. The GitHub Actions pinned in CISEC-04 are not npm packages; their authenticity is established by the immutable commit SHAs resolved via the live GitHub API (table in §CISEC-04).
+
+## Validation Architecture (consolidated)
+
+> `workflow.nyquist_validation` not found in `.planning/config.json` lookup — treat as enabled.
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | Vitest 4.1.6 (jsdom unit / node integration), Playwright (E2E) |
+| Config file | `vitest.config.ts` (projects: `unit`, `component`, `integration`) |
+| Quick run command | `bun run test:unit -- --run <file>` |
+| Full suite command | `bun run validate:quick` (typecheck + lint + unit) |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| CISEC-01 | Valid Stripe sig accepted; tampered/wrong-secret/stale rejected | unit | `bun run test:unit -- --run src/lib/__tests__/stripe-webhook-signature.test.ts` | ❌ Wave 0 |
+| CISEC-02 | `vercel.json` script-src has no `'unsafe-inline'`; proxy emits nonce CSP | unit + E2E | `bun run test:unit -- --run src/lib/__tests__/csp-header.test.ts` + `owner-axe` E2E | ❌ Wave 0 |
+| CISEC-03 | `auth-email-send` uses `timingSafeEqualStr`, not `!==` | unit (grep) | `bun run test:unit -- --run supabase/functions/_shared/__tests__/timing-safe.test.ts` | ❌ Wave 0 |
+| CISEC-04 | Every third-party `uses:` is a 40-hex SHA | unit (grep) | vitest `readFileSync` over `.github/workflows/*` + `codeql.yml` actions scan | ❌ Wave 0 |
+
+### Sampling Rate
+- **Per task commit:** the requirement's quick unit command.
+- **Per wave merge:** `bun run validate:quick`.
+- **Phase gate:** full suite green + CodeQL `Analyze (actions)` green before `/gsd:verify-work`.
+
+### Wave 0 Gaps
+- [ ] `src/lib/__tests__/stripe-webhook-signature.test.ts` — CISEC-01
+- [ ] `src/lib/__tests__/csp-header.test.ts` (asserts no `unsafe-inline` in `vercel.json` script-src + proxy nonce) — CISEC-02
+- [ ] `supabase/functions/_shared/timing-safe.ts` + its vitest test — CISEC-03
+- [ ] A workflow-pin grep test (CISEC-04) — small; can live in `src/lib/__tests__/` or a shell assertion in CI.
+- Framework install: none needed (Vitest present).
+
+## Security Domain
+
+> `security_enforcement` not explicitly `false` — included.
+
+### Applicable ASVS Categories
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | yes | Constant-time hook-secret compare (CISEC-03); Stripe signature verify (CISEC-01) |
+| V5 Input Validation | yes | Stripe signature = authenticated input boundary |
+| V6 Cryptography | yes | `crypto.subtle.timingSafeEqual` (never hand-roll); HMAC via Stripe SDK |
+| V14 Configuration | yes | CSP hardening (CISEC-02); SHA-pinned CI supply chain (CISEC-04) |
+
+### Known Threat Patterns for this stack
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Stripe webhook spoofing | Spoofing | SDK signature verification (already present) + CI-gated regression test (CISEC-01) |
+| Timing side-channel on secret compare | Information Disclosure | Constant-time compare (CISEC-03) |
+| Inline-script XSS | Tampering | Nonce + `strict-dynamic`, drop `unsafe-inline` (CISEC-02) |
+| Supply-chain action-tag repointing | Tampering / Elevation | Immutable commit-SHA pins (CISEC-04) |
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | Stripe webhook signature scheme is identical between Node SDK v22 and Deno SDK v20 | CISEC-01 | LOW — same documented `t=,v1=` HMAC-SHA256 protocol; if wrong, the unit test still guards the SDK contract the function uses |
+| A2 | `next-themes@0.4.6` inline no-flash script is trusted by `strict-dynamic` (or accepts a `nonce` prop) | CISEC-02 | MEDIUM — must browser-verify; if neither, a dark-mode flash appears. Needs a real-deploy check |
+| A3 | `style-src 'self'` (no inline) suffices given CLAUDE.md forbids inline styles | CISEC-02 | MEDIUM — verify no library injects inline `<style>`; Tailwind emits a stylesheet, not inline |
+| A4 | GitHub-owned `actions/*` SHAs resolved on 2026-06-04 are current latest | CISEC-04 | LOW — Dependabot will bump; pinning a slightly-older patch is safe |
+| A5 | `nyquist_validation` is enabled (config key not located this session) | Validation | LOW — including the section is the safe default |
+
+## Open Questions
+
+1. **CISEC-02 scope: full-dynamic vs route-scoped nonce CSP?**
+   - What we know: nonce CSP forces dynamic rendering; the app is SEO-sensitive with many static pages.
+   - What's unclear: whether the owner accepts full-dynamic (perf/SEO/cost hit) or wants route-scoping (option 1).
+   - Recommendation: **Lock this in `/gsd:discuss-phase 1` before planning.** Default to route-scoped (option 1).
+
+2. **CISEC-01: keep or delete the existing Deno integration test?**
+   - Recommendation: keep as local/manual documentation; the Vitest test is the CI gate. Non-blocking.
+
+3. **CISEC-04: pin `github/codeql-action` to SHA or keep `@v3`?**
+   - Recommendation: pin for uniformity; `@v3` is an acceptable documented exception (GitHub-recommended for CodeQL query freshness).
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| `unsafe-inline` static CSP | Per-request nonce + `strict-dynamic` in proxy | Next 13.4.20+ proper nonce handling | Removes the largest XSS hole; costs dynamic rendering |
+| `middleware.ts` | `proxy.ts` | Next 16 | Repo already migrated; nonce goes in `proxy.ts` |
+| Mutable action tags | Commit-SHA pins + Dependabot comment | GitHub supply-chain guidance (post-tj-actions/2025 incidents) | Defeats tag-repointing |
+
+**Deprecated/outdated:**
+- Pages-Router `_document.tsx` nonce injection — N/A in App Router; `strict-dynamic` replaces it.
+- Reading the nonce at `next.config` build time — impossible per-request; must be in `proxy.ts`.
+
+## Sources
+
+### Primary (HIGH confidence)
+- Repo source files (read directly): `vercel.json`, `src/proxy.ts`, `src/lib/supabase/middleware.ts`, `supabase/functions/stripe-webhooks/index.ts` (+ test), `supabase/functions/auth-email-send/index.ts`, `supabase/functions/resend-webhook/index.ts`, `supabase/functions/docuseal-webhook/index.ts`, `supabase/functions/n8n-blog-ingest/index.ts`, all `.github/workflows/*.yml`, `next.config.ts`, `src/app/layout.tsx`, `src/components/seo/json-ld-script.tsx`, `src/components/seo/seo-json-ld.tsx`, `src/providers/theme-provider.tsx`, `vitest.config.ts`, `package.json`, `supabase/functions/deno.json`.
+- `nextjs.org/docs/app/guides/content-security-policy` (v16.2.7, lastUpdated 2026-03-20) — canonical nonce + strict-dynamic pattern, dynamic-rendering requirement.
+- Live GitHub API (`gh api`) 2026-06-04 — all CISEC-04 SHA resolutions + annotated-tag dereferences.
+- `node -e require('stripe')` — confirmed `generateTestHeaderString` + `constructEvent` exist in installed SDK.
+
+### Secondary (MEDIUM confidence)
+- `github.com/vercel/next.js/discussions/81703` — App Router cannot manually nonce hydration scripts; `strict-dynamic` is the supported path.
+- MDN CSP `script-src` reference — `type="application/ld+json"` is not executable, not governed by `script-src`.
+
+### Tertiary (LOW confidence)
+- WebSearch general CSP/nonce articles — used only to corroborate the official Next docs.
+
+## Metadata
+
+**Confidence breakdown:**
+- CISEC-01: HIGH — SDK capability verified by direct `node -e`; placement verified against vitest config.
+- CISEC-02: HIGH on the pattern (official current docs match repo version), MEDIUM on the `next-themes`/Vercel-beacon edge cases (need browser verify) and the scope decision (owner call).
+- CISEC-03: HIGH — three existing in-repo patterns; one-line swap.
+- CISEC-04: HIGH — every SHA resolved live this session, annotated tags dereferenced.
+
+**Research date:** 2026-06-04
+**Valid until:** 2026-07-04 (stable) — but CISEC-04 SHAs drift as actions release; re-resolve at plan time if >2 weeks old.
+
+## Sources
+
+- [Next.js Content Security Policy guide](https://nextjs.org/docs/app/guides/content-security-policy)
+- [vercel/next.js discussion #81703 — script-src unsafe-inline in production](https://github.com/vercel/next.js/discussions/81703)
+- [MDN — Content-Security-Policy script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src)
+- [GitHub — Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

--- a/.planning/phases/01-security-ci-hardening/01-VALIDATION.md
+++ b/.planning/phases/01-security-ci-hardening/01-VALIDATION.md
@@ -1,0 +1,81 @@
+---
+phase: 1
+slug: security-ci-hardening
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-06-04
+---
+
+# Phase 1 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+> Source: `01-RESEARCH.md` Validation Architecture sections (CISEC-01..04).
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | Vitest 4 (unit, jsdom/node) + source-grep drift guards + CI workflow checks |
+| **Config file** | `vitest.config.ts` (unit project); `.github/workflows/*.yml` for CI gates |
+| **Quick run command** | `bunx vitest --run --project unit <phase test files>` |
+| **Full suite command** | `bun run validate:quick` (typecheck + lint + unit) |
+| **Estimated runtime** | ~20 s unit; CodeQL `actions` scan ~45 s in CI |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `bunx vitest --run --project unit <touched test files>`
+- **After every plan wave:** Run `bun run validate:quick`
+- **Before `/gsd:verify-work`:** Full suite green + the new CI workflows green on the PR
+- **Max feedback latency:** ~20 s (unit); CI gates confirm on push
+
+---
+
+## Per-Task Verification Map
+
+Requirement-level contract (task IDs assigned by the planner; rows expand per task).
+
+| Requirement | Secure Behavior | Test Type | Automated Command | Notes |
+|-------------|-----------------|-----------|-------------------|-------|
+| CISEC-01 | A tampered Stripe-webhook signature is rejected; a valid one (minted via the `stripe` SDK `generateTestHeaderString`) is accepted | unit | `bunx vitest --run --project unit <webhook-signature test>` | runs in the already-green `checks` gate — no serve/secrets |
+| CISEC-02 | Authenticated routes serve a per-request nonce CSP with `strict-dynamic`; no `script-src 'unsafe-inline'` on those routes; marketing/blog CSP unchanged | unit + manual | `bunx vitest --run <proxy-nonce test>` + grep `vercel.json`/`src/proxy.ts` | deployed-header check is manual (see Manual-Only) |
+| CISEC-03 | `auth-email-send` compares the hook secret in constant time; no `token !== hookSecret` short-circuit remains | unit + grep | `bunx vitest --run <_shared/timing-safe test>` + `grep -n "!== hookSecret" supabase/functions/auth-email-send/index.ts` (expect no match) | shared `_shared/timing-safe.ts` helper |
+| CISEC-04 | Every third-party `uses:` under `.github/workflows/` is a 40-char commit SHA with a version comment; CodeQL `actions` scan clean | grep + CI | drift-guard test asserting no non-SHA third-party `uses:`; CodeQL `Analyze (actions)` green | first-party `actions/*` + `github/codeql-action/*` pinned too (uniform) |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] Webhook-signature Vitest spec (CISEC-01) — new test file asserting accept/reject
+- [ ] `supabase/functions/_shared/timing-safe.ts` + its Vitest/Deno spec (CISEC-03)
+- [ ] Workflow-pin drift-guard test (CISEC-04) — scans `.github/workflows/*.yml` for non-SHA third-party `uses:`
+- [ ] Proxy-nonce unit spec (CISEC-02) — asserts nonce generated + propagated on auth routes
+
+*Existing Vitest + CI infrastructure covers the run harness; only the specs above are new.*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Deployed CSP response header carries the nonce + `strict-dynamic` on an authenticated route, and marketing/blog still serve their static CSP with no console CSP violations | CISEC-02 | Real CSP enforcement + the next-themes/no-flash + Sentry-tunnel script execution can only be confirmed against a deployed response in a browser | After deploy: load `/dashboard` and `/` (marketing), inspect the `Content-Security-Policy` response header, and confirm zero CSP-violation errors in the console on both |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have an `<automated>` verify or a Wave 0 dependency
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references (4 new specs above)
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30 s
+- [ ] `nyquist_compliant: true` set in frontmatter after planner maps tasks
+
+**Approval:** pending

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -19,6 +19,16 @@ export function Providers({
 	children,
 	initialThemeMode = DEFAULT_THEME_MODE,
 }: ProvidersProps) {
+	// CISEC-02 note: next-themes injects a bare inline no-flash <script>.
+	// On private routes (which carry the nonce CSP with 'strict-dynamic')
+	// that script is un-nonced, so it's CSP-blocked → a one-paint flash of
+	// the default theme before React hydrates the correct theme. We do NOT
+	// thread a nonce here because `Providers` renders from the ROOT layout
+	// (shared by static marketing routes); reading the per-request nonce via
+	// `headers()` would force every marketing page dynamic — the exact
+	// regression CISEC-02's route-scoping avoids. Eliminating the private-
+	// route FOUC requires a private-scoped theme provider that reads the
+	// nonce only under the (owner) segment — tracked as a v4.0 follow-up.
 	return (
 		<ThemeProvider
 			attribute="class"

--- a/src/lib/__tests__/csp-header.test.ts
+++ b/src/lib/__tests__/csp-header.test.ts
@@ -8,8 +8,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  * CISEC-02 regression guard. Pins two things that would silently
  * regress the security fix:
  *
- *  1. `vercel.json`'s static `script-src` never reintroduces
- *     `'unsafe-inline'` (the marketing/static-route fallback CSP).
+ *  1. `vercel.json`'s static `script-src` RETAINS `'unsafe-inline'`.
+ *     Public/static routes are intentionally NOT nonced (a per-request
+ *     nonce forces dynamic rendering — CISEC-02 keeps marketing static),
+ *     and Next emits bare, non-nonced inline scripts there (next-themes
+ *     no-flash, React hydration runtime, RSC flight payload). Removing
+ *     `'unsafe-inline'` from the static CSP would CSP-block all of them
+ *     and dead-render every marketing/login/pricing page. The nonce
+ *     hardening is private-route-only (assertions b-d).
  *
  *  2. On a PRIVATE route the proxy forwards the per-request nonce CSP on
  *     the REQUEST `Content-Security-Policy` header passed to
@@ -143,11 +149,17 @@ describe("CISEC-02 CSP hardening", () => {
 		}));
 	});
 
-	it("(a) vercel.json static script-src has no 'unsafe-inline'", () => {
+	it("(a) vercel.json static script-src RETAINS 'unsafe-inline' (public routes are un-nonced)", () => {
+		// Public/static routes are intentionally NOT nonced — a nonce forces
+		// dynamic rendering, and CISEC-02 keeps marketing static. Next emits
+		// bare inline scripts (next-themes no-flash, React hydration runtime,
+		// RSC flight) on those pages, so the static CSP MUST keep
+		// 'unsafe-inline' or every public page is dead-rendered. The nonce
+		// hardening lives on private routes only (assertions b-d).
 		const csp = readVercelCsp();
 		const scriptSrc = scriptSrcDirective(csp);
 		expect(scriptSrc).not.toBe("");
-		expect(scriptSrc).not.toContain("'unsafe-inline'");
+		expect(scriptSrc).toContain("'unsafe-inline'");
 	});
 
 	it("(b) forwards the nonce CSP on the REQUEST headers passed to updateSession on a private route", async () => {

--- a/src/lib/__tests__/csp-header.test.ts
+++ b/src/lib/__tests__/csp-header.test.ts
@@ -1,0 +1,208 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { User } from "@supabase/supabase-js";
+import { type NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * CISEC-02 regression guard. Pins two things that would silently
+ * regress the security fix:
+ *
+ *  1. `vercel.json`'s static `script-src` never reintroduces
+ *     `'unsafe-inline'` (the marketing/static-route fallback CSP).
+ *
+ *  2. On a PRIVATE route the proxy forwards the per-request nonce CSP on
+ *     the REQUEST `Content-Security-Policy` header passed to
+ *     `updateSession` (the load-bearing path Next 16.2.6 parses for the
+ *     hydration-script nonce — app-render.js:167-168), NOT only on the
+ *     response, and the request-side nonce token is byte-for-byte equal
+ *     to the response-side nonce token. The request-side assertion is
+ *     the one that FAILS under a naive response-only wiring.
+ *
+ * This test uses the REAL `next/server` `NextResponse` so the response
+ * `Content-Security-Policy` header is genuine; only `updateSession`, the
+ * Supabase gate client, Sentry, and `#env` are mocked.
+ */
+
+// `updateSession` is mocked so we can (a) capture the `requestHeaders`
+// argument the proxy forwards and (b) return a real NextResponse the
+// proxy can attach the response CSP to.
+const mockUpdateSession =
+	vi.fn<
+		(
+			request: NextRequest,
+			requestHeaders?: Headers,
+		) => Promise<{ user: User | null; supabaseResponse: NextResponse }>
+	>();
+
+vi.mock("#lib/supabase/middleware", () => ({
+	updateSession: (request: NextRequest, requestHeaders?: Headers) =>
+		mockUpdateSession(request, requestHeaders),
+}));
+
+// Gate query — return an active, non-admin owner so a private route
+// reaches the pass-through return where the response CSP is set.
+vi.mock("@supabase/ssr", () => ({
+	createServerClient: () => ({
+		from: () => ({
+			select: () => ({
+				eq: () => ({
+					maybeSingle: async () => ({
+						data: { is_admin: false, subscription_status: "active" },
+						error: null,
+					}),
+				}),
+			}),
+		}),
+	}),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
+}));
+
+vi.mock("#env", () => ({
+	env: {
+		NEXT_PUBLIC_SUPABASE_URL: "http://test",
+		NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test",
+	},
+}));
+
+import { proxy } from "#proxy";
+
+function buildRequest(pathname: string): NextRequest {
+	const url = new URL(pathname, "http://localhost:3050");
+	const nextUrl = Object.assign(url, {
+		clone: () => new URL(url.toString()),
+	});
+	const cookieStore = new Map<string, { name: string; value: string }>();
+
+	return {
+		nextUrl,
+		url: url.toString(),
+		headers: new Headers(),
+		cookies: {
+			getAll: () => [...cookieStore.values()],
+			set: (name: string, value: string) => {
+				cookieStore.set(name, { name, value });
+			},
+			get: (name: string) => cookieStore.get(name),
+		},
+	} as unknown as NextRequest;
+}
+
+function makeUser(): User {
+	return {
+		id: "user-123",
+		app_metadata: {},
+		aud: "authenticated",
+		created_at: "2026-01-01",
+	} as User;
+}
+
+/** Isolates the `script-src` directive from a serialized CSP string. */
+function scriptSrcDirective(csp: string): string {
+	return (
+		csp
+			.split(";")
+			.map((d) => d.trim())
+			.find((d) => d.startsWith("script-src")) ?? ""
+	);
+}
+
+/** Extracts the `nonce-XXX` token (with quotes) from a CSP string. */
+function extractNonceToken(csp: string): string | null {
+	const match = csp.match(/'nonce-[^']+'/);
+	return match ? match[0] : null;
+}
+
+// Vitest runs from the repo root, so vercel.json is at cwd/vercel.json.
+const VERCEL_JSON_PATH = resolve(process.cwd(), "vercel.json");
+
+function readVercelCsp(): string {
+	const raw = JSON.parse(readFileSync(VERCEL_JSON_PATH, "utf8")) as {
+		headers: { source: string; headers: { key: string; value: string }[] }[];
+	};
+	for (const entry of raw.headers) {
+		const csp = entry.headers.find((h) => h.key === "Content-Security-Policy");
+		if (csp) return csp.value;
+	}
+	throw new Error("No Content-Security-Policy header found in vercel.json");
+}
+
+describe("CISEC-02 CSP hardening", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Default happy path: authenticated active owner, real NextResponse.
+		mockUpdateSession.mockImplementation(async (_request, requestHeaders) => ({
+			user: makeUser(),
+			supabaseResponse: NextResponse.next(
+				requestHeaders ? { request: { headers: requestHeaders } } : undefined,
+			),
+		}));
+	});
+
+	it("(a) vercel.json static script-src has no 'unsafe-inline'", () => {
+		const csp = readVercelCsp();
+		const scriptSrc = scriptSrcDirective(csp);
+		expect(scriptSrc).not.toBe("");
+		expect(scriptSrc).not.toContain("'unsafe-inline'");
+	});
+
+	it("(b) forwards the nonce CSP on the REQUEST headers passed to updateSession on a private route", async () => {
+		await proxy(buildRequest("/dashboard"));
+
+		expect(mockUpdateSession).toHaveBeenCalledOnce();
+		const requestHeaders = mockUpdateSession.mock.calls[0]?.[1];
+		expect(requestHeaders).toBeInstanceOf(Headers);
+
+		const requestCsp = requestHeaders?.get("content-security-policy");
+		expect(requestCsp).toBeTruthy();
+		const requestScriptSrc = scriptSrcDirective(requestCsp ?? "");
+		expect(requestScriptSrc).toContain("'nonce-");
+		expect(requestScriptSrc).toContain("'strict-dynamic'");
+		expect(requestScriptSrc).not.toContain("'unsafe-inline'");
+	});
+
+	it("(c) request-side nonce equals response-side nonce on a private route", async () => {
+		const response = await proxy(buildRequest("/dashboard"));
+
+		const requestHeaders = mockUpdateSession.mock.calls[0]?.[1];
+		const requestCsp = requestHeaders?.get("content-security-policy") ?? "";
+		const responseCsp = response.headers.get("content-security-policy") ?? "";
+
+		const requestNonce = extractNonceToken(requestCsp);
+		const responseNonce = extractNonceToken(responseCsp);
+
+		expect(requestNonce).toBeTruthy();
+		expect(responseNonce).toBeTruthy();
+		// Same per-request nonce on both sides — the assertion that pins
+		// success criterion 2 and fails under response-only wiring.
+		expect(requestNonce).toBe(responseNonce);
+	});
+
+	it("(d) private-route response CSP has nonce + strict-dynamic and no script-src unsafe-inline", async () => {
+		const response = await proxy(buildRequest("/dashboard"));
+
+		const responseCsp = response.headers.get("content-security-policy") ?? "";
+		const responseScriptSrc = scriptSrcDirective(responseCsp);
+		expect(responseScriptSrc).toContain("'nonce-");
+		expect(responseScriptSrc).toContain("'strict-dynamic'");
+		expect(responseScriptSrc).not.toContain("'unsafe-inline'");
+		// style-src keeps 'unsafe-inline' (locked CISEC-02 decision).
+		expect(responseCsp).toContain("style-src 'self' 'unsafe-inline'");
+	});
+
+	it("(e) does NOT forward a nonce CSP on a public route", async () => {
+		const response = await proxy(buildRequest("/"));
+
+		expect(mockUpdateSession).toHaveBeenCalledOnce();
+		const requestHeaders = mockUpdateSession.mock.calls[0]?.[1];
+		// updateSession is called WITHOUT a CSP-bearing request-headers arg.
+		expect(requestHeaders?.get("content-security-policy") ?? null).toBeNull();
+		// No per-request nonce CSP on the response — the static vercel.json
+		// header governs public routes.
+		expect(response.headers.get("content-security-policy") ?? null).toBeNull();
+	});
+});

--- a/src/lib/__tests__/stripe-webhook-signature.test.ts
+++ b/src/lib/__tests__/stripe-webhook-signature.test.ts
@@ -1,0 +1,95 @@
+/**
+ * CISEC-01 — Stripe-webhook signature accept/reject contract gate.
+ *
+ * Guards the verification contract relied on by the Edge Function at
+ * `supabase/functions/stripe-webhooks/index.ts:73`, where every webhook
+ * delivery is authenticated via `stripe.webhooks.constructEventAsync(...)`.
+ * That function owns no hand-rolled crypto — it delegates 100% of signature
+ * verification to the Stripe SDK. This unit test pins the exact security
+ * contract (a valid signature is accepted; tampered/wrong-secret/stale
+ * signatures are rejected) inside the already-green `checks` gate, with no
+ * server, no prod secret, and no `supabase functions serve`.
+ *
+ * Async vs sync note: the Edge Function uses `constructEventAsync` because the
+ * Deno runtime requires the async Web-Crypto variant. The Node SDK here uses
+ * the synchronous `constructEvent` — both implement the identical signed-header
+ * scheme (an HMAC-SHA256 over the timestamp-and-payload, carried in the
+ * Stripe-Signature header). Do NOT "fix" this test to call the async variant to
+ * match the Edge Function; the synchronous path is the correct Node-side mirror
+ * of the same contract.
+ *
+ * `generateTestHeaderString` is a real SDK method that mints a genuine HMAC —
+ * it is NOT a mock. Never hand-roll the Stripe-Signature header string here;
+ * doing so re-introduces the exact bug class this test guards against.
+ */
+import Stripe from "stripe";
+import { describe, expect, it } from "vitest";
+
+// Throwaway, non-secret values — never a real key or signing secret. The
+// signing secret only has to be internally consistent between minting the
+// header and verifying it; its byte length matches the `whsec_` + 24-char
+// shape Stripe emits so the test exercises a realistic secret size.
+const SECRET = `whsec_test_${"x".repeat(24)}`;
+const WRONG_SECRET = `whsec_wrong_${"y".repeat(24)}`;
+const stripe = new Stripe("sk_test_x");
+
+// Minimal but well-formed event envelope; only `id` / `type` round-trip is
+// asserted on the accept path.
+const PAYLOAD = JSON.stringify({
+	id: "evt_test_cisec01",
+	type: "checkout.session.completed",
+});
+
+describe("Stripe webhook signature verification contract (CISEC-01)", () => {
+	it("accepts a correctly-signed payload and round-trips the event", () => {
+		const header = stripe.webhooks.generateTestHeaderString({
+			payload: PAYLOAD,
+			secret: SECRET,
+		});
+
+		const event: Stripe.Event = stripe.webhooks.constructEvent(
+			PAYLOAD,
+			header,
+			SECRET,
+		);
+
+		expect(event.id).toBe("evt_test_cisec01");
+		expect(event.type).toBe("checkout.session.completed");
+	});
+
+	it("rejects a tampered body (payload mutated after signing)", () => {
+		const header = stripe.webhooks.generateTestHeaderString({
+			payload: PAYLOAD,
+			secret: SECRET,
+		});
+
+		expect(() =>
+			stripe.webhooks.constructEvent(`${PAYLOAD} `, header, SECRET),
+		).toThrow();
+	});
+
+	it("rejects a signature minted with the wrong secret", () => {
+		const header = stripe.webhooks.generateTestHeaderString({
+			payload: PAYLOAD,
+			secret: SECRET,
+		});
+
+		expect(() =>
+			stripe.webhooks.constructEvent(PAYLOAD, header, WRONG_SECRET),
+		).toThrow();
+	});
+
+	it("rejects a stale timestamp outside the tolerance window", () => {
+		const tolerance = 300; // seconds — same order as Stripe's default.
+		const staleTimestamp = Math.floor(Date.now() / 1000) - 10_000;
+		const header = stripe.webhooks.generateTestHeaderString({
+			payload: PAYLOAD,
+			secret: SECRET,
+			timestamp: staleTimestamp,
+		});
+
+		expect(() =>
+			stripe.webhooks.constructEvent(PAYLOAD, header, SECRET, tolerance),
+		).toThrow();
+	});
+});

--- a/src/lib/__tests__/timing-safe.test.ts
+++ b/src/lib/__tests__/timing-safe.test.ts
@@ -1,0 +1,44 @@
+/**
+ * CISEC-03 — Constant-time hook-secret compare contract gate.
+ *
+ * Pins the behavior of the shared `timingSafeEqualStr` helper at
+ * `supabase/functions/_shared/timing-safe.ts`, used by `auth-email-send` to
+ * compare the Authorization Bearer token against `SUPABASE_AUTH_HOOK_SECRET`
+ * in constant time (closing the timing side-channel CISEC-03).
+ *
+ * The helper is pure TS — it depends only on `TextEncoder` + `crypto.subtle`,
+ * both available in node/jsdom — so it runs in the `checks`/`unit` gate with no
+ * server, no Deno runtime, and no prod secret.
+ */
+import { describe, expect, it } from "vitest";
+
+import { timingSafeEqualStr } from "../../../supabase/functions/_shared/timing-safe";
+
+describe("timingSafeEqualStr", () => {
+	it("returns true for equal strings", () => {
+		expect(timingSafeEqualStr("abc", "abc")).toBe(true);
+	});
+
+	it("returns false for unequal strings of the same length", () => {
+		expect(timingSafeEqualStr("abc", "abd")).toBe(false);
+	});
+
+	it("returns false for strings of different length", () => {
+		expect(timingSafeEqualStr("abc", "abcd")).toBe(false);
+	});
+
+	it("returns true for two empty strings", () => {
+		expect(timingSafeEqualStr("", "")).toBe(true);
+	});
+
+	it("returns true for a longer secret comparing equal", () => {
+		const secret = "super-secret-hook-token-0123456789";
+		expect(timingSafeEqualStr(secret, secret)).toBe(true);
+	});
+
+	it("returns false when only the final byte differs", () => {
+		expect(timingSafeEqualStr("hook-secret-value", "hook-secret-valuf")).toBe(
+			false,
+		);
+	});
+});

--- a/src/lib/__tests__/workflow-pins.test.ts
+++ b/src/lib/__tests__/workflow-pins.test.ts
@@ -29,14 +29,23 @@ interface UsesEntry {
 	readonly line: number;
 	/** The action reference after `uses:` and before any trailing comment, e.g. "actions/checkout@<sha>". */
 	readonly ref: string;
+	/** The full `uses:` value INCLUDING any trailing comment, e.g. "actions/checkout@<sha> # v6.0.3". */
+	readonly full: string;
 	/** Repo owner segment, e.g. "actions", "github", "oven-sh". */
 	readonly owner: string;
 }
 
 const WORKFLOWS_DIR = join(process.cwd(), ".github", "workflows");
 
-// A 40-hex commit SHA, optionally followed by a space + trailing version comment.
-const SHA_PIN = /@[0-9a-f]{40}(?:\s|$)/;
+// The action ref must END at a 40-hex commit SHA (no mutable tag like @v2).
+// Matched against `ref` (whitespace-delimited token, comment stripped).
+const SHA_PIN = /@[0-9a-f]{40}$/;
+
+// A SHA pin FOLLOWED BY a trailing `# vX.Y.Z`-style version comment.
+// Matched against the full line so the comment is actually enforced
+// (the previous guard ran against the comment-stripped ref, so the
+// version-comment requirement in the docstring was never checked).
+const SHA_PIN_WITH_COMMENT = /@[0-9a-f]{40}\s+#\s*v\d/;
 
 // Owners that are first-party (GitHub-published). Still pinned uniformly per the
 // locked decision, but tracked separately so the third-party assertion can be
@@ -53,15 +62,18 @@ function collectUses(): UsesEntry[] {
 			const trimmed = raw.trim();
 			// Skip blank lines and YAML comments.
 			if (trimmed === "" || trimmed.startsWith("#")) return;
-			// Match `uses:` keys (with or without a leading `- `).
-			const match = /^-?\s*uses:\s*(\S+)/.exec(trimmed);
+			// Match `uses:` keys (with or without a leading `- `). Capture the
+			// ref token (group 1) and the full value incl. trailing comment
+			// (group 2) so we can assert both the SHA and its version comment.
+			const match = /^-?\s*uses:\s*(\S+)(.*)$/.exec(trimmed);
 			if (!match) return;
 			const ref = match[1] ?? "";
+			const full = `${ref}${match[2] ?? ""}`.trim();
 			// Local/composite actions (`./...` or `docker://...`) are not pinnable
 			// to a commit SHA — exclude them from the SHA assertion.
 			if (ref.startsWith("./") || ref.startsWith("docker://")) return;
 			const owner = ref.split("/")[0] ?? "";
-			entries.push({ file, line: index + 1, ref, owner });
+			entries.push({ file, line: index + 1, ref, full, owner });
 		});
 	}
 
@@ -97,6 +109,21 @@ describe("CISEC-04 — GitHub Actions are SHA-pinned", () => {
 		expect(
 			violators,
 			`Unpinned action(s) — uniform pinning requires every uses: be a 40-char commit SHA with a trailing "# vX.Y.Z" comment:\n${violators.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("every pinned uses: carries a trailing # vX.Y.Z version comment", () => {
+		// The SHA alone is unreadable; the version comment is what lets a
+		// human (and Dependabot) track what the SHA resolves to. Enforced
+		// against the FULL line — the prior guard only ran the SHA regex
+		// against the comment-stripped ref, so this requirement was unchecked.
+		const violators = entries
+			.filter((e) => !SHA_PIN_WITH_COMMENT.test(e.full))
+			.map((e) => `${e.file}:${e.line} → ${e.full}`);
+
+		expect(
+			violators,
+			`Pinned action(s) missing a trailing "# vX.Y.Z" version comment:\n${violators.join("\n")}`,
 		).toEqual([]);
 	});
 });

--- a/src/lib/__tests__/workflow-pins.test.ts
+++ b/src/lib/__tests__/workflow-pins.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Drift guard (CISEC-04): every `uses:` across .github/workflows/*.yml must be
+ * pinned to a 40-char commit SHA with a trailing `# vX.Y.Z` version comment.
+ *
+ * A mutable action tag (`@v2`, `@v6`) can be repointed by a repo compromise to a
+ * malicious commit — only the immutable commit SHA defends against tag-repointing
+ * supply-chain attacks (post tj-actions/2025 incidents). The highest-blast-radius
+ * action here is anthropics/claude-code-action (requests `id-token: write` OIDC).
+ *
+ * Two assertions, per the locked uniform-pinning decision:
+ *  (a) THIRD-PARTY (owner ∉ {actions, github}) MUST be a 40-hex SHA — the hard
+ *      security requirement; a regression here is a supply-chain hole.
+ *  (b) EVERY `uses:` (including first-party actions/* and github/codeql-action/*)
+ *      MUST be a 40-hex SHA — the stricter uniform guard so a future un-pinned
+ *      first-party action also trips this test.
+ *
+ * Failures list the offending `file:line → ref` so a regression is actionable.
+ *
+ * Pure filesystem read — never touches the DOM.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+interface UsesEntry {
+	/** Workflow filename, e.g. "ci-cd.yml". */
+	readonly file: string;
+	/** 1-based line number of the `uses:` line within the file. */
+	readonly line: number;
+	/** The action reference after `uses:` and before any trailing comment, e.g. "actions/checkout@<sha>". */
+	readonly ref: string;
+	/** Repo owner segment, e.g. "actions", "github", "oven-sh". */
+	readonly owner: string;
+}
+
+const WORKFLOWS_DIR = join(process.cwd(), ".github", "workflows");
+
+// A 40-hex commit SHA, optionally followed by a space + trailing version comment.
+const SHA_PIN = /@[0-9a-f]{40}(?:\s|$)/;
+
+// Owners that are first-party (GitHub-published). Still pinned uniformly per the
+// locked decision, but tracked separately so the third-party assertion can be
+// reported distinctly from the uniform one.
+const FIRST_PARTY_OWNERS = new Set(["actions", "github"]);
+
+function collectUses(): UsesEntry[] {
+	const files = readdirSync(WORKFLOWS_DIR).filter((f) => f.endsWith(".yml"));
+	const entries: UsesEntry[] = [];
+
+	for (const file of files) {
+		const lines = readFileSync(join(WORKFLOWS_DIR, file), "utf8").split("\n");
+		lines.forEach((raw, index) => {
+			const trimmed = raw.trim();
+			// Skip blank lines and YAML comments.
+			if (trimmed === "" || trimmed.startsWith("#")) return;
+			// Match `uses:` keys (with or without a leading `- `).
+			const match = /^-?\s*uses:\s*(\S+)/.exec(trimmed);
+			if (!match) return;
+			const ref = match[1] ?? "";
+			// Local/composite actions (`./...` or `docker://...`) are not pinnable
+			// to a commit SHA — exclude them from the SHA assertion.
+			if (ref.startsWith("./") || ref.startsWith("docker://")) return;
+			const owner = ref.split("/")[0] ?? "";
+			entries.push({ file, line: index + 1, ref, owner });
+		});
+	}
+
+	return entries;
+}
+
+describe("CISEC-04 — GitHub Actions are SHA-pinned", () => {
+	const entries = collectUses();
+
+	it("finds at least one uses: line to guard", () => {
+		// Sanity check: if the parser silently matched nothing, the assertions
+		// below would vacuously pass and the guard would be useless.
+		expect(entries.length).toBeGreaterThan(0);
+	});
+
+	it("every third-party uses: is pinned to a 40-char commit SHA", () => {
+		const violators = entries
+			.filter((e) => !FIRST_PARTY_OWNERS.has(e.owner))
+			.filter((e) => !SHA_PIN.test(e.ref))
+			.map((e) => `${e.file}:${e.line} → ${e.ref}`);
+
+		expect(
+			violators,
+			`Unpinned third-party action(s) — pin to a 40-char commit SHA with a trailing "# vX.Y.Z" comment:\n${violators.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("every uses: (first-party included) is pinned to a 40-char commit SHA", () => {
+		const violators = entries
+			.filter((e) => !SHA_PIN.test(e.ref))
+			.map((e) => `${e.file}:${e.line} → ${e.ref}`);
+
+		expect(
+			violators,
+			`Unpinned action(s) — uniform pinning requires every uses: be a 40-char commit SHA with a trailing "# vX.Y.Z" comment:\n${violators.join("\n")}`,
+		).toEqual([]);
+	});
+});

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -20,11 +20,32 @@ import type { Database } from "#types/supabase";
  * routine "no valid session" outcome — battle-test Session 7 saw ~25
  * such 503s on RSC prefetches because the agent's hand-crafted
  * workaround cookie occasionally tripped Supabase's JWT validator.
+ *
+ * `requestHeaders` (CISEC-02): when provided, the pass-through
+ * `NextResponse.next({ request: { headers } })` carries these headers
+ * INTO the request Next renders against. This is the load-bearing path
+ * for the per-request nonce CSP — the proxy sets the
+ * `Content-Security-Policy` header (with `'nonce-<nonce>'
+ * 'strict-dynamic'`) on `requestHeaders` and Next 16.2.6 sources the
+ * hydration-script nonce by parsing that `Content-Security-Policy`
+ * header off the forwarded request (`getScriptNonceFromHeader`,
+ * app-render.js:167-168) — it never reads `x-nonce`. So threading the
+ * `Content-Security-Policy`-bearing `requestHeaders` through here on
+ * private routes is what makes framework scripts get auto-nonced under
+ * `'strict-dynamic'`. Both construction sites (init + the cookie
+ * `setAll` rebuild) must carry it or the cookie-sync rebuild drops the
+ * `Content-Security-Policy` header and the dashboard hydration scripts
+ * are blocked. When undefined (public-route call), the original
+ * `NextResponse.next({ request })` behavior is preserved exactly.
  */
 export async function updateSession(
 	request: NextRequest,
+	requestHeaders?: Headers,
 ): Promise<{ user: User | null; supabaseResponse: NextResponse }> {
-	let supabaseResponse = NextResponse.next({ request });
+	const nextOptions = requestHeaders
+		? { request: { headers: requestHeaders } }
+		: { request };
+	let supabaseResponse = NextResponse.next(nextOptions);
 
 	const supabase = createServerClient<Database>(
 		process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -39,9 +60,22 @@ export async function updateSession(
 					cookiesToSet.forEach(({ name, value }) =>
 						request.cookies.set(name, value),
 					);
+					// CISEC-02 cookie-sync correctness: when forwarding a custom
+					// `requestHeaders` (the nonce CSP path), the rebuild below
+					// uses THOSE headers, not the mutated `request`. So mirror
+					// the freshly-updated `cookie` header from `request` into
+					// `requestHeaders` before the rebuild, or downstream Server
+					// Components would read the stale pre-refresh cookies.
+					if (requestHeaders) {
+						requestHeaders.set("cookie", request.headers.get("cookie") ?? "");
+					}
 					// Re-create response with updated request to keep cookies in sync
-					// (Pitfall 1: must pass { request } to avoid cookie desync)
-					supabaseResponse = NextResponse.next({ request });
+					// (Pitfall 1: must pass { request } to avoid cookie desync).
+					// CISEC-02: re-thread `requestHeaders` here too so the nonce
+					// CSP on the forwarded request survives the cookie-sync
+					// rebuild — otherwise the auth cookie write drops the CSP and
+					// Next can't auto-nonce the hydration scripts.
+					supabaseResponse = NextResponse.next(nextOptions);
 					// Set cookies on the response for the browser
 					cookiesToSet.forEach(({ name, value, options }) =>
 						supabaseResponse.cookies.set(name, value, options),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -50,6 +50,47 @@ function isPrivateRoute(pathname: string): boolean {
 	);
 }
 
+/**
+ * CISEC-02 — Builds the per-request nonce CSP applied ONLY to private
+ * (authenticated) routes. Marketing/blog/static pages keep the static
+ * `vercel.json` CSP so they stay statically rendered (a nonce forces
+ * dynamic rendering).
+ *
+ * The load-bearing directive is `script-src 'self' 'nonce-<nonce>'
+ * 'strict-dynamic'`. Next 16.2.6 parses this string off the forwarded
+ * REQUEST `content-security-policy` header (getScriptNonceFromHeader,
+ * app-render.js:167-168) to auto-nonce its hydration scripts — it never
+ * reads `x-nonce`. `'strict-dynamic'` is mandatory in the App Router
+ * (no `_document.tsx` to manually nonce hydration scripts) and it makes
+ * the browser ignore host allowlists in `script-src`, so the
+ * `*.supabase.co *.sentry.io *.stripe.com` allowlist stays in
+ * `connect-src`, NOT `script-src`. `'unsafe-eval'` is gated to dev only.
+ *
+ * `style-src` keeps `'unsafe-inline'` (locked CISEC-02 decision —
+ * script-src-scoped only; runtime-injected inline styles are a
+ * documented MEDIUM-risk follow-up, not part of this plan). The
+ * directive set otherwise mirrors `vercel.json` so private routes lose
+ * nothing except `script-src 'unsafe-inline'`.
+ */
+function buildNonceCsp(nonce: string): string {
+	const isDev = process.env.NODE_ENV === "development";
+	const scriptSrc = `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${
+		isDev ? " 'unsafe-eval'" : ""
+	}`;
+	return [
+		"default-src 'self'",
+		scriptSrc,
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' data: blob:",
+		"connect-src 'self' *.supabase.co *.sentry.io *.stripe.com",
+		"font-src 'self'",
+		"object-src 'none'",
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+	].join("; ");
+}
+
 function redirectWithCookies(
 	url: URL,
 	supabaseResponse: NextResponse,
@@ -64,15 +105,50 @@ function redirectWithCookies(
 // Next.js 16: proxy.ts replaces deprecated middleware.ts
 export async function proxy(request: NextRequest): Promise<NextResponse> {
 	const { pathname } = request.nextUrl;
+	const privateRoute = isPrivateRoute(pathname);
 
-	const { user, supabaseResponse } = await updateSession(request);
+	// CISEC-02 — On private (authenticated) routes ONLY, generate a
+	// per-request nonce and forward the nonce CSP on the REQUEST
+	// `Content-Security-Policy` header so Next 16 auto-nonces its
+	// hydration scripts at render time (see buildNonceCsp). `x-nonce` is a
+	// non-load-bearing convenience for app code that reads `headers()`.
+	// Public/marketing/static routes are NOT touched here — they stay on
+	// the static `vercel.json` CSP so they remain statically rendered.
+	let nonceCsp: string | undefined;
+	let requestHeaders: Headers | undefined;
+	if (privateRoute) {
+		const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+		nonceCsp = buildNonceCsp(nonce);
+		requestHeaders = new Headers(request.headers);
+		// THE load-bearing header: Next parses the nonce off the forwarded
+		// request's `content-security-policy` (app-render.js:167-168).
+		requestHeaders.set("Content-Security-Policy", nonceCsp);
+		// Convenience only — NOT how Next sources the hydration nonce.
+		requestHeaders.set("x-nonce", nonce);
+	}
+
+	const { user, supabaseResponse } = await updateSession(
+		request,
+		requestHeaders,
+	);
+
+	// Sets the per-request nonce CSP on a private-route response so the
+	// browser enforces it. Applied to BOTH the pass-through and every
+	// redirect return below. No-op on public routes (nonceCsp undefined).
+	const withCsp = <T extends NextResponse>(response: T): T => {
+		if (nonceCsp) {
+			response.headers.set("Content-Security-Policy", nonceCsp);
+		}
+		return response;
+	};
 
 	// Everything that isn't a known private route — public pages, unknown
 	// URLs, blog slugs, comparison pages, etc. — passes through so Next.js
 	// can render the matched page or its `not-found.tsx`. Auth-gating
 	// arbitrary typo URLs was making `/featres` redirect to `/login` instead
-	// of showing a 404, which is hostile UX.
-	if (!isPrivateRoute(pathname)) {
+	// of showing a 404, which is hostile UX. These keep the static
+	// `vercel.json` CSP — no per-request nonce CSP is applied.
+	if (!privateRoute) {
 		return supabaseResponse;
 	}
 
@@ -80,7 +156,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 		const url = request.nextUrl.clone();
 		url.pathname = "/login";
 		url.searchParams.set("redirect", pathname);
-		return redirectWithCookies(url, supabaseResponse);
+		return withCsp(redirectWithCookies(url, supabaseResponse));
 	}
 
 	// Allowlist check BEFORE the DB query (cycle-2 P2-2 perf fix). These
@@ -96,7 +172,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 		pathname.startsWith("/auth/");
 	const isAdminRoute = pathname.startsWith("/admin");
 	if (!isAdminRoute && isSubscriptionAllowlisted) {
-		return supabaseResponse;
+		return withCsp(supabaseResponse);
 	}
 
 	// Single combined fetch for both gates. One DB round-trip instead of
@@ -176,15 +252,14 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 		const url = request.nextUrl.clone();
 		url.pathname = "/login";
 		url.searchParams.set("redirect", pathname);
-		return redirectWithCookies(url, supabaseResponse);
+		return withCsp(redirectWithCookies(url, supabaseResponse));
 	}
 
 	// /admin/* is admin-only. The (admin) route group's layout.tsx performs a
 	// second server-side is_admin check against public.users.
 	if (isAdminRoute && !gateRow.is_admin) {
-		return redirectWithCookies(
-			new URL("/dashboard", request.url),
-			supabaseResponse,
+		return withCsp(
+			redirectWithCookies(new URL("/dashboard", request.url), supabaseResponse),
 		);
 	}
 
@@ -196,14 +271,13 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 	if (!gateRow.is_admin && !isAdminRoute) {
 		const status = gateRow.subscription_status;
 		if (!status || !ACTIVE_SUBSCRIPTION_STATUSES.has(status)) {
-			return redirectWithCookies(
-				new URL("/pricing", request.url),
-				supabaseResponse,
+			return withCsp(
+				redirectWithCookies(new URL("/pricing", request.url), supabaseResponse),
 			);
 		}
 	}
 
-	return supabaseResponse;
+	return withCsp(supabaseResponse);
 }
 
 export const config = {

--- a/supabase/functions/_shared/timing-safe.ts
+++ b/supabase/functions/_shared/timing-safe.ts
@@ -1,0 +1,43 @@
+// Shared constant-time string compare for Edge Functions.
+//
+// Lifted from the proven resend-webhook pattern (resend-webhook/index.ts:145-168):
+// crypto.subtle.timingSafeEqual when the runtime exposes it, with an XOR-loop
+// fallback for portability across Deno runtimes that lack it.
+//
+// IMPORTANT: this compares RAW secret strings directly (no HMAC). It is for
+// callers that hold a shared secret and need a constant-time equality check —
+// e.g. auth-email-send comparing the Authorization Bearer token against
+// SUPABASE_AUTH_HOOK_SECRET. The other webhooks (resend/docuseal/n8n) compare an
+// HMAC digest against a computed digest; those keep their own HMAC machinery.
+//
+// The `crypto.subtle as unknown as { ... }` below is a runtime feature-detection
+// shim (matching resend-webhook:151), NOT an RPC/PostgREST boundary cast — so it
+// is outside the scope of CLAUDE.md rule #8 (which targets RPC/PostgREST returns).
+
+export function timingSafeEqualStr(a: string, b: string): boolean {
+	const enc = new TextEncoder();
+	const ab = enc.encode(a);
+	const bb = enc.encode(b);
+	// Early-return on length mismatch is acceptable: the secret's length is not
+	// itself secret, and all three existing inline helpers do the same.
+	if (ab.length !== bb.length) return false;
+
+	// Feature-detect crypto.subtle.timingSafeEqual via a runtime shim cast.
+	const subtle = crypto.subtle as unknown as {
+		timingSafeEqual?: (x: Uint8Array, y: Uint8Array) => boolean;
+	};
+	if (typeof subtle.timingSafeEqual === "function") {
+		try {
+			return subtle.timingSafeEqual(ab, bb);
+		} catch {
+			// fall through to the XOR-loop fallback
+		}
+	}
+
+	// Constant-time XOR-loop fallback. `?? 0` guards satisfy noUncheckedIndexedAccess.
+	let d = 0;
+	for (let i = 0; i < ab.length; i++) {
+		d |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+	}
+	return d === 0;
+}

--- a/supabase/functions/auth-email-send/index.ts
+++ b/supabase/functions/auth-email-send/index.ts
@@ -23,6 +23,7 @@ import {
 	logEvent,
 } from "../_shared/errors.ts";
 import { sendEmail } from "../_shared/resend.ts";
+import { timingSafeEqualStr } from "../_shared/timing-safe.ts";
 
 interface AuthEmailHookPayload {
 	user: { email: string; user_metadata: Record<string, unknown> };
@@ -78,7 +79,7 @@ Deno.serve(async (req: Request) => {
 		const hookSecret = env["SUPABASE_AUTH_HOOK_SECRET"];
 		const authHeader = req.headers.get("authorization") ?? "";
 		const token = authHeader.replace(/^Bearer\s+/i, "");
-		if (token !== hookSecret) {
+		if (!timingSafeEqualStr(token, hookSecret)) {
 			captureWebhookError(new Error("Unauthorized: invalid hook secret"), {
 				message: "[AUTH_EMAIL] Unauthorized: invalid hook secret",
 			});

--- a/vercel.json
+++ b/vercel.json
@@ -99,7 +99,7 @@
 				},
 				{
 					"key": "Content-Security-Policy",
-					"value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' *.supabase.co *.sentry.io *.stripe.com; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+					"value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' *.supabase.co *.sentry.io *.stripe.com; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 				}
 			]
 		},

--- a/vercel.json
+++ b/vercel.json
@@ -99,7 +99,7 @@
 				},
 				{
 					"key": "Content-Security-Policy",
-					"value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' *.supabase.co *.sentry.io *.stripe.com; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+					"value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' *.supabase.co *.sentry.io *.stripe.com; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 				}
 			]
 		},


### PR DESCRIPTION
## Summary

**v4.0 Phase 1 — Security-CI Hardening.** Closes the four CISEC requirements: the remaining supply-chain / runtime hardening gaps from the verified 2026-05-29 audit, each regression-pinned with a test.

| Req | What | Key files |
|-----|------|-----------|
| **CISEC-01** | Stripe-webhook signature accept/reject gate as a **Vitest** unit test (mints a real signature via the `stripe` SDK `generateTestHeaderString` — runs in the already-green `checks` gate, no serve/secrets) | `src/lib/__tests__/stripe-webhook-signature.test.ts` |
| **CISEC-02** | **Route-scoped** per-request **nonce CSP + `strict-dynamic`** on authenticated routes; `script-src 'unsafe-inline'` dropped there. Marketing/blog stay static (their `vercel.json` CSP is unchanged). | `src/proxy.ts`, `src/lib/supabase/middleware.ts`, `vercel.json`, `csp-header.test.ts` |
| **CISEC-03** | Constant-time hook-secret compare in `auth-email-send` via a shared `_shared/timing-safe.ts` helper (kills the `token !== hookSecret` timing side-channel) | `supabase/functions/_shared/timing-safe.ts`, `auth-email-send/index.ts`, `timing-safe.test.ts` |
| **CISEC-04** | **SHA-pin every** workflow `uses:` (18 actions, re-resolved live) + a drift-guard test that fails on any non-SHA third-party action | 6 `.github/workflows/*.yml`, `workflow-pins.test.ts` |

## The CSP nonce detail (CISEC-02)

The plan-checker caught a real bug in the first draft: Next 16 sources the hydration-script nonce from the `Content-Security-Policy` header on the **forwarded request** (`getScriptNonceFromHeader`, `app-render.js:167`) — **not** from `x-nonce`. The shipped implementation threads the nonce CSP through `updateSession`'s `NextResponse.next({ request: { headers } })` at both construction sites; the unit test asserts the **request-side nonce equals the response-side nonce**. A response-only wiring would have advertised a nonce CSP while leaving hydration scripts unnonced → blank dashboard.

## Tests
All new specs green (4 + 5 + 6 + 3 = 18 assertions); full unit suite + typecheck + lint green in every commit's lefthook gate. CodeQL + gitleaks (the gates from PR #781) run on this PR too.

## ⚠ Manual / out-of-band steps before this is fully done
1. **CSP browser-verify (CISEC-02)** — after the Vercel preview builds, confirm `/dashboard` fully hydrates with **zero `script-src` console violations** (next-themes no-flash, Sentry tunnel, Vercel Analytics beacon) and the nonce + `strict-dynamic` header is present; and `/` (marketing) still serves its static CSP. *(I'll run this against the preview before recommending merge.)*
2. **Edge Function redeploy (CISEC-03)** — `auth-email-send` needs an out-of-band `bun scripts/deploy-edge-functions.ts` post-merge (no CI deploy step for Edge Functions).

[hudsor01]
