### PR TITLE
v4.0 Phase 3: Stats RPC Consolidation (PERF-02, PERF-03)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -94,7 +94,10 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   2. `tenantQueries.stats()` is served by a single `get_tenant_stats()` RPC — no 3 HEAD counts — and any embedded-resource filter uses an inner join.
   3. Both new RPCs validate `auth.uid()`, lock `search_path = public`, and a dual-client (ownerA/ownerB) RLS test confirms ownerB cannot read ownerA's stats.
   4. The dashboard / consuming surfaces render identical values to the pre-consolidation multi-query path (no regression).
-**Plans**: TBD
+**Plans**: 3 plans (Wave 1: migration + db:types regen [BLOCKING]; Wave 2: hook rewire ∥ RLS test)
+- [ ] 03-01-PLAN.md — PERF-02, PERF-03: one migration defining both SECURITY DEFINER RPCs, [BLOCKING] prod apply + filename reconcile, `bun run db:types` regen
+- [ ] 03-02-PLAN.md — PERF-02, PERF-03: Zod-validated `mapUnitStats`/`mapTenantStats` mappers + rewire `unitQueries.stats()` / `tenantQueries.stats()` to the RPCs (no-regression value pins)
+- [ ] 03-03-PLAN.md — PERF-02, PERF-03: dual-client ownerA/ownerB RLS test pinning the `auth.uid()` 'Unauthorized' owner-isolation guard for both RPCs
 
 ### Phase 4: Cron Stagger & Index Cleanup
 **Goal**: The four pg_cron cleanup jobs no longer contend at a single timestamp, and confirmed-unused indexes are dropped in one migration while every FK-supporting index is explicitly retained.
@@ -153,9 +156,9 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 
 | Phase | Milestone | Plans | Status | Completed |
 |-------|-----------|-------|--------|-----------|
-| 1. Security-CI Hardening | v4.0 | 3/4 | In Progress|  |
-| 2. Typed RPC Boundaries | v4.0 | 3/4 | In Progress | - |
-| 3. Stats RPC Consolidation | v4.0 | 0/? | Not started | - |
+| 1. Security-CI Hardening | v4.0 | 4/4 | Shipped (PR #783) | 2026-06-04 |
+| 2. Typed RPC Boundaries | v4.0 | 4/4 | Shipped (PR #785) | 2026-06-05 |
+| 3. Stats RPC Consolidation | v4.0 | 3/3 | Executed (awaiting PR) | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 0/? | Not started | - |
 | 5. Cross-Owner RLS Coverage | v4.0 | 0/? | Not started | - |
 | 6. Auth & Dollar-Hook Unit Tests | v4.0 | 0/? | Not started | - |
@@ -163,4 +166,4 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 | 8. SEO Recovery | v4.0 | 0/? | Not started | - |
 
 ---
-*Last updated: 2026-06-04 — v4.0 Hardening & Hygiene roadmap created (8 phases, 21/21 requirements mapped). v3.0 (3 phases, 12/12), v2.0 (7 phases, 34/34), v1.0 (15 phases, 56/56) archived above.*
+*Last updated: 2026-06-05 — Phase 3 (Stats RPC Consolidation) planned: 3 plans across 2 waves (PERF-02 + PERF-03). v4.0 Hardening & Hygiene roadmap (8 phases, 21/21 requirements mapped). v3.0 (3 phases, 12/12), v2.0 (7 phases, 34/34), v1.0 (15 phases, 56/56) archived above.*

--- a/.planning/phases/03-stats-rpc-consolidation/03-01-SUMMARY.md
+++ b/.planning/phases/03-stats-rpc-consolidation/03-01-SUMMARY.md
@@ -1,0 +1,25 @@
+# Plan 03-01 Summary — Stats RPCs Migration (PERF-02, PERF-03)
+
+**Status:** Complete
+**Branch:** gsd/phase-3-stats-rpc-consolidation
+**Commit:** `96d9dc043`
+
+## What shipped
+- `supabase/migrations/20260606041458_stats_consolidation_rpcs.sql` — `get_unit_stats(p_user_id uuid)` + `get_tenant_stats(p_user_id uuid)`, both `RETURNS jsonb`, `SECURITY DEFINER`, `SET search_path TO 'public'`, `auth.uid()` identity guard (`raise exception 'Unauthorized'`), scoped `where owner_user_id = p_user_id`, `REVOKE ALL FROM PUBLIC` + `GRANT EXECUTE TO authenticated` (anon never granted).
+  - `get_unit_stats`: `jsonb_build_object` of total/occupied/available/maintenance counts + `coalesce(sum(rent_amount) filter (where status != 'inactive'), 0)` — the SQL rent sum that **kills the unbounded client-side rent_amount fetch** (PERF-02).
+  - `get_tenant_stats`: total + active/inactive counted by **`tenants.status`** (PERF-03 correctness fix — replaces the broken `users.status` left-join embed filter).
+- `src/types/supabase.ts` — regenerated; both RPCs declared `{ Args: { p_user_id: string }; Returns: Json }`.
+
+## Prod apply + verification (the [BLOCKING] checkpoint)
+- Applied via Supabase MCP `apply_migration` → **prod version `20260606041458`**. Repo filename reconciled to match (was authored `...041429`, 29s drift; migration-mcp-prod-drift convention).
+- Prod smoke-verify via MCP `execute_sql`: both functions `prosecdef = true`, `config = search_path=public`, `has_function_privilege('authenticated', …) = true`, `has_function_privilege('anon', …) = false`. ✓
+- `supabase.ts` regen: `bun run db:types` (CLI) **failed Unauthorized** (the same expired `SUPABASE_ACCESS_TOKEN` that blocked the edge-fn deploy) → regenerated via the MCP `generate_typescript_types` tool instead (the script's own documented fallback). Net diff was only the 2 new function lines (no formatting churn). `bun run typecheck` clean.
+
+## Correctness note (NOT a regression — for the verifier)
+`get_tenant_stats` counts active/inactive by `tenants.status`. The OLD `tenantQueries.stats()` counted via `.eq("users.status", …)` on a LEFT-joined `users` embed with no inner join — a broken filter (the audit's flagged bug). The new counts are CORRECT and MAY DIFFER from the old buggy numbers. `total` is unaffected. This is an intended correction; do not flag the changed active/inactive count as a regression.
+
+## Operational note
+The expired `SUPABASE_ACCESS_TOKEN` (env) blocks the CLI path for both `db:types` and edge-function deploys. MCP tools (apply_migration, generate_typescript_types, execute_sql) use a working auth channel and were used throughout. Refreshing the token would restore the CLI path.
+
+## Next
+Wave 2: 03-02 (mappers + hook rewire) ∥ 03-03 (dual-client RLS test) — both depend on these RPCs now being live.

--- a/.planning/phases/03-stats-rpc-consolidation/03-02-SUMMARY.md
+++ b/.planning/phases/03-stats-rpc-consolidation/03-02-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+phase: 03-stats-rpc-consolidation
+plan: 02
+subsystem: stats-rpc-frontend
+tags: [perf, rpc-consolidation, boundary-mapper, zod, tanstack-query]
+requires:
+  - "get_unit_stats(p_user_id) RPC live in prod (03-01)"
+  - "get_tenant_stats(p_user_id) RPC live in prod (03-01)"
+  - "UnitStats / TenantStats types in src/types/stats.ts"
+provides:
+  - "mapUnitStats validated boundary mapper"
+  - "mapTenantStats validated boundary mapper"
+  - "unitQueries.stats() served by a single get_unit_stats RPC"
+  - "tenantQueries.stats() served by a single get_tenant_stats RPC"
+affects:
+  - "useUnitStats() / useTenantStats() consumers (dashboard + list KPI cards)"
+tech-stack:
+  added: []
+  patterns:
+    - "Zod safeParse boundary mapper mirroring mapMaintenanceRow (CLAUDE.md RPC return typing)"
+    - "getCachedUser -> supabase.rpc -> handlePostgrestError -> typed mapper stats hook body"
+key-files:
+  created:
+    - src/hooks/api/query-keys/unit-mappers.ts
+    - src/hooks/api/query-keys/unit-mappers.test.ts
+    - src/hooks/api/query-keys/tenant-stats-mapper.ts
+    - src/hooks/api/query-keys/tenant-stats-mapper.test.ts
+  modified:
+    - src/hooks/api/query-keys/unit-keys.ts
+    - src/hooks/api/query-keys/tenant-keys.ts
+    - src/test/mocks/msw/handlers/rpc.ts
+    - src/hooks/api/__tests__/use-tenant.test.tsx
+decisions:
+  - "Derive vacant/occupancyRate/averageRent/occupancyChange/totalPotentialRent in the typed mapper (not SQL) — keeps the RPCs lean per 03-CONTEXT Claude's-discretion clause"
+  - "averageRent divides by total (== old rentAmounts.length == non-inactive row count) — value identical, pinned in no-regression test"
+metrics:
+  duration: ~12m
+  completed: 2026-06-06
+  tasks: 2
+  files: 8
+---
+
+# Phase 3 Plan 02: Stats Mappers + Hook Rewire Summary
+
+Added Zod-validated `mapUnitStats` / `mapTenantStats` boundary mappers and rewired `unitQueries.stats()` + `tenantQueries.stats()` to resolve each via a single owner-scoped RPC (`get_unit_stats` / `get_tenant_stats`) through those mappers — deleting the 4 HEAD counts + unbounded `rent_amount` fetch (PERF-02) and the 3 HEAD counts + broken `users.status` filter (PERF-03).
+
+## What Changed
+
+### Task 1 — Boundary mappers (commit `21c6a46`)
+- `unit-mappers.ts` exports `mapUnitStats(raw: unknown): UnitStats`. Module-local `z.object` validates the five RPC numeric keys (`total, occupied, available, maintenance, totalActualRent`) via `safeParse`; throws a descriptive `mapUnitStats:` error on drift. Derives `vacant = available`, `occupancyRate = total>0 ? round(occupied/total*100) : 0`, `averageRent = total>0 ? totalActualRent/total : 0`, `occupancyChange = 0` (stub), `totalPotentialRent = totalActualRent` (alias).
+- `tenant-stats-mapper.ts` exports `mapTenantStats(raw: unknown): TenantStats`. Module-local `z.object` validates `total, active, inactive`; throws on drift. Derives `totalTenants = total`, `activeTenants = active`, `newThisMonth = 0` (stub).
+- Both reuse the existing `UnitStats` / `TenantStats` types from `#types/stats` — no duplicate type declarations. No `as unknown as`, no `: any`.
+- Co-located tests (14 cases) including the no-regression value pin: for `{total:10, occupied:6, available:3, maintenance:1, totalActualRent:12000}` → `occupancyRate=60`, `averageRent=1200`, `vacant=3`, `occupancyChange=0`, `totalPotentialRent=12000` — identical to the old multi-query path. Plus zero-guard (total=0 → rate=0, avg=0) and drift-throws.
+
+### Task 2 — Hook rewire + MSW handlers (commit `61a872485`)
+- `unit-keys.ts` `stats()` queryFn replaced with `getCachedUser` guard → `supabase.rpc("get_unit_stats", { p_user_id: user.id })` → `handlePostgrestError(error, "units")` → `mapUnitStats(data)`. The `Promise.all([...])`, all five HEAD/fetch results, the manual `rentAmounts` reduce, and the inline derivation are deleted.
+- `tenant-keys.ts` `stats()` queryFn replaced the same way with `get_tenant_stats` → `mapTenantStats(data)`. The `Promise.all([...])` and both broken `.eq("users.status", ...)` filters are deleted entirely. Added the `getCachedUser` import.
+- `src/test/mocks/msw/handlers/rpc.ts` gains `get_unit_stats` and `get_tenant_stats` `http.post` handlers returning realistic raw-aggregate jsonb.
+- `use-tenant.test.tsx` `useTenantStats` test rewired: added `rpc` to the mocked `createClient`, a default `get_tenant_stats` rpc mock in `beforeEach`, and the test now asserts `rpc("get_tenant_stats", { p_user_id })` was called and the mapped output matches (`totalTenants/activeTenants/newThisMonth` derived).
+
+## No-Regression / Correctness Notes
+
+- **UnitStats values pinned identical.** The mapper's `averageRent` divides `totalActualRent` by `total`; the old code divided by `rentAmounts.length`, which equals the non-inactive row count == `total`, so the value is the same. Pinned in `unit-mappers.test.ts`.
+- **Tenant active/inactive counts may now DIFFER — intended correctness fix, NOT a regression.** The old path counted active/inactive via `.eq("users.status", ...)` on a non-inner-joined `users` embed (a broken filter — the audit's flagged bug). The RPC now counts by `tenants.status` server-side, producing correct counts. `total` is unaffected (it had no filter). Per 03-CONTEXT, changed active/inactive counts are the deliberate PERF-03 correction.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. The only adjustment was a commit-message body line-length reflow (commitlint `body-max-line-length` 100) and a Biome import-ordering fix in `tenant-keys.ts` (`mapTenantStats` sorted after the `tenant-mappers` imports) — both mechanical gate-satisfying tweaks, not behavioral deviations.
+
+## Out of Scope (noted, not fixed)
+
+- `biome.json` `$schema` version (2.4.15) lags the installed Biome CLI (2.4.16) — an informational lint note, pre-existing and unrelated to this plan's changes.
+
+## Verification
+
+- `bun run typecheck` — clean (`tsc --noEmit` exit 0).
+- `bun run lint` — clean (Biome: 0 errors; only the pre-existing schema-version info note).
+- Mapper tests: `unit-mappers.test.ts` + `tenant-stats-mapper.test.ts` — 14/14 pass (incl. no-regression value pin).
+- Hook test: `use-tenant.test.tsx` — 16/16 pass against the new rpc mock.
+- Full unit suite ran green inside both lefthook pre-commit gates (no repo-wide regressions).
+- grep confirms: `count: "exact", head: true` GONE from both stats blocks; `.eq("users.status", ...)` filter GONE from tenant-keys (only the explanatory comment references it); `select("rent_amount")` unbounded fetch GONE from unit-keys; MSW handlers present for both RPCs; no `as unknown as` / `: any` in either mapper.
+
+## Threat Flags
+
+None — no new security surface. The RPC identity guard (`auth.uid()` check) lives server-side in the 03-01 functions; the hooks pass the authenticated user's own id. The mapper Zod safeParse mitigates T-03-04 (malformed/drifted jsonb fails loudly). No package installs (T-03-SC N/A).
+
+## Self-Check: PASSED
+
+- All 5 created/summary files exist on disk.
+- Both task commits (`21c6a46`, `61a872485`) present in git history.

--- a/.planning/phases/03-stats-rpc-consolidation/03-03-SUMMARY.md
+++ b/.planning/phases/03-stats-rpc-consolidation/03-03-SUMMARY.md
@@ -1,0 +1,47 @@
+# Plan 03-03 Summary — Dual-Client Stats RPC RLS Test (PERF-02, PERF-03)
+
+**Status:** Complete
+**Branch:** gsd/phase-3-stats-rpc-consolidation
+**Commit:** `fe1444a3a`
+
+## One-liner
+Dual-client (ownerA/ownerB) RLS integration test pinning the `auth.uid()` identity guard on `get_unit_stats` + `get_tenant_stats` — cross-owner calls are rejected with `'Unauthorized'`, each owner's self-call returns only their own counts. Runs in the `rls-security` CI gate.
+
+## What shipped
+- `tests/integration/rls/stats-rpcs.rls.test.ts` (228 lines) — mirrors `dashboard-rpc-open-maintenance.test.ts` exactly:
+  - **`beforeAll`:** dual clients via `createTestClient` + `getTestCredentials`, owner ids via `clientX.auth.getUser()`. Creates fresh owner-A fixtures (one property → one `available` unit at a known `FIXTURE_RENT` → one `active` tenant) so the self-call returns non-zero counts this test owns.
+  - **`afterAll`:** FK-safe cleanup (unit → property; tenant standalone), all under ownerA.
+  - **5 cases:**
+    1. ownerB → `get_unit_stats(ownerA_id)` rejected: `data` null, `error` non-null, `error.message` matches `/unauthorized/i`.
+    2. ownerB → `get_tenant_stats(ownerA_id)` rejected, same shape.
+    3. ownerA self-call `get_unit_stats(ownerA_id)`: `error` null, `data` non-null, all aggregates are numbers, `total`/`available` >= 1, `totalActualRent` >= `FIXTURE_RENT` (>= assertions, not hard-pins — synthetic account may carry prior fixtures).
+    4. ownerA self-call `get_tenant_stats(ownerA_id)`: `error` null, `data` non-null, counted by `tenants.status` (`active` fixture → `active` >= 1, `total` >= 1).
+    5. ownerB self-call `get_unit_stats(ownerB_id)` succeeds (positive isolation control — proves the guard rejects only the id mismatch, not every call).
+
+## Why `/unauthorized/i` (not `/access denied/i`)
+The new stats RPCs raise the bare message `'Unauthorized'` (mirroring `get_maintenance_stats` per 03-CONTEXT.md + 03-01-SUMMARY.md), NOT the "Access denied: cannot request data for another user" message the dashboard-group RPCs use in `rpc-auth.test.ts`. The assertion is `/unauthorized/i` to match what the RPC actually raises.
+
+## Type discipline
+RPC results (`jsonb` → `Json` in the generated client) are narrowed via plain boundary casts `data as UnitStatsRaw` / `data as TenantStatsRaw` to local numeric interfaces — the same pattern the sibling `dashboard-rpc-open-maintenance.test.ts` uses (`data as { property_performance: ... }`). No `as unknown as`, no `: any`, no barrel files. The Zod-validated version of this narrowing lives in the src mappers (Plan 03-02); this test only needs the raw numeric fields.
+
+## Verification
+- **Typecheck:** `bun run typecheck` clean (`tsc --noEmit`, zero errors).
+- **Acceptance criteria (all met, verified against file content):**
+  - References both `get_unit_stats` and `get_tenant_stats`. ✓
+  - `/unauthorized/i` asserted on `error.message` for both RPCs (2 occurrences) + `expect(data).toBeNull()` for both cross-owner cases. ✓
+  - Self-call success cases assert `error` null + `data` non-null for both RPCs. ✓
+  - Uses `createTestClient` + `getTestCredentials` from `../setup/supabase-client`; fixtures cleaned in `afterAll`. ✓
+  - No `as unknown as` / `: any`. ✓
+  - 228 lines (> 60 min). ✓
+- **Local integration run: DEFERRED to CI.** The targeted local run (`bun run test:integration -- tests/integration/rls/stats-rpcs.rls.test.ts`) failed at `globalSetup` with "E2E owner credentials missing" — the synthetic `E2E_OWNER_*` accounts are GitHub repo secrets provided to the `rls-security` CI job, not present in this local environment (and `.env.local` is sandbox-blocked from reads). This is the documented condition (the sibling test's own header notes: "CI provides the env vars via repo secrets; local runs require `.env.local`"). The test is structurally identical to the passing sibling RLS tests; the `rls-security` CI gate (which fails hard when secrets are missing, per CLAUDE.md) is the authoritative live run. Respected the ~45 sign-ins/min auth limit — single attempt, no back-to-back reruns.
+
+## Deviations from Plan
+None — plan executed as written. The test file already existed untracked in the working tree (authored to spec earlier, never committed); it matched the plan's acceptance criteria exactly, so it was verified-as-correct and committed without modification rather than rewritten.
+
+## Threat coverage
+Pins T-03-06 (Information Disclosure / Elevation of Privilege — cross-owner stats read): the test IS the regression proof for the T-03-01 guard. A future refactor dropping the `auth.uid() != p_user_id` guard fails the `rls-security` CI gate with another owner's aggregates leaking (non-null cross-owner data). T-03-07 (false-green via silent skip) is bounded by the CI job failing hard when the required secrets are absent.
+
+## Self-Check: PASSED
+- File exists: `tests/integration/rls/stats-rpcs.rls.test.ts` (committed in `fe1444a3a`). ✓
+- Commit exists: `fe1444a3a` on `gsd/phase-3-stats-rpc-consolidation`. ✓
+- Typecheck + full lefthook gate (gitleaks, lockfile-verify, lint, typecheck, unit-tests, commitlint) all passed at commit time. ✓

--- a/.planning/phases/03-stats-rpc-consolidation/03-CONTEXT.md
+++ b/.planning/phases/03-stats-rpc-consolidation/03-CONTEXT.md
@@ -1,0 +1,109 @@
+# Phase 3: Stats RPC Consolidation - Context
+
+**Gathered:** 2026-06-05
+**Status:** Ready for planning
+**Source:** Live-DB-grounded (Supabase MCP introspection) — research spawn skipped; the facts below are verified, not assumed.
+
+<domain>
+## Phase Boundary
+
+Replace the two multi-query stat hooks with single owner-scoped SECURITY DEFINER RPCs, mirroring the existing `get_maintenance_stats` pattern, each returning through a typed mapper, with owner isolation pinned by a dual-client RLS test.
+
+- **PERF-02:** `unitQueries.stats()` (`src/hooks/api/query-keys/unit-keys.ts` ~:180-252) currently fires **4 HEAD counts + 1 UNBOUNDED `rent_amount` fetch** → `get_unit_stats(p_user_id uuid)`.
+- **PERF-03:** `tenantQueries.stats()` (`src/hooks/api/query-keys/tenant-keys.ts` ~:148-180) currently fires **3 HEAD counts**, two filtering the JOINED `users.status` embedded resource without an inner join (broken) → `get_tenant_stats(p_user_id uuid)`.
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED)
+
+### Both RPCs mirror `get_maintenance_stats` EXACTLY (canonical pattern — see Canonical References)
+- Signature `(p_user_id uuid) RETURNS jsonb`, `LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'`.
+- First statement: `if p_user_id != (select auth.uid()) then raise exception 'Unauthorized'; end if;` (SEC-01 identity guard).
+- `jsonb_build_object` of `count(*) filter (where ...)` aggregates, scoped `where owner_user_id = p_user_id`.
+- Grant: EXECUTE to `authenticated` only; the function is owner-self-scoped via the `auth.uid()` guard + `owner_user_id` filter (matches the steady-state `authenticated_security_definer` KEEP set — these are legit owner-scoped RPCs, NOT anon-executable).
+
+### Verified scoping facts (live DB)
+- `units` HAS `owner_user_id` DIRECTLY → scope `get_unit_stats` on `units.owner_user_id` (NO property join needed).
+- `tenants` HAS its own `status` column AND `owner_user_id` → scope `get_tenant_stats` on `tenants.owner_user_id`, count by **`tenants.status`** (NOT the joined `users.status`).
+- `get_unit_stats`/`get_tenant_stats` do NOT exist yet. `get_maintenance_stats`, `get_lease_stats`, `get_dashboard_stats` exist (the pattern).
+
+### `get_unit_stats` return + no-regression contract
+The current `UnitStats` (`src/types/stats.ts:48`) final values must be preserved. Current logic:
+- `total` = count(status != 'inactive'); `occupied` = count(status='occupied'); `available` = count(status='available'); `maintenance` = count(status='maintenance').
+- `totalActualRent` = sum(rent_amount) over non-inactive units (this is the UNBOUNDED fetch to kill — do it as `sum(rent_amount) filter (where status != 'inactive')` in SQL).
+- Derived (keep in the typed mapper OR SQL): `vacant = available`; `occupancyRate = total>0 ? round(occupied/total*100) : 0`; `averageRent = total>0 ? totalActualRent/total : 0`; `occupancyChange = 0` (preserve the current hardcoded stub); `totalPotentialRent = totalActualRent` (preserve the current alias).
+- RPC returns the raw aggregates (`total, occupied, available, maintenance, totalActualRent`); a typed `mapUnitStats` mapper derives the rest. Final `UnitStats` values must be IDENTICAL to today.
+
+### `get_tenant_stats` return + the correctness note
+Current `TenantStats` (`src/types/stats.ts:20`) values: `total`, `active`, `inactive`, `newThisMonth: 0` (stub — keep 0), `totalTenants = total`, `activeTenants = active`.
+- RPC returns `total` = count(*), `active` = count(status='active'), `inactive` = count(status='inactive'), scoped `where owner_user_id = p_user_id`, counting by **`tenants.status`**.
+- **CORRECTNESS NOTE (not a regression):** the OLD path counted active/inactive via `.eq("users.status", ...)` on a LEFT-joined `users` embed with NO inner join — a broken filter (the audit's flagged bug). Switching to `tenants.status` produces CORRECT counts that MAY DIFFER from the old (buggy) numbers. This is a deliberate correctness fix. `total` is unaffected (it had no filter). Do NOT treat a changed active/inactive count as a regression in verification — the success criterion "render identical values" applies to `total` + the un-broken fields; the tenant active/inactive fix is an intended correction. Document it in the SUMMARY.
+- The mapper derives `totalTenants = total`, `activeTenants = active`, `newThisMonth = 0` (preserve stub).
+
+### Typed mappers (Phase 2 pattern)
+- `mapUnitStats(raw: unknown): UnitStats` + `mapTenantStats(raw: unknown): TenantStats` — Zod-validated boundary mappers mirroring `mapDocumentRow`/the Phase-2 mappers. Validate the numeric count fields; the RPC returns a known jsonb shape. Reuse `UnitStats`/`TenantStats` types from `src/types/stats.ts` — no duplicates.
+
+### Migration
+- New migration `supabase/migrations/YYYYMMDDHHmmss_*.sql` defining both RPCs. Applied to prod via Supabase MCP `apply_migration`; RECONCILE the repo filename timestamp against the prod-assigned one via `mcp__supabase__list_migrations` after apply (migration-mcp-prod-drift). Verify the migration applies cleanly against live prod.
+
+### Dual-client RLS test
+- `tests/integration/rls/` dual-client (ownerA/ownerB) test: ownerB calling `get_unit_stats(ownerA_id)` / `get_tenant_stats(ownerA_id)` is rejected (the `auth.uid()` guard raises 'Unauthorized'); each owner sees only their own counts. Runs in the `rls-security` CI gate.
+
+### Claude's Discretion
+- Whether to derive `vacant/occupancyRate/averageRent` in SQL or the typed mapper (either is fine; mapper keeps SQL lean).
+- Exact jsonb key names (keep them clear; the mapper bridges to the `UnitStats`/`TenantStats` field names).
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+### The RPC pattern to mirror EXACTLY (live prod `get_maintenance_stats`)
+```sql
+CREATE OR REPLACE FUNCTION public.get_maintenance_stats(p_user_id uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+begin
+  if p_user_id != (select auth.uid()) then
+    raise exception 'Unauthorized';
+  end if;
+  return (
+    select jsonb_build_object(
+      'open', count(*) filter (where status = 'open'),
+      ... ,
+      'total', count(*)
+    )
+    from maintenance_requests
+    where owner_user_id = p_user_id
+  );
+end;
+$function$
+```
+
+### Mapper pattern
+- `src/hooks/api/query-keys/document-keys.ts` (`mapDocumentRow`) + the Phase-2 mappers (`analytics-mappers.ts`, `tenant-mappers.ts`, `maintenance-mappers.ts`).
+
+### RLS test pattern
+- `tests/integration/rls/` — existing dual-client ownerA/ownerB tests (e.g. `bulk-import-create-lease.test.ts`).
+
+### Types
+- `src/types/stats.ts` — `UnitStats` (:48), `TenantStats` (:20). REUSE — no duplicates.
+
+### How the RPC is called from the hook
+- Replace the `Promise.all([...HEAD counts...])` body with `supabase.rpc('get_unit_stats', { p_user_id })` → `mapUnitStats(data)`. Get `p_user_id` from the authed user (mirror how other RPC hooks pass the owner id).
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+- Kill the unbounded `rent_amount` fetch entirely — the sum moves into SQL (`sum(rent_amount) filter (where status != 'inactive')`).
+- The tenant `users.status` embedded filter is DELETED (not "add an inner join") — the correct source is `tenants.status`, scoped by `owner_user_id`.
+</specifics>
+
+<deferred>
+## Deferred Ideas
+None — phase scope is the two RPCs + mappers + RLS test.
+</deferred>
+
+---
+
+*Phase: 03-stats-rpc-consolidation*
+*Context gathered: 2026-06-05 — live-DB-grounded; canonical get_maintenance_stats body + scoping columns + no-regression contract verified via MCP.*

--- a/src/hooks/api/__tests__/use-tenant.test.tsx
+++ b/src/hooks/api/__tests__/use-tenant.test.tsx
@@ -75,6 +75,7 @@ vi.stubGlobal("fetch", mockFetch);
 
 // Supabase mock with configurable from() responses
 const supabaseFromMock = vi.fn();
+const supabaseRpcMock = vi.fn();
 let supabaseInsertMock = vi.fn();
 let supabaseUpdateMock = vi.fn();
 const supabaseAuthGetUserMock = vi.fn();
@@ -83,6 +84,7 @@ const supabaseAuthGetSessionMock = vi.fn();
 vi.mock("#lib/supabase/client", () => ({
 	createClient: () => ({
 		from: supabaseFromMock,
+		rpc: supabaseRpcMock,
 		auth: {
 			getUser: supabaseAuthGetUserMock,
 			getSession: supabaseAuthGetSessionMock,
@@ -153,6 +155,12 @@ describe("Query Hooks", () => {
 
 		supabaseAuthGetSessionMock.mockResolvedValue({
 			data: { session: { access_token: "test-jwt-token" } },
+		});
+
+		// Default: rpc() returns the get_tenant_stats jsonb aggregate shape.
+		supabaseRpcMock.mockResolvedValue({
+			data: { total: 15, active: 12, inactive: 3 },
+			error: null,
 		});
 
 		// Default: from() returns a query chain with mock tenant data
@@ -269,12 +277,10 @@ describe("Query Hooks", () => {
 	});
 
 	describe("useTenantStats", () => {
-		it("should aggregate tenant counts from tenants table", async () => {
-			supabaseFromMock.mockImplementation((table: string) => {
-				if (table === "tenants") {
-					return createQueryChain({ data: null, count: 10 });
-				}
-				return createQueryChain({ data: null, count: 0 });
+		it("aggregates tenant counts via the get_tenant_stats RPC through mapTenantStats", async () => {
+			supabaseRpcMock.mockResolvedValue({
+				data: { total: 15, active: 12, inactive: 3 },
+				error: null,
 			});
 
 			const { result } = renderHook(() => useTenantStats(), {
@@ -282,10 +288,21 @@ describe("Query Hooks", () => {
 			});
 
 			await waitFor(() => {
-				expect(result.current.isSuccess || result.current.isError).toBe(true);
+				expect(result.current.isSuccess).toBe(true);
 			});
 
-			expect(supabaseFromMock).toHaveBeenCalledWith("tenants");
+			// Single owner-scoped RPC — no HEAD counts, no users.status filter.
+			expect(supabaseRpcMock).toHaveBeenCalledWith("get_tenant_stats", {
+				p_user_id: "owner-user-123",
+			});
+			expect(result.current.data).toMatchObject({
+				total: 15,
+				active: 12,
+				inactive: 3,
+				totalTenants: 15,
+				activeTenants: 12,
+				newThisMonth: 0,
+			});
 		});
 	});
 

--- a/src/hooks/api/query-keys/tenant-keys.ts
+++ b/src/hooks/api/query-keys/tenant-keys.ts
@@ -17,11 +17,13 @@ import { QUERY_CACHE_TIMES } from "#lib/constants/query-config";
 import { handlePostgrestError } from "#lib/postgrest-error-handler";
 import { sanitizeSearchInput } from "#lib/sanitize-search";
 import { createClient } from "#lib/supabase/client";
+import { getCachedUser } from "#lib/supabase/get-cached-user";
 import type { PaginatedResponse, TenantFilters } from "#types/api-contracts";
 import type { Tenant, TenantWithLeaseInfo } from "#types/core";
 import type { TenantStats } from "#types/stats";
 import type { TenantPostgrestRow } from "./tenant-mappers";
 import { mapTenantRow } from "./tenant-mappers";
+import { mapTenantStats } from "./tenant-stats-mapper";
 
 const TENANT_BASE_SELECT =
 	"id, user_id, owner_user_id, first_name, last_name, name, email, phone, status, created_at, updated_at, date_of_birth, emergency_contact_name, emergency_contact_phone, emergency_contact_relationship, identity_verified, ssn_last_four";
@@ -138,44 +140,28 @@ export const tenantQueries = {
 
 	/**
 	 * Tenant statistics
-	 * Aggregates tenant counts by user status via PostgREST
+	 * Single owner-scoped `get_tenant_stats` RPC through the typed
+	 * `mapTenantStats` boundary mapper (PERF-03). Replaces the prior 3 HEAD
+	 * counts — two of which filtered the non-inner-joined `users.status` embed
+	 * (a broken filter). The correct counts now come from `tenants.status`
+	 * server-side, so active/inactive may legitimately differ from the old
+	 * buggy numbers (intended correctness fix, not a regression).
 	 */
 	stats: () =>
 		queryOptions({
 			queryKey: [...tenantQueries.all(), "stats"],
 			queryFn: async (): Promise<TenantStats> => {
 				const supabase = createClient();
-				const [totalResult, activeResult, inactiveResult] = await Promise.all([
-					supabase.from("tenants").select("id", { count: "exact", head: true }),
-					supabase
-						.from("tenants")
-						.select("id", { count: "exact", head: true })
-						.eq("users.status", "active"),
-					supabase
-						.from("tenants")
-						.select("id", { count: "exact", head: true })
-						.eq("users.status", "inactive"),
-				]);
+				const user = await getCachedUser();
+				if (!user) throw new Error("Not authenticated");
 
-				if (totalResult.error)
-					handlePostgrestError(totalResult.error, "tenants");
-				if (activeResult.error)
-					handlePostgrestError(activeResult.error, "tenants");
-				if (inactiveResult.error)
-					handlePostgrestError(inactiveResult.error, "tenants");
+				const { data, error } = await supabase.rpc("get_tenant_stats", {
+					p_user_id: user.id,
+				});
 
-				const total = totalResult.count ?? 0;
-				const active = activeResult.count ?? 0;
-				const inactive = inactiveResult.count ?? 0;
+				if (error) handlePostgrestError(error, "tenants");
 
-				return {
-					total,
-					active,
-					inactive,
-					newThisMonth: 0,
-					totalTenants: total,
-					activeTenants: active,
-				};
+				return mapTenantStats(data);
 			},
 			...QUERY_CACHE_TIMES.DETAIL,
 			gcTime: 30 * 60 * 1000,

--- a/src/hooks/api/query-keys/tenant-stats-mapper.test.ts
+++ b/src/hooks/api/query-keys/tenant-stats-mapper.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the tenant-stats boundary mapper (PERF-03, Phase 3).
+ *
+ * `mapTenantStats` validates the `get_tenant_stats` RPC jsonb at the boundary,
+ * mirroring `mapMaintenanceRow`: each numeric count field is Zod-validated via
+ * `safeParse` so a dropped/renamed RPC key throws a descriptive
+ * `mapTenantStats:` error instead of leaking `undefined`. The remaining
+ * `TenantStats` fields (totalTenants / activeTenants / newThisMonth) are DERIVED
+ * per the LOCKED contract in 03-CONTEXT.md.
+ *
+ * Note: the RPC counts by `tenants.status` — the CORRECT source — so the
+ * active/inactive values may differ from the old buggy `.eq("users.status", ...)`
+ * path. That is the deliberate PERF-03 correctness fix, NOT a regression.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mapTenantStats } from "./tenant-stats-mapper";
+
+const validRaw = {
+	total: 15,
+	active: 12,
+	inactive: 3,
+};
+
+describe("mapTenantStats", () => {
+	it("maps the RPC jsonb to the TenantStats shape with derived fields", () => {
+		const mapped = mapTenantStats(validRaw);
+		expect(mapped.total).toBe(15);
+		expect(mapped.active).toBe(12);
+		expect(mapped.inactive).toBe(3);
+		// Derived per the LOCKED contract.
+		expect(mapped.totalTenants).toBe(15);
+		expect(mapped.activeTenants).toBe(12);
+		expect(mapped.newThisMonth).toBe(0); // preserved stub
+	});
+
+	it("handles all-zero counts", () => {
+		const mapped = mapTenantStats({ total: 0, active: 0, inactive: 0 });
+		expect(mapped.total).toBe(0);
+		expect(mapped.active).toBe(0);
+		expect(mapped.inactive).toBe(0);
+		expect(mapped.totalTenants).toBe(0);
+		expect(mapped.activeTenants).toBe(0);
+		expect(mapped.newThisMonth).toBe(0);
+	});
+
+	it("throws when a count field is missing (Zod safeParse fails loudly)", () => {
+		const { active: _omit, ...withoutActive } = validRaw;
+		expect(() => mapTenantStats(withoutActive)).toThrow(/mapTenantStats/);
+	});
+
+	it("throws when a count field is non-numeric", () => {
+		expect(() => mapTenantStats({ ...validRaw, inactive: "3" })).toThrow(
+			/mapTenantStats/,
+		);
+	});
+
+	it("throws on a null raw value", () => {
+		expect(() => mapTenantStats(null)).toThrow(/mapTenantStats/);
+	});
+
+	it("surfaces a descriptive boundary error message on drift", () => {
+		expect(() => mapTenantStats({ ...validRaw, total: undefined })).toThrow(
+			expect.objectContaining({
+				message: expect.stringContaining("mapTenantStats"),
+			}),
+		);
+	});
+});

--- a/src/hooks/api/query-keys/tenant-stats-mapper.ts
+++ b/src/hooks/api/query-keys/tenant-stats-mapper.ts
@@ -1,0 +1,59 @@
+/**
+ * Tenant-stats boundary mapper (PERF-03, Phase 3 — typed RPC boundaries).
+ *
+ * `mapTenantStats` maps the `get_tenant_stats(p_user_id)` RPC jsonb into the
+ * strictly-typed `TenantStats` (= `src/types/stats.ts`), Zod-validating at the
+ * boundary. Mirrors `mapMaintenanceRow` in `maintenance-mappers.ts` (CLAUDE.md's
+ * "RPC / PostgREST Return Typing" rule): the numeric count fields are validated
+ * via `safeParse` so a dropped/renamed RPC key throws a descriptive
+ * `mapTenantStats:` error rather than leaking `undefined`.
+ *
+ * The RPC returns the raw aggregates (`{ total, active, inactive }`), counting
+ * by `tenants.status` (the CORRECT source). The old path counted active/inactive
+ * via a broken `.eq("users.status", ...)` filter on a non-inner-joined `users`
+ * embed — so these values may legitimately DIFFER from the old (buggy) numbers.
+ * That is the deliberate PERF-03 correctness fix, NOT a regression.
+ *
+ * The remaining `TenantStats` fields are DERIVED here per the LOCKED contract:
+ *   - totalTenants  = total
+ *   - activeTenants = active
+ *   - newThisMonth  = 0  (preserved stub)
+ */
+
+import { z } from "zod";
+import type { TenantStats } from "#types/stats";
+
+// The raw jsonb aggregate contract from `get_tenant_stats` (Plan 03-01). Each
+// count is NOT NULL in the RPC return, so `z.number()` runs unconditionally —
+// a missing/non-numeric key fails the safeParse and throws at the boundary.
+const tenantStatsRpcSchema = z.object({
+	total: z.number(),
+	active: z.number(),
+	inactive: z.number(),
+});
+
+/**
+ * Map the `get_tenant_stats` RPC jsonb to the strictly-typed `TenantStats`,
+ * deriving totalTenants / activeTenants / newThisMonth per the LOCKED contract.
+ * Throws a descriptive `mapTenantStats:` error if any numeric count field is
+ * missing or non-numeric.
+ */
+export function mapTenantStats(raw: unknown): TenantStats {
+	const parsed = tenantStatsRpcSchema.safeParse(raw);
+	if (!parsed.success) {
+		throw new Error(
+			`mapTenantStats: malformed get_tenant_stats response — ${parsed.error.message}`,
+		);
+	}
+
+	const { total, active, inactive } = parsed.data;
+
+	return {
+		total,
+		active,
+		inactive,
+		newThisMonth: 0,
+		totalTenants: total,
+		activeTenants: active,
+	};
+}

--- a/src/hooks/api/query-keys/unit-keys.ts
+++ b/src/hooks/api/query-keys/unit-keys.ts
@@ -22,6 +22,7 @@ import type { PaginatedResponse } from "#types/api-contracts";
 import type { Unit } from "#types/core";
 import type { UnitStats } from "#types/stats";
 import { mutationKeys } from "../mutation-keys";
+import { mapUnitStats } from "./unit-mappers";
 
 /**
  * Unit query filters
@@ -173,82 +174,26 @@ export const unitQueries = {
 
 	/**
 	 * Unit statistics
-	 * Aggregates counts by status directly via PostgREST
+	 * Single owner-scoped `get_unit_stats` RPC through the typed `mapUnitStats`
+	 * boundary mapper (PERF-02). Replaces the prior 4 HEAD counts + unbounded
+	 * `rent_amount` fetch — the aggregation now runs server-side and the derived
+	 * fields are computed in the mapper per the no-regression contract.
 	 */
 	stats: () =>
 		queryOptions({
 			queryKey: [...unitQueries.all(), "stats"],
 			queryFn: async (): Promise<UnitStats> => {
 				const supabase = createClient();
+				const user = await getCachedUser();
+				if (!user) throw new Error("Not authenticated");
 
-				const [
-					totalResult,
-					occupiedResult,
-					availableResult,
-					maintenanceResult,
-					rentResult,
-				] = await Promise.all([
-					supabase
-						.from("units")
-						.select("id", { count: "exact", head: true })
-						.neq("status", "inactive"),
-					supabase
-						.from("units")
-						.select("id", { count: "exact", head: true })
-						.eq("status", "occupied"),
-					supabase
-						.from("units")
-						.select("id", { count: "exact", head: true })
-						.eq("status", "available"),
-					supabase
-						.from("units")
-						.select("id", { count: "exact", head: true })
-						.eq("status", "maintenance"),
-					supabase
-						.from("units")
-						.select("rent_amount")
-						.neq("status", "inactive"),
-				]);
+				const { data, error } = await supabase.rpc("get_unit_stats", {
+					p_user_id: user.id,
+				});
 
-				if (totalResult.error) handlePostgrestError(totalResult.error, "units");
-				if (occupiedResult.error)
-					handlePostgrestError(occupiedResult.error, "units");
-				if (availableResult.error)
-					handlePostgrestError(availableResult.error, "units");
-				if (maintenanceResult.error)
-					handlePostgrestError(maintenanceResult.error, "units");
-				if (rentResult.error) handlePostgrestError(rentResult.error, "units");
+				if (error) handlePostgrestError(error, "units");
 
-				const total = totalResult.count ?? 0;
-				const occupied = occupiedResult.count ?? 0;
-				const available = availableResult.count ?? 0;
-				const maintenance = maintenanceResult.count ?? 0;
-				const vacant = available;
-				const occupancyRate =
-					total > 0 ? Math.round((occupied / total) * 100) : 0;
-
-				const rentAmounts = (rentResult.data ?? []).map(
-					(r: { rent_amount: number | null }) => r.rent_amount ?? 0,
-				);
-				const totalActualRent = rentAmounts.reduce(
-					(sum: number, amt: number) => sum + amt,
-					0,
-				);
-				const averageRent =
-					rentAmounts.length > 0 ? totalActualRent / rentAmounts.length : 0;
-
-				return {
-					total,
-					occupied,
-					vacant,
-					maintenance,
-					available,
-					averageRent,
-					occupancyRate,
-					occupancyChange: 0,
-					totalPotentialRent: totalActualRent,
-					totalActualRent,
-				};
+				return mapUnitStats(data);
 			},
 			...QUERY_CACHE_TIMES.DETAIL,
 			gcTime: 30 * 60 * 1000,

--- a/src/hooks/api/query-keys/unit-mappers.test.ts
+++ b/src/hooks/api/query-keys/unit-mappers.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the unit-stats boundary mapper (PERF-02, Phase 3).
+ *
+ * `mapUnitStats` validates the `get_unit_stats` RPC jsonb at the boundary,
+ * mirroring `mapMaintenanceRow` in `maintenance-mappers.ts`: each numeric count
+ * field is Zod-validated via `safeParse` so a dropped/renamed RPC key throws a
+ * descriptive `mapUnitStats:` error instead of leaking `undefined` into the KPI
+ * cards. The remaining `UnitStats` fields (vacant / occupancyRate / averageRent /
+ * occupancyChange / totalPotentialRent) are DERIVED per the LOCKED no-regression
+ * contract in 03-CONTEXT.md — the final values must be identical to the old
+ * multi-query path.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mapUnitStats } from "./unit-mappers";
+
+const validRaw = {
+	total: 10,
+	occupied: 6,
+	available: 3,
+	maintenance: 1,
+	totalActualRent: 12000,
+};
+
+describe("mapUnitStats", () => {
+	it("maps the RPC jsonb to the UnitStats shape with derived fields", () => {
+		const mapped = mapUnitStats(validRaw);
+		expect(mapped.total).toBe(10);
+		expect(mapped.occupied).toBe(6);
+		expect(mapped.available).toBe(3);
+		expect(mapped.maintenance).toBe(1);
+		expect(mapped.totalActualRent).toBe(12000);
+		// Derived per the LOCKED contract.
+		expect(mapped.vacant).toBe(3); // vacant = available
+		expect(mapped.occupancyChange).toBe(0); // preserved stub
+		expect(mapped.totalPotentialRent).toBe(12000); // alias of totalActualRent
+	});
+
+	it("pins the no-regression values for the {10,6,3,1,12000} fixture", () => {
+		// IDENTICAL to what the old 4-HEAD-count + unbounded-rent-fetch path
+		// produced for the same aggregates: occupancyRate = round(6/10*100) = 60,
+		// averageRent = 12000/10 = 1200 (old path divided by rentAmounts.length
+		// which equals the non-inactive row count == total).
+		const mapped = mapUnitStats(validRaw);
+		expect(mapped.occupancyRate).toBe(60);
+		expect(mapped.averageRent).toBe(1200);
+		expect(mapped.vacant).toBe(3);
+		expect(mapped.occupancyChange).toBe(0);
+		expect(mapped.totalPotentialRent).toBe(12000);
+		expect(mapped.totalActualRent).toBe(12000);
+	});
+
+	it("rounds occupancyRate to the nearest integer (matching the old Math.round)", () => {
+		// 5/9 = 55.55... -> round -> 56
+		const mapped = mapUnitStats({
+			total: 9,
+			occupied: 5,
+			available: 3,
+			maintenance: 1,
+			totalActualRent: 9000,
+		});
+		expect(mapped.occupancyRate).toBe(56);
+		expect(mapped.averageRent).toBe(1000);
+	});
+
+	it("guards divide-by-zero when total is 0", () => {
+		const mapped = mapUnitStats({
+			total: 0,
+			occupied: 0,
+			available: 0,
+			maintenance: 0,
+			totalActualRent: 0,
+		});
+		expect(mapped.occupancyRate).toBe(0);
+		expect(mapped.averageRent).toBe(0);
+	});
+
+	it("throws when a count field is missing (Zod safeParse fails loudly)", () => {
+		const { occupied: _omit, ...withoutOccupied } = validRaw;
+		expect(() => mapUnitStats(withoutOccupied)).toThrow(/mapUnitStats/);
+	});
+
+	it("throws when a count field is non-numeric", () => {
+		expect(() =>
+			mapUnitStats({ ...validRaw, totalActualRent: "12000" }),
+		).toThrow(/mapUnitStats/);
+	});
+
+	it("throws on a null raw value", () => {
+		expect(() => mapUnitStats(null)).toThrow(/mapUnitStats/);
+	});
+
+	it("surfaces a descriptive boundary error message on drift", () => {
+		expect(() => mapUnitStats({ ...validRaw, total: undefined })).toThrow(
+			expect.objectContaining({
+				message: expect.stringContaining("mapUnitStats"),
+			}),
+		);
+	});
+});

--- a/src/hooks/api/query-keys/unit-mappers.ts
+++ b/src/hooks/api/query-keys/unit-mappers.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit-stats boundary mapper (PERF-02, Phase 3 — typed RPC boundaries).
+ *
+ * `mapUnitStats` maps the `get_unit_stats(p_user_id)` RPC jsonb into the
+ * strictly-typed `UnitStats` (= `src/types/stats.ts`), Zod-validating at the
+ * boundary. Mirrors `mapMaintenanceRow` in `maintenance-mappers.ts` (CLAUDE.md's
+ * "RPC / PostgREST Return Typing" rule): the numeric count fields are validated
+ * via `safeParse` so a dropped/renamed RPC key throws a descriptive
+ * `mapUnitStats:` error rather than leaking `undefined` into the KPI cards.
+ *
+ * The RPC returns only the raw aggregates
+ * (`{ total, occupied, available, maintenance, totalActualRent }`); the remaining
+ * `UnitStats` fields are DERIVED here per the LOCKED no-regression contract in
+ * 03-CONTEXT.md so the final values stay IDENTICAL to the old multi-query path:
+ *   - vacant            = available
+ *   - occupancyRate     = total > 0 ? round(occupied / total * 100) : 0
+ *   - averageRent       = total > 0 ? totalActualRent / total : 0
+ *   - occupancyChange   = 0  (preserved hardcoded stub)
+ *   - totalPotentialRent = totalActualRent  (preserved alias)
+ *
+ * The old path divided `totalActualRent` by `rentAmounts.length`, which equals
+ * the non-inactive row count == `total`, so dividing by `total` here is the same
+ * value (pinned in the no-regression test).
+ */
+
+import { z } from "zod";
+import type { UnitStats } from "#types/stats";
+
+// The raw jsonb aggregate contract from `get_unit_stats` (Plan 03-01). Each
+// count is NOT NULL in the RPC return, so `z.number()` runs unconditionally —
+// a missing/non-numeric key fails the safeParse and throws at the boundary.
+const unitStatsRpcSchema = z.object({
+	total: z.number(),
+	occupied: z.number(),
+	available: z.number(),
+	maintenance: z.number(),
+	totalActualRent: z.number(),
+});
+
+/**
+ * Map the `get_unit_stats` RPC jsonb to the strictly-typed `UnitStats`,
+ * deriving vacant / occupancyRate / averageRent / occupancyChange /
+ * totalPotentialRent per the LOCKED contract. Throws a descriptive
+ * `mapUnitStats:` error if any numeric count field is missing or non-numeric.
+ */
+export function mapUnitStats(raw: unknown): UnitStats {
+	const parsed = unitStatsRpcSchema.safeParse(raw);
+	if (!parsed.success) {
+		throw new Error(
+			`mapUnitStats: malformed get_unit_stats response — ${parsed.error.message}`,
+		);
+	}
+
+	const { total, occupied, available, maintenance, totalActualRent } =
+		parsed.data;
+
+	const vacant = available;
+	const occupancyRate = total > 0 ? Math.round((occupied / total) * 100) : 0;
+	const averageRent = total > 0 ? totalActualRent / total : 0;
+
+	return {
+		total,
+		occupied,
+		vacant,
+		maintenance,
+		available,
+		averageRent,
+		occupancyRate,
+		occupancyChange: 0,
+		totalPotentialRent: totalActualRent,
+		totalActualRent,
+	};
+}

--- a/src/test/mocks/msw/handlers/rpc.ts
+++ b/src/test/mocks/msw/handlers/rpc.ts
@@ -34,6 +34,26 @@ export const rpcHandlers = [
 		});
 	}),
 
+	// Unit stats (PERF-02) — raw aggregates; mapUnitStats derives the rest.
+	http.post(supabaseUrl("/rest/v1/rpc/get_unit_stats"), () => {
+		return rpcResponse({
+			total: 20,
+			occupied: 15,
+			available: 4,
+			maintenance: 1,
+			totalActualRent: 24000,
+		});
+	}),
+
+	// Tenant stats (PERF-03) — counts by tenants.status.
+	http.post(supabaseUrl("/rest/v1/rpc/get_tenant_stats"), () => {
+		return rpcResponse({
+			total: 15,
+			active: 12,
+			inactive: 3,
+		});
+	}),
+
 	// User profile
 	http.post(supabaseUrl("/rest/v1/rpc/get_user_profile"), () => {
 		return rpcResponse({

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -2508,11 +2508,13 @@ export type Database = {
 				Args: { p_customer_id: string };
 				Returns: Json;
 			};
+			get_tenant_stats: { Args: { p_user_id: string }; Returns: Json };
 			get_tenants_by_owner: { Args: { p_user_id: string }; Returns: string[] };
 			get_tenants_with_lease_by_owner: {
 				Args: { p_user_id: string };
 				Returns: string[];
 			};
+			get_unit_stats: { Args: { p_user_id: string }; Returns: Json };
 			get_user_dashboard_activities: {
 				Args: { p_limit?: number; p_offset?: number; p_user_id: string };
 				Returns: {

--- a/supabase/migrations/20260606041458_stats_consolidation_rpcs.sql
+++ b/supabase/migrations/20260606041458_stats_consolidation_rpcs.sql
@@ -1,0 +1,77 @@
+-- Phase 3 (v4.0): Stats RPC consolidation (PERF-02, PERF-03).
+--
+-- Two owner-scoped SECURITY DEFINER stats RPCs mirroring the canonical
+-- get_maintenance_stats pattern exactly (jsonb return, search_path locked
+-- to public, auth.uid() identity guard, owner_user_id scope, authenticated-
+-- only EXECUTE).
+--
+--  - get_unit_stats: moves the rent total into SQL via
+--    sum(rent_amount) filter (...), eliminating the previous UNBOUNDED
+--    client-side rent_amount fetch (PERF-02). rent_amount is dollars
+--    numeric — NOT converted to cents.
+--  - get_tenant_stats: counts active/inactive against tenants.status,
+--    replacing the previous BROKEN users.status left-join embed filter
+--    (PERF-03 — a deliberate correctness fix; the active/inactive counts
+--    MAY differ from the old buggy numbers, which is intended, not a
+--    regression). total is unaffected.
+--
+-- The derived UnitStats/TenantStats fields (vacant, occupancyRate,
+-- averageRent, totalTenants, activeTenants, newThisMonth, etc.) are
+-- computed in the typed mappers on the frontend, not here.
+
+create or replace function public.get_unit_stats(p_user_id uuid)
+  returns jsonb
+  language plpgsql
+  security definer
+  set search_path to 'public'
+as $function$
+begin
+  -- SEC-01: validate caller identity (RLS is bypassed in definer context)
+  if p_user_id != (select auth.uid()) then
+    raise exception 'Unauthorized';
+  end if;
+
+  return (
+    select jsonb_build_object(
+      'total', count(*) filter (where status != 'inactive'),
+      'occupied', count(*) filter (where status = 'occupied'),
+      'available', count(*) filter (where status = 'available'),
+      'maintenance', count(*) filter (where status = 'maintenance'),
+      'totalActualRent',
+        coalesce(sum(rent_amount) filter (where status != 'inactive'), 0)
+    )
+    from units
+    where owner_user_id = p_user_id
+  );
+end;
+$function$;
+
+revoke all on function public.get_unit_stats(uuid) from public;
+grant execute on function public.get_unit_stats(uuid) to authenticated;
+
+create or replace function public.get_tenant_stats(p_user_id uuid)
+  returns jsonb
+  language plpgsql
+  security definer
+  set search_path to 'public'
+as $function$
+begin
+  -- SEC-01: validate caller identity (RLS is bypassed in definer context)
+  if p_user_id != (select auth.uid()) then
+    raise exception 'Unauthorized';
+  end if;
+
+  return (
+    select jsonb_build_object(
+      'total', count(*),
+      'active', count(*) filter (where status = 'active'),
+      'inactive', count(*) filter (where status = 'inactive')
+    )
+    from tenants
+    where owner_user_id = p_user_id
+  );
+end;
+$function$;
+
+revoke all on function public.get_tenant_stats(uuid) from public;
+grant execute on function public.get_tenant_stats(uuid) to authenticated;

--- a/tests/integration/rls/stats-rpcs.rls.test.ts
+++ b/tests/integration/rls/stats-rpcs.rls.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration tests for the Phase 3 (PERF-02 / PERF-03) stats RPCs —
+ * `get_unit_stats(p_user_id uuid)` + `get_tenant_stats(p_user_id uuid)`.
+ *
+ * Both functions are SECURITY DEFINER, which bypasses RLS, so the
+ * per-aggregate `where owner_user_id = p_user_id` filter is NOT enough on
+ * its own — the function trusts whatever uuid the caller passes. The first
+ * statement in each body is the identity guard, mirroring
+ * `get_maintenance_stats`:
+ *
+ *   if p_user_id != (select auth.uid()) then raise exception 'Unauthorized';
+ *
+ * This file IS the regression proof for that guard (success criterion 3 /
+ * threat T-03-06): ownerB calling `get_X_stats(ownerA_id)` is rejected with
+ * a `/unauthorized/i` error and null data; each owner's self-call succeeds
+ * and returns only their own counts. It runs in the `rls-security` CI gate,
+ * so a future refactor that drops the guard fails CI with another owner's
+ * stats leaking.
+ *
+ * Note: the stats RPCs raise the bare message 'Unauthorized' (matching
+ * `get_maintenance_stats`), NOT the "Access denied: cannot request data for
+ * another user" message used by the dashboard-group RPCs in
+ * `rpc-auth.test.ts` — hence the `/unauthorized/i` assertion here.
+ *
+ * Pattern matches `tests/integration/rls/dashboard-rpc-open-maintenance.test.ts`
+ * (dual client, fixture-create + cleanup, graceful skip if fixtures fail).
+ * `getTestCredentials()` throws when the four E2E_OWNER_* env vars are unset;
+ * CI provides them via repo secrets, local runs require `.env.local`.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+// The RPCs return jsonb (typed `Json` in the generated client). Narrow to the
+// known aggregate shapes here rather than reaching for `as unknown as` — the
+// mappers in src do the Zod-validated version; this test only needs the raw
+// numeric fields the RPC emits.
+interface UnitStatsRaw {
+	total: number;
+	occupied: number;
+	available: number;
+	maintenance: number;
+	totalActualRent: number;
+}
+
+interface TenantStatsRaw {
+	total: number;
+	active: number;
+	inactive: number;
+}
+
+const FIXTURE_RENT = 1337;
+
+describe("get_unit_stats / get_tenant_stats — owner-isolation RLS", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+	let ownerAId: string;
+	let ownerBId: string;
+
+	// Fixtures created in beforeAll, cleaned in afterAll.
+	let propertyA: { id: string } | null = null;
+	let unitA: { id: string } | null = null;
+	let tenantA: { id: string } | null = null;
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		const {
+			data: { user: userA },
+		} = await clientA.auth.getUser();
+		const {
+			data: { user: userB },
+		} = await clientB.auth.getUser();
+		ownerAId = userA!.id;
+		ownerBId = userB!.id;
+
+		// Fresh owner-A fixtures so the self-call returns non-zero counts that
+		// this test owns. afterAll removes them. One property → one available
+		// unit (known rent) → one active tenant.
+		const { data: pA } = await clientA
+			.from("properties")
+			.insert({
+				name: "Stats RPC Test Property A",
+				address_line1: "1 Stats St",
+				city: "Testville",
+				state: "CA",
+				postal_code: "94105",
+				country: "US",
+				property_type: "APARTMENT",
+				owner_user_id: ownerAId,
+			})
+			.select("id")
+			.single();
+		propertyA = pA ? { id: pA.id } : null;
+
+		if (propertyA) {
+			const { data: uA } = await clientA
+				.from("units")
+				.insert({
+					property_id: propertyA.id,
+					unit_number: "STATS-A-101",
+					bedrooms: 1,
+					bathrooms: 1,
+					rent_amount: FIXTURE_RENT,
+					status: "available",
+					owner_user_id: ownerAId,
+				})
+				.select("id")
+				.single();
+			unitA = uA ? { id: uA.id } : null;
+		}
+
+		const { data: tA } = await clientA
+			.from("tenants")
+			.insert({
+				email: `stats-rpc-test-tenant-a-${Date.now()}@example.com`,
+				first_name: "Stats",
+				last_name: "TestA",
+				status: "active",
+				owner_user_id: ownerAId,
+			})
+			.select("id")
+			.single();
+		tenantA = tA ? { id: tA.id } : null;
+	});
+
+	afterAll(async () => {
+		// FK-safe order: unit (child of property) before property; tenant is
+		// standalone. All under ownerA.
+		if (unitA) await clientA.from("units").delete().eq("id", unitA.id);
+		if (propertyA)
+			await clientA.from("properties").delete().eq("id", propertyA.id);
+		if (tenantA) await clientA.from("tenants").delete().eq("id", tenantA.id);
+	});
+
+	// -------------------------------------------------------------------------
+	// ISOLATION — ownerB passing ownerA's user_id is rejected with Unauthorized
+	// -------------------------------------------------------------------------
+
+	it("rejects ownerB calling get_unit_stats(ownerA_id) with Unauthorized", async () => {
+		// SECURITY DEFINER bypasses RLS; the `auth.uid() != p_user_id` guard is
+		// the only thing stopping ownerB from reading ownerA's unit aggregates.
+		// If a future refactor drops the guard, this fails with non-null data
+		// (ownerA's counts leaking to ownerB — the P0 this test pins).
+		const { data, error } = await clientB.rpc("get_unit_stats", {
+			p_user_id: ownerAId,
+		});
+		expect(data).toBeNull();
+		expect(error).not.toBeNull();
+		expect(error?.message).toMatch(/unauthorized/i);
+	});
+
+	it("rejects ownerB calling get_tenant_stats(ownerA_id) with Unauthorized", async () => {
+		const { data, error } = await clientB.rpc("get_tenant_stats", {
+			p_user_id: ownerAId,
+		});
+		expect(data).toBeNull();
+		expect(error).not.toBeNull();
+		expect(error?.message).toMatch(/unauthorized/i);
+	});
+
+	// -------------------------------------------------------------------------
+	// SELF-CALL SUCCESS — each owner reads only their own counts
+	// -------------------------------------------------------------------------
+
+	it("allows ownerA self-call to get_unit_stats and reflects the fixtures", async () => {
+		if (!unitA) {
+			console.warn("Skipping: ownerA unit fixture not created");
+			return;
+		}
+
+		const { data, error } = await clientA.rpc("get_unit_stats", {
+			p_user_id: ownerAId,
+		});
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+
+		const stats = data as UnitStatsRaw;
+		// Don't hard-pin exact totals — the synthetic account may carry prior
+		// fixtures. Assert the aggregates are numbers and >= the values this
+		// test just created (one available unit at FIXTURE_RENT).
+		expect(typeof stats.total).toBe("number");
+		expect(typeof stats.occupied).toBe("number");
+		expect(typeof stats.available).toBe("number");
+		expect(typeof stats.maintenance).toBe("number");
+		expect(typeof stats.totalActualRent).toBe("number");
+		expect(stats.total).toBeGreaterThanOrEqual(1);
+		expect(stats.available).toBeGreaterThanOrEqual(1);
+		expect(stats.totalActualRent).toBeGreaterThanOrEqual(FIXTURE_RENT);
+	});
+
+	it("allows ownerA self-call to get_tenant_stats and counts by tenants.status", async () => {
+		if (!tenantA) {
+			console.warn("Skipping: ownerA tenant fixture not created");
+			return;
+		}
+
+		const { data, error } = await clientA.rpc("get_tenant_stats", {
+			p_user_id: ownerAId,
+		});
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+
+		const stats = data as TenantStatsRaw;
+		// Counting is by `tenants.status` (PERF-03 correctness fix). The active
+		// fixture tenant guarantees active >= 1 and total >= 1.
+		expect(typeof stats.total).toBe("number");
+		expect(typeof stats.active).toBe("number");
+		expect(typeof stats.inactive).toBe("number");
+		expect(stats.total).toBeGreaterThanOrEqual(1);
+		expect(stats.active).toBeGreaterThanOrEqual(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// ISOLATION (positive) — ownerB's own self-call succeeds, proving the guard
+	// rejects only the mismatch, not every call.
+	// -------------------------------------------------------------------------
+
+	it("allows ownerB self-call to get_unit_stats(ownerB_id) — guard rejects only the mismatch", async () => {
+		const { data, error } = await clientB.rpc("get_unit_stats", {
+			p_user_id: ownerBId,
+		});
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

**v4.0 Phase 3 — Stats RPC Consolidation (PERF-02, PERF-03).** Replaces two multi-query stat hooks with single owner-scoped SECURITY DEFINER RPCs, each returning through a Zod-validated typed mapper, with owner isolation pinned by a dual-client RLS test.

| Before | After |
|--------|-------|
| `unitQueries.stats()` — **4 HEAD counts + 1 unbounded `rent_amount` fetch** | one `get_unit_stats()` RPC (rent summed in SQL) |
| `tenantQueries.stats()` — **3 HEAD counts**, two filtering a broken `users.status` left-join embed | one `get_tenant_stats()` RPC counting by `tenants.status` |

## Plans
- **03-01** — Migration defining both RPCs (mirror `get_maintenance_stats`: `jsonb`, `SECURITY DEFINER`, `search_path=public`, `auth.uid()` guard, `owner_user_id` scope, authenticated-only EXECUTE). **Applied to prod** via Supabase MCP (version `20260606041458`, filename reconciled); `supabase.ts` regenerated via the MCP types tool. Verified in prod: both `prosecdef=true`, search_path=public, authenticated EXECUTE ✓, anon denied ✓.
- **03-02** — Zod-validated `mapUnitStats`/`mapTenantStats` + both `stats()` hooks rewired to single `supabase.rpc(...)` calls. The HEAD counts, unbounded fetch, and `users.status` filter are **gone**.
- **03-03** — Dual-client (ownerA/ownerB) RLS test: ownerB calling `get_unit_stats(ownerA_id)`/`get_tenant_stats(ownerA_id)` is rejected by the `auth.uid()` guard ('Unauthorized'); each owner sees only their own counts. Runs in the `rls-security` CI gate.

## No-regression contract
`UnitStats` values are **identical** to the pre-consolidation path (the mapper derives `vacant=available`, `occupancyRate`, `averageRent`, `occupancyChange:0` stub, `totalPotentialRent=totalActualRent` alias). 

**One intended value change (NOT a regression):** tenant `active`/`inactive` now count by `tenants.status`. The old path filtered `.eq("users.status", …)` on a left-join embed with no inner join — a broken filter (the audit's flagged bug). The new counts are correct and may differ from the old buggy numbers. `total` is unaffected.

## Tests
30 mapper/hook unit assertions (valid→mapped, drift→throws, no-regression value pins) + the dual-client RLS integration test (deferred to the `rls-security` CI gate — local lacks the synthetic-owner secrets, as designed). typecheck + lint green in every commit's lefthook gate.

## Note
The expired env `SUPABASE_ACCESS_TOKEN` blocks the CLI path (`db:types`, function deploys); MCP tools (apply_migration / generate_typescript_types / execute_sql) use a working channel and were used here. Refreshing the token restores the CLI path. The project is healthy/serving — the Free-tier quota banner does not affect DDL or writes.

[hudsor01]
