### PR TITLE
fix(proxy): extend nonce CSP to credential-entry auth routes

### DIFF
--- a/src/lib/__tests__/csp-header.test.ts
+++ b/src/lib/__tests__/csp-header.test.ts
@@ -14,8 +14,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  *     and Next emits bare, non-nonced inline scripts there (next-themes
  *     no-flash, React hydration runtime, RSC flight payload). Removing
  *     `'unsafe-inline'` from the static CSP would CSP-block all of them
- *     and dead-render every marketing/login/pricing page. The nonce
- *     hardening is private-route-only (assertions b-d).
+ *     and dead-render every marketing page. The nonce hardening applies
+ *     to private routes (assertions b-d) AND credential-entry auth routes
+ *     (assertion f) — both are non-SEO surfaces where dynamic rendering
+ *     is acceptable; true-public marketing routes stay static (e).
  *
  *  2. On a PRIVATE route the proxy forwards the per-request nonce CSP on
  *     the REQUEST `Content-Security-Policy` header passed to
@@ -206,7 +208,7 @@ describe("CISEC-02 CSP hardening", () => {
 		expect(responseCsp).toContain("style-src 'self' 'unsafe-inline'");
 	});
 
-	it("(e) does NOT forward a nonce CSP on a public route", async () => {
+	it("(e) does NOT forward a nonce CSP on a public marketing route", async () => {
 		const response = await proxy(buildRequest("/"));
 
 		expect(mockUpdateSession).toHaveBeenCalledOnce();
@@ -216,5 +218,32 @@ describe("CISEC-02 CSP hardening", () => {
 		// No per-request nonce CSP on the response — the static vercel.json
 		// header governs public routes.
 		expect(response.headers.get("content-security-policy") ?? null).toBeNull();
+	});
+
+	// Credential-entry auth routes (/login, /auth/*) are public (not
+	// auth-gated) but DO get the hardened nonce CSP — an inline-script XSS on
+	// a credential page is the highest-value target. Pinned on /login and a
+	// token-handling /auth/* page; both must get request+response nonce CSP
+	// without being redirected (they are not auth-gated).
+	it.each([
+		"/login",
+		"/auth/update-password",
+	])("(f) applies the nonce CSP to credential-entry auth route %s (request + response, not auth-gated)", async (authPath) => {
+		const response = await proxy(buildRequest(authPath));
+
+		// Request-side: the load-bearing nonce CSP is forwarded so Next
+		// nonces the auth page's hydration scripts.
+		const requestHeaders = mockUpdateSession.mock.calls[0]?.[1];
+		const requestCsp = requestHeaders?.get("content-security-policy") ?? "";
+		expect(scriptSrcDirective(requestCsp)).toContain("'nonce-");
+		expect(scriptSrcDirective(requestCsp)).toContain("'strict-dynamic'");
+
+		// Response-side: same nonce, no unsafe-inline in script-src. And
+		// the route is NOT redirected (status < 300) — it stays a public
+		// page, just hardened.
+		const responseCsp = response.headers.get("content-security-policy") ?? "";
+		expect(extractNonceToken(requestCsp)).toBe(extractNonceToken(responseCsp));
+		expect(scriptSrcDirective(responseCsp)).not.toContain("'unsafe-inline'");
+		expect(response.status).toBeLessThan(300);
 	});
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -50,11 +50,37 @@ function isPrivateRoute(pathname: string): boolean {
 	);
 }
 
+// Public-but-credential-sensitive routes: the login form and the auth
+// token-handling pages (password update, email confirm). These are NOT
+// auth-gated (a logged-out user must reach /login), but they DO get the
+// hardened nonce CSP — an inline-script XSS on a credential-entry page is
+// the highest-value target, and these pages are not SEO-ranking surfaces,
+// so the dynamic-render cost of a per-request nonce is acceptable here
+// (unlike marketing/blog, which stay static). See needsNonceCsp.
+const AUTH_ROUTE_PREFIXES = ["/login", "/auth"];
+
+function isAuthRoute(pathname: string): boolean {
+	return AUTH_ROUTE_PREFIXES.some(
+		(prefix) => pathname === prefix || pathname.startsWith(prefix + "/"),
+	);
+}
+
 /**
- * CISEC-02 — Builds the per-request nonce CSP applied ONLY to private
- * (authenticated) routes. Marketing/blog/static pages keep the static
- * `vercel.json` CSP so they stay statically rendered (a nonce forces
- * dynamic rendering).
+ * Routes that receive the per-request nonce CSP: authenticated app routes
+ * PLUS the credential-entry auth routes. Kept separate from `isPrivateRoute`
+ * (the auth gate) so /login can be nonce-hardened without being auth-gated
+ * into a redirect loop.
+ */
+function needsNonceCsp(pathname: string): boolean {
+	return isPrivateRoute(pathname) || isAuthRoute(pathname);
+}
+
+/**
+ * CISEC-02 — Builds the per-request nonce CSP applied to private
+ * (authenticated) routes AND credential-entry auth routes (/login,
+ * /auth/*). Marketing/blog/static pages keep the static `vercel.json`
+ * CSP so they stay statically rendered (a nonce forces dynamic
+ * rendering); auth pages aren't SEO surfaces so the cost is acceptable.
  *
  * The load-bearing directive is `script-src 'self' 'nonce-<nonce>'
  * 'strict-dynamic'`. Next 16.2.6 parses this string off the forwarded
@@ -107,16 +133,18 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 	const { pathname } = request.nextUrl;
 	const privateRoute = isPrivateRoute(pathname);
 
-	// CISEC-02 — On private (authenticated) routes ONLY, generate a
-	// per-request nonce and forward the nonce CSP on the REQUEST
-	// `Content-Security-Policy` header so Next 16 auto-nonces its
-	// hydration scripts at render time (see buildNonceCsp). `x-nonce` is a
-	// non-load-bearing convenience for app code that reads `headers()`.
-	// Public/marketing/static routes are NOT touched here — they stay on
-	// the static `vercel.json` CSP so they remain statically rendered.
+	// CISEC-02 — On private (authenticated) routes AND credential-entry auth
+	// routes (/login, /auth/*), generate a per-request nonce and forward the
+	// nonce CSP on the REQUEST `Content-Security-Policy` header so Next 16
+	// auto-nonces its hydration scripts at render time (see buildNonceCsp).
+	// `x-nonce` is a non-load-bearing convenience for app code that reads
+	// `headers()`. Marketing/blog/static routes are NOT touched here — they
+	// stay on the static `vercel.json` CSP so they remain statically
+	// rendered (a nonce forces dynamic rendering; auth pages aren't SEO
+	// surfaces so the cost is acceptable there, marketing pages are).
 	let nonceCsp: string | undefined;
 	let requestHeaders: Headers | undefined;
-	if (privateRoute) {
+	if (needsNonceCsp(pathname)) {
 		const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
 		nonceCsp = buildNonceCsp(nonce);
 		requestHeaders = new Headers(request.headers);
@@ -146,10 +174,11 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 	// URLs, blog slugs, comparison pages, etc. — passes through so Next.js
 	// can render the matched page or its `not-found.tsx`. Auth-gating
 	// arbitrary typo URLs was making `/featres` redirect to `/login` instead
-	// of showing a 404, which is hostile UX. These keep the static
-	// `vercel.json` CSP — no per-request nonce CSP is applied.
+	// of showing a 404, which is hostile UX. `withCsp` applies the nonce CSP
+	// for credential-entry auth routes (/login, /auth/*) and is a no-op for
+	// true-public routes (marketing keeps the static `vercel.json` CSP).
 	if (!privateRoute) {
-		return supabaseResponse;
+		return withCsp(supabaseResponse);
 	}
 
 	if (!user) {


### PR DESCRIPTION
## Summary

Security follow-up to **CISEC-02** (v4.0 Phase 1). Extends the route-scoped per-request nonce CSP to the **credential-entry auth routes** (`/login`, `/auth/update-password`, `/auth/confirm-email`), which previously served the static `script-src 'self' 'unsafe-inline'`.

**Why:** An automated security review flagged that `'unsafe-inline'` on a credential-entry page is the highest-value inline-script XSS target. The SEO objection that keeps marketing pages static **does not apply to the auth pages** — they're client-rendered, not ranking surfaces — so the per-request-nonce dynamic-render cost is acceptable there. (`/login` already reads `useSearchParams` → already dynamic, so effectively zero added cost.)

This was surfaced and adjudicated during Phase 1 review: not a regression (the public CSP was net-zero vs `main`), not currently exploitable (no injection sink — React auto-escapes, the `?redirect=` param goes to navigation not the DOM), but a legitimate defense-in-depth improvement at the right layer.

## Change

| File | What |
|------|------|
| `src/proxy.ts` | Separate `needsNonceCsp` (private **or** auth routes) from `isPrivateRoute` (the auth gate) so `/login` is nonce-hardened **without** being auth-gated into a redirect loop. The public early-return now wraps `withCsp` — a no-op for true-public marketing routes, applies the nonce for auth routes. New `AUTH_ROUTE_PREFIXES` / `isAuthRoute`. |
| `src/lib/__tests__/csp-header.test.ts` | New assertion **(f)**: `/login` + `/auth/update-password` get the request+response nonce CSP (no `unsafe-inline`) and are **not** redirected (status < 300). Assertion (e) clarified to "public marketing route" (still no nonce). |

**Unchanged:** marketing/blog stay static on the `vercel.json` CSP; the private-route nonce path (assertions b–d) is untouched.

## Tests
30 proxy/CSP tests pass (incl. the 2 new auth-route cases); typecheck + lint clean.

[hudsor01]
