### PR TITLE
v4.0 Phase 2: Typed RPC Boundaries (TYPE-01..03)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -17,7 +17,7 @@
 ### TYPE — typed RPC/PostgREST boundaries (zero-tolerance rule #8)
 
 - [ ] **TYPE-01**: The analytics RPC factories (`use-analytics.ts` `LeaseAnalyticsPageData`) return data through a typed mapper with Zod validation — no `as unknown as`.
-- [ ] **TYPE-02**: The tenant and maintenance factories (`tenant-mutation-options.ts`, `maintenance-keys.ts`) return data through typed mappers — no `as unknown as`.
+- [x] **TYPE-02**: The tenant and maintenance factories (`tenant-mutation-options.ts`, `maintenance-keys.ts`) return data through typed mappers — no `as unknown as`.
 - [ ] **TYPE-03**: The remaining `src/hooks/api/` RPC-boundary casts (`expiring-leases-widget.tsx` and any siblings) are eliminated, and a drift-guard test asserts zero `as unknown as` at PostgREST/RPC boundaries under `src/hooks/api/` (library-shim casts in chart/slider excluded).
 
 ### PERF — query + cron consolidation
@@ -76,7 +76,7 @@ Deferred follow-ups (small, optional, non-blocking — fold into a later milesto
 | CISEC-03 | Phase 1 — Security-CI Hardening | Complete |
 | CISEC-04 | Phase 1 — Security-CI Hardening | Pending |
 | TYPE-01 | Phase 2 — Typed RPC Boundaries | Pending |
-| TYPE-02 | Phase 2 — Typed RPC Boundaries | Pending |
+| TYPE-02 | Phase 2 — Typed RPC Boundaries | Complete |
 | TYPE-03 | Phase 2 — Typed RPC Boundaries | Pending |
 | PERF-02 | Phase 3 — Stats RPC Consolidation | Pending |
 | PERF-03 | Phase 3 — Stats RPC Consolidation | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -81,7 +81,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   4. A drift-guard test asserts zero `as unknown as` at PostgREST/RPC boundaries under `src/hooks/api/` (library-shim casts in chart/slider excluded), and `bun run typecheck` stays clean.
 **Plans**: 4 plans (all Wave 1 — parallel, zero file overlap)
 - [ ] 02-01-PLAN.md — TYPE-01: mapLeaseAnalytics validated mapper for use-analytics.ts lease paths
-- [ ] 02-02-PLAN.md — TYPE-02: validated mapTenantBaseRow + upgrade mapTenantRow; tenant-mutation-options.ts write boundary
+- [x] 02-02-PLAN.md — TYPE-02: validated mapTenantBaseRow + upgrade mapTenantRow; tenant-mutation-options.ts write boundary (commit 81d740d23)
 - [ ] 02-03-PLAN.md — TYPE-02: mapMaintenanceRow validated mapper across maintenance-keys.ts read/write boundaries
 - [ ] 02-04-PLAN.md — TYPE-03: mapExpiringLeaseRow validated mapper + zero-`as unknown as` drift guard
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -79,7 +79,11 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   2. `tenant-mutation-options.ts` and `maintenance-keys.ts` return data through typed mappers — no `as unknown as`.
   3. The remaining `src/hooks/api/` RPC-boundary casts (`expiring-leases-widget.tsx` and siblings) are eliminated.
   4. A drift-guard test asserts zero `as unknown as` at PostgREST/RPC boundaries under `src/hooks/api/` (library-shim casts in chart/slider excluded), and `bun run typecheck` stays clean.
-**Plans**: TBD
+**Plans**: 4 plans (all Wave 1 — parallel, zero file overlap)
+- [ ] 02-01-PLAN.md — TYPE-01: mapLeaseAnalytics validated mapper for use-analytics.ts lease paths
+- [ ] 02-02-PLAN.md — TYPE-02: validated mapTenantBaseRow + upgrade mapTenantRow; tenant-mutation-options.ts write boundary
+- [ ] 02-03-PLAN.md — TYPE-02: mapMaintenanceRow validated mapper across maintenance-keys.ts read/write boundaries
+- [ ] 02-04-PLAN.md — TYPE-03: mapExpiringLeaseRow validated mapper + zero-`as unknown as` drift guard
 
 ### Phase 3: Stats RPC Consolidation
 **Goal**: The unit and tenant stat hooks each resolve through a single owner-scoped SECURITY DEFINER RPC instead of multiple HEAD counts plus an unbounded fetch, with owner-isolation pinned by a dual-client RLS test.
@@ -150,7 +154,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 | Phase | Milestone | Plans | Status | Completed |
 |-------|-----------|-------|--------|-----------|
 | 1. Security-CI Hardening | v4.0 | 3/4 | In Progress|  |
-| 2. Typed RPC Boundaries | v4.0 | 0/? | Not started | - |
+| 2. Typed RPC Boundaries | v4.0 | 0/4 | Planned | - |
 | 3. Stats RPC Consolidation | v4.0 | 0/? | Not started | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 0/? | Not started | - |
 | 5. Cross-Owner RLS Coverage | v4.0 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -82,7 +82,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 **Plans**: 4 plans (all Wave 1 — parallel, zero file overlap)
 - [ ] 02-01-PLAN.md — TYPE-01: mapLeaseAnalytics validated mapper for use-analytics.ts lease paths
 - [x] 02-02-PLAN.md — TYPE-02: validated mapTenantBaseRow + upgrade mapTenantRow; tenant-mutation-options.ts write boundary (commit 81d740d23)
-- [ ] 02-03-PLAN.md — TYPE-02: mapMaintenanceRow validated mapper across maintenance-keys.ts read/write boundaries
+- [x] 02-03-PLAN.md — TYPE-02: mapMaintenanceRow validated mapper across maintenance-keys.ts read/write boundaries (commits 2219f2a20, 4439223a3)
 - [ ] 02-04-PLAN.md — TYPE-03: mapExpiringLeaseRow validated mapper + zero-`as unknown as` drift guard
 
 ### Phase 3: Stats RPC Consolidation
@@ -154,7 +154,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 | Phase | Milestone | Plans | Status | Completed |
 |-------|-----------|-------|--------|-----------|
 | 1. Security-CI Hardening | v4.0 | 3/4 | In Progress|  |
-| 2. Typed RPC Boundaries | v4.0 | 0/4 | Planned | - |
+| 2. Typed RPC Boundaries | v4.0 | 3/4 | In Progress | - |
 | 3. Stats RPC Consolidation | v4.0 | 0/? | Not started | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 0/? | Not started | - |
 | 5. Cross-Owner RLS Coverage | v4.0 | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v4.0
 milestone_name: Hardening & Hygiene
 status: planning
-last_updated: "2026-06-05T21:31:05.921Z"
-last_activity: 2026-06-05 — executed Phase 2 plan 02-02 (TYPE-02 tenant boundary validation)
+last_updated: "2026-06-05T21:43:54.948Z"
+last_activity: 2026-06-05 — executed Phase 2 plan 02-03 (TYPE-02 maintenance boundary → mapMaintenanceRow)
 progress:
   total_phases: 8
   completed_phases: 1
   total_plans: 8
   completed_plans: 7
-  percent: 14
+  percent: 88
 ---
 
 # Project State
@@ -24,11 +24,11 @@ See: .planning/PROJECT.md (updated 2026-06-04 — v4.0 Hardening & Hygiene activ
 
 ## Current Position
 
-Phase: 1 of 8 (Security-CI Hardening) — v4.0
-Plan: — (not yet planned)
-Status: Roadmap created; ready to plan Phase 1
-Progress: [████████░░] 75%
-Last activity: 2026-06-04 — v4.0 roadmap created (8 phases, 21/21 requirements mapped)
+Phase: 2 of 8 (Typed RPC Boundaries) — v4.0
+Plan: 03 of 04 complete (02-04 pending)
+Status: 02-03 executed — TYPE-02 maintenance boundary routed through validated mapMaintenanceRow
+Progress: [█████████░] 88%
+Last activity: 2026-06-05 — executed Phase 2 plan 02-03 (TYPE-02 maintenance boundary → mapMaintenanceRow)
 
 ## Roadmap Summary (v4.0)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v4.0
 milestone_name: Hardening & Hygiene
 status: planning
-last_updated: "2026-06-04T18:16:25.570Z"
-last_activity: 2026-06-04 — v4.0 roadmap created (8 phases, 21/21 requirements mapped)
+last_updated: "2026-06-05T21:31:05.921Z"
+last_activity: 2026-06-05 — executed Phase 2 plan 02-02 (TYPE-02 tenant boundary validation)
 progress:
   total_phases: 8
-  completed_phases: 0
-  total_plans: 4
-  completed_plans: 3
-  percent: 0
+  completed_phases: 1
+  total_plans: 8
+  completed_plans: 7
+  percent: 14
 ---
 
 # Project State

--- a/.planning/phases/02-typed-rpc-boundaries/02-01-PLAN.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-01-PLAN.md
@@ -1,0 +1,149 @@
+---
+phase: 02-typed-rpc-boundaries
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/hooks/api/query-keys/analytics-mappers.ts
+  - src/hooks/api/use-analytics.ts
+  - src/hooks/api/query-keys/analytics-mappers.test.ts
+autonomous: true
+requirements: [TYPE-01]
+must_haves:
+  truths:
+    - "use-analytics.ts leasePageData() returns LeaseAnalyticsPageData through a validated mapper, not a raw `{} as LeaseAnalyticsPageData` cast"
+    - "use-analytics.ts overviewPageData().lease returns through the same validated mapper"
+    - "An RPC return missing/wrong-shaped enum/numeric fields falls back to a safe empty LeaseAnalyticsPageData instead of leaking undefined to consumers"
+    - "No `as unknown as` and no bare `{} as LeaseAnalyticsPageData` cast remains in use-analytics.ts on the lease path"
+  artifacts:
+    - path: "src/hooks/api/query-keys/analytics-mappers.ts"
+      provides: "mapLeaseAnalytics validated mapper + lease analytics Zod schema"
+      contains: "mapLeaseAnalytics"
+    - path: "src/hooks/api/use-analytics.ts"
+      provides: "lease analytics path routed through mapLeaseAnalytics"
+      contains: "mapLeaseAnalytics"
+    - path: "src/hooks/api/query-keys/analytics-mappers.test.ts"
+      provides: "unit coverage: valid row mapped, invalid/missing → safe fallback, enum/numeric drift rejected"
+      contains: "mapLeaseAnalytics"
+  key_links:
+    - from: "src/hooks/api/use-analytics.ts"
+      to: "src/hooks/api/query-keys/analytics-mappers.ts"
+      via: "import mapLeaseAnalytics"
+      pattern: "mapLeaseAnalytics"
+---
+
+<objective>
+Convert the TYPE-01 analytics boundary — the `LeaseAnalyticsPageData` paths in `use-analytics.ts` — from raw `{} as LeaseAnalyticsPageData` / `jsonObjectOrEmpty<LeaseAnalyticsPageData>` casts to a typed mapper (`mapLeaseAnalytics`) that field-validates the enum-shaped and numeric fields via Zod `safeParse` and falls back to a safe empty shape on invalid/empty RPC data.
+
+Purpose: `get_occupancy_trends_optimized` returns untyped JSON (`fetchOccupancyTrends` returns `unknown`). Today the lease path blind-casts it to `LeaseAnalyticsPageData`, so RPC drift silently produces `undefined` field reads downstream. A validated mapper catches drift at the boundary, mirroring `mapDocumentRow`.
+Output: `analytics-mappers.ts` with `mapLeaseAnalytics`, wired into `use-analytics.ts`'s `leasePageData()` and `overviewPageData()`, plus unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-typed-rpc-boundaries/02-CONTEXT.md
+
+<interfaces>
+<!-- Target type (REUSE — do not duplicate). From src/types/analytics-page-data.ts: -->
+LeaseAnalyticsPageData {
+  metrics: LeaseAnalyticsPageResponse["metrics"];   // LeaseFinancialSummary
+  profitability: LeaseAnalyticsPageResponse["profitability"]; // LeaseFinancialInsight[]
+  renewalRates: LeaseLifecyclePoint[];
+  vacancyTrends: VacancyTrendPoint[];
+  leaseDistribution: LeaseAnalyticsPageResponse["statusBreakdown"]; // LeaseStatusBreakdown[]
+  lifecycle: LeaseLifecyclePoint[];
+  statusBreakdown: LeaseAnalyticsPageResponse["statusBreakdown"];
+}
+
+<!-- From src/types/analytics.ts: -->
+LeaseFinancialSummary { totalLeases:number; activeLeases:number; expiringSoon:number; totalrent_amount:number; averageLeaseValue:number; }
+LeaseLifecyclePoint { period:string; renewals:number; expirations:number; noticesGiven:number; }
+LeaseStatusBreakdown { status:string; count:number; percentage:number; }
+LeaseFinancialInsight { lease_id:string; propertyName:string; tenantName:string; rent_amount:number; outstandingBalance:number; profitabilityScore?:number|null; }
+VacancyTrendPoint { period:string; vacancyRate:number; turnovers:number; avgVacancyDays:number; }
+
+<!-- The RPC source: fetchOccupancyTrends(months) in src/hooks/api/query-keys/analytics-keys.ts returns Promise<unknown> (data ?? {}). -->
+<!-- Canonical reference mapper: mapDocumentRow in src/hooks/api/query-keys/document-keys.ts. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create analytics-mappers.ts with mapLeaseAnalytics + Zod schema</name>
+  <read_first>
+    - src/hooks/api/query-keys/document-keys.ts (mapDocumentRow pattern: requireString throws on NOT-NULL, nullable left nullable, validated-mapper-at-boundary)
+    - src/types/analytics-page-data.ts (LeaseAnalyticsPageData — the target type; REUSE, do not duplicate)
+    - src/types/analytics.ts lines 285-303 (LeaseLifecyclePoint, LeaseStatusBreakdown, LeaseFinancialSummary, LeaseFinancialInsight shapes)
+    - src/hooks/api/query-keys/analytics-keys.ts lines 52-62 (fetchOccupancyTrends — returns unknown / `data ?? {}`)
+    - src/lib/rpc-shape.ts (jsonObjectOrEmpty — the structural-only guard being replaced for field validation)
+  </read_first>
+  <behavior>
+    - mapLeaseAnalytics(raw: unknown) → LeaseAnalyticsPageData
+    - Valid raw object with well-formed metrics/profitability/lifecycle/statusBreakdown/vacancyTrends → returns a fully-shaped LeaseAnalyticsPageData with `renewalRates` and `lifecycle` both populated from the lifecycle array, and `leaseDistribution` and `statusBreakdown` both populated from the statusBreakdown array.
+    - raw === null / undefined / {} / non-object → returns the safe empty fallback (zeroed metrics, empty arrays) — never throws (analytics "no data yet" is a valid render state per jsonObjectOrEmpty precedent).
+    - raw with a numeric field arriving as a non-number (e.g. metrics.totalLeases as a string), or a statusBreakdown row missing `status`/`count`, or a lifecycle row missing `period` → that malformed sub-shape is rejected by Zod safeParse and coerced to the empty/default for that branch, not leaked as-is.
+  </behavior>
+  <action>
+    Create src/hooks/api/query-keys/analytics-mappers.ts. Import the target types `LeaseAnalyticsPageData` and `VacancyTrendPoint` from `#types/analytics-page-data`, and `LeaseLifecyclePoint`, `LeaseStatusBreakdown`, `LeaseFinancialSummary`, `LeaseFinancialInsight` from `#types/analytics` — REUSE these, define no new duplicate interfaces (CLAUDE.md type-lookup order). Define module-local Zod schemas with `zod` (`import { z } from "zod"`): `leaseFinancialSummarySchema` (five numeric fields), `leaseLifecyclePointSchema` (period string + three numeric counts), `leaseStatusBreakdownSchema` (status string, count + percentage numeric), `leaseFinancialInsightSchema` (string ids/names + numeric amounts + nullable optional profitabilityScore), `vacancyTrendPointSchema` (period string + three numeric). Compose a top-level `leaseAnalyticsRawSchema` that `safeParse`s an object with optional `metrics`, `profitability`, `lifecycle`, `statusBreakdown`, `vacancyTrends` keys. Export `mapLeaseAnalytics(raw: unknown): LeaseAnalyticsPageData`: define an `emptyLeaseAnalytics()` helper returning the zeroed-metrics/empty-arrays fallback; run `leaseAnalyticsRawSchema.safeParse(raw)`; on `!success` return the empty fallback; on success build the `LeaseAnalyticsPageData` where `renewalRates` and `lifecycle` both come from the parsed lifecycle (default `[]`), and `leaseDistribution` and `statusBreakdown` both come from the parsed statusBreakdown (default `[]`), `metrics` from parsed metrics or the zeroed default, `profitability`/`vacancyTrends` defaulting to `[]`. Mirror `mapDocumentRow`'s boundary-validation discipline — no `as unknown as`, no bare `as LeaseAnalyticsPageData`. Add a top-of-file docstring citing the mapDocumentRow precedent and CLAUDE.md RPC-return-typing rule. Keep the file under the 300-line cap.
+  </action>
+  <verify>
+    <automated>grep -q "mapLeaseAnalytics" src/hooks/api/query-keys/analytics-mappers.ts && grep -q "safeParse" src/hooks/api/query-keys/analytics-mappers.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - src/hooks/api/query-keys/analytics-mappers.ts exists and exports `mapLeaseAnalytics`
+    - File contains `safeParse` (field-level Zod validation, not just structural)
+    - File imports `LeaseAnalyticsPageData` from `#types/analytics-page-data` (no duplicate type definition)
+    - `grep -c "as unknown as" src/hooks/api/query-keys/analytics-mappers.ts` returns 0 (ignoring comments via `grep -v '^[[:space:]]*[/*]'` if needed)
+    - `bun run typecheck` is clean
+  </acceptance_criteria>
+  <done>mapLeaseAnalytics exists, field-validates via Zod safeParse, reuses the existing LeaseAnalyticsPageData type, typecheck clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Wire mapLeaseAnalytics into use-analytics.ts + add unit tests</name>
+  <read_first>
+    - src/hooks/api/use-analytics.ts lines 57-69 (leasePageData) and 116-156 (overviewPageData — the `lease:` branch)
+    - src/hooks/api/query-keys/analytics-mappers.ts (the mapper from Task 1)
+    - src/hooks/api/query-keys/document-keys.ts (mapDocumentRow validation discipline, for test-case shaping)
+  </read_first>
+  <action>
+    In src/hooks/api/use-analytics.ts: import `mapLeaseAnalytics` from `./query-keys/analytics-mappers`. In `leasePageData().queryFn`, replace the `jsonObjectOrEmpty<LeaseAnalyticsPageData>(data, {} as LeaseAnalyticsPageData)` return with `return mapLeaseAnalytics(data)`. In `overviewPageData().queryFn`, replace the `lease: jsonObjectOrEmpty<LeaseAnalyticsPageData>(occupancyData, {} as LeaseAnalyticsPageData)` with `lease: mapLeaseAnalytics(occupancyData)`. Remove the now-unused `jsonObjectOrEmpty` import only if no other call site in the file still uses it (the financial/maintenance paths use `jsonObject`, which stays — keep `jsonObject`). Do NOT touch the financial, maintenance, occupancy, propertyPerformance, or ownerPaymentSummary paths — those are out of TYPE-01 scope. Then create src/hooks/api/query-keys/analytics-mappers.test.ts (Vitest) covering: (a) a fully-valid raw occupancy/lease object maps to a populated LeaseAnalyticsPageData with lifecycle===renewalRates source and statusBreakdown===leaseDistribution source; (b) `null`, `undefined`, `{}`, and a non-object primitive each return the zeroed empty fallback without throwing; (c) a raw object whose `metrics.totalLeases` is a string and whose `statusBreakdown` contains a row missing `count` falls back safely for those branches. Use `.rejects.toMatchObject` is N/A here (mapper never throws); assert returned shapes with `expect(...).toEqual`/`toMatchObject`.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/hooks/api/query-keys/analytics-mappers.test.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "as LeaseAnalyticsPageData" src/hooks/api/use-analytics.ts` returns 0 (the `{} as LeaseAnalyticsPageData` casts are gone)
+    - `grep -q "mapLeaseAnalytics" src/hooks/api/use-analytics.ts` succeeds on both lease call sites
+    - use-analytics.ts still contains `jsonObject<FinancialAnalyticsPageData>` and `jsonObject<MaintenanceInsightsPageData>` (out-of-scope paths untouched)
+    - `bun run test:unit -- --run src/hooks/api/query-keys/analytics-mappers.test.ts` passes (valid-maps, empty-fallback, drift-rejected cases all green)
+    - `bun run typecheck` is clean
+  </acceptance_criteria>
+  <done>Both lease call sites route through mapLeaseAnalytics, no `as LeaseAnalyticsPageData` cast remains, out-of-scope analytics paths untouched, tests green.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck` clean
+- `bun run lint` clean on the two modified files
+- `bun run test:unit -- --run src/hooks/api/query-keys/analytics-mappers.test.ts` passes
+- Lease analytics path validates via Zod safeParse; no `{} as LeaseAnalyticsPageData` remains
+</verification>
+
+<success_criteria>
+TYPE-01 satisfied: `use-analytics.ts` returns `LeaseAnalyticsPageData` through a validated `mapLeaseAnalytics()` mapper with Zod field validation, no `as unknown as` / no bare `{} as LeaseAnalyticsPageData`, out-of-scope analytics paths untouched, typecheck clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-typed-rpc-boundaries/02-01-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-typed-rpc-boundaries/02-01-SUMMARY.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-01-SUMMARY.md
@@ -1,0 +1,77 @@
+---
+phase: 02-typed-rpc-boundaries
+plan: 01
+subsystem: analytics-data-layer
+tags: [type-safety, zod, rpc-boundary, mapper]
+requires: []
+provides:
+  - "mapLeaseAnalytics validated boundary mapper (Zod safeParse, safe-empty fallback)"
+  - "lease analytics RPC path field-validated at the boundary"
+affects:
+  - src/hooks/api/use-analytics.ts
+tech-stack:
+  added: []
+  patterns:
+    - "validated-mapper-at-RPC-boundary (mirrors mapDocumentRow)"
+    - "per-branch Zod .catch(undefined) so one drifted sub-shape degrades alone"
+    - "exactOptionalPropertyTypes-safe optional-field normalization (omit key when undefined)"
+key-files:
+  created:
+    - src/hooks/api/query-keys/analytics-mappers.ts
+    - src/hooks/api/query-keys/analytics-mappers.test.ts
+  modified:
+    - src/hooks/api/use-analytics.ts
+decisions:
+  - "Mapper never throws (analytics 'no data yet' is a valid render state per the jsonObjectOrEmpty precedent the lease path used before) — degrades to a zeroed/empty LeaseAnalyticsPageData instead."
+  - "Validation depth: top-level branches (metrics/profitability/lifecycle/statusBreakdown/vacancyTrends) each get a full field-level Zod object schema; a malformed sub-shape clears only that branch via .catch(undefined), keeping well-formed siblings."
+  - "Dropped the `satisfies z.ZodType<T>` schema assertions — they conflict with exactOptionalPropertyTypes on the nullable-optional profitabilityScore. Structural assignability + the toLeaseFinancialInsight normalizer enforce the contract instead."
+metrics:
+  duration: "~7 min"
+  completed: 2026-06-05
+  tasks: 2
+  files: 3
+---
+
+# Phase 2 Plan 01: Typed Lease-Analytics RPC Boundary (TYPE-01) Summary
+
+Added `mapLeaseAnalytics` — a Zod-`safeParse`-validated mapper that replaces the raw `{} as LeaseAnalyticsPageData` / `jsonObjectOrEmpty<LeaseAnalyticsPageData>` casts on the `use-analytics.ts` lease paths, catching RPC drift at the boundary while keeping the analytics "no data yet" empty-render state valid (never throws).
+
+## What Was Built
+
+- **`src/hooks/api/query-keys/analytics-mappers.ts`** — `mapLeaseAnalytics(raw: unknown): LeaseAnalyticsPageData`. Five field-level Zod schemas (lease financial summary, financial insight, lifecycle point, status breakdown, vacancy trend) composed into a top-level `leaseAnalyticsRawSchema` where each branch is `.optional().catch(undefined)`. On a failed `safeParse` (null / undefined / non-object) or any drifted branch, the mapper degrades to a zeroed-metrics / empty-arrays `LeaseAnalyticsPageData`. The lifecycle array feeds both `lifecycle` and `renewalRates`; the statusBreakdown array feeds both `statusBreakdown` and `leaseDistribution` (page-compatibility aliases on the existing type). Mirrors `mapDocumentRow`'s boundary-validation discipline; reuses `LeaseAnalyticsPageData` + `LeaseFinancial*` types (no duplicates).
+- **`src/hooks/api/use-analytics.ts`** — `leasePageData().queryFn` and `overviewPageData().lease` now `return mapLeaseAnalytics(...)`. Removed both `{} as LeaseAnalyticsPageData` casts and the now-unused `jsonObjectOrEmpty` import (kept `jsonObject` for the out-of-scope financial/maintenance paths).
+- **`src/hooks/api/query-keys/analytics-mappers.test.ts`** — 9 unit tests: valid-maps (lifecycle↔renewalRates, statusBreakdown↔leaseDistribution sourcing), empty fallback for null/undefined/`{}`/non-object primitive, metrics-zeroed-on-string-drift, statusBreakdown-dropped-on-missing-count, lifecycle-dropped-on-missing-period, nullable/omitted profitabilityScore.
+
+## Verification Results
+
+- `bun run typecheck` — clean
+- `bun run lint` (biome, on all 3 touched files) — clean, no fixes
+- `bunx vitest --run --project unit src/hooks/api/query-keys/analytics-mappers.test.ts` — 9 passed (9)
+- `grep -c "as LeaseAnalyticsPageData" src/hooks/api/use-analytics.ts` — 0
+- `grep -c "as unknown as" src/hooks/api/query-keys/analytics-mappers.ts` — 1 (docstring-only, references the rule; mirrors `mapDocumentRow`'s own docstring)
+- Out-of-scope paths (financial / maintenance / occupancy / propertyPerformance / ownerPaymentSummary) untouched; `jsonObject<FinancialAnalyticsPageData>` + `jsonObject<MaintenanceInsightsPageData>` still present.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] `satisfies z.ZodType<T>` conflicted with `exactOptionalPropertyTypes`**
+- **Found during:** Task 1 typecheck
+- **Issue:** `LeaseFinancialInsight.profitabilityScore?: number | null` rejects the literal value `undefined` under `exactOptionalPropertyTypes: true`, but Zod's `.optional()` widens the parsed value to `number | null | undefined`, so the `satisfies z.ZodType<LeaseFinancialInsight>` assertion (and the downstream array assignment) failed to typecheck.
+- **Fix:** Dropped the `satisfies` assertions (schemas still infer correct shapes) and added a `toLeaseFinancialInsight` normalizer that includes `profitabilityScore` only when it is not `undefined`. The mapper's typed return (`LeaseAnalyticsPageData`) remains the enforced contract.
+- **Files modified:** src/hooks/api/query-keys/analytics-mappers.ts
+- **Commit:** 445de2ac2
+
+No other deviations — plan executed as written (2-task split: mapper, then wiring + tests).
+
+## Known Stubs
+
+None. The "safe empty" fallback is an intentional, documented render state (analytics aggregate "no data yet"), not a stub — it matches the pre-existing `jsonObjectOrEmpty` lease-path behavior, now field-validated.
+
+## Self-Check: PASSED
+
+- FOUND: src/hooks/api/query-keys/analytics-mappers.ts
+- FOUND: src/hooks/api/query-keys/analytics-mappers.test.ts
+- FOUND: src/hooks/api/use-analytics.ts (modified)
+- FOUND: commit 445de2ac2 (Task 1 mapper)
+- FOUND: commit 00062f29f (Task 2 wiring + tests)

--- a/.planning/phases/02-typed-rpc-boundaries/02-02-PLAN.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-02-PLAN.md
@@ -1,0 +1,144 @@
+---
+phase: 02-typed-rpc-boundaries
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/hooks/api/query-keys/tenant-mappers.ts
+  - src/hooks/api/query-keys/tenant-mutation-options.ts
+  - src/hooks/api/query-keys/tenant-mappers.test.ts
+autonomous: true
+requirements: [TYPE-02]
+must_haves:
+  truths:
+    - "tenant-mutation-options.ts create/update return a validated Tenant row, not a raw `created as Tenant` / `updated as Tenant` cast"
+    - "mapTenantRow field-validates the enum-shaped (status) and NOT-NULL (id) fields via Zod safeParse instead of plain `as TenantWithLeaseInfo` shaping"
+    - "An insert/update response missing the NOT-NULL id throws at the boundary; an invalid status enum is rejected"
+    - "Nullable-in-DB tenant fields (owner_user_id, email, name, etc.) stay nullable — not over-validated"
+  artifacts:
+    - path: "src/hooks/api/query-keys/tenant-mappers.ts"
+      provides: "mapTenantRow upgraded to Zod-validate + new mapTenantBaseRow for create/update returns"
+      contains: "safeParse"
+    - path: "src/hooks/api/query-keys/tenant-mutation-options.ts"
+      provides: "create/update route through the validated tenant mapper"
+      contains: "mapTenant"
+    - path: "src/hooks/api/query-keys/tenant-mappers.test.ts"
+      provides: "unit coverage: valid row mapped; missing id throws; bad status rejected"
+      contains: "mapTenant"
+  key_links:
+    - from: "src/hooks/api/query-keys/tenant-mutation-options.ts"
+      to: "src/hooks/api/query-keys/tenant-mappers.ts"
+      via: "import the validated tenant mapper"
+      pattern: "mapTenant"
+---
+
+<objective>
+Convert the TYPE-02 tenant boundary — the `created as Tenant` / `updated as Tenant` / `updated as TenantPostgrestRow` casts in `tenant-mutation-options.ts` — to typed mappers with Zod field validation, AND upgrade the existing `mapTenantRow` in `tenant-mappers.ts` (which today shapes without `safeParse`) to field-validate.
+
+Purpose: tenant insert/update PostgREST responses are blind-cast to `Tenant`. A dropped column or a bad `status` enum slips through silently. Field-level Zod validation at the boundary catches drift, mirroring `mapDocumentRow`.
+Output: an upgraded `mapTenantRow` plus a `mapTenantBaseRow` (for the `.select().single()` flat-row create/update returns), wired into `tenant-mutation-options.ts`, with unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-typed-rpc-boundaries/02-CONTEXT.md
+
+<interfaces>
+<!-- Target types (REUSE — do not duplicate). From src/types/core.ts: -->
+Tenant = Tables<"tenants">;          // flat tenants row
+TenantWithLeaseInfo                   // enriched shape mapTenantRow already returns
+
+<!-- tenants Row NOT-NULL fields (from src/types/supabase.ts): id (string), status (string). -->
+<!-- tenants Row NULLABLE fields: created_at, date_of_birth, email, emergency_contact_*, first_name, identity_verified, last_name, name, owner_user_id, phone, ssn_last_four, updated_at, user_id. -->
+
+<!-- REUSE existing enum schema. From src/lib/validation/tenants.ts: -->
+tenantStatusSchema = z.enum(["active","inactive","pending","SUSPENDED","DELETED"])
+TENANT_ACTIVE_STATUSES = ["active","inactive","pending","moved_out"] as const
+<!-- NOTE: markMovedOut sets status="moved_out", which is in TENANT_ACTIVE_STATUSES but NOT tenantStatusSchema.
+     Validate the persisted status against the UNION of both sets so moved_out is accepted. -->
+
+<!-- Existing mapper to UPGRADE. From src/hooks/api/query-keys/tenant-mappers.ts: -->
+mapTenantRow(row: TenantPostgrestRow): TenantWithLeaseInfo   // ends in a bare `as TenantWithLeaseInfo` — add safeParse
+TenantPostgrestRow                                          // the nested-join raw shape (exported)
+
+<!-- Canonical reference mapper: mapDocumentRow in src/hooks/api/query-keys/document-keys.ts. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add validation to mapTenantRow + add mapTenantBaseRow in tenant-mappers.ts</name>
+  <read_first>
+    - src/hooks/api/query-keys/tenant-mappers.ts (the full file — mapTenantRow + TenantPostgrestRow; ends in `as TenantWithLeaseInfo`)
+    - src/hooks/api/query-keys/document-keys.ts (mapDocumentRow: requireString throws on NOT-NULL, nullable left nullable — the discipline to mirror)
+    - src/lib/validation/tenants.ts lines 18-38 (tenantStatusSchema + TENANT_ACTIVE_STATUSES — REUSE; do not redefine the status enum)
+    - src/types/core.ts (Tenant = Tables<"tenants">; TenantWithLeaseInfo — REUSE)
+  </read_first>
+  <behavior>
+    - mapTenantBaseRow(raw: unknown) → Tenant: a valid flat tenants row (NOT-NULL id present, status a recognized value) maps through; a row missing `id` throws; a row whose `status` is not in the accepted union throws (or is rejected via safeParse error surfaced as a thrown boundary error). Nullable fields (owner_user_id, email, name, etc.) pass through as their value-or-null.
+    - mapTenantRow(row): keeps its existing TenantWithLeaseInfo output shape and join-flattening logic, but now validates the row's `id` (throw if missing) and `status` (safeParse against the accepted union, default to "active" only when null/absent as today) before returning — and the final return no longer relies on a bare `as TenantWithLeaseInfo` to paper over an unvalidated shape.
+  </behavior>
+  <action>
+    In src/hooks/api/query-keys/tenant-mappers.ts: import `z` from `zod`, `tenantStatusSchema` and `TENANT_ACTIVE_STATUSES` from `#lib/validation/tenants`, and `Tenant` from `#types/core`. Define a module-local `tenantPersistedStatusSchema` as the union of `tenantStatusSchema` and `z.enum(TENANT_ACTIVE_STATUSES)` (so `moved_out` from markMovedOut is accepted) — or equivalently `z.enum([...new Set([...statuses])])`. Add a `requireString(raw, field)` helper mirroring mapDocumentRow that throws on a missing/non-string NOT-NULL field. Add and export `mapTenantBaseRow(raw: unknown): Tenant`: treat `raw` as `Record<string, unknown>`, `requireString` the `id`, validate `status` via `tenantPersistedStatusSchema.safeParse` (throw a descriptive boundary error on failure), pass nullable fields through as `(raw.x as T | null) ?? null`, and return the `Tenant` shape. Upgrade the existing `mapTenantRow`: before building `base`, `requireString(row, "id")` and run `tenantPersistedStatusSchema.safeParse(row.status)` when `row.status` is non-null (throw on invalid), keeping the existing `?? "active"` default for the null branch; keep all the join-flattening logic intact. Mirror mapDocumentRow's "throw early so a dropped NOT-NULL column surfaces immediately" docstring note. Keep nullable-in-DB fields nullable (do not require owner_user_id/email/name). Stay under the 300-line cap (split is not needed; the file is ~178 lines).
+  </action>
+  <verify>
+    <automated>grep -q "mapTenantBaseRow" src/hooks/api/query-keys/tenant-mappers.ts && grep -q "safeParse" src/hooks/api/query-keys/tenant-mappers.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - tenant-mappers.ts exports `mapTenantBaseRow` and still exports `mapTenantRow` + `TenantPostgrestRow`
+    - tenant-mappers.ts contains `safeParse` (mapTenantRow is now validated, not just shaped)
+    - tenant-mappers.ts imports `tenantStatusSchema`/`TENANT_ACTIVE_STATUSES` from `#lib/validation/tenants` (REUSE — no redefined status enum)
+    - tenant-mappers.ts imports `Tenant` from `#types/core` (no duplicate Tenant type)
+    - `bun run typecheck` clean
+  </acceptance_criteria>
+  <done>mapTenantBaseRow added, mapTenantRow validates id + status via Zod safeParse, reuses existing status enum + Tenant type, nullable fields stay nullable, typecheck clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Route tenant create/update through mapTenantBaseRow + add unit tests</name>
+  <read_first>
+    - src/hooks/api/query-keys/tenant-mutation-options.ts (lines 31-40 create `created as Tenant`; 54-64 update `updated as Tenant`; 119-139 markMovedOut already uses mapTenantRow via `updated as TenantPostgrestRow`)
+    - src/hooks/api/query-keys/tenant-mappers.ts (mapTenantBaseRow + upgraded mapTenantRow from Task 1)
+    - src/hooks/api/query-keys/document-keys.ts (test-case shaping reference for valid/missing/invalid rows)
+  </read_first>
+  <action>
+    In src/hooks/api/query-keys/tenant-mutation-options.ts: import `mapTenantBaseRow` from `./tenant-mappers` (the file already imports `mapTenantRow` + `TenantPostgrestRow`). In `create().mutationFn`, replace `return created as Tenant` with `return mapTenantBaseRow(created)`. In `update().mutationFn`, replace `return updated as Tenant` with `return mapTenantBaseRow(updated)`. Leave `markMovedOut` as-is except confirm it still routes through the now-validated `mapTenantRow(updated as TenantPostgrestRow)` — that call already exists and Task 1 upgraded the mapper, so no change beyond verifying it compiles. Remove the now-unused `Tenant` import only if nothing else in the file references it (the function return-type annotations `Promise<Tenant>` still reference it — KEEP the `Tenant` type import). Then create src/hooks/api/query-keys/tenant-mappers.test.ts (Vitest) covering: (a) mapTenantBaseRow on a valid flat row (id + status="active" + some nullable fields null) returns the Tenant shape; (b) mapTenantBaseRow on a row missing `id` throws — assert via `expect(() => mapTenantBaseRow(row)).toThrow()` or `.toMatchObject({ message: expect.stringContaining("id") })`; (c) mapTenantBaseRow on a row with `status: "bogus_status"` is rejected (throws); (d) mapTenantBaseRow accepts `status: "moved_out"` (in the union); (e) mapTenantRow on a minimal valid nested row returns TenantWithLeaseInfo and on a row missing `id` throws. Per the Vitest 4 + chai 6 gotcha, prefer `.rejects.toMatchObject`/synchronous `expect(fn).toThrow()` over `.toThrow('string')`.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/hooks/api/query-keys/tenant-mappers.test.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "created as Tenant" src/hooks/api/query-keys/tenant-mutation-options.ts` returns 0
+    - `grep -c "updated as Tenant\b" src/hooks/api/query-keys/tenant-mutation-options.ts` returns 0 (the `updated as Tenant` cast is gone; `updated as TenantPostgrestRow` in markMovedOut may remain — it feeds the validated mapTenantRow)
+    - `grep -q "mapTenantBaseRow" src/hooks/api/query-keys/tenant-mutation-options.ts` succeeds
+    - `bun run test:unit -- --run src/hooks/api/query-keys/tenant-mappers.test.ts` passes (valid-maps, missing-id-throws, bad-status-rejected, moved_out-accepted)
+    - `bun run typecheck` clean
+  </acceptance_criteria>
+  <done>create/update route through mapTenantBaseRow, no `created as Tenant`/`updated as Tenant` cast remains at the boundary, markMovedOut feeds the validated mapTenantRow, tests green.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck` clean
+- `bun run lint` clean on the three modified files
+- `bun run test:unit -- --run src/hooks/api/query-keys/tenant-mappers.test.ts` passes
+- No `created as Tenant` / `updated as Tenant` cast remains at the tenant write boundary
+</verification>
+
+<success_criteria>
+TYPE-02 (tenant half) satisfied: tenant create/update return through a validated `mapTenantBaseRow()`, `mapTenantRow` field-validates id + status via Zod safeParse, existing status enum + Tenant type reused (no duplicates), nullable fields stay nullable, typecheck clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-typed-rpc-boundaries/02-02-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-typed-rpc-boundaries/02-02-PLAN.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-02-PLAN.md
@@ -13,7 +13,7 @@ requirements: [TYPE-02]
 must_haves:
   truths:
     - "tenant-mutation-options.ts create/update return a validated Tenant row, not a raw `created as Tenant` / `updated as Tenant` cast"
-    - "mapTenantRow field-validates the enum-shaped (status) and NOT-NULL (id) fields via Zod safeParse instead of plain `as TenantWithLeaseInfo` shaping"
+    - "mapTenantRow validates `id`/`status` BEFORE the final `as TenantWithLeaseInfo`, so the cast is over a validated shape (the plain `as` for the conditional-spread structural gap is acceptable per CONTEXT; only `as unknown as` is forbidden)"
     - "An insert/update response missing the NOT-NULL id throws at the boundary; an invalid status enum is rejected"
     - "Nullable-in-DB tenant fields (owner_user_id, email, name, etc.) stay nullable — not over-validated"
   artifacts:
@@ -66,8 +66,15 @@ TENANT_ACTIVE_STATUSES = ["active","inactive","pending","moved_out"] as const
      Validate the persisted status against the UNION of both sets so moved_out is accepted. -->
 
 <!-- Existing mapper to UPGRADE. From src/hooks/api/query-keys/tenant-mappers.ts: -->
-mapTenantRow(row: TenantPostgrestRow): TenantWithLeaseInfo   // ends in a bare `as TenantWithLeaseInfo` — add safeParse
+mapTenantRow(row: TenantPostgrestRow): TenantWithLeaseInfo   // ends in a plain `as TenantWithLeaseInfo` over a conditional-spread object — add safeParse BEFORE the cast
 TenantPostgrestRow                                          // the nested-join raw shape (exported)
+
+<!-- NOTE on the surviving `as TenantWithLeaseInfo`: the final return is a plain `as Type`
+     (NOT `as unknown as`) — CONTEXT explicitly permits a plain `as` after validation, and the
+     drift guard only scans for `as unknown as`. It survives because the conditional-spread object
+     (optional lease fields spread conditionally) can't be structurally proven to match the optional
+     fields. Task 1 adds id/status validation BEFORE that cast so it is over a validated shape;
+     it does NOT need to remove the plain `as`. -->
 
 <!-- Canonical reference mapper: mapDocumentRow in src/hooks/api/query-keys/document-keys.ts. -->
 </interfaces>
@@ -78,17 +85,17 @@ TenantPostgrestRow                                          // the nested-join r
 <task type="auto" tdd="true">
   <name>Task 1: Add validation to mapTenantRow + add mapTenantBaseRow in tenant-mappers.ts</name>
   <read_first>
-    - src/hooks/api/query-keys/tenant-mappers.ts (the full file — mapTenantRow + TenantPostgrestRow; ends in `as TenantWithLeaseInfo`)
+    - src/hooks/api/query-keys/tenant-mappers.ts (the full file — mapTenantRow + TenantPostgrestRow; ends in a plain `as TenantWithLeaseInfo`)
     - src/hooks/api/query-keys/document-keys.ts (mapDocumentRow: requireString throws on NOT-NULL, nullable left nullable — the discipline to mirror)
     - src/lib/validation/tenants.ts lines 18-38 (tenantStatusSchema + TENANT_ACTIVE_STATUSES — REUSE; do not redefine the status enum)
     - src/types/core.ts (Tenant = Tables<"tenants">; TenantWithLeaseInfo — REUSE)
   </read_first>
   <behavior>
     - mapTenantBaseRow(raw: unknown) → Tenant: a valid flat tenants row (NOT-NULL id present, status a recognized value) maps through; a row missing `id` throws; a row whose `status` is not in the accepted union throws (or is rejected via safeParse error surfaced as a thrown boundary error). Nullable fields (owner_user_id, email, name, etc.) pass through as their value-or-null.
-    - mapTenantRow(row): keeps its existing TenantWithLeaseInfo output shape and join-flattening logic, but now validates the row's `id` (throw if missing) and `status` (safeParse against the accepted union, default to "active" only when null/absent as today) before returning — and the final return no longer relies on a bare `as TenantWithLeaseInfo` to paper over an unvalidated shape.
+    - mapTenantRow(row): keeps its existing TenantWithLeaseInfo output shape and join-flattening logic, but now validates the row's `id` (throw if missing) and `status` (safeParse against the accepted union, default to "active" only when null/absent as today) BEFORE the final return. The plain `as TenantWithLeaseInfo` over the conditional-spread object remains (acceptable per CONTEXT — only `as unknown as` is forbidden), but it now covers a validated `id`/`status`.
   </behavior>
   <action>
-    In src/hooks/api/query-keys/tenant-mappers.ts: import `z` from `zod`, `tenantStatusSchema` and `TENANT_ACTIVE_STATUSES` from `#lib/validation/tenants`, and `Tenant` from `#types/core`. Define a module-local `tenantPersistedStatusSchema` as the union of `tenantStatusSchema` and `z.enum(TENANT_ACTIVE_STATUSES)` (so `moved_out` from markMovedOut is accepted) — or equivalently `z.enum([...new Set([...statuses])])`. Add a `requireString(raw, field)` helper mirroring mapDocumentRow that throws on a missing/non-string NOT-NULL field. Add and export `mapTenantBaseRow(raw: unknown): Tenant`: treat `raw` as `Record<string, unknown>`, `requireString` the `id`, validate `status` via `tenantPersistedStatusSchema.safeParse` (throw a descriptive boundary error on failure), pass nullable fields through as `(raw.x as T | null) ?? null`, and return the `Tenant` shape. Upgrade the existing `mapTenantRow`: before building `base`, `requireString(row, "id")` and run `tenantPersistedStatusSchema.safeParse(row.status)` when `row.status` is non-null (throw on invalid), keeping the existing `?? "active"` default for the null branch; keep all the join-flattening logic intact. Mirror mapDocumentRow's "throw early so a dropped NOT-NULL column surfaces immediately" docstring note. Keep nullable-in-DB fields nullable (do not require owner_user_id/email/name). Stay under the 300-line cap (split is not needed; the file is ~178 lines).
+    In src/hooks/api/query-keys/tenant-mappers.ts: import `z` from `zod`, `tenantStatusSchema` and `TENANT_ACTIVE_STATUSES` from `#lib/validation/tenants`, and `Tenant` from `#types/core`. Define a module-local `tenantPersistedStatusSchema` as the union of `tenantStatusSchema` and `z.enum(TENANT_ACTIVE_STATUSES)` (so `moved_out` from markMovedOut is accepted) — or equivalently `z.enum([...new Set([...statuses])])`. Add a `requireString(raw, field)` helper mirroring mapDocumentRow that throws on a missing/non-string NOT-NULL field. Add and export `mapTenantBaseRow(raw: unknown): Tenant`: treat `raw` as `Record<string, unknown>`, `requireString` the `id`, validate `status` via `tenantPersistedStatusSchema.safeParse` (throw a descriptive boundary error on failure), pass nullable fields through as `(raw.x as T | null) ?? null`, and return the `Tenant` shape. Upgrade the existing `mapTenantRow`: before building `base`, `requireString(row, "id")` and run `tenantPersistedStatusSchema.safeParse(row.status)` when `row.status` is non-null (throw on invalid), keeping the existing `?? "active"` default for the null branch; keep all the join-flattening logic intact, and keep the final plain `as TenantWithLeaseInfo` (do not attempt to remove it — it papers over the conditional-spread structural gap, which CONTEXT permits as a plain `as`). Mirror mapDocumentRow's "throw early so a dropped NOT-NULL column surfaces immediately" docstring note. Keep nullable-in-DB fields nullable (do not require owner_user_id/email/name). Stay under the 300-line cap (split is not needed; the file is ~178 lines).
   </action>
   <verify>
     <automated>grep -q "mapTenantBaseRow" src/hooks/api/query-keys/tenant-mappers.ts && grep -q "safeParse" src/hooks/api/query-keys/tenant-mappers.ts && bun run typecheck</automated>
@@ -98,9 +105,10 @@ TenantPostgrestRow                                          // the nested-join r
     - tenant-mappers.ts contains `safeParse` (mapTenantRow is now validated, not just shaped)
     - tenant-mappers.ts imports `tenantStatusSchema`/`TENANT_ACTIVE_STATUSES` from `#lib/validation/tenants` (REUSE — no redefined status enum)
     - tenant-mappers.ts imports `Tenant` from `#types/core` (no duplicate Tenant type)
+    - `grep -c "as unknown as" src/hooks/api/query-keys/tenant-mappers.ts` returns 0 (the surviving `as TenantWithLeaseInfo` is a plain `as` and is acceptable)
     - `bun run typecheck` clean
   </acceptance_criteria>
-  <done>mapTenantBaseRow added, mapTenantRow validates id + status via Zod safeParse, reuses existing status enum + Tenant type, nullable fields stay nullable, typecheck clean.</done>
+  <done>mapTenantBaseRow added, mapTenantRow validates id + status via Zod safeParse BEFORE the plain `as TenantWithLeaseInfo`, reuses existing status enum + Tenant type, nullable fields stay nullable, typecheck clean.</done>
 </task>
 
 <task type="auto">
@@ -136,9 +144,10 @@ TenantPostgrestRow                                          // the nested-join r
 </verification>
 
 <success_criteria>
-TYPE-02 (tenant half) satisfied: tenant create/update return through a validated `mapTenantBaseRow()`, `mapTenantRow` field-validates id + status via Zod safeParse, existing status enum + Tenant type reused (no duplicates), nullable fields stay nullable, typecheck clean.
+TYPE-02 (tenant half) satisfied: tenant create/update return through a validated `mapTenantBaseRow()`, `mapTenantRow` field-validates id + status via Zod safeParse before its plain `as TenantWithLeaseInfo`, existing status enum + Tenant type reused (no duplicates), nullable fields stay nullable, typecheck clean.
 </success_criteria>
 
 <output>
 Create `.planning/phases/02-typed-rpc-boundaries/02-02-SUMMARY.md` when done
 </output>
+</content>

--- a/.planning/phases/02-typed-rpc-boundaries/02-02-SUMMARY.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-02-SUMMARY.md
@@ -1,0 +1,88 @@
+---
+phase: 02-typed-rpc-boundaries
+plan: 02
+subsystem: data-layer
+tags: [type-safety, zod, postgrest-boundary, tenants]
+requires: []
+provides:
+  - "mapTenantBaseRow validated flat-row mapper for tenant create/update returns"
+  - "mapTenantRow upgraded to Zod-validate id + status before its plain as TenantWithLeaseInfo"
+affects:
+  - src/hooks/api/query-keys/tenant-mutation-options.ts
+  - src/hooks/api/use-tenant-mutations.ts
+tech-stack:
+  added: []
+  patterns:
+    - "Field-level Zod safeParse at the PostgREST write boundary (mirrors mapDocumentRow)"
+    - "Persisted-status union = tenantStatusSchema.options TENANT_ACTIVE_STATUSES (accepts moved_out)"
+key-files:
+  created:
+    - src/hooks/api/query-keys/tenant-mappers.test.ts
+  modified:
+    - src/hooks/api/query-keys/tenant-mappers.ts
+    - src/hooks/api/query-keys/tenant-mutation-options.ts
+    - src/hooks/api/__tests__/use-tenant.test.tsx
+decisions:
+  - "Imported Tenant from #types/core (= Tables<\"tenants\">), not the Zod-inferred Tenant in #lib/validation/tenants — the plan/CONTEXT pin the generated DB row type"
+  - "Validated id/status inline in mapTenantRow (typed TenantPostgrestRow) rather than casting to Record to avoid introducing any as-cast the TYPE-03 drift guard scans for"
+  - "Tenant.status is typed plain `string` in the generated types, so no exactOptionalPropertyTypes/Zod-widening fight — no normalizer needed (02-01's normalizer precedent did not apply here)"
+metrics:
+  duration: ~12m
+  completed: 2026-06-05
+  tasks: 2
+  files: 4
+  commits: 1
+---
+
+# Phase 2 Plan 02: Typed Tenant RPC Boundary (TYPE-02 tenant half) Summary
+
+Tenant create/update PostgREST returns now route through a Zod-field-validated `mapTenantBaseRow()` instead of `created as Tenant` / `updated as Tenant` blind casts, and the existing `mapTenantRow` field-validates `id` + `status` before its (CONTEXT-permitted plain) `as TenantWithLeaseInfo`.
+
+## What Was Built
+
+- **`mapTenantBaseRow(raw: unknown): Tenant`** — new exported mapper for the flat `.select().single()` insert/update return. `requireString` throws on a missing/non-string NOT-NULL `id`; `status` is validated via `tenantPersistedStatusSchema.safeParse` (throws a descriptive boundary error on drift). All nullable-in-DB columns (`owner_user_id`, `email`, `name`, `phone`, `identity_verified`, etc.) pass through as value-or-null — not over-validated.
+- **`tenantPersistedStatusSchema`** — module-local `z.enum` over the de-duped union of `tenantStatusSchema.options` (`active`/`inactive`/`pending`/`SUSPENDED`/`DELETED`) and `TENANT_ACTIVE_STATUSES` (adds `moved_out`). REUSES both exports from `#lib/validation/tenants`; no redefined status enum. The union is required because `markMovedOut` persists `status: "moved_out"`, which is in `TENANT_ACTIVE_STATUSES` but absent from `tenantStatusSchema`.
+- **`mapTenantRow` upgrade** — re-checks `row.id` (throws if non-string) and validates a non-null `status` against the same union (keeps the historical `?? "active"` null-default) BEFORE the join-flattening logic. The final plain `as TenantWithLeaseInfo` over the conditional-spread object survives (acceptable per CONTEXT — only `as unknown as` is forbidden; `grep -c "as unknown as"` returns 0) and now covers a validated `id`/`status`.
+- **`tenant-mutation-options.ts` wiring** — `create()` and `update()` mutationFns return `mapTenantBaseRow(created)` / `mapTenantBaseRow(updated)`. `markMovedOut` is unchanged and feeds the now-validated `mapTenantRow`. The `Tenant` type import is retained (still used by the `Promise<Tenant>` return annotations).
+- **`tenant-mappers.test.ts`** — 9 cases: valid flat row maps + nullable fields stay null; missing `id` throws; bogus `status` rejected; `moved_out`/`SUSPENDED`/`DELETED` accepted; nested `mapTenantRow` maps + null-status defaults to `active` + missing-id throws + bad-status throws.
+
+## How It Works
+
+Both mappers mirror `mapDocumentRow` in `document-keys.ts` (CLAUDE.md's cited boundary-validation reference): throw early on a dropped NOT-NULL column so the boundary surfaces RPC/`.select()` drift loudly instead of leaking `"undefined"` (broken React keys, detail-page lookups) or a silently-accepted bad enum downstream. `Tenant.status` being a plain `string` in the generated types meant no `exactOptionalPropertyTypes` widening conflict, so 02-01's normalizer pattern was unnecessary here — the validated string assigns directly.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Stale `mockTenant` fixture in use-tenant.test.tsx**
+- **Found during:** Task 2 (lefthook pre-commit unit-tests gate caught 2 failures in `use-tenant.test.tsx`)
+- **Issue:** The `mockTenant` fixture (consumed by the create/update mutation mocks' `.single()` returns) was missing the NOT-NULL `status` field (and `owner_user_id`/`first_name`/`last_name`/`name`/`email`/`phone`), and carried a stale `stripe_customer_id` that is not a real `tenants` column. With the new boundary validation, `mapTenantBaseRow` correctly threw `invalid 'status' value 'undefined'` for `useCreateTenantMutation` + `useUpdateTenantMutation`.
+- **Fix:** Updated the fixture to a realistic `tenants` row with `status: "active"` plus the contact columns; dropped the non-column `stripe_customer_id`. This is directly caused by the current task's change (the validation is the point) and in scope.
+- **Files modified:** src/hooks/api/__tests__/use-tenant.test.tsx
+- **Commit:** 81d740d23
+
+### Test-command note
+The plan's per-file command `bun run test:unit -- --run <file>` double-passes `--run` (the `test:unit` script already includes `--run --project unit`) and errors with "Expected a single value for option --run". Ran via `bun run test:unit -- <file>` (and `bunx vitest --run --project unit <file>`) instead — same project, same result. No code impact.
+
+## Verification
+
+- `bun run typecheck` — clean (`tsc --noEmit`)
+- `bun run lint` — clean on all four modified files (Biome)
+- `bun run test:unit -- src/hooks/api/query-keys/tenant-mappers.test.ts` — 9/9 pass
+- `bun run test:unit -- src/hooks/api/__tests__/use-tenant.test.tsx` — 16/16 pass
+- Full lefthook pre-commit gate (gitleaks, lockfile-verify, lint, typecheck, all 106,374 unit tests, commitlint) passed on commit `81d740d23` — committed without `--no-verify`
+- `grep -c "created as Tenant"` / `grep -cE "updated as Tenant\b"` in tenant-mutation-options.ts → 0
+- `grep -c "as unknown as"` in tenant-mappers.ts → 0
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, or schema changes. This tightens an existing write boundary with field validation.
+
+## Self-Check: PASSED
+
+- All 5 files verified present on disk (4 source + SUMMARY.md)
+- Commit `81d740d23` verified in git history

--- a/.planning/phases/02-typed-rpc-boundaries/02-03-PLAN.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-03-PLAN.md
@@ -14,17 +14,17 @@ must_haves:
   truths:
     - "maintenance-keys.ts list/detail/urgent/overdue + create/update return MaintenanceRequest rows through a validated mapper, not raw `as MaintenanceRequest` / `as MaintenanceRequest[]` casts"
     - "A maintenance row missing a NOT-NULL field (id/title/status/priority/owner_user_id/tenant_id/unit_id/description) throws at the boundary"
-    - "An invalid status or priority enum value is rejected via Zod safeParse"
+    - "Persisted status is validated against the FULL 7-value DB CHECK set (open/assigned/in_progress/needs_reassignment/completed/cancelled/on_hold) via a module-local maintenancePersistedStatusSchema — assigned/needs_reassignment rows written by vendorMutations map cleanly, and an unrecognized status or priority enum is rejected via Zod safeParse"
     - "Nullable-in-DB fields (actual_cost, scheduled_date, completed_at, etc.) stay nullable"
   artifacts:
     - path: "src/hooks/api/query-keys/maintenance-mappers.ts"
-      provides: "mapMaintenanceRow validated mapper + maintenance Zod schema"
+      provides: "mapMaintenanceRow validated mapper + module-local maintenancePersistedStatusSchema (full 7-value DB set)"
       contains: "mapMaintenanceRow"
     - path: "src/hooks/api/query-keys/maintenance-keys.ts"
       provides: "all maintenance read/write boundaries routed through mapMaintenanceRow"
       contains: "mapMaintenanceRow"
     - path: "src/hooks/api/query-keys/maintenance-mappers.test.ts"
-      provides: "unit coverage: valid row mapped; missing NOT-NULL throws; enum drift rejected"
+      provides: "unit coverage: valid row mapped; assigned/needs_reassignment accepted; missing NOT-NULL throws; enum drift rejected"
       contains: "mapMaintenanceRow"
   key_links:
     - from: "src/hooks/api/query-keys/maintenance-keys.ts"
@@ -36,8 +36,8 @@ must_haves:
 <objective>
 Convert the TYPE-02 maintenance boundary — the raw `as MaintenanceRequest` / `as MaintenanceRequest[]` casts in `maintenance-keys.ts` (list, detail, urgent, overdue, create, update) — to a typed `mapMaintenanceRow` mapper with Zod field validation, mirroring `mapDocumentRow`.
 
-Purpose: `maintenance-keys.ts` returns PostgREST rows blind-cast to `MaintenanceRequest[]`. A dropped column or a bad `status`/`priority` enum slips through silently and breaks the kanban/list/detail surfaces downstream. Field-level Zod validation catches drift at the boundary.
-Output: `maintenance-mappers.ts` with `mapMaintenanceRow`, wired into every `maintenance-keys.ts` read+write boundary, with unit tests.
+Purpose: `maintenance-keys.ts` returns PostgREST rows blind-cast to `MaintenanceRequest[]`. A dropped column or a bad `status`/`priority` enum slips through silently and breaks the kanban/list/detail surfaces downstream. Field-level Zod validation catches drift at the boundary — but the validation must match the LIVE DB constraint (full 7-value status set), not the stale 5-value input schema, or it would itself break the assigned/reassignment rows it is meant to protect.
+Output: `maintenance-mappers.ts` with `mapMaintenanceRow` (validating persisted status against a module-local 7-value schema), wired into every `maintenance-keys.ts` read+write boundary, with unit tests.
 </objective>
 
 <execution_context>
@@ -61,9 +61,24 @@ MaintenanceRequest = Tables<"maintenance_requests">;
                inspection_date, inspection_findings, inspector_id, requested_by,
                scheduled_date, updated_at, vendor_id -->
 
-<!-- REUSE existing enum schemas. From src/lib/validation/maintenance.ts: -->
-maintenancePrioritySchema = z.enum(["low","normal","medium","high","urgent"])
-maintenanceStatusSchema   = z.enum(["open","in_progress","completed","cancelled","on_hold"])
+<!-- REUSE existing PRIORITY enum (matches the DB). From src/lib/validation/maintenance.ts: -->
+maintenancePrioritySchema = z.enum(["low","normal","medium","high","urgent"])  // 5 values = DB CHECK — reuse for persisted validation
+
+<!-- DO NOT reuse maintenanceStatusSchema for PERSISTED validation. It is a STALE 5-value
+     INPUT schema z.enum(["open","in_progress","completed","cancelled","on_hold"]) — it omits
+     "assigned" and "needs_reassignment", which vendorMutations.assign/unassign actively WRITE
+     (maintenance-keys.ts ~:496/:510) and which then flow back through list()/detail()/urgent().
+     The live DB CHECK constraint (migration 20260221120000_add_maintenance_status_vendor_statuses.sql,
+     no later override) permits the FULL 7-value set:
+       open, assigned, in_progress, needs_reassignment, completed, cancelled, on_hold.
+     Validating a PERSISTED status against the 5-value schema would throw on every assigned/
+     reassignment row and break maintenance list/detail/urgent/kanban in prod — the exact
+     over-validation failure 02-CONTEXT warns against. Task 1 defines a module-local
+     maintenancePersistedStatusSchema (the full 7-value DB set) and validates persisted status
+     against THAT — mirroring plan 02-02's own tenant `moved_out` union precedent. The shared
+     maintenanceStatusSchema stays untouched (it gates create/update INPUT — the create form must
+     not offer vendor-workflow statuses). -->
+maintenancePersistedStatusSchema = z.enum(["open","assigned","in_progress","needs_reassignment","completed","cancelled","on_hold"])  // full DB CHECK — module-local in maintenance-mappers.ts
 
 <!-- The list() property_id branch embeds units!inner(property_id) then strips `units`
      before casting (maintenance-keys.ts lines 79-90). The mapper must accept a row that
@@ -76,32 +91,37 @@ maintenanceStatusSchema   = z.enum(["open","in_progress","completed","cancelled"
 <tasks>
 
 <task type="auto" tdd="true">
-  <name>Task 1: Create maintenance-mappers.ts with mapMaintenanceRow + Zod schema</name>
+  <name>Task 1: Create maintenance-mappers.ts with mapMaintenanceRow + module-local 7-value persisted status schema</name>
   <read_first>
     - src/hooks/api/query-keys/document-keys.ts (mapDocumentRow: requireString throws on NOT-NULL, nullable left nullable — the discipline to mirror)
     - src/types/core.ts (MaintenanceRequest = Tables<"maintenance_requests"> — REUSE; do not duplicate)
-    - src/lib/validation/maintenance.ts lines 24-42 (maintenancePrioritySchema + maintenanceStatusSchema — REUSE; do not redefine the enums)
-    - src/hooks/api/query-keys/maintenance-keys.ts lines 44-46 (MAINTENANCE_SELECT_COLUMNS — the exact column set the mapper covers) and lines 79-90 (the units!inner embed that the mapper must ignore)
+    - src/lib/validation/maintenance.ts lines 24-42 (maintenancePrioritySchema — REUSE as-is; AND see maintenanceStatusSchema, which is the STALE 5-value INPUT enum — do NOT reuse it for persisted validation and do NOT widen it)
+    - supabase/migrations/20260221120000_add_maintenance_status_vendor_statuses.sql (the live 7-value DB CHECK — the source of truth for the persisted status set; cite it in the schema's code comment for lockstep)
+    - src/hooks/api/query-keys/maintenance-keys.ts lines 44-46 (MAINTENANCE_SELECT_COLUMNS — the exact column set the mapper covers), lines 79-90 (the units!inner embed that the mapper must ignore), and lines ~496/~510 (vendorMutations.assign/unassign writing status="assigned"/"needs_reassignment" — the rows the mapper MUST accept)
   </read_first>
   <behavior>
-    - mapMaintenanceRow(raw: unknown) → MaintenanceRequest: a valid row (all 8 NOT-NULL fields present, status/priority recognized) maps through; a row missing `id`/`title`/`description`/`owner_user_id`/`tenant_id`/`unit_id` throws; a row whose `status` or `priority` is not in the recognized enum is rejected (throws). Nullable fields (actual_cost, scheduled_date, completed_at, estimated_cost, assigned_to, requested_by, inspector_id, inspection_date, inspection_findings, vendor_id, created_at, updated_at) pass through as value-or-null.
+    - mapMaintenanceRow(raw: unknown) → MaintenanceRequest: a valid row (all 8 NOT-NULL fields present, status in the full 7-value DB set, priority recognized) maps through; a row missing `id`/`title`/`description`/`owner_user_id`/`tenant_id`/`unit_id` throws.
+    - status is validated UNCONDITIONALLY against the module-local 7-value `maintenancePersistedStatusSchema`. A row with `status: "assigned"` or `status: "needs_reassignment"` (written by vendorMutations) maps cleanly. A row with an unrecognized status (e.g. "bogus") is rejected (throws). A row with `status` absent/null throws — `safeParse` runs on the raw status value with NO `!= null` short-circuit, so a dropped NOT-NULL `status` column surfaces immediately instead of passing through as undefined.
+    - priority is validated via the reused `maintenancePrioritySchema` (5 values = DB). An unrecognized priority is rejected (throws).
+    - Nullable fields (actual_cost, scheduled_date, completed_at, estimated_cost, assigned_to, requested_by, inspector_id, inspection_date, inspection_findings, vendor_id, created_at, updated_at) pass through as value-or-null.
     - A row carrying an extra `units` embed key (from the property_id join branch) maps cleanly — the extra key is ignored, output is a clean MaintenanceRequest.
   </behavior>
   <action>
-    Create src/hooks/api/query-keys/maintenance-mappers.ts. Import `z` from `zod`, `maintenancePrioritySchema` and `maintenanceStatusSchema` from `#lib/validation/maintenance` (REUSE — define no new enum), and `MaintenanceRequest` from `#types/core` (REUSE — no duplicate type). Add a `requireString(raw, field)` helper mirroring mapDocumentRow that throws on a missing/non-string NOT-NULL field. Export `mapMaintenanceRow(raw: unknown): MaintenanceRequest`: treat `raw` as `Record<string, unknown>`; `requireString` each of `id`, `description`, `owner_user_id`, `tenant_id`, `title`, `unit_id`; validate `status` via `maintenanceStatusSchema.safeParse` and `priority` via `maintenancePrioritySchema.safeParse`, throwing a descriptive boundary error (`mapMaintenanceRow: invalid status '<v>'`) on `!success`; pass each nullable column through as `(raw.x as T | null) ?? null` for the numeric (actual_cost, estimated_cost) / string (assigned_to, requested_by, inspector_id, inspection_date, inspection_findings, scheduled_date, completed_at, vendor_id, created_at, updated_at) nullable fields; return the assembled `MaintenanceRequest` (only the maintenance_requests columns — never spread an embedded `units`/`vendors` key). Add a top-of-file docstring citing mapDocumentRow + CLAUDE.md RPC-return-typing rule. Keep under the 300-line cap.
+    Create src/hooks/api/query-keys/maintenance-mappers.ts. Import `z` from `zod`, `maintenancePrioritySchema` from `#lib/validation/maintenance` (REUSE — priority matches the DB), and `MaintenanceRequest` from `#types/core` (REUSE — no duplicate type). Define a module-local `const maintenancePersistedStatusSchema = z.enum(["open","assigned","in_progress","needs_reassignment","completed","cancelled","on_hold"])` — the FULL live DB CHECK set. Add a code comment directly above it citing migration `20260221120000_add_maintenance_status_vendor_statuses.sql` as the source of truth and stating WHY the shared `maintenanceStatusSchema` is NOT reused (it is the stale 5-value INPUT enum; reusing it would throw on assigned/needs_reassignment rows that vendorMutations actively persist). Do NOT import or widen `maintenanceStatusSchema`. Add a `requireString(raw, field)` helper mirroring mapDocumentRow that throws on a missing/non-string NOT-NULL field. Export `mapMaintenanceRow(raw: unknown): MaintenanceRequest`: treat `raw` as `Record<string, unknown>`; `requireString` each of `id`, `description`, `owner_user_id`, `tenant_id`, `title`, `unit_id`; validate `status` by calling `maintenancePersistedStatusSchema.safeParse(raw.status)` UNCONDITIONALLY (no `if (raw.status != null)` guard — an absent/null status must produce `!success` and throw) with a descriptive boundary error (`mapMaintenanceRow: invalid status '<v>'`) on `!success`; validate `priority` via `maintenancePrioritySchema.safeParse(raw.priority)` unconditionally, throwing on `!success`; pass each nullable column through as `(raw.x as T | null) ?? null` for the numeric (actual_cost, estimated_cost) / string (assigned_to, requested_by, inspector_id, inspection_date, inspection_findings, scheduled_date, completed_at, vendor_id, created_at, updated_at) nullable fields; return the assembled `MaintenanceRequest` (only the maintenance_requests columns — never spread an embedded `units`/`vendors` key). Add a top-of-file docstring citing mapDocumentRow + CLAUDE.md RPC-return-typing rule. Keep under the 300-line cap.
   </action>
   <verify>
-    <automated>grep -q "mapMaintenanceRow" src/hooks/api/query-keys/maintenance-mappers.ts && grep -q "safeParse" src/hooks/api/query-keys/maintenance-mappers.ts && bun run typecheck</automated>
+    <automated>grep -q "mapMaintenanceRow" src/hooks/api/query-keys/maintenance-mappers.ts && grep -q "maintenancePersistedStatusSchema" src/hooks/api/query-keys/maintenance-mappers.ts && grep -q "needs_reassignment" src/hooks/api/query-keys/maintenance-mappers.ts && grep -q "safeParse" src/hooks/api/query-keys/maintenance-mappers.ts && bun run typecheck</automated>
   </verify>
   <acceptance_criteria>
     - src/hooks/api/query-keys/maintenance-mappers.ts exists and exports `mapMaintenanceRow`
-    - File contains `safeParse` (enum field validation)
-    - File imports `maintenanceStatusSchema`/`maintenancePrioritySchema` from `#lib/validation/maintenance` (REUSE — no redefined enums)
+    - File defines a module-local `maintenancePersistedStatusSchema` whose `z.enum` lists all 7 DB values (open, assigned, in_progress, needs_reassignment, completed, cancelled, on_hold) with a comment citing migration `20260221120000`
+    - File does NOT import `maintenanceStatusSchema` and does NOT widen it (the shared 5-value input enum is left untouched); priority still reuses `maintenancePrioritySchema` from `#lib/validation/maintenance`
+    - status `safeParse` runs UNCONDITIONALLY on the raw status value — there is no `!= null` short-circuit around it; a row with `status` absent/null throws
     - File imports `MaintenanceRequest` from `#types/core` (no duplicate type)
     - `grep -c "as unknown as" src/hooks/api/query-keys/maintenance-mappers.ts` returns 0
     - `bun run typecheck` clean
   </acceptance_criteria>
-  <done>mapMaintenanceRow exists, throws on missing NOT-NULL, rejects bad status/priority via Zod safeParse, reuses existing enums + MaintenanceRequest type, nullable fields stay nullable, typecheck clean.</done>
+  <done>mapMaintenanceRow exists, validates persisted status against the module-local 7-value DB set unconditionally (assigned/needs_reassignment accepted, absent status throws), rejects bad status/priority via Zod safeParse, reuses priority enum + MaintenanceRequest type without widening the stale input status enum, nullable fields stay nullable, typecheck clean.</done>
 </task>
 
 <task type="auto">
@@ -120,7 +140,7 @@ maintenanceStatusSchema   = z.enum(["open","in_progress","completed","cancelled"
     - overdue() (`return (data as MaintenanceRequest[]) ?? []`): same `.map(mapMaintenanceRow)` pattern.
     - maintenanceMutations.create() (`return created as MaintenanceRequest`): `return mapMaintenanceRow(created as Record<string, unknown>)`.
     - maintenanceMutations.update() (`return updated as MaintenanceRequest`): `return mapMaintenanceRow(updated as Record<string, unknown>)`.
-    Do NOT touch the `stats()` RPC path (`get_maintenance_stats` returns a numeric record, not a MaintenanceRequest — out of scope and a different shape), the `photos()` path (separate PhotoRow type), or the vendorMutations (out of TYPE-02 scope — vendor casts are deferred). Keep the file under the 300-line cap (it is ~517 lines but pre-existing; do not expand it materially — the mapper replaces inline casts roughly 1:1). Then create src/hooks/api/query-keys/maintenance-mappers.test.ts (Vitest) covering: (a) a valid maintenance row maps to MaintenanceRequest; (b) a row missing `id` throws (`expect(() => mapMaintenanceRow(row)).toThrow()`); (c) a row with `status: "bogus"` is rejected; (d) a row with `priority: "extreme"` is rejected; (e) a row carrying an extra `units: { property_id }` embed maps cleanly with no `units` key on the output; (f) nullable fields (actual_cost: null, scheduled_date: null) pass through as null. Per the Vitest 4 + chai 6 gotcha, use `expect(fn).toThrow()` / `.toMatchObject({ message: expect.stringContaining(...) })`, never `.toThrow('string')`.
+    Do NOT touch the `stats()` RPC path (`get_maintenance_stats` returns a numeric record, not a MaintenanceRequest — out of scope and a different shape), the `photos()` path (separate PhotoRow type), or the vendorMutations (out of TYPE-02 scope — vendor casts are deferred; note that assign/unassign write status="assigned"/"needs_reassignment", which Task 1's persisted schema is built to accept on the read path). Keep the file under the 300-line cap (it is ~517 lines but pre-existing; do not expand it materially — the mapper replaces inline casts roughly 1:1). Then create src/hooks/api/query-keys/maintenance-mappers.test.ts (Vitest) covering: (a) a valid maintenance row maps to MaintenanceRequest; (b) a row missing `id` throws (`expect(() => mapMaintenanceRow(row)).toThrow()`); (c) a row with `status: "bogus"` is rejected; (d) a row with `priority: "extreme"` is rejected; (e) a row with `status: "assigned"` maps cleanly AND a row with `status: "needs_reassignment"` maps cleanly (the vendorMutations-written statuses — guards against the stale-5-value regression); (f) a row with `status` absent/null throws (proves the unconditional safeParse); (g) a row carrying an extra `units: { property_id }` embed maps cleanly with no `units` key on the output; (h) nullable fields (actual_cost: null, scheduled_date: null) pass through as null. Per the Vitest 4 + chai 6 gotcha, use `expect(fn).toThrow()` / `.toMatchObject({ message: expect.stringContaining(...) })`, never `.toThrow('string')`.
   </action>
   <verify>
     <automated>bun run test:unit -- --run src/hooks/api/query-keys/maintenance-mappers.test.ts && bun run typecheck</automated>
@@ -129,10 +149,10 @@ maintenanceStatusSchema   = z.enum(["open","in_progress","completed","cancelled"
     - `grep -c "as MaintenanceRequest" src/hooks/api/query-keys/maintenance-keys.ts` returns 0 at read/write boundaries (the `Promise<MaintenanceRequest>` / `MaintenanceRequest[]` return-type annotations and the `MaintenanceRequest[] | null` local declaration are type annotations, not casts — those may remain; the assertion targets `as MaintenanceRequest` cast expressions specifically: `grep -E "as MaintenanceRequest(\[\])?[;,) ]" src/hooks/api/query-keys/maintenance-keys.ts` returns nothing)
     - `grep -q "mapMaintenanceRow" src/hooks/api/query-keys/maintenance-keys.ts` succeeds across list/detail/urgent/overdue/create/update
     - maintenance-keys.ts `stats()`, `photos()`, and `vendorMutations` are untouched (out of scope)
-    - `bun run test:unit -- --run src/hooks/api/query-keys/maintenance-mappers.test.ts` passes (valid-maps, missing-id-throws, bad-status/priority-rejected, units-embed-ignored, nullable-passthrough)
+    - `bun run test:unit -- --run src/hooks/api/query-keys/maintenance-mappers.test.ts` passes (valid-maps, missing-id-throws, bad-status/priority-rejected, assigned/needs_reassignment-accepted, absent-status-throws, units-embed-ignored, nullable-passthrough)
     - `bun run typecheck` clean
   </acceptance_criteria>
-  <done>list/detail/urgent/overdue/create/update route through mapMaintenanceRow, no `as MaintenanceRequest` cast expression remains at those boundaries, stats/photos/vendor untouched, tests green.</done>
+  <done>list/detail/urgent/overdue/create/update route through mapMaintenanceRow, no `as MaintenanceRequest` cast expression remains at those boundaries, assigned/needs_reassignment rows verified-accepted, absent-status throws, stats/photos/vendor untouched, tests green.</done>
 </task>
 
 </tasks>
@@ -142,12 +162,15 @@ maintenanceStatusSchema   = z.enum(["open","in_progress","completed","cancelled"
 - `bun run lint` clean on the three modified files
 - `bun run test:unit -- --run src/hooks/api/query-keys/maintenance-mappers.test.ts` passes
 - No `as MaintenanceRequest` cast expression remains at the maintenance read/write boundaries
+- Persisted status validated against the full 7-value DB set (assigned/needs_reassignment accepted, absent status throws)
 </verification>
 
 <success_criteria>
-TYPE-02 (maintenance half) satisfied: all maintenance read/write boundaries return through a validated `mapMaintenanceRow()` with Zod field validation, existing status/priority enums + MaintenanceRequest type reused (no duplicates), nullable fields stay nullable, out-of-scope stats/photos/vendor paths untouched, typecheck clean.
+TYPE-02 (maintenance half) satisfied: all maintenance read/write boundaries return through a validated `mapMaintenanceRow()` with Zod field validation; persisted status is validated against a module-local 7-value schema matching the live DB CHECK (assigned/needs_reassignment accepted, absent status throws unconditionally) without widening the stale input enum; priority enum + MaintenanceRequest type reused (no duplicates); nullable fields stay nullable; out-of-scope stats/photos/vendor paths untouched; typecheck clean.
 </success_criteria>
 
 <output>
 Create `.planning/phases/02-typed-rpc-boundaries/02-03-SUMMARY.md` when done
 </output>
+</content>
+</invoke>

--- a/.planning/phases/02-typed-rpc-boundaries/02-03-PLAN.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-03-PLAN.md
@@ -1,0 +1,153 @@
+---
+phase: 02-typed-rpc-boundaries
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/hooks/api/query-keys/maintenance-mappers.ts
+  - src/hooks/api/query-keys/maintenance-keys.ts
+  - src/hooks/api/query-keys/maintenance-mappers.test.ts
+autonomous: true
+requirements: [TYPE-02]
+must_haves:
+  truths:
+    - "maintenance-keys.ts list/detail/urgent/overdue + create/update return MaintenanceRequest rows through a validated mapper, not raw `as MaintenanceRequest` / `as MaintenanceRequest[]` casts"
+    - "A maintenance row missing a NOT-NULL field (id/title/status/priority/owner_user_id/tenant_id/unit_id/description) throws at the boundary"
+    - "An invalid status or priority enum value is rejected via Zod safeParse"
+    - "Nullable-in-DB fields (actual_cost, scheduled_date, completed_at, etc.) stay nullable"
+  artifacts:
+    - path: "src/hooks/api/query-keys/maintenance-mappers.ts"
+      provides: "mapMaintenanceRow validated mapper + maintenance Zod schema"
+      contains: "mapMaintenanceRow"
+    - path: "src/hooks/api/query-keys/maintenance-keys.ts"
+      provides: "all maintenance read/write boundaries routed through mapMaintenanceRow"
+      contains: "mapMaintenanceRow"
+    - path: "src/hooks/api/query-keys/maintenance-mappers.test.ts"
+      provides: "unit coverage: valid row mapped; missing NOT-NULL throws; enum drift rejected"
+      contains: "mapMaintenanceRow"
+  key_links:
+    - from: "src/hooks/api/query-keys/maintenance-keys.ts"
+      to: "src/hooks/api/query-keys/maintenance-mappers.ts"
+      via: "import mapMaintenanceRow"
+      pattern: "mapMaintenanceRow"
+---
+
+<objective>
+Convert the TYPE-02 maintenance boundary — the raw `as MaintenanceRequest` / `as MaintenanceRequest[]` casts in `maintenance-keys.ts` (list, detail, urgent, overdue, create, update) — to a typed `mapMaintenanceRow` mapper with Zod field validation, mirroring `mapDocumentRow`.
+
+Purpose: `maintenance-keys.ts` returns PostgREST rows blind-cast to `MaintenanceRequest[]`. A dropped column or a bad `status`/`priority` enum slips through silently and breaks the kanban/list/detail surfaces downstream. Field-level Zod validation catches drift at the boundary.
+Output: `maintenance-mappers.ts` with `mapMaintenanceRow`, wired into every `maintenance-keys.ts` read+write boundary, with unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-typed-rpc-boundaries/02-CONTEXT.md
+
+<interfaces>
+<!-- Target type (REUSE — do not duplicate). From src/types/core.ts: -->
+MaintenanceRequest = Tables<"maintenance_requests">;
+
+<!-- maintenance_requests Row (from src/types/supabase.ts):
+     NOT-NULL: id, description, owner_user_id, priority, status, tenant_id, title, unit_id
+     NULLABLE: actual_cost, assigned_to, completed_at, created_at, estimated_cost,
+               inspection_date, inspection_findings, inspector_id, requested_by,
+               scheduled_date, updated_at, vendor_id -->
+
+<!-- REUSE existing enum schemas. From src/lib/validation/maintenance.ts: -->
+maintenancePrioritySchema = z.enum(["low","normal","medium","high","urgent"])
+maintenanceStatusSchema   = z.enum(["open","in_progress","completed","cancelled","on_hold"])
+
+<!-- The list() property_id branch embeds units!inner(property_id) then strips `units`
+     before casting (maintenance-keys.ts lines 79-90). The mapper must accept a row that
+     may carry an extra `units` key and ignore it (map only the MaintenanceRequest columns). -->
+
+<!-- Canonical reference mapper: mapDocumentRow in src/hooks/api/query-keys/document-keys.ts. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create maintenance-mappers.ts with mapMaintenanceRow + Zod schema</name>
+  <read_first>
+    - src/hooks/api/query-keys/document-keys.ts (mapDocumentRow: requireString throws on NOT-NULL, nullable left nullable — the discipline to mirror)
+    - src/types/core.ts (MaintenanceRequest = Tables<"maintenance_requests"> — REUSE; do not duplicate)
+    - src/lib/validation/maintenance.ts lines 24-42 (maintenancePrioritySchema + maintenanceStatusSchema — REUSE; do not redefine the enums)
+    - src/hooks/api/query-keys/maintenance-keys.ts lines 44-46 (MAINTENANCE_SELECT_COLUMNS — the exact column set the mapper covers) and lines 79-90 (the units!inner embed that the mapper must ignore)
+  </read_first>
+  <behavior>
+    - mapMaintenanceRow(raw: unknown) → MaintenanceRequest: a valid row (all 8 NOT-NULL fields present, status/priority recognized) maps through; a row missing `id`/`title`/`description`/`owner_user_id`/`tenant_id`/`unit_id` throws; a row whose `status` or `priority` is not in the recognized enum is rejected (throws). Nullable fields (actual_cost, scheduled_date, completed_at, estimated_cost, assigned_to, requested_by, inspector_id, inspection_date, inspection_findings, vendor_id, created_at, updated_at) pass through as value-or-null.
+    - A row carrying an extra `units` embed key (from the property_id join branch) maps cleanly — the extra key is ignored, output is a clean MaintenanceRequest.
+  </behavior>
+  <action>
+    Create src/hooks/api/query-keys/maintenance-mappers.ts. Import `z` from `zod`, `maintenancePrioritySchema` and `maintenanceStatusSchema` from `#lib/validation/maintenance` (REUSE — define no new enum), and `MaintenanceRequest` from `#types/core` (REUSE — no duplicate type). Add a `requireString(raw, field)` helper mirroring mapDocumentRow that throws on a missing/non-string NOT-NULL field. Export `mapMaintenanceRow(raw: unknown): MaintenanceRequest`: treat `raw` as `Record<string, unknown>`; `requireString` each of `id`, `description`, `owner_user_id`, `tenant_id`, `title`, `unit_id`; validate `status` via `maintenanceStatusSchema.safeParse` and `priority` via `maintenancePrioritySchema.safeParse`, throwing a descriptive boundary error (`mapMaintenanceRow: invalid status '<v>'`) on `!success`; pass each nullable column through as `(raw.x as T | null) ?? null` for the numeric (actual_cost, estimated_cost) / string (assigned_to, requested_by, inspector_id, inspection_date, inspection_findings, scheduled_date, completed_at, vendor_id, created_at, updated_at) nullable fields; return the assembled `MaintenanceRequest` (only the maintenance_requests columns — never spread an embedded `units`/`vendors` key). Add a top-of-file docstring citing mapDocumentRow + CLAUDE.md RPC-return-typing rule. Keep under the 300-line cap.
+  </action>
+  <verify>
+    <automated>grep -q "mapMaintenanceRow" src/hooks/api/query-keys/maintenance-mappers.ts && grep -q "safeParse" src/hooks/api/query-keys/maintenance-mappers.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - src/hooks/api/query-keys/maintenance-mappers.ts exists and exports `mapMaintenanceRow`
+    - File contains `safeParse` (enum field validation)
+    - File imports `maintenanceStatusSchema`/`maintenancePrioritySchema` from `#lib/validation/maintenance` (REUSE — no redefined enums)
+    - File imports `MaintenanceRequest` from `#types/core` (no duplicate type)
+    - `grep -c "as unknown as" src/hooks/api/query-keys/maintenance-mappers.ts` returns 0
+    - `bun run typecheck` clean
+  </acceptance_criteria>
+  <done>mapMaintenanceRow exists, throws on missing NOT-NULL, rejects bad status/priority via Zod safeParse, reuses existing enums + MaintenanceRequest type, nullable fields stay nullable, typecheck clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Route all maintenance-keys.ts boundaries through mapMaintenanceRow + add unit tests</name>
+  <read_first>
+    - src/hooks/api/query-keys/maintenance-keys.ts (lines 88-90 list property_id branch `units` strip + `as MaintenanceRequest`; 112 list else branch `as MaintenanceRequest[]`; 156 detail `as MaintenanceRequest`; 206 urgent `as MaintenanceRequest[]`; 280 overdue `as MaintenanceRequest[]`; 312 create `as MaintenanceRequest`; 338 update `as MaintenanceRequest`)
+    - src/hooks/api/query-keys/maintenance-mappers.ts (mapMaintenanceRow from Task 1)
+    - src/hooks/api/query-keys/document-keys.ts (the `((data ?? []) as Record<string, unknown>[]).map(mapX)` boundary pattern at lines 205-207)
+  </read_first>
+  <action>
+    In src/hooks/api/query-keys/maintenance-keys.ts: import `mapMaintenanceRow` from `./maintenance-mappers`. Replace each cast boundary:
+    - list() property_id branch (currently `(result.data ?? []).map(({ units: _units, ...row }) => row as MaintenanceRequest)`): map through `mapMaintenanceRow` instead — `(result.data ?? []).map((row) => mapMaintenanceRow(row))` (the mapper already ignores the `units` embed, so the destructure-strip is no longer needed; drop the `_units` destructure).
+    - list() else branch (`data = result.data as MaintenanceRequest[]`): change the `data` local typing to allow mapping; after the query, set `data = ((result.data ?? []) as Record<string, unknown>[]).map(mapMaintenanceRow)`. Adjust the `let data: MaintenanceRequest[] | null` declaration as needed so both branches assign a `MaintenanceRequest[]`.
+    - detail() (`return data as MaintenanceRequest`): `return mapMaintenanceRow(data as Record<string, unknown>)` (detail also embeds `vendors(...)` — the mapper ignores it).
+    - urgent() (`return (data as MaintenanceRequest[]) ?? []`): `return ((data ?? []) as Record<string, unknown>[]).map(mapMaintenanceRow)`.
+    - overdue() (`return (data as MaintenanceRequest[]) ?? []`): same `.map(mapMaintenanceRow)` pattern.
+    - maintenanceMutations.create() (`return created as MaintenanceRequest`): `return mapMaintenanceRow(created as Record<string, unknown>)`.
+    - maintenanceMutations.update() (`return updated as MaintenanceRequest`): `return mapMaintenanceRow(updated as Record<string, unknown>)`.
+    Do NOT touch the `stats()` RPC path (`get_maintenance_stats` returns a numeric record, not a MaintenanceRequest — out of scope and a different shape), the `photos()` path (separate PhotoRow type), or the vendorMutations (out of TYPE-02 scope — vendor casts are deferred). Keep the file under the 300-line cap (it is ~517 lines but pre-existing; do not expand it materially — the mapper replaces inline casts roughly 1:1). Then create src/hooks/api/query-keys/maintenance-mappers.test.ts (Vitest) covering: (a) a valid maintenance row maps to MaintenanceRequest; (b) a row missing `id` throws (`expect(() => mapMaintenanceRow(row)).toThrow()`); (c) a row with `status: "bogus"` is rejected; (d) a row with `priority: "extreme"` is rejected; (e) a row carrying an extra `units: { property_id }` embed maps cleanly with no `units` key on the output; (f) nullable fields (actual_cost: null, scheduled_date: null) pass through as null. Per the Vitest 4 + chai 6 gotcha, use `expect(fn).toThrow()` / `.toMatchObject({ message: expect.stringContaining(...) })`, never `.toThrow('string')`.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/hooks/api/query-keys/maintenance-mappers.test.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "as MaintenanceRequest" src/hooks/api/query-keys/maintenance-keys.ts` returns 0 at read/write boundaries (the `Promise<MaintenanceRequest>` / `MaintenanceRequest[]` return-type annotations and the `MaintenanceRequest[] | null` local declaration are type annotations, not casts — those may remain; the assertion targets `as MaintenanceRequest` cast expressions specifically: `grep -E "as MaintenanceRequest(\[\])?[;,) ]" src/hooks/api/query-keys/maintenance-keys.ts` returns nothing)
+    - `grep -q "mapMaintenanceRow" src/hooks/api/query-keys/maintenance-keys.ts` succeeds across list/detail/urgent/overdue/create/update
+    - maintenance-keys.ts `stats()`, `photos()`, and `vendorMutations` are untouched (out of scope)
+    - `bun run test:unit -- --run src/hooks/api/query-keys/maintenance-mappers.test.ts` passes (valid-maps, missing-id-throws, bad-status/priority-rejected, units-embed-ignored, nullable-passthrough)
+    - `bun run typecheck` clean
+  </acceptance_criteria>
+  <done>list/detail/urgent/overdue/create/update route through mapMaintenanceRow, no `as MaintenanceRequest` cast expression remains at those boundaries, stats/photos/vendor untouched, tests green.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck` clean
+- `bun run lint` clean on the three modified files
+- `bun run test:unit -- --run src/hooks/api/query-keys/maintenance-mappers.test.ts` passes
+- No `as MaintenanceRequest` cast expression remains at the maintenance read/write boundaries
+</verification>
+
+<success_criteria>
+TYPE-02 (maintenance half) satisfied: all maintenance read/write boundaries return through a validated `mapMaintenanceRow()` with Zod field validation, existing status/priority enums + MaintenanceRequest type reused (no duplicates), nullable fields stay nullable, out-of-scope stats/photos/vendor paths untouched, typecheck clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-typed-rpc-boundaries/02-03-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-typed-rpc-boundaries/02-03-SUMMARY.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-03-SUMMARY.md
@@ -1,0 +1,87 @@
+---
+phase: 02-typed-rpc-boundaries
+plan: 03
+subsystem: data-layer
+tags: [type-safety, zod, postgrest-boundary, maintenance]
+requires: []
+provides:
+  - "mapMaintenanceRow validated boundary mapper for maintenance_requests read/write returns"
+  - "module-local maintenancePersistedStatusSchema (full 7-value DB CHECK set)"
+affects:
+  - src/hooks/api/query-keys/maintenance-keys.ts
+tech-stack:
+  added: []
+  patterns:
+    - "Field-level Zod safeParse at the PostgREST read+write boundary (mirrors mapDocumentRow)"
+    - "Persisted-status schema = full 7-value DB CHECK set, distinct from the 5-value create/update INPUT enum"
+key-files:
+  created:
+    - src/hooks/api/query-keys/maintenance-mappers.ts
+    - src/hooks/api/query-keys/maintenance-mappers.test.ts
+  modified:
+    - src/hooks/api/query-keys/maintenance-keys.ts
+decisions:
+  - "Persisted status validated against a module-local 7-value maintenancePersistedStatusSchema (open/assigned/in_progress/needs_reassignment/completed/cancelled/on_hold), NOT the stale 5-value maintenanceStatusSchema input enum — validating the input enum would throw on assigned/needs_reassignment rows written by vendorMutations and break the maintenance surfaces"
+  - "Imported MaintenanceRequest from #types/core (= Tables<\"maintenance_requests\">) — no duplicate type; priority reuses maintenancePrioritySchema (5 values = DB CHECK)"
+  - "MaintenanceRequest.status/priority are typed plain `string` in the generated types, so no exactOptionalPropertyTypes/Zod-widening fight — 02-01's normalizer precedent did not apply"
+  - "status safeParse runs UNCONDITIONALLY (no `!= null` short-circuit) so a dropped NOT-NULL status column throws at the boundary instead of leaking undefined"
+metrics:
+  duration: ~10m
+  completed: 2026-06-05
+  tasks: 2
+  files: 3
+  commits: 2
+---
+
+# Phase 2 Plan 03: Typed Maintenance RPC Boundary (TYPE-02 maintenance half) Summary
+
+Maintenance `maintenance_requests` PostgREST read+write returns now route through a Zod-field-validated `mapMaintenanceRow()` instead of `data as MaintenanceRequest[]` / `as MaintenanceRequest` blind casts at list (both branches), detail, urgent, overdue, create, and update — with persisted `status` validated against the FULL live 7-value DB CHECK set so vendor-workflow rows (`assigned` / `needs_reassignment`) map cleanly instead of throwing.
+
+## What Was Built
+
+- **`mapMaintenanceRow(raw: unknown): MaintenanceRequest`** — new exported mapper in `maintenance-mappers.ts`. `requireString` throws on a missing/non-string NOT-NULL column (`id`, `owner_user_id`, `unit_id`, `tenant_id`, `title`, `description`); `status` and `priority` are validated via `safeParse` (throw a descriptive `mapMaintenanceRow: invalid status/priority '<v>'` boundary error on drift). All nullable-in-DB columns (`actual_cost`, `estimated_cost`, `assigned_to`, `requested_by`, `inspector_id`, `inspection_date`, `inspection_findings`, `scheduled_date`, `completed_at`, `vendor_id`, `created_at`, `updated_at`) pass through as value-or-null — not over-validated. Accepts (and ignores) an extra `units` (list property_id join) or `vendors` (detail join) embed key — only maintenance_requests columns are read, so the embeds never appear on output.
+- **`maintenancePersistedStatusSchema`** — module-local `z.enum(["open","assigned","in_progress","needs_reassignment","completed","cancelled","on_hold"])`, the FULL live DB CHECK set from migration `20260221120000_add_maintenance_status_vendor_statuses.sql` (cited in a code comment). Deliberately NOT the shared `maintenanceStatusSchema` (the stale 5-value INPUT enum that gates the create/update form and omits `assigned`/`needs_reassignment`). `vendorMutations.assign`/`unassign` actively PERSIST those two statuses, which then flow back through `list`/`detail`/`urgent`/`overdue` — validating a persisted status against the 5-value input enum would throw on every assigned/reassignment row and break the maintenance list/detail/urgent/kanban surfaces in prod. The shared input enum is left untouched (it validates a different boundary). Mirrors plan 02-02's tenant `moved_out` persisted-status union precedent.
+- **`maintenance-keys.ts` wiring** — six boundaries rewired:
+  - `list()` property_id branch: `(result.data ?? []).map(mapMaintenanceRow)` (drops the manual `{ units: _units, ...row }` destructure-strip — the mapper ignores the `units!inner(property_id)` embed).
+  - `list()` else branch: `((result.data ?? []) as Record<string, unknown>[]).map(mapMaintenanceRow)`.
+  - `detail()`: `mapMaintenanceRow(data as Record<string, unknown>)` (the `vendors(...)` embed is ignored by the mapper).
+  - `urgent()` / `overdue()`: `((data ?? []) as Record<string, unknown>[]).map(mapMaintenanceRow)`.
+  - `maintenanceMutations.create()` / `update()`: `mapMaintenanceRow(created/updated as Record<string, unknown>)`.
+- **`maintenance-mappers.test.ts`** — 14 cases: valid row maps + nullable fields stay null; missing `id` throws; missing `title` throws; bogus `status` rejected; bogus `priority` rejected; `assigned` accepted; `needs_reassignment` accepted; the other four DB-CHECK statuses (`in_progress`/`completed`/`cancelled`/`on_hold`) accepted; absent `status` throws and null `status` throws (proves the unconditional safeParse); `units` embed ignored; `vendors` embed ignored; populated nullable fields pass through; descriptive boundary error message asserted.
+
+## How It Works
+
+The mapper mirrors `mapDocumentRow` in `document-keys.ts` (CLAUDE.md's cited boundary-validation reference): throw early on a dropped NOT-NULL column so the boundary surfaces RPC/`.select()` drift loudly instead of leaking `"undefined"` (broken React keys, kanban grouping, detail-page lookups) or a silently-accepted bad enum downstream. The persisted-vs-input status distinction is the load-bearing decision: the live DB CHECK constraint permits 7 values, the create/update form schema permits 5, and the read path must validate against the DB's 7 — otherwise the validation meant to protect the surfaces would itself break them on every vendor-assigned row. `MaintenanceRequest.status`/`priority` being plain `string` in the generated types meant no `exactOptionalPropertyTypes` widening conflict, so 02-01's normalizer pattern was unnecessary — the validated string assigns directly.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. (Plan 02-03 had already been revised pre-execution to specify the 7-value persisted schema; this execution implemented that specification verbatim. Biome reformatted two `expect(...).toThrow(...)` line-wraps in the test file during the lint gate — a formatting-only change, no logic difference.)
+
+## Scope Boundaries Honored
+
+- `stats()` (`get_maintenance_stats` RPC → `as Record<string, number>`), `photos()` (`as PhotoRow[]`), and `vendorMutations` (`create`/`update` → `as Vendor`; `assign`/`unassign` write the persisted statuses the mapper accepts) are all out of TYPE-02 scope and left untouched.
+- The shared `maintenanceStatusSchema` in `#lib/validation/maintenance` was NOT widened — it still gates create/update INPUT with the 5-value set.
+- No out-of-scope file touched (analytics/tenant/expiring-leases/property/lease/etc.).
+
+## Verification
+
+- `bun run typecheck` — clean.
+- `bun run lint` (biome) — clean on all 3 modified files.
+- `bunx vitest --run --project unit src/hooks/api/query-keys/maintenance-mappers.test.ts` — 14/14 pass (incl. the `assigned` + `needs_reassignment` acceptance cases and the absent/null-status throw cases).
+- `grep -E "as MaintenanceRequest(\[\])?[;,) ]" src/hooks/api/query-keys/maintenance-keys.ts` — no cast expressions remain at the read/write boundaries (only `MaintenanceRequest`/`MaintenanceRequest[]` type annotations + the `let data` declaration remain).
+- `grep -c "as unknown as" src/hooks/api/query-keys/maintenance-mappers.ts` — 0.
+- Both commits passed the full lefthook pre-commit gate (gitleaks, lockfile-verify, lint, typecheck, full unit suite) + commitlint — neither used `--no-verify`.
+
+## Commits
+
+- `2219f2a20` feat(02-03): add validated mapMaintenanceRow boundary mapper
+- `4439223a3` refactor(02-03): route maintenance-keys boundaries through mapMaintenanceRow
+
+## Self-Check: PASSED
+
+- FOUND: src/hooks/api/query-keys/maintenance-mappers.ts
+- FOUND: src/hooks/api/query-keys/maintenance-mappers.test.ts
+- FOUND: src/hooks/api/query-keys/maintenance-keys.ts (modified)
+- FOUND: .planning/phases/02-typed-rpc-boundaries/02-03-SUMMARY.md
+- FOUND commit: 2219f2a20
+- FOUND commit: 4439223a3

--- a/.planning/phases/02-typed-rpc-boundaries/02-04-PLAN.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-04-PLAN.md
@@ -1,0 +1,152 @@
+---
+phase: 02-typed-rpc-boundaries
+plan: 04
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/dashboard/expiring-leases-widget.tsx
+  - src/components/dashboard/expiring-leases-mapper.ts
+  - src/components/dashboard/expiring-leases-mapper.test.ts
+  - src/lib/__tests__/rpc-boundary-cast-pins.test.ts
+autonomous: true
+requirements: [TYPE-03]
+must_haves:
+  truths:
+    - "expiring-leases-widget.tsx maps its PostgREST join rows through a validated mapper (mapExpiringLeaseRow) instead of an inline untyped projection"
+    - "A drift-guard test asserts zero `as unknown as` casts at PostgREST/RPC boundaries under src/hooks/api/ (test-mock casts and comments excluded)"
+    - "The drift guard fails with an actionable file:line message if an `as unknown as` boundary cast is reintroduced"
+    - "bun run typecheck stays clean across the phase"
+  artifacts:
+    - path: "src/components/dashboard/expiring-leases-mapper.ts"
+      provides: "mapExpiringLeaseRow validated mapper + Zod schema for the expiring-lease join row"
+      contains: "mapExpiringLeaseRow"
+    - path: "src/components/dashboard/expiring-leases-widget.tsx"
+      provides: "widget queryFn routed through mapExpiringLeaseRow"
+      contains: "mapExpiringLeaseRow"
+    - path: "src/lib/__tests__/rpc-boundary-cast-pins.test.ts"
+      provides: "drift guard: zero `as unknown as` at src/hooks/api boundaries"
+      contains: "as unknown as"
+    - path: "src/components/dashboard/expiring-leases-mapper.test.ts"
+      provides: "unit coverage: valid row mapped; missing NOT-NULL throws; null joins → null"
+      contains: "mapExpiringLeaseRow"
+  key_links:
+    - from: "src/components/dashboard/expiring-leases-widget.tsx"
+      to: "src/components/dashboard/expiring-leases-mapper.ts"
+      via: "import mapExpiringLeaseRow"
+      pattern: "mapExpiringLeaseRow"
+    - from: "src/lib/__tests__/rpc-boundary-cast-pins.test.ts"
+      to: "src/hooks/api/**"
+      via: "filesystem readFileSync scan"
+      pattern: "as unknown as"
+---
+
+<objective>
+Convert the TYPE-03 boundary — the expiring-leases widget's PostgREST join projection — to a validated mapper (`mapExpiringLeaseRow`), AND add the phase's drift-guard test that asserts zero `as unknown as` casts at RPC/PostgREST boundaries under `src/hooks/api/`, mirroring the Phase-1 `workflow-pins.test.ts` style.
+
+Purpose (mapper): `expiring-leases-widget.tsx` projects raw PostgREST join rows via an inline untyped `.map()` (`row.tenants?.name`, `row.units?.properties?.name`). It is not field-validated — a dropped column reads as `undefined` silently. A validated mapper catches drift, mirroring `mapDocumentRow`.
+Purpose (drift guard): the rule-#8 `as unknown as` violation the 2026-05-29 audit flagged is already resolved (only comments + test-mock casts remain). The guard PINS that state so the violation cannot silently return — a filesystem scan that fails with `file:line → ref` on any boundary `as unknown as` reintroduction.
+Output: `expiring-leases-mapper.ts` with `mapExpiringLeaseRow`, wired into the widget; `rpc-boundary-cast-pins.test.ts` drift guard; unit tests for the mapper.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-typed-rpc-boundaries/02-CONTEXT.md
+
+<interfaces>
+<!-- The widget defines its own row shape (KEEP it co-located; it is the page-local display type). From src/components/dashboard/expiring-leases-widget.tsx: -->
+ExpiringLeaseRow {
+  id: string;
+  end_date: string;
+  rent_amount: number;
+  tenant_name: string | null;
+  unit_name: string | null;
+  property_name: string | null;
+}
+
+<!-- The raw PostgREST select shape (lines 42-56) — a nested FK join:
+     { id, end_date, rent_amount, tenants: { name } | null, units: { unit_number, properties: { name } | null } | null } -->
+<!-- NOT-NULL on the row: id, end_date, rent_amount. Nested joins (tenants/units/properties) may be null. -->
+
+<!-- Drift-guard reference (style + filesystem-scan discipline): src/lib/__tests__/workflow-pins.test.ts -->
+<!-- Confirmed `as unknown as` matches under src/hooks/api today: only src/hooks/api/use-billing-mutations.test.ts (test-mock fetch casts) + 2 comment lines (property-stats-keys.ts, inspection-keys.ts) + 1 docstring (document-keys.ts). The guard must EXCLUDE *.test.ts files and comment/docstring lines so it pins the production-boundary state. -->
+
+<!-- Canonical reference mapper: mapDocumentRow in src/hooks/api/query-keys/document-keys.ts. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Extract mapExpiringLeaseRow validated mapper + wire into the widget</name>
+  <read_first>
+    - src/components/dashboard/expiring-leases-widget.tsx (lines 18-25 ExpiringLeaseRow; 31-70 queryFn select + inline `.map` projection)
+    - src/hooks/api/query-keys/document-keys.ts (mapDocumentRow: requireString throws on NOT-NULL, nullable joins left nullable — the discipline to mirror)
+  </read_first>
+  <behavior>
+    - mapExpiringLeaseRow(raw: unknown) → ExpiringLeaseRow: a valid join row (id/end_date strings, rent_amount number, optional nested tenants/units/properties) maps to the flat ExpiringLeaseRow with tenant_name/unit_name/property_name pulled from the nested joins or null when the join is absent.
+    - A row missing `id` or `end_date` throws (NOT-NULL boundary); a row with non-number `rent_amount` is rejected via Zod.
+    - A row with `tenants: null` / `units: null` / `units.properties: null` maps to tenant_name/unit_name/property_name === null (no throw — joins are legitimately nullable).
+  </behavior>
+  <action>
+    Create src/components/dashboard/expiring-leases-mapper.ts. Move the `ExpiringLeaseRow` interface out of the widget into this file and export it (the widget will import it). Import `z` from `zod`. Define a `expiringLeaseRawSchema` (Zod) for the nested join: `id` string, `end_date` string, `rent_amount` number, optional/nullable `tenants` object `{ name: string | null }`, optional/nullable `units` object `{ unit_number: string | null, properties: { name: string | null } | null }`. Export `mapExpiringLeaseRow(raw: unknown): ExpiringLeaseRow`: run `expiringLeaseRawSchema.safeParse(raw)`; on `!success` throw a descriptive boundary error (`mapExpiringLeaseRow: invalid expiring-lease row` with the Zod issue path) — for the NOT-NULL `id`/`end_date`/`rent_amount` fields this surfaces a dropped column immediately, mirroring mapDocumentRow's throw-early discipline; on success return `{ id, end_date, rent_amount, tenant_name: parsed.tenants?.name ?? null, unit_name: parsed.units?.unit_number ?? null, property_name: parsed.units?.properties?.name ?? null }`. Add a docstring citing mapDocumentRow + CLAUDE.md RPC-return-typing rule. In src/components/dashboard/expiring-leases-widget.tsx: import `mapExpiringLeaseRow` and `ExpiringLeaseRow` from `./expiring-leases-mapper`; remove the local `ExpiringLeaseRow` interface (now imported); replace the inline `.map((row) => ({ ... }))` projection with `.map((row) => mapExpiringLeaseRow(row))` (the queryFn return type stays `Promise<ExpiringLeaseRow[]>`). Leave the select query, the `daysUntil` helper, and all JSX untouched. Confirm the widget stays under the 300-line component cap (it shrinks).
+  </action>
+  <verify>
+    <automated>grep -q "mapExpiringLeaseRow" src/components/dashboard/expiring-leases-mapper.ts && grep -q "mapExpiringLeaseRow" src/components/dashboard/expiring-leases-widget.tsx && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - src/components/dashboard/expiring-leases-mapper.ts exists, exports `mapExpiringLeaseRow` + `ExpiringLeaseRow`, contains `safeParse`
+    - src/components/dashboard/expiring-leases-widget.tsx imports `mapExpiringLeaseRow` and no longer declares a local `ExpiringLeaseRow` interface
+    - widget queryFn maps via `mapExpiringLeaseRow` (no inline object-literal projection of the raw row remains)
+    - `grep -c "as unknown as" src/components/dashboard/expiring-leases-mapper.ts` returns 0
+    - `bun run typecheck` clean
+  </acceptance_criteria>
+  <done>mapExpiringLeaseRow extracted + field-validates via Zod safeParse, widget routes through it, ExpiringLeaseRow reused (not duplicated), typecheck clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add the rpc-boundary-cast-pins drift guard + mapper unit tests</name>
+  <read_first>
+    - src/lib/__tests__/workflow-pins.test.ts (the full Phase-1 drift-guard style: readdirSync/readFileSync, per-line scan, skip comment lines, actionable `file:line → ref` failure messages, a "finds at least one file to guard" sanity assertion)
+    - src/hooks/api/use-billing-mutations.test.ts lines 62/88/115/146/176 (the `as unknown as typeof fetch` test-mock casts that must be EXCLUDED — they are `.test.ts`)
+    - src/components/dashboard/expiring-leases-mapper.ts (the mapper to unit-test, from Task 1)
+  </read_first>
+  <action>
+    Create src/lib/__tests__/rpc-boundary-cast-pins.test.ts (Vitest, pure filesystem read — never touches the DOM), mirroring workflow-pins.test.ts structure. Recursively walk `src/hooks/api/` via `readdirSync(..., { withFileTypes: true })` collecting `.ts`/`.tsx` files but EXCLUDING any file ending in `.test.ts`/`.test.tsx`/`.spec.ts` (test-mock casts like `as unknown as typeof fetch` are legitimate test scaffolding, out of the production-boundary scope). For each collected file, read it, split into lines, and for each line: strip trailing `//` line-comments and skip lines that are wholly a comment (`trimmed.startsWith("//")` or `startsWith("*")` or `startsWith("/*")`) so the 2 comment-references and the document-keys docstring mention do not trip the guard; flag any remaining line containing the literal `as unknown as`. Build a `violations` array of `` `${relativePath}:${lineNumber} → ${trimmedLine}` ``. Assertions: (a) a sanity `it("finds at least one production boundary file to guard")` asserting the collected-file count > 0 (so a broken walker can't vacuously pass); (b) `it("no `as unknown as` cast at any src/hooks/api PostgREST/RPC boundary")` asserting `expect(violations, "Reintroduced `as unknown as` boundary cast(s) — route through a validated mapper instead:\n" + violations.join("\n")).toEqual([])`. Reference CLAUDE.md Rule #8 + the mapDocumentRow pattern in the file docstring. Then create src/components/dashboard/expiring-leases-mapper.test.ts (Vitest) covering: (a) a valid nested join row maps to the flat ExpiringLeaseRow with all three join names populated; (b) a row with `tenants: null` and `units: null` maps to tenant_name/unit_name/property_name all null; (c) a row with `units` present but `units.properties: null` maps property_name to null; (d) a row missing `id` throws; (e) a row with `rent_amount` as a string is rejected. Use `expect(fn).toThrow()` / `.toMatchObject({ message: expect.stringContaining(...) })` per the Vitest 4 + chai 6 gotcha, never `.toThrow('string')`.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/lib/__tests__/rpc-boundary-cast-pins.test.ts src/components/dashboard/expiring-leases-mapper.test.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - src/lib/__tests__/rpc-boundary-cast-pins.test.ts exists, walks `src/hooks/api/`, excludes `*.test.ts`/`*.spec.ts`, skips comment lines
+    - The guard has a "finds at least one file" sanity assertion AND the zero-`as unknown as` assertion (it passes today — only test-mock + comment casts exist)
+    - The guard FAILS if an `as unknown as` is added to a non-test production file under src/hooks/api/ (verifiable by reasoning: a single matching non-comment line in a non-`.test.ts` file populates `violations`)
+    - `bun run test:unit -- --run src/lib/__tests__/rpc-boundary-cast-pins.test.ts src/components/dashboard/expiring-leases-mapper.test.ts` passes
+    - `bun run typecheck` clean
+  </acceptance_criteria>
+  <done>Drift guard pins zero `as unknown as` at src/hooks/api boundaries (test-mock + comments excluded), fails actionably on reintroduction; mapper unit tests green.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck` clean
+- `bun run lint` clean on the modified files
+- `bun run test:unit -- --run src/lib/__tests__/rpc-boundary-cast-pins.test.ts src/components/dashboard/expiring-leases-mapper.test.ts` passes
+- Drift guard is green today and fails on any reintroduced boundary `as unknown as`
+</verification>
+
+<success_criteria>
+TYPE-03 satisfied: the expiring-leases boundary routes through a validated `mapExpiringLeaseRow()`, and a drift-guard test asserts zero `as unknown as` at PostgREST/RPC boundaries under `src/hooks/api/` (library/test-mock casts excluded), with `bun run typecheck` clean.
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-typed-rpc-boundaries/02-04-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-typed-rpc-boundaries/02-04-SUMMARY.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-04-SUMMARY.md
@@ -1,0 +1,21 @@
+# Plan 02-04 Summary — Expiring-Leases Mapper + RPC-Boundary Drift Guard (TYPE-03)
+
+**Status:** Complete
+**Branch:** gsd/phase-2-typed-rpc-boundaries
+**Commits:** `1a7217904` (feat: mapper + widget + mapper test), `ff3ed8fa9` (test: drift guard)
+
+## What shipped
+- `src/components/dashboard/expiring-leases-mapper.ts` — `mapExpiringLeaseRow(raw: unknown): ExpiringLeaseRow` with Zod field validation (mirrors `mapDocumentRow`). Reuses the existing `ExpiringLeaseRow` type — no duplicate.
+- `src/components/dashboard/expiring-leases-widget.tsx` — the `Row[]` cast replaced with `(data ?? []).map(mapExpiringLeaseRow)`. No `as unknown as`, no `as Row[]`.
+- `src/components/dashboard/expiring-leases-mapper.test.ts` — mapper unit coverage (valid→mapped, invalid/missing→handled).
+- `src/lib/__tests__/rpc-boundary-cast-pins.test.ts` — TYPE-03 drift guard: filesystem scan of `src/hooks/api/**` (production `.ts`/`.tsx`), FAILS on any `as unknown as` outside `*.test.ts`/`*.spec.ts` + wholly-comment lines. Mirrors `workflow-pins.test.ts` (sanity "finds files to guard" assertion + actionable `file:line → snippet` failures).
+
+## Verification
+- 7/7 unit tests pass (mapper + drift guard). `bun run typecheck` clean; `biome` clean. Full lefthook gate passed on both commits — no `--no-verify`.
+- **Drift guard proven load-bearing:** planted a temporary `as unknown as` under `src/hooks/api/` → the guard FAILED with `__drift_probe_tmp.ts:1 → …: expected [Array(1)] to deeply equal []`; removed the probe → guard passes clean. It is not a false-green.
+
+## Recovery note
+The first 02-04 executor run dropped on an API ConnectionRefused mid-execution. Its uncommitted work was on disk (mapper + widget edit + both tests) plus a leftover `__driftProbe` (`as unknown as number`) it had planted in `property-stats-keys.ts` to verify the guard. On resume: reverted the stray probe (`git restore property-stats-keys.ts`), re-ran the verification cleanly (incl. the load-bearing proof above), fixed one biome format nit, and committed. No duplicate work; no out-of-scope file left modified.
+
+## Scope
+Only `expiring-leases-widget.tsx` + the new mapper + the drift-guard test. No out-of-scope files touched (property-stats probe reverted to clean).

--- a/.planning/phases/02-typed-rpc-boundaries/02-CONTEXT.md
+++ b/.planning/phases/02-typed-rpc-boundaries/02-CONTEXT.md
@@ -1,0 +1,72 @@
+# Phase 2: Typed RPC Boundaries - Context
+
+**Gathered:** 2026-06-05
+**Status:** Ready for planning
+**Source:** Re-scoped after live-code verification + user decision (full Zod validation)
+
+<domain>
+## Phase Boundary
+
+Convert the **phase's named RPC/PostgREST read+write boundaries** to typed mappers with **field-level Zod validation**, and add a drift guard so the rule-#8 `as unknown as` violation cannot silently return.
+
+**Critical reality check (verified 2026-06-05):** The `as unknown as` double-casts the 2026-05-29 audit flagged are ALREADY GONE — the only 2 matches in `src/hooks` are in comments. Since the audit, the code gained:
+- `src/lib/rpc-shape.ts` — `jsonObject<T>()`/`jsonArray<T>()` do STRUCTURAL validation (throw if not object/array) then `return data as T`. NOT field-level validation.
+- `tenant-mappers.ts` — `mapTenantRow` typed shaping function, but NO Zod `safeParse`.
+- `maintenance-keys.ts` — still raw `data as MaintenanceRequest[]` (no mapper, no validation).
+
+So the rule-#8 violation is resolved; what remains for the phase's success criteria ("typed mapper WITH Zod validation") is the field-level validation + the drift guard.
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED)
+
+### Scope — IN (the phase requirements only)
+- **TYPE-01:** `src/hooks/api/use-analytics.ts` — the `LeaseAnalyticsPageData` paths (`{} as LeaseAnalyticsPageData` fallbacks at :64/:150 + the `jsonObjectOrEmpty<LeaseAnalyticsPageData>` returns). Replace with a typed mapper that field-validates via Zod `safeParse` and falls back safely on invalid/empty.
+- **TYPE-02:** `src/hooks/api/query-keys/tenant-mutation-options.ts` (`created as Tenant` :39, `updated as Tenant` :63, the `updated as TenantPostgrestRow` :139) AND `src/hooks/api/query-keys/maintenance-keys.ts` (the raw `as MaintenanceRequest`/`as MaintenanceRequest[]` casts at :89/:112/:156/:206/:280/:312/:338). Route through typed mappers with Zod field validation. Upgrade the existing `mapTenantRow` in `tenant-mappers.ts` to validate (it currently shapes without `safeParse`).
+- **TYPE-03:** `src/components/dashboard/expiring-leases-widget.tsx` (the `Row[]` cast at ~:71) → validated mapper. PLUS a drift-guard test asserting **zero `as unknown as`** at PostgREST/RPC boundaries under `src/hooks/api/` (library-shim casts in chart-tooltip/slider excluded), and `bun run typecheck` stays clean.
+
+### Full-Zod standard (LOCKED — user chose "Full Zod validation")
+- Each mapper validates the enum-shaped + NOT-NULL fields via Zod `safeParse` (mirror `mapDocumentRow` in `document-keys.ts` — the canonical reference CLAUDE.md cites: `requireString` throws on missing NOT-NULL, enum fields validated). Use Zod `safeParse` for enum/shape fields; throw on missing NOT-NULL.
+- Nullable-in-DB fields stay nullable (don't over-validate — match the real column nullability, like `mapDocumentRow` does for `created_at`).
+- No `as unknown as`. Plain `as Type` at the boundary is replaced by the mapper's validated return.
+
+### Scope — OUT (explicitly deferred, NOT this phase)
+- The broader `as Type` cast surface across the data layer — `property-keys.ts`, `lease-keys.ts`, `use-vendor.ts`, `expense-keys.ts`, `blog-keys.ts`, `session-keys.ts`, `subscription-verification-keys.ts`, `use-auth.ts`, `use-tour-progress.ts`. These share the plain-`as` pattern but are NOT in the TYPE-01/02/03 requirements. Converting all ~14 files would be a data-layer-wide rewrite beyond this phase. Flag as a candidate future phase; do NOT touch here.
+
+### Claude's Discretion
+- Where to place the new schemas/mappers (co-locate next to the existing mapper in the relevant `query-keys/*.ts` / a `*-mappers.ts`, following `tenant-mappers.ts` precedent).
+- Whether the analytics `LeaseAnalyticsPageData` (a nested aggregate shape) gets a full Zod object schema or a targeted validator for its enum/numeric fields — pick the pragmatic validation depth that catches real RPC drift without over-engineering a deep nested schema.
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### The validated-mapper pattern (the standard to mirror)
+- `src/hooks/api/query-keys/document-keys.ts` — `mapDocumentRow` (CLAUDE.md's cited reference): `requireString` throws on missing NOT-NULL, enum-shaped fields validated, nullable fields left nullable.
+- `src/hooks/api/query-keys/document-category-keys.ts` — `mapDocumentCategoryRow` (slug regex validation, non-null treatment per DEFAULT+trigger).
+
+### Existing partial work to upgrade
+- `src/hooks/api/query-keys/tenant-mappers.ts` — `mapTenantRow` (shapes but doesn't Zod-validate; add validation).
+- `src/lib/rpc-shape.ts` — `jsonObject`/`jsonArray` structural guards (the boundary the analytics path uses today).
+
+### Types
+- `src/types/` — browse for `Tenant`, `TenantWithLeaseInfo`, `MaintenanceRequest`, `LeaseAnalyticsPageData`, the expiring-leases `Row` shape before defining any schema (CLAUDE.md type-lookup order — no duplicate types).
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+- The drift-guard test (TYPE-03) should scan `src/hooks/api/**` source for `as unknown as` and fail on any match outside an explicit allowlist (chart-tooltip/slider library shims live in `src/components/ui/`, not `src/hooks/api/`, so the hooks/api scan is naturally clean — pin it).
+- Mirror the Phase-1 drift-guard test style (`workflow-pins.test.ts`) — filesystem read, actionable `file:line` failure messages.
+</specifics>
+
+<deferred>
+## Deferred Ideas
+- Data-layer-wide `as Type` → validated-mapper conversion (property/lease/vendor/expense/blog/session/auth/tour-progress) — a future "Typed Data Layer" phase if desired.
+</deferred>
+
+---
+
+*Phase: 02-typed-rpc-boundaries*
+*Context gathered: 2026-06-05 — re-scoped after live verification; user locked "full Zod validation" for the phase's named boundaries.*

--- a/src/components/dashboard/expiring-leases-mapper.test.ts
+++ b/src/components/dashboard/expiring-leases-mapper.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the expiring-leases boundary mapper (TYPE-03, Phase 2).
+ *
+ * `mapExpiringLeaseRow` validates a nested `leases` PostgREST FK-join row at the
+ * boundary, mirroring `mapDocumentRow` in
+ * `src/hooks/api/query-keys/document-keys.ts` (CLAUDE.md's cited reference):
+ * NOT-NULL fields (`id`/`end_date`/`rent_amount`) throw if absent or the wrong
+ * type, and the nullable FK joins (`tenants`/`units`/`units.properties`) stay
+ * nullable so an absent join maps to `null` instead of throwing.
+ *
+ * Vitest-4 + chai-6 gotcha: assert thrown messages via
+ * `.toThrow(/.../)` / `expect(fn).toThrow()`, never `.toThrow("plain string")`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mapExpiringLeaseRow } from "./expiring-leases-mapper";
+
+const fullRow = {
+	id: "00000000-0000-0000-0000-000000000001",
+	end_date: "2026-08-01",
+	rent_amount: 1850,
+	tenants: { name: "Jane Doe" },
+	units: {
+		unit_number: "4B",
+		properties: { name: "Maple Court" },
+	},
+};
+
+describe("mapExpiringLeaseRow", () => {
+	it("maps a valid nested join row to the flat ExpiringLeaseRow with all join names populated", () => {
+		expect(mapExpiringLeaseRow(fullRow)).toEqual({
+			id: "00000000-0000-0000-0000-000000000001",
+			end_date: "2026-08-01",
+			rent_amount: 1850,
+			tenant_name: "Jane Doe",
+			unit_name: "4B",
+			property_name: "Maple Court",
+		});
+	});
+
+	it("maps tenants:null and units:null to tenant_name/unit_name/property_name all null", () => {
+		const row = {
+			id: "00000000-0000-0000-0000-000000000002",
+			end_date: "2026-09-15",
+			rent_amount: 2000,
+			tenants: null,
+			units: null,
+		};
+
+		expect(mapExpiringLeaseRow(row)).toEqual({
+			id: "00000000-0000-0000-0000-000000000002",
+			end_date: "2026-09-15",
+			rent_amount: 2000,
+			tenant_name: null,
+			unit_name: null,
+			property_name: null,
+		});
+	});
+
+	it("maps a present units with units.properties:null to property_name null", () => {
+		const row = {
+			id: "00000000-0000-0000-0000-000000000003",
+			end_date: "2026-10-01",
+			rent_amount: 1500,
+			tenants: { name: "Sam Smith" },
+			units: { unit_number: "1A", properties: null },
+		};
+
+		const mapped = mapExpiringLeaseRow(row);
+		expect(mapped.unit_name).toBe("1A");
+		expect(mapped.property_name).toBeNull();
+		expect(mapped.tenant_name).toBe("Sam Smith");
+	});
+
+	it("throws when the NOT-NULL id field is missing", () => {
+		const { id: _omit, ...withoutId } = fullRow;
+		expect(() => mapExpiringLeaseRow(withoutId)).toThrow(
+			/mapExpiringLeaseRow: invalid expiring-lease row/,
+		);
+	});
+
+	it("rejects a row where rent_amount is a string (RPC drift)", () => {
+		const row = { ...fullRow, rent_amount: "1850" };
+		expect(() => mapExpiringLeaseRow(row)).toThrow(
+			/mapExpiringLeaseRow: invalid expiring-lease row at 'rent_amount'/,
+		);
+	});
+});

--- a/src/components/dashboard/expiring-leases-mapper.ts
+++ b/src/components/dashboard/expiring-leases-mapper.ts
@@ -1,0 +1,81 @@
+/**
+ * Boundary mapper for the expiring-leases dashboard widget (TYPE-03, Phase 2).
+ *
+ * `expiring-leases-widget.tsx` reads a nested PostgREST FK join off `leases`
+ * (`tenants:primary_tenant_id (name)`, `units:unit_id (unit_number,
+ * properties:property_id (name))`). The old path projected those raw rows via
+ * an inline untyped `.map()` (`row.tenants?.name`, `row.units?.properties?.name`)
+ * — not field-validated, so a dropped column in the `.select(...)` read as
+ * `undefined` silently instead of failing at the boundary.
+ *
+ * `mapExpiringLeaseRow` replaces that inline projection with a Zod `safeParse`
+ * field-validation, mirroring `mapDocumentRow` in
+ * `src/hooks/api/query-keys/document-keys.ts` (the canonical reference CLAUDE.md
+ * cites for the "RPC / PostgREST Return Typing" rule — typed mapper at every
+ * boundary, never `as unknown as`).
+ *
+ * Discipline mirrored from `mapDocumentRow`:
+ *  - NOT-NULL fields (`id`, `end_date`, `rent_amount`) throw if missing or the
+ *    wrong type — a dropped column surfaces immediately instead of silently
+ *    producing `undefined`.
+ *  - Nullable-in-DB joins (`tenants`, `units`, `units.properties`) stay nullable
+ *    — an absent join legitimately maps to `null`, no throw.
+ */
+
+import { z } from "zod";
+
+export interface ExpiringLeaseRow {
+	id: string;
+	end_date: string;
+	rent_amount: number;
+	tenant_name: string | null;
+	unit_name: string | null;
+	property_name: string | null;
+}
+
+// The raw nested PostgREST join shape. NOT-NULL columns (id/end_date/
+// rent_amount) are required; the FK joins are nullable (a lease may have no
+// primary tenant / unit, and a unit may have no property row). Nested name
+// fields are nullable to match real column nullability.
+const expiringLeaseRawSchema = z.object({
+	id: z.string(),
+	end_date: z.string(),
+	rent_amount: z.number(),
+	tenants: z.object({ name: z.string().nullable() }).nullable().optional(),
+	units: z
+		.object({
+			unit_number: z.string().nullable(),
+			properties: z
+				.object({ name: z.string().nullable() })
+				.nullable()
+				.optional(),
+		})
+		.nullable()
+		.optional(),
+});
+
+/**
+ * Maps one raw expiring-lease join row into the flat `ExpiringLeaseRow` the
+ * widget renders. Throws on a missing/typed-wrong NOT-NULL field (boundary
+ * surfaces RPC drift loudly); maps absent joins to `null`.
+ */
+export function mapExpiringLeaseRow(raw: unknown): ExpiringLeaseRow {
+	const parsed = expiringLeaseRawSchema.safeParse(raw);
+	if (!parsed.success) {
+		const firstIssue = parsed.error.issues[0];
+		const path = firstIssue?.path.join(".") || "<root>";
+		throw new Error(
+			`mapExpiringLeaseRow: invalid expiring-lease row at '${path}' — ${firstIssue?.message ?? "validation failed"}`,
+		);
+	}
+
+	const { id, end_date, rent_amount, tenants, units } = parsed.data;
+	return {
+		id,
+		end_date,
+		rent_amount,
+		tenant_name: tenants?.name ?? null,
+		unit_name: units?.unit_number ?? null,
+		property_name: units?.properties?.name ?? null,
+	};
+}

--- a/src/components/dashboard/expiring-leases-widget.tsx
+++ b/src/components/dashboard/expiring-leases-widget.tsx
@@ -14,15 +14,10 @@ import { Skeleton } from "#components/ui/skeleton";
 import { leaseQueries } from "#hooks/api/query-keys/lease-keys";
 import { handlePostgrestError } from "#lib/postgrest-error-handler";
 import { createClient } from "#lib/supabase/client";
-
-interface ExpiringLeaseRow {
-	id: string;
-	end_date: string;
-	rent_amount: number;
-	tenant_name: string | null;
-	unit_name: string | null;
-	property_name: string | null;
-}
+import {
+	type ExpiringLeaseRow,
+	mapExpiringLeaseRow,
+} from "./expiring-leases-mapper";
 
 /**
  * Enriched expiring-lease list joined with tenant + unit + property for
@@ -57,14 +52,7 @@ const expiringLeasesWithContext = queryOptions({
 
 		if (error) handlePostgrestError(error, "leases");
 
-		return (data ?? []).map((row) => ({
-			id: row.id,
-			end_date: row.end_date,
-			rent_amount: row.rent_amount,
-			tenant_name: row.tenants?.name ?? null,
-			unit_name: row.units?.unit_number ?? null,
-			property_name: row.units?.properties?.name ?? null,
-		}));
+		return (data ?? []).map((row) => mapExpiringLeaseRow(row));
 	},
 	staleTime: 5 * 60 * 1000,
 });

--- a/src/hooks/api/__tests__/use-tenant.test.tsx
+++ b/src/hooks/api/__tests__/use-tenant.test.tsx
@@ -106,10 +106,19 @@ function createWrapper() {
 	};
 }
 
-// Sample tenant data matching DB schema
+// Sample tenant data matching DB schema. `status` is NOT NULL on the
+// tenants row and is now field-validated at the create/update boundary by
+// mapTenantBaseRow (TYPE-02), so the fixture must carry a valid status.
 const mockTenant = {
 	id: "tenant-123",
 	user_id: "user-123",
+	owner_user_id: "owner-user-123",
+	first_name: "John",
+	last_name: "Doe",
+	name: "John Doe",
+	email: "john@example.com",
+	phone: "555-1234",
+	status: "active",
 	created_at: "2024-01-01T00:00:00Z",
 	updated_at: "2024-01-01T00:00:00Z",
 	date_of_birth: null,
@@ -118,7 +127,6 @@ const mockTenant = {
 	emergency_contact_relationship: null,
 	identity_verified: null,
 	ssn_last_four: null,
-	stripe_customer_id: null,
 };
 
 const mockTenantWithLease = {

--- a/src/hooks/api/query-keys/analytics-mappers.test.ts
+++ b/src/hooks/api/query-keys/analytics-mappers.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for `mapLeaseAnalytics` — the typed RPC→LeaseAnalyticsPageData
+ * boundary mapper introduced in Phase 2 (TYPE-01).
+ *
+ * Mirrors the discipline of `document-keys.test.ts`'s `mapDocumentRow`
+ * tests, with one key difference: an analytics aggregate's "no data yet"
+ * state is a valid render state (per the `jsonObjectOrEmpty` precedent the
+ * lease path used before this mapper), so the mapper NEVER throws — it
+ * field-validates via Zod `safeParse` and falls back to a safe empty shape
+ * on null/undefined/non-object/drifted input. These tests pin both the
+ * happy path (well-formed RPC return maps to populated page data) and the
+ * drift path (malformed sub-shapes degrade to empty/default, not leaked).
+ */
+
+import { describe, expect, it } from "vitest";
+import { mapLeaseAnalytics } from "./analytics-mappers";
+
+const validRaw = {
+	metrics: {
+		totalLeases: 12,
+		activeLeases: 9,
+		expiringSoon: 2,
+		totalrent_amount: 18500,
+		averageLeaseValue: 1541.67,
+	},
+	profitability: [
+		{
+			lease_id: "00000000-0000-0000-0000-000000000001",
+			propertyName: "Maple Court",
+			tenantName: "Jordan Lee",
+			rent_amount: 1500,
+			outstandingBalance: 0,
+			profitabilityScore: 0.82,
+		},
+	],
+	lifecycle: [
+		{ period: "2026-01", renewals: 3, expirations: 1, noticesGiven: 2 },
+		{ period: "2026-02", renewals: 1, expirations: 0, noticesGiven: 1 },
+	],
+	statusBreakdown: [
+		{ status: "active", count: 9, percentage: 75 },
+		{ status: "expiring", count: 2, percentage: 16.67 },
+	],
+	vacancyTrends: [
+		{ period: "2026-01", vacancyRate: 5, turnovers: 1, avgVacancyDays: 12 },
+	],
+};
+
+const emptyMetrics = {
+	totalLeases: 0,
+	activeLeases: 0,
+	expiringSoon: 0,
+	totalrent_amount: 0,
+	averageLeaseValue: 0,
+};
+
+describe("mapLeaseAnalytics", () => {
+	it("maps a fully-valid RPC object to a populated LeaseAnalyticsPageData", () => {
+		const mapped = mapLeaseAnalytics(validRaw);
+
+		expect(mapped.metrics).toEqual(validRaw.metrics);
+		expect(mapped.profitability).toEqual(validRaw.profitability);
+		expect(mapped.vacancyTrends).toEqual(validRaw.vacancyTrends);
+		// lifecycle source feeds BOTH lifecycle and renewalRates
+		expect(mapped.lifecycle).toEqual(validRaw.lifecycle);
+		expect(mapped.renewalRates).toEqual(validRaw.lifecycle);
+		// statusBreakdown source feeds BOTH statusBreakdown and leaseDistribution
+		expect(mapped.statusBreakdown).toEqual(validRaw.statusBreakdown);
+		expect(mapped.leaseDistribution).toEqual(validRaw.statusBreakdown);
+	});
+
+	it("returns the safe empty fallback for null without throwing", () => {
+		const mapped = mapLeaseAnalytics(null);
+		expect(mapped.metrics).toEqual(emptyMetrics);
+		expect(mapped.profitability).toEqual([]);
+		expect(mapped.renewalRates).toEqual([]);
+		expect(mapped.vacancyTrends).toEqual([]);
+		expect(mapped.leaseDistribution).toEqual([]);
+		expect(mapped.lifecycle).toEqual([]);
+		expect(mapped.statusBreakdown).toEqual([]);
+	});
+
+	it("returns the safe empty fallback for undefined", () => {
+		expect(mapLeaseAnalytics(undefined).metrics).toEqual(emptyMetrics);
+		expect(mapLeaseAnalytics(undefined).lifecycle).toEqual([]);
+	});
+
+	it("returns the safe empty fallback for an empty object", () => {
+		const mapped = mapLeaseAnalytics({});
+		expect(mapped.metrics).toEqual(emptyMetrics);
+		expect(mapped.profitability).toEqual([]);
+		expect(mapped.statusBreakdown).toEqual([]);
+	});
+
+	it("returns the safe empty fallback for a non-object primitive", () => {
+		expect(mapLeaseAnalytics("not-an-object").metrics).toEqual(emptyMetrics);
+		expect(mapLeaseAnalytics(42).metrics).toEqual(emptyMetrics);
+		expect(mapLeaseAnalytics(true).lifecycle).toEqual([]);
+	});
+
+	it("coerces metrics to the zeroed default when a numeric field is a string", () => {
+		const drifted = {
+			...validRaw,
+			metrics: { ...validRaw.metrics, totalLeases: "12" },
+		};
+		const mapped = mapLeaseAnalytics(drifted);
+		// metrics branch rejected → zeroed default, not leaked
+		expect(mapped.metrics).toEqual(emptyMetrics);
+		// well-formed sibling branches still map
+		expect(mapped.lifecycle).toEqual(validRaw.lifecycle);
+		expect(mapped.statusBreakdown).toEqual(validRaw.statusBreakdown);
+	});
+
+	it("drops the statusBreakdown branch when a row is missing count", () => {
+		const drifted = {
+			...validRaw,
+			statusBreakdown: [{ status: "active", percentage: 75 }],
+		};
+		const mapped = mapLeaseAnalytics(drifted);
+		expect(mapped.statusBreakdown).toEqual([]);
+		expect(mapped.leaseDistribution).toEqual([]);
+		// sibling branches unaffected
+		expect(mapped.metrics).toEqual(validRaw.metrics);
+		expect(mapped.lifecycle).toEqual(validRaw.lifecycle);
+	});
+
+	it("drops the lifecycle branch when a row is missing period", () => {
+		const drifted = {
+			...validRaw,
+			lifecycle: [{ renewals: 3, expirations: 1, noticesGiven: 2 }],
+		};
+		const mapped = mapLeaseAnalytics(drifted);
+		expect(mapped.lifecycle).toEqual([]);
+		expect(mapped.renewalRates).toEqual([]);
+		// sibling branches unaffected
+		expect(mapped.statusBreakdown).toEqual(validRaw.statusBreakdown);
+	});
+
+	it("allows nullable profitabilityScore (omitted or null)", () => {
+		const raw = {
+			...validRaw,
+			profitability: [
+				{
+					lease_id: "00000000-0000-0000-0000-000000000001",
+					propertyName: "Maple Court",
+					tenantName: "Jordan Lee",
+					rent_amount: 1500,
+					outstandingBalance: 0,
+				},
+				{
+					lease_id: "00000000-0000-0000-0000-000000000002",
+					propertyName: "Oak Lane",
+					tenantName: "Sam Park",
+					rent_amount: 1700,
+					outstandingBalance: 200,
+					profitabilityScore: null,
+				},
+			],
+		};
+		const mapped = mapLeaseAnalytics(raw);
+		expect(mapped.profitability).toHaveLength(2);
+		expect(mapped.profitability[0]?.profitabilityScore).toBeUndefined();
+		expect(mapped.profitability[1]?.profitabilityScore).toBeNull();
+	});
+});

--- a/src/hooks/api/query-keys/analytics-mappers.ts
+++ b/src/hooks/api/query-keys/analytics-mappers.ts
@@ -1,0 +1,169 @@
+/**
+ * Boundary mapper for the lease-analytics RPC return (TYPE-01, Phase 2).
+ *
+ * `get_occupancy_trends_optimized` (called via `fetchOccupancyTrends`) is
+ * typed `unknown` at the TS boundary — the RPC returns untyped JSON. The
+ * old lease path blind-cast it to `LeaseAnalyticsPageData` via
+ * `jsonObjectOrEmpty<LeaseAnalyticsPageData>(data, {} as ...)`, which only
+ * structural-checks "is this an object" and then leaks every field as-is.
+ * RPC drift (a numeric metric arriving as a string, a status row missing
+ * `count`) then surfaced downstream as silent `undefined` field reads /
+ * NaN charts instead of failing loudly at the boundary.
+ *
+ * `mapLeaseAnalytics` replaces that cast with field-level Zod `safeParse`
+ * validation, mirroring `mapDocumentRow` in `document-keys.ts` (the
+ * canonical reference CLAUDE.md cites for the "RPC / PostgREST Return
+ * Typing" rule — typed mapper at every boundary, never `as unknown as`).
+ *
+ * Difference from `mapDocumentRow`: an analytics aggregate's "no data yet"
+ * state is a valid render state (per the `jsonObjectOrEmpty` precedent), so
+ * this mapper NEVER throws. On null/undefined/non-object/drifted input it
+ * degrades to a safe empty `LeaseAnalyticsPageData` (zeroed metrics, empty
+ * arrays). Each top-level branch is validated independently, so a single
+ * malformed sub-shape clears only that branch — well-formed sibling
+ * branches still map through.
+ *
+ * Types are REUSED from `#types/analytics-page-data` / `#types/analytics`
+ * per CLAUDE.md's type-lookup order — no duplicate interfaces defined here.
+ */
+
+import { z } from "zod";
+import type {
+	LeaseFinancialInsight,
+	LeaseFinancialSummary,
+} from "#types/analytics";
+import type { LeaseAnalyticsPageData } from "#types/analytics-page-data";
+
+// Field-level schemas — one per sub-shape. Numeric fields must be real
+// numbers (a string-typed metric is RPC drift, not valid data), string
+// fields must be strings. `profitabilityScore` is the only nullable-optional
+// field (matches `LeaseFinancialInsight`'s `number | null` + optional).
+const leaseFinancialSummarySchema = z.object({
+	totalLeases: z.number(),
+	activeLeases: z.number(),
+	expiringSoon: z.number(),
+	totalrent_amount: z.number(),
+	averageLeaseValue: z.number(),
+});
+
+const leaseFinancialInsightSchema = z.object({
+	lease_id: z.string(),
+	propertyName: z.string(),
+	tenantName: z.string(),
+	rent_amount: z.number(),
+	outstandingBalance: z.number(),
+	profitabilityScore: z.number().nullable().optional(),
+});
+
+const leaseLifecyclePointSchema = z.object({
+	period: z.string(),
+	renewals: z.number(),
+	expirations: z.number(),
+	noticesGiven: z.number(),
+});
+
+const leaseStatusBreakdownSchema = z.object({
+	status: z.string(),
+	count: z.number(),
+	percentage: z.number(),
+});
+
+const vacancyTrendPointSchema = z.object({
+	period: z.string(),
+	vacancyRate: z.number(),
+	turnovers: z.number(),
+	avgVacancyDays: z.number(),
+});
+
+// Top-level schema. Every branch is optional + `.catch(undefined)` so a
+// single malformed sub-shape clears ONLY that branch instead of failing the
+// whole parse — well-formed siblings still map. The object envelope itself
+// is validated by `safeParse`; non-objects fall through to the empty shape.
+const leaseAnalyticsRawSchema = z.object({
+	metrics: leaseFinancialSummarySchema.optional().catch(undefined),
+	profitability: z
+		.array(leaseFinancialInsightSchema)
+		.optional()
+		.catch(undefined),
+	lifecycle: z.array(leaseLifecyclePointSchema).optional().catch(undefined),
+	statusBreakdown: z
+		.array(leaseStatusBreakdownSchema)
+		.optional()
+		.catch(undefined),
+	vacancyTrends: z.array(vacancyTrendPointSchema).optional().catch(undefined),
+});
+
+// `exactOptionalPropertyTypes: true` makes `profitabilityScore?: number |
+// null` reject the literal value `undefined` (the key may be absent, but if
+// present its value must be `number | null`). Zod's `.optional()` widens the
+// parsed value to `number | null | undefined`, so we normalize each row:
+// include the key only when it carries a real value, omit it otherwise.
+function toLeaseFinancialInsight(row: {
+	lease_id: string;
+	propertyName: string;
+	tenantName: string;
+	rent_amount: number;
+	outstandingBalance: number;
+	profitabilityScore?: number | null | undefined;
+}): LeaseFinancialInsight {
+	const base: LeaseFinancialInsight = {
+		lease_id: row.lease_id,
+		propertyName: row.propertyName,
+		tenantName: row.tenantName,
+		rent_amount: row.rent_amount,
+		outstandingBalance: row.outstandingBalance,
+	};
+	if (row.profitabilityScore !== undefined) {
+		base.profitabilityScore = row.profitabilityScore;
+	}
+	return base;
+}
+
+function emptyMetrics(): LeaseFinancialSummary {
+	return {
+		totalLeases: 0,
+		activeLeases: 0,
+		expiringSoon: 0,
+		totalrent_amount: 0,
+		averageLeaseValue: 0,
+	};
+}
+
+function emptyLeaseAnalytics(): LeaseAnalyticsPageData {
+	return {
+		metrics: emptyMetrics(),
+		profitability: [],
+		renewalRates: [],
+		vacancyTrends: [],
+		leaseDistribution: [],
+		lifecycle: [],
+		statusBreakdown: [],
+	};
+}
+
+/**
+ * Validate + shape an untyped lease-analytics RPC return into a
+ * `LeaseAnalyticsPageData`. Never throws — invalid/empty input degrades to
+ * the safe empty shape. The lifecycle array feeds both `lifecycle` and
+ * `renewalRates`; the statusBreakdown array feeds both `statusBreakdown` and
+ * `leaseDistribution` (those are page-compatibility aliases on the type).
+ */
+export function mapLeaseAnalytics(raw: unknown): LeaseAnalyticsPageData {
+	const parsed = leaseAnalyticsRawSchema.safeParse(raw);
+	if (!parsed.success) {
+		return emptyLeaseAnalytics();
+	}
+
+	const { metrics, profitability, lifecycle, statusBreakdown, vacancyTrends } =
+		parsed.data;
+
+	return {
+		metrics: metrics ?? emptyMetrics(),
+		profitability: (profitability ?? []).map(toLeaseFinancialInsight),
+		renewalRates: lifecycle ?? [],
+		vacancyTrends: vacancyTrends ?? [],
+		leaseDistribution: statusBreakdown ?? [],
+		lifecycle: lifecycle ?? [],
+		statusBreakdown: statusBreakdown ?? [],
+	};
+}

--- a/src/hooks/api/query-keys/maintenance-keys.ts
+++ b/src/hooks/api/query-keys/maintenance-keys.ts
@@ -28,6 +28,7 @@ import type {
 	VendorUpdateInput,
 } from "#types/domain";
 import { mutationKeys } from "../mutation-keys";
+import { mapMaintenanceRow } from "./maintenance-mappers";
 
 /**
  * Maintenance query filters
@@ -74,8 +75,9 @@ export const maintenanceQueries = {
 				if (filters?.property_id) {
 					// Join through units when filtering by property_id.
 					// PostgREST `units!inner(property_id)` filter adds a `units`
-					// embed to each row that the application MaintenanceRequest
-					// type does not carry -- drop it after the filter applies.
+					// embed to each row -- mapMaintenanceRow reads only the
+					// maintenance_requests columns, so the embed is ignored and
+					// each row is field-validated at the boundary.
 					const result = await supabase
 						.from("maintenance_requests")
 						.select(
@@ -85,9 +87,7 @@ export const maintenanceQueries = {
 						.eq("units.property_id", filters.property_id)
 						.order("created_at", { ascending: false })
 						.range(offset, offset + limit - 1);
-					data = (result.data ?? []).map(
-						({ units: _units, ...row }) => row as MaintenanceRequest,
-					);
+					data = (result.data ?? []).map(mapMaintenanceRow);
 					error = result.error;
 					count = result.count;
 				} else {
@@ -109,7 +109,9 @@ export const maintenanceQueries = {
 					q = q.range(offset, offset + limit - 1);
 
 					const result = await q;
-					data = result.data as MaintenanceRequest[];
+					data = ((result.data ?? []) as Record<string, unknown>[]).map(
+						mapMaintenanceRow,
+					);
 					error = result.error;
 					count = result.count;
 				}
@@ -153,7 +155,8 @@ export const maintenanceQueries = {
 
 				if (error) handlePostgrestError(error, "maintenance_requests");
 
-				return data as MaintenanceRequest;
+				// detail() embeds `vendors(...)` — mapMaintenanceRow ignores it.
+				return mapMaintenanceRow(data as Record<string, unknown>);
 			},
 			...QUERY_CACHE_TIMES.DETAIL,
 			enabled: !!id,
@@ -203,7 +206,9 @@ export const maintenanceQueries = {
 
 				if (error) handlePostgrestError(error, "maintenance_requests");
 
-				return (data as MaintenanceRequest[]) ?? [];
+				return ((data ?? []) as Record<string, unknown>[]).map(
+					mapMaintenanceRow,
+				);
 			},
 			staleTime: 30 * 1000,
 			gcTime: 5 * 60 * 1000,
@@ -277,7 +282,9 @@ export const maintenanceQueries = {
 
 				if (error) handlePostgrestError(error, "maintenance_requests");
 
-				return (data as MaintenanceRequest[]) ?? [];
+				return ((data ?? []) as Record<string, unknown>[]).map(
+					mapMaintenanceRow,
+				);
 			},
 			...QUERY_CACHE_TIMES.STATS,
 		}),
@@ -309,7 +316,7 @@ export const maintenanceMutations = {
 
 				if (error) handlePostgrestError(error, "maintenance_requests");
 
-				return created as MaintenanceRequest;
+				return mapMaintenanceRow(created as Record<string, unknown>);
 			},
 		}),
 
@@ -335,7 +342,7 @@ export const maintenanceMutations = {
 
 				if (error) handlePostgrestError(error, "maintenance_requests");
 
-				return updated as MaintenanceRequest;
+				return mapMaintenanceRow(updated as Record<string, unknown>);
 			},
 		}),
 

--- a/src/hooks/api/query-keys/maintenance-mappers.test.ts
+++ b/src/hooks/api/query-keys/maintenance-mappers.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the maintenance boundary mapper (TYPE-02, Phase 2).
+ *
+ * `mapMaintenanceRow` validates a `maintenance_requests` PostgREST row at the
+ * boundary, mirroring `mapDocumentRow` in `document-keys.ts` (CLAUDE.md's cited
+ * reference): NOT-NULL fields throw if absent, `status`/`priority` are validated
+ * via Zod `safeParse`, and nullable-in-DB fields stay nullable.
+ *
+ * The critical pins here: persisted `status` is validated against the FULL
+ * 7-value DB CHECK set (migration 20260221120000), NOT the stale 5-value input
+ * `maintenanceStatusSchema`. So `status: "assigned"` and `status:
+ * "needs_reassignment"` (written by vendorMutations.assign / unassign) MUST map
+ * cleanly — validating against the 5-value input enum would throw on those rows
+ * and break the maintenance list/detail/urgent/kanban surfaces in prod. The
+ * `status` safeParse is unconditional, so an absent/null status throws too.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mapMaintenanceRow } from "./maintenance-mappers";
+
+const validRow = {
+	id: "00000000-0000-0000-0000-000000000001",
+	owner_user_id: "00000000-0000-0000-0000-0000000000ff",
+	unit_id: "00000000-0000-0000-0000-000000000002",
+	tenant_id: "00000000-0000-0000-0000-000000000003",
+	title: "Leaky faucet",
+	description: "Kitchen faucet drips continuously",
+	priority: "high",
+	status: "open",
+	vendor_id: null,
+	requested_by: null,
+	assigned_to: null,
+	estimated_cost: null,
+	actual_cost: null,
+	scheduled_date: null,
+	completed_at: null,
+	inspection_date: null,
+	inspection_findings: null,
+	inspector_id: null,
+	created_at: "2026-01-01T00:00:00.000Z",
+	updated_at: "2026-01-02T00:00:00.000Z",
+};
+
+describe("mapMaintenanceRow", () => {
+	it("maps a valid maintenance row to the MaintenanceRequest shape", () => {
+		const mapped = mapMaintenanceRow(validRow);
+		expect(mapped.id).toBe("00000000-0000-0000-0000-000000000001");
+		expect(mapped.title).toBe("Leaky faucet");
+		expect(mapped.description).toBe("Kitchen faucet drips continuously");
+		expect(mapped.priority).toBe("high");
+		expect(mapped.status).toBe("open");
+		// Nullable-in-DB fields stay nullable, not over-validated into throws.
+		expect(mapped.actual_cost).toBeNull();
+		expect(mapped.scheduled_date).toBeNull();
+		expect(mapped.completed_at).toBeNull();
+		expect(mapped.vendor_id).toBeNull();
+	});
+
+	it("throws when the NOT-NULL id is missing", () => {
+		const { id: _omitId, ...withoutId } = validRow;
+		expect(() => mapMaintenanceRow(withoutId)).toThrow(/id/);
+	});
+
+	it("throws when the NOT-NULL title is missing", () => {
+		const { title: _omitTitle, ...withoutTitle } = validRow;
+		expect(() => mapMaintenanceRow(withoutTitle)).toThrow(/title/);
+	});
+
+	it("rejects an unrecognized status enum", () => {
+		expect(() => mapMaintenanceRow({ ...validRow, status: "bogus" })).toThrow(
+			/status/,
+		);
+	});
+
+	it("rejects an unrecognized priority enum", () => {
+		expect(() =>
+			mapMaintenanceRow({ ...validRow, priority: "extreme" }),
+		).toThrow(/priority/);
+	});
+
+	it("accepts status='assigned' (written by vendorMutations.assign)", () => {
+		const mapped = mapMaintenanceRow({ ...validRow, status: "assigned" });
+		expect(mapped.status).toBe("assigned");
+	});
+
+	it("accepts status='needs_reassignment' (written by vendorMutations.unassign)", () => {
+		const mapped = mapMaintenanceRow({
+			...validRow,
+			status: "needs_reassignment",
+		});
+		expect(mapped.status).toBe("needs_reassignment");
+	});
+
+	it("accepts the remaining DB-CHECK statuses (in_progress, completed, cancelled, on_hold)", () => {
+		for (const status of ["in_progress", "completed", "cancelled", "on_hold"]) {
+			expect(mapMaintenanceRow({ ...validRow, status }).status).toBe(status);
+		}
+	});
+
+	it("throws when status is absent (unconditional safeParse — no != null short-circuit)", () => {
+		const { status: _omitStatus, ...withoutStatus } = validRow;
+		expect(() => mapMaintenanceRow(withoutStatus)).toThrow(/status/);
+	});
+
+	it("throws when status is null (unconditional safeParse)", () => {
+		expect(() => mapMaintenanceRow({ ...validRow, status: null })).toThrow(
+			/status/,
+		);
+	});
+
+	it("ignores an extra `units` embed key from the property_id join branch", () => {
+		const mapped = mapMaintenanceRow({
+			...validRow,
+			units: { property_id: "00000000-0000-0000-0000-0000000000aa" },
+		});
+		expect(mapped.id).toBe("00000000-0000-0000-0000-000000000001");
+		expect("units" in mapped).toBe(false);
+	});
+
+	it("ignores an extra `vendors` embed key from the detail join branch", () => {
+		const mapped = mapMaintenanceRow({
+			...validRow,
+			vendors: { id: "v1", name: "Acme Plumbing", trade: "plumbing" },
+		});
+		expect(mapped.id).toBe("00000000-0000-0000-0000-000000000001");
+		expect("vendors" in mapped).toBe(false);
+	});
+
+	it("passes populated nullable fields through unchanged", () => {
+		const mapped = mapMaintenanceRow({
+			...validRow,
+			actual_cost: 125.5,
+			estimated_cost: 100,
+			scheduled_date: "2026-02-01",
+			completed_at: "2026-02-03T12:00:00.000Z",
+			vendor_id: "00000000-0000-0000-0000-0000000000bb",
+		});
+		expect(mapped.actual_cost).toBe(125.5);
+		expect(mapped.estimated_cost).toBe(100);
+		expect(mapped.scheduled_date).toBe("2026-02-01");
+		expect(mapped.completed_at).toBe("2026-02-03T12:00:00.000Z");
+		expect(mapped.vendor_id).toBe("00000000-0000-0000-0000-0000000000bb");
+	});
+
+	it("surfaces a descriptive boundary error message on status drift", () => {
+		expect(() => mapMaintenanceRow({ ...validRow, status: "bogus" })).toThrow(
+			expect.objectContaining({
+				message: expect.stringContaining("mapMaintenanceRow"),
+			}),
+		);
+	});
+});

--- a/src/hooks/api/query-keys/maintenance-mappers.ts
+++ b/src/hooks/api/query-keys/maintenance-mappers.ts
@@ -1,0 +1,128 @@
+/**
+ * Maintenance Row Mapper (TYPE-02, Phase 2 — typed RPC/PostgREST boundaries).
+ *
+ * `mapMaintenanceRow` maps a `maintenance_requests` PostgREST row into the
+ * strictly-typed `MaintenanceRequest` (= Tables<"maintenance_requests">),
+ * field-validating at the boundary. Mirrors `mapDocumentRow` in
+ * `document-keys.ts` (CLAUDE.md's cited reference for the "RPC / PostgREST
+ * Return Typing" rule): `requireString` throws on a missing NOT-NULL column so
+ * a dropped `.select(...)` field surfaces immediately rather than silently
+ * producing `"undefined"` downstream (broken React keys, kanban grouping,
+ * detail-page lookups). `status` and `priority` are validated via Zod
+ * `safeParse` so an enum drift fails loudly instead of leaking. Nullable-in-DB
+ * fields stay nullable — they are not over-validated into false throws.
+ *
+ * Extracted as a co-located mapper (tenant-mappers.ts precedent) rather than
+ * inlined in maintenance-keys.ts, which is already near the 300-line cap.
+ */
+
+import { z } from "zod";
+import { maintenancePrioritySchema } from "#lib/validation/maintenance";
+import type { MaintenanceRequest } from "#types/core";
+
+// PERSISTED maintenance status set — the FULL live DB CHECK constraint from
+// migration 20260221120000_add_maintenance_status_vendor_statuses.sql (the
+// source of truth; no later override widens or narrows it):
+//   open, assigned, in_progress, needs_reassignment, completed, cancelled, on_hold
+//
+// This is intentionally NOT the shared `maintenanceStatusSchema` from
+// #lib/validation/maintenance. That schema is the STALE 5-value INPUT enum
+// (open/in_progress/completed/cancelled/on_hold) — it gates the create/update
+// FORM (which must not offer vendor-workflow statuses) and omits "assigned" and
+// "needs_reassignment". vendorMutations.assign / unassign actively PERSIST those
+// two statuses (maintenance-keys.ts), and those rows flow back through
+// list()/detail()/urgent()/overdue(). Validating a persisted status against the
+// 5-value input schema would throw on every assigned/reassignment row and break
+// the maintenance surfaces in prod — the exact over-validation failure 02-CONTEXT
+// warns against. So this is a module-local schema (mirrors plan 02-02's tenant
+// `moved_out` persisted-status union precedent). Do NOT widen the shared input
+// enum to "fix" this — the two schemas validate different boundaries.
+const maintenancePersistedStatusSchema = z.enum([
+	"open",
+	"assigned",
+	"in_progress",
+	"needs_reassignment",
+	"completed",
+	"cancelled",
+	"on_hold",
+]);
+
+/**
+ * Throw on a missing/non-string NOT-NULL field. Mirrors the `requireString`
+ * helper in `mapDocumentRow` — surfaces a dropped column at the boundary.
+ */
+function requireString(raw: Record<string, unknown>, field: string): string {
+	const value = raw[field];
+	if (typeof value !== "string") {
+		throw new Error(
+			`mapMaintenanceRow: NOT NULL field '${field}' missing or non-string from PostgREST response`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Validate a PERSISTED maintenance `status` against the full 7-value DB CHECK
+ * set. `status` is NOT NULL in the DB, so an absent/null value is itself drift —
+ * the safeParse runs UNCONDITIONALLY (no `!= null` short-circuit), so a dropped
+ * NOT-NULL status column throws here instead of leaking through as `undefined`.
+ */
+function requirePersistedStatus(value: unknown): string {
+	const parsed = maintenancePersistedStatusSchema.safeParse(value);
+	if (!parsed.success) {
+		throw new Error(
+			`mapMaintenanceRow: invalid status '${String(value)}' from PostgREST response`,
+		);
+	}
+	return parsed.data;
+}
+
+/**
+ * Validate a PERSISTED maintenance `priority` against the 5-value DB enum
+ * (reused `maintenancePrioritySchema` — it matches the DB CHECK exactly).
+ * `priority` is NOT NULL, so the safeParse runs unconditionally.
+ */
+function requirePersistedPriority(value: unknown): string {
+	const parsed = maintenancePrioritySchema.safeParse(value);
+	if (!parsed.success) {
+		throw new Error(
+			`mapMaintenanceRow: invalid priority '${String(value)}' from PostgREST response`,
+		);
+	}
+	return parsed.data;
+}
+
+/**
+ * Map a `maintenance_requests` PostgREST row to the strictly-typed
+ * `MaintenanceRequest`. Accepts a row that may carry an extra `units` (from the
+ * list() property_id `units!inner(property_id)` embed) or `vendors` (from the
+ * detail() `vendors(...)` embed) key — only the maintenance_requests columns are
+ * read, so the embed keys are ignored and never appear on the output.
+ */
+export function mapMaintenanceRow(raw: unknown): MaintenanceRequest {
+	const row = (raw ?? {}) as Record<string, unknown>;
+	return {
+		// NOT-NULL columns — throw if a dropped .select() column made them absent.
+		id: requireString(row, "id"),
+		owner_user_id: requireString(row, "owner_user_id"),
+		unit_id: requireString(row, "unit_id"),
+		tenant_id: requireString(row, "tenant_id"),
+		title: requireString(row, "title"),
+		description: requireString(row, "description"),
+		priority: requirePersistedPriority(row.priority),
+		status: requirePersistedStatus(row.status),
+		// Nullable-in-DB columns — pass through as value-or-null.
+		vendor_id: (row.vendor_id as string | null) ?? null,
+		requested_by: (row.requested_by as string | null) ?? null,
+		assigned_to: (row.assigned_to as string | null) ?? null,
+		estimated_cost: (row.estimated_cost as number | null) ?? null,
+		actual_cost: (row.actual_cost as number | null) ?? null,
+		scheduled_date: (row.scheduled_date as string | null) ?? null,
+		completed_at: (row.completed_at as string | null) ?? null,
+		inspection_date: (row.inspection_date as string | null) ?? null,
+		inspection_findings: (row.inspection_findings as string | null) ?? null,
+		inspector_id: (row.inspector_id as string | null) ?? null,
+		created_at: (row.created_at as string | null) ?? null,
+		updated_at: (row.updated_at as string | null) ?? null,
+	};
+}

--- a/src/hooks/api/query-keys/tenant-mappers.test.ts
+++ b/src/hooks/api/query-keys/tenant-mappers.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the tenant boundary mappers (TYPE-02, Phase 2).
+ *
+ * `mapTenantBaseRow` validates a flat `tenants` insert/update return
+ * (`.select().single()`) at the PostgREST boundary, and the upgraded
+ * `mapTenantRow` validates the nested-join read shape. Both mirror
+ * `mapDocumentRow` in `document-keys.ts` (CLAUDE.md's cited reference):
+ * `requireString` throws on a missing NOT-NULL `id`, `status` is validated
+ * via Zod `safeParse`, and nullable-in-DB fields stay nullable.
+ *
+ * These tests pin the happy path (valid row maps through), the drift path
+ * (a dropped NOT-NULL `id` or a bogus `status` enum fails loudly at the
+ * boundary instead of leaking downstream), and the `moved_out` carve-out
+ * (markMovedOut persists a status that is in TENANT_ACTIVE_STATUSES but not
+ * tenantStatusSchema, so the persisted-status union must accept it).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	mapTenantBaseRow,
+	mapTenantRow,
+	type TenantPostgrestRow,
+} from "./tenant-mappers";
+
+const validBaseRow = {
+	id: "00000000-0000-0000-0000-000000000001",
+	user_id: null,
+	owner_user_id: "00000000-0000-0000-0000-0000000000ff",
+	first_name: "Jordan",
+	last_name: "Lee",
+	name: "Jordan Lee",
+	email: "jordan@example.com",
+	phone: null,
+	status: "active",
+	created_at: "2026-01-01T00:00:00.000Z",
+	updated_at: "2026-01-02T00:00:00.000Z",
+	date_of_birth: null,
+	emergency_contact_name: null,
+	emergency_contact_phone: null,
+	emergency_contact_relationship: null,
+	identity_verified: null,
+	ssn_last_four: null,
+};
+
+const minimalNestedRow: TenantPostgrestRow = {
+	id: "00000000-0000-0000-0000-000000000002",
+	user_id: null,
+	owner_user_id: "00000000-0000-0000-0000-0000000000ff",
+	first_name: "Sam",
+	last_name: "Rivera",
+	name: null,
+	email: "sam@example.com",
+	phone: null,
+	status: "active",
+	created_at: "2026-01-01T00:00:00.000Z",
+	updated_at: "2026-01-02T00:00:00.000Z",
+	date_of_birth: null,
+	emergency_contact_name: null,
+	emergency_contact_phone: null,
+	emergency_contact_relationship: null,
+	identity_verified: null,
+	ssn_last_four: null,
+};
+
+describe("mapTenantBaseRow", () => {
+	it("maps a valid flat tenants row to the Tenant shape", () => {
+		const mapped = mapTenantBaseRow(validBaseRow);
+		expect(mapped.id).toBe("00000000-0000-0000-0000-000000000001");
+		expect(mapped.status).toBe("active");
+		expect(mapped.email).toBe("jordan@example.com");
+		// Nullable-in-DB fields stay nullable, not over-validated into throws.
+		expect(mapped.user_id).toBeNull();
+		expect(mapped.phone).toBeNull();
+		expect(mapped.identity_verified).toBeNull();
+	});
+
+	it("throws when the NOT-NULL id is missing", () => {
+		const { id: _omitId, ...withoutId } = validBaseRow;
+		expect(() => mapTenantBaseRow(withoutId)).toThrow(/id/);
+	});
+
+	it("throws when status is not in the accepted union", () => {
+		expect(() =>
+			mapTenantBaseRow({ ...validBaseRow, status: "bogus_status" }),
+		).toThrow(/status/);
+	});
+
+	it("accepts status='moved_out' (in TENANT_ACTIVE_STATUSES)", () => {
+		const mapped = mapTenantBaseRow({ ...validBaseRow, status: "moved_out" });
+		expect(mapped.status).toBe("moved_out");
+	});
+
+	it("accepts the system statuses SUSPENDED and DELETED", () => {
+		expect(
+			mapTenantBaseRow({ ...validBaseRow, status: "SUSPENDED" }).status,
+		).toBe("SUSPENDED");
+		expect(
+			mapTenantBaseRow({ ...validBaseRow, status: "DELETED" }).status,
+		).toBe("DELETED");
+	});
+});
+
+describe("mapTenantRow", () => {
+	it("maps a minimal valid nested row to TenantWithLeaseInfo", () => {
+		const mapped = mapTenantRow(minimalNestedRow);
+		expect(mapped.id).toBe("00000000-0000-0000-0000-000000000002");
+		expect(mapped.status).toBe("active");
+		expect(mapped.email).toBe("sam@example.com");
+		expect(mapped.currentLease).toBeNull();
+	});
+
+	it("defaults a null status to 'active'", () => {
+		const mapped = mapTenantRow({ ...minimalNestedRow, status: null });
+		expect(mapped.status).toBe("active");
+	});
+
+	it("throws when the NOT-NULL id is missing", () => {
+		// mapTenantRow accepts the nested-join shape; force a dropped NOT-NULL
+		// id via a plain `as` over a partial row (not `as unknown as`, which the
+		// TYPE-03 drift guard forbids under src/hooks/api/**).
+		const { id: _omitId, ...withoutId } = minimalNestedRow;
+		expect(() =>
+			mapTenantRow(
+				withoutId as Partial<TenantPostgrestRow> as TenantPostgrestRow,
+			),
+		).toThrow(/id/);
+	});
+
+	it("throws when a non-null status is not in the accepted union", () => {
+		expect(() =>
+			mapTenantRow({ ...minimalNestedRow, status: "bogus_status" }),
+		).toThrow(/status/);
+	});
+});

--- a/src/hooks/api/query-keys/tenant-mappers.ts
+++ b/src/hooks/api/query-keys/tenant-mappers.ts
@@ -1,12 +1,107 @@
 /**
- * Tenant Row Mapper
- * Maps raw PostgREST tenant rows (with user and lease_tenants joins)
- * to the TenantWithLeaseInfo shape expected by the frontend.
+ * Tenant Row Mappers (TYPE-02, Phase 2 — typed RPC/PostgREST boundaries).
+ *
+ * `mapTenantBaseRow` maps a flat `tenants` insert/update return
+ * (`.select().single()`); `mapTenantRow` maps the nested-join read shape
+ * (with user + lease_tenants joins) to `TenantWithLeaseInfo`.
+ *
+ * Both field-validate at the boundary, mirroring `mapDocumentRow` in
+ * `document-keys.ts` (CLAUDE.md's cited reference for the "RPC / PostgREST
+ * Return Typing" rule). NOT-NULL `id` throws if absent — the boundary should
+ * surface a dropped `.select()` column immediately rather than silently
+ * producing `"undefined"` downstream (broken React keys, signed-URL targets,
+ * detail-page lookups). `status` is validated via Zod `safeParse` against the
+ * accepted-status union so an enum drift fails loudly instead of leaking.
+ * Nullable-in-DB fields (owner_user_id, email, name, etc.) stay nullable —
+ * they're not over-validated into false throws.
  *
  * Extracted from tenant-keys.ts for maintainability.
  */
 
-import type { TenantWithLeaseInfo } from "#types/core";
+import { z } from "zod";
+import {
+	TENANT_ACTIVE_STATUSES,
+	tenantStatusSchema,
+} from "#lib/validation/tenants";
+import type { Tenant, TenantWithLeaseInfo } from "#types/core";
+
+// Statuses that may legitimately be PERSISTED on a tenants row. This is the
+// union of `tenantStatusSchema` (active/inactive/pending/SUSPENDED/DELETED)
+// and `TENANT_ACTIVE_STATUSES` (which adds `moved_out`, set by markMovedOut
+// but absent from tenantStatusSchema). REUSE both — do not redefine the enum.
+// `z.enum` requires a non-empty literal tuple, so de-dupe into an array first.
+const PERSISTED_TENANT_STATUSES = [
+	...new Set<string>([
+		...tenantStatusSchema.options,
+		...TENANT_ACTIVE_STATUSES,
+	]),
+] as [string, ...string[]];
+
+const tenantPersistedStatusSchema = z.enum(PERSISTED_TENANT_STATUSES);
+
+/**
+ * Throw on a missing/non-string NOT-NULL field. Mirrors the `requireString`
+ * helper in `mapDocumentRow` — surfaces a dropped column at the boundary.
+ */
+function requireString(
+	raw: Record<string, unknown>,
+	field: string,
+	mapper: string,
+): string {
+	const value = raw[field];
+	if (typeof value !== "string") {
+		throw new Error(
+			`${mapper}: NOT NULL field '${field}' missing or non-string from PostgREST response`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Validate a persisted tenant `status` against the accepted-status union.
+ * Throws a descriptive boundary error on drift. `status` is NOT NULL in the
+ * DB, so a missing value is itself drift.
+ */
+function requireTenantStatus(value: unknown, mapper: string): string {
+	const parsed = tenantPersistedStatusSchema.safeParse(value);
+	if (!parsed.success) {
+		throw new Error(
+			`${mapper}: invalid 'status' value '${String(value)}' from PostgREST response`,
+		);
+	}
+	return parsed.data;
+}
+
+/**
+ * Map a flat `tenants` row (the `.select().single()` insert/update return)
+ * into the strictly-typed `Tenant` (= Tables<"tenants">). Validates the
+ * NOT-NULL `id` + `status`; passes nullable columns through as value-or-null.
+ */
+export function mapTenantBaseRow(raw: unknown): Tenant {
+	const row = (raw ?? {}) as Record<string, unknown>;
+	return {
+		id: requireString(row, "id", "mapTenantBaseRow"),
+		status: requireTenantStatus(row.status, "mapTenantBaseRow"),
+		user_id: (row.user_id as string | null) ?? null,
+		owner_user_id: (row.owner_user_id as string | null) ?? null,
+		first_name: (row.first_name as string | null) ?? null,
+		last_name: (row.last_name as string | null) ?? null,
+		name: (row.name as string | null) ?? null,
+		email: (row.email as string | null) ?? null,
+		phone: (row.phone as string | null) ?? null,
+		date_of_birth: (row.date_of_birth as string | null) ?? null,
+		emergency_contact_name:
+			(row.emergency_contact_name as string | null) ?? null,
+		emergency_contact_phone:
+			(row.emergency_contact_phone as string | null) ?? null,
+		emergency_contact_relationship:
+			(row.emergency_contact_relationship as string | null) ?? null,
+		identity_verified: (row.identity_verified as boolean | null) ?? null,
+		ssn_last_four: (row.ssn_last_four as string | null) ?? null,
+		created_at: (row.created_at as string | null) ?? null,
+		updated_at: (row.updated_at as string | null) ?? null,
+	};
+}
 
 export interface TenantPostgrestRow {
 	id: string;
@@ -71,6 +166,25 @@ export interface TenantPostgrestRow {
 }
 
 export function mapTenantRow(row: TenantPostgrestRow): TenantWithLeaseInfo {
+	// Validate the NOT-NULL id + the persisted status BEFORE shaping, so a
+	// dropped column or an enum drift fails loudly at the boundary instead of
+	// leaking through the plain `as TenantWithLeaseInfo` below. `id` is typed
+	// `string` on TenantPostgrestRow but the PostgREST response is untyped at
+	// runtime, so re-check it. The null-status branch keeps the historical
+	// `?? "active"` default (status is NOT NULL in the DB, but the nested-join
+	// select can legally observe a NULL during transitional states); a
+	// non-null status must be a recognized value.
+	if (typeof row.id !== "string") {
+		throw new Error(
+			"mapTenantRow: NOT NULL field 'id' missing or non-string from PostgREST response",
+		);
+	}
+	const id = row.id;
+	const status =
+		row.status == null
+			? "active"
+			: requireTenantStatus(row.status, "mapTenantRow");
+
 	const user = row.users ?? null;
 	const leaseRows = row.lease_tenants ?? [];
 
@@ -96,10 +210,10 @@ export function mapTenantRow(row: TenantPostgrestRow): TenantWithLeaseInfo {
 
 	// Build base fields (required fields only, no optional undefined assignments)
 	const base = {
-		id: row.id,
+		id,
 		user_id: row.user_id,
 		owner_user_id: row.owner_user_id,
-		status: row.status ?? "active",
+		status,
 		created_at: row.created_at,
 		updated_at: row.updated_at,
 		date_of_birth: row.date_of_birth,

--- a/src/hooks/api/query-keys/tenant-mutation-options.ts
+++ b/src/hooks/api/query-keys/tenant-mutation-options.ts
@@ -6,7 +6,11 @@ import { createClient } from "#lib/supabase/client";
 import type { TenantCreate, TenantUpdate } from "#lib/validation/tenants";
 import type { Tenant, TenantWithLeaseInfo } from "#types/core";
 import { mutationKeys } from "../mutation-keys";
-import { mapTenantRow, type TenantPostgrestRow } from "./tenant-mappers";
+import {
+	mapTenantBaseRow,
+	mapTenantRow,
+	type TenantPostgrestRow,
+} from "./tenant-mappers";
 
 export const tenantMutations = {
 	create: () =>
@@ -36,7 +40,7 @@ export const tenantMutations = {
 
 				if (error) handlePostgrestError(error, "tenants");
 
-				return created as Tenant;
+				return mapTenantBaseRow(created);
 			},
 		}),
 
@@ -60,7 +64,7 @@ export const tenantMutations = {
 
 				if (error) handlePostgrestError(error, "tenants");
 
-				return updated as Tenant;
+				return mapTenantBaseRow(updated);
 			},
 		}),
 

--- a/src/hooks/api/use-analytics.ts
+++ b/src/hooks/api/use-analytics.ts
@@ -7,7 +7,7 @@
 
 import { queryOptions } from "@tanstack/react-query";
 import { handlePostgrestError } from "#lib/postgrest-error-handler";
-import { jsonObject, jsonObjectOrEmpty } from "#lib/rpc-shape";
+import { jsonObject } from "#lib/rpc-shape";
 import { createClient } from "#lib/supabase/client";
 import { getCachedUser } from "#lib/supabase/get-cached-user";
 import type { PropertyPerformanceEntry } from "#types/analytics";
@@ -20,6 +20,7 @@ import type {
 } from "#types/analytics-page-data";
 import type { OwnerPaymentSummaryResponse } from "#types/api-contracts";
 import { fetchOccupancyTrends } from "./query-keys/analytics-keys";
+import { mapLeaseAnalytics } from "./query-keys/analytics-mappers";
 
 /**
  * Analytics query factory
@@ -59,10 +60,7 @@ export const analyticsQueries = {
 			queryKey: analyticsQueries.lease(),
 			queryFn: async (): Promise<LeaseAnalyticsPageData> => {
 				const data = await fetchOccupancyTrends(12);
-				return jsonObjectOrEmpty<LeaseAnalyticsPageData>(
-					data,
-					{} as LeaseAnalyticsPageData,
-				);
+				return mapLeaseAnalytics(data);
 			},
 			staleTime: 2 * 60 * 1000,
 			gcTime: 10 * 60 * 1000,
@@ -145,10 +143,7 @@ export const analyticsQueries = {
 					maintenance: jsonObject<MaintenanceInsightsPageData>(
 						maintenanceResult.data,
 					),
-					lease: jsonObjectOrEmpty<LeaseAnalyticsPageData>(
-						occupancyData,
-						{} as LeaseAnalyticsPageData,
-					),
+					lease: mapLeaseAnalytics(occupancyData),
 				};
 			},
 			staleTime: 2 * 60 * 1000,

--- a/src/lib/__tests__/rpc-boundary-cast-pins.test.ts
+++ b/src/lib/__tests__/rpc-boundary-cast-pins.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Drift guard (TYPE-03, Phase 2): zero `as unknown as` casts at the
+ * PostgREST/RPC boundaries under `src/hooks/api/`.
+ *
+ * CLAUDE.md Zero-Tolerance Rule #8 forbids `as unknown as` type assertions —
+ * the data layer must route through validated mapper functions at the RPC /
+ * PostgREST boundary instead (the canonical reference is `mapDocumentRow` in
+ * `src/hooks/api/query-keys/document-keys.ts`). The 2026-05-29 audit flagged
+ * this violation; it is already resolved (only comment/docstring mentions and
+ * legitimate test-mock `fetch` casts remain). This test PINS that state so the
+ * violation cannot silently return.
+ *
+ * Scope: production source under `src/hooks/api/` only.
+ *  - `*.test.ts` / `*.test.tsx` / `*.spec.ts` are EXCLUDED — test-mock casts
+ *    like `fetchMock as unknown as typeof fetch` are legitimate test
+ *    scaffolding, not production boundary code.
+ *  - Wholly-comment lines (`//`, `/*`, ` * `) are SKIPPED so the docstring /
+ *    comment mentions of the rule (e.g. "...never `as unknown as`") don't trip
+ *    the guard.
+ *  - The library-shim casts (chart-tooltip / slider) live under
+ *    `src/components/ui/`, NOT `src/hooks/api/`, so this scan is naturally
+ *    clean on the production-boundary surface.
+ *
+ * Failures list the offending `file:line → snippet` so a regression is
+ * actionable. Pure filesystem read — never touches the DOM.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const HOOKS_API_DIR = join(process.cwd(), "src", "hooks", "api");
+const FORBIDDEN_CAST = "as unknown as";
+
+interface BoundaryFile {
+	/** Absolute path on disk. */
+	readonly absPath: string;
+	/** Path relative to the repo root, e.g. "src/hooks/api/query-keys/foo.ts". */
+	readonly relPath: string;
+}
+
+/** A `*.test.ts`/`*.test.tsx`/`*.spec.ts(x)` file — test scaffolding, excluded. */
+function isTestFile(name: string): boolean {
+	return /\.(test|spec)\.tsx?$/.test(name);
+}
+
+/** Recursively collect production `.ts`/`.tsx` files under `src/hooks/api/`. */
+function collectBoundaryFiles(dir: string): BoundaryFile[] {
+	const out: BoundaryFile[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const abs = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			out.push(...collectBoundaryFiles(abs));
+			continue;
+		}
+		if (!/\.tsx?$/.test(entry.name)) continue;
+		if (isTestFile(entry.name)) continue;
+		out.push({ absPath: abs, relPath: relative(process.cwd(), abs) });
+	}
+	return out;
+}
+
+/**
+ * Is this line wholly a comment? We strip the production-boundary scope to
+ * actual code, so docstring / comment mentions of the rule (the only current
+ * matches under `src/hooks/api/`) don't register as violations.
+ */
+function isCommentLine(trimmed: string): boolean {
+	return (
+		trimmed.startsWith("//") ||
+		trimmed.startsWith("*") ||
+		trimmed.startsWith("/*")
+	);
+}
+
+function findViolations(files: BoundaryFile[]): string[] {
+	const violations: string[] = [];
+	for (const file of files) {
+		const lines = readFileSync(file.absPath, "utf8").split("\n");
+		lines.forEach((raw, index) => {
+			const trimmed = raw.trim();
+			if (trimmed === "" || isCommentLine(trimmed)) return;
+			// Strip a trailing `//` line-comment so an inline mention after real
+			// code doesn't trip the guard (the cast itself, if real, lives in the
+			// code portion before any `//`).
+			const codePortion = trimmed.split("//")[0] ?? trimmed;
+			if (codePortion.includes(FORBIDDEN_CAST)) {
+				violations.push(`${file.relPath}:${index + 1} → ${trimmed}`);
+			}
+		});
+	}
+	return violations;
+}
+
+describe("TYPE-03 — zero `as unknown as` at src/hooks/api boundaries", () => {
+	const files = collectBoundaryFiles(HOOKS_API_DIR);
+
+	it("finds at least one production boundary file to guard", () => {
+		// Sanity check: if the walker silently matched nothing, the assertion
+		// below would vacuously pass and the guard would be useless.
+		expect(files.length).toBeGreaterThan(0);
+	});
+
+	it("no `as unknown as` cast at any src/hooks/api PostgREST/RPC boundary", () => {
+		const violations = findViolations(files);
+		expect(
+			violations,
+			`Reintroduced \`as unknown as\` boundary cast(s) — route through a validated mapper instead (see mapDocumentRow in document-keys.ts):\n${violations.join("\n")}`,
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

**v4.0 Phase 2 — Typed RPC Boundaries (TYPE-01..03).** Routes the phase's named RPC/PostgREST boundaries through typed mappers with **field-level Zod validation**, and adds a drift guard so the rule-#8 `as unknown as` violation cannot silently return.

**Scope correction (verified against live code):** The `as unknown as` double-casts the 2026-05-29 audit flagged were **already remediated** since the audit (only comment mentions remain). This phase delivers the success criteria's *deeper* bar — typed mappers **with Zod validation**, not just "no double-cast" — for the named boundaries, plus the missing drift guard. The broader `as Type` surface (property/lease/vendor/expense/blog/session/auth keys) is explicitly out of scope (a future "Typed Data Layer" phase).

| Plan | Req | What |
|------|-----|------|
| 02-01 | TYPE-01 | `mapLeaseAnalytics` Zod-validated mapper for `use-analytics.ts` `LeaseAnalyticsPageData` (safe-empty fallback — "no data yet" is valid; never throws) |
| 02-02 | TYPE-02 | `mapTenantBaseRow` + upgraded `mapTenantRow` (validates `id`/`status` before the conditional-spread `as`); tenant create/update boundary |
| 02-03 | TYPE-02 | `mapMaintenanceRow` across list/detail/urgent/overdue/create/update |
| 02-04 | TYPE-03 | `mapExpiringLeaseRow` + **drift-guard test** (zero `as unknown as` under `src/hooks/api/`) |

## The maintenance status detail (caught by the plan-checker)

The first draft validated maintenance `status` against the shared `maintenanceStatusSchema` — a **stale 5-value** enum. The live DB CHECK (migration `20260221120000`) allows **7** (`assigned`, `needs_reassignment` are written by the vendor-assign flow). Validating reads against 5 would have thrown on every assigned/reassignment row and broken the maintenance surfaces in prod. Fixed: a module-local `maintenancePersistedStatusSchema` (full 7-value set, migration cited), unconditional `safeParse` (missing NOT-NULL status throws), shared input enum left un-widened. Tests pin `assigned`/`needs_reassignment` map cleanly + absent throws.

## Tests
39 mapper/guard assertions across 5 files (valid→mapped, missing-NOT-NULL→throws, enum-drift→rejected, nullable-passthrough). The drift guard is **proven load-bearing** (fails on a planted `as unknown as`, passes clean otherwise). Full unit suite + typecheck + lint green in every commit's lefthook gate.

## Mappers mirror the canonical `mapDocumentRow` pattern
`requireString` throws on missing NOT-NULL; enum fields validated via Zod `safeParse`; DB-nullable columns left nullable. All target types reused from `src/types/` — no duplicates.

[hudsor01]
