### PR TITLE
v4.0 Phase 4: Cron Stagger & Index Cleanup (PERF-01, PERF-04)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -100,14 +100,15 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 - [ ] 03-03-PLAN.md — PERF-02, PERF-03: dual-client ownerA/ownerB RLS test pinning the `auth.uid()` 'Unauthorized' owner-isolation guard for both RPCs
 
 ### Phase 4: Cron Stagger & Index Cleanup
-**Goal**: The four pg_cron cleanup jobs no longer contend at a single timestamp, and confirmed-unused indexes are dropped in one migration while every FK-supporting index is explicitly retained.
+**Goal**: The four pg_cron cleanup jobs no longer contend at a single timestamp, and the one provably-dead index is dropped in one migration while every FK-supporting index is explicitly retained.
 **Depends on**: Nothing (pure DB-ops migration; deliberately separate from the stats-RPC phase so migration-boundary work is not bunched)
 **Requirements**: PERF-01, PERF-04
 **Success Criteria** (what must be TRUE):
-  1. The 4 cleanup jobs (`cleanup-cron-history`, `cleanup-pg-net-responses`, `cleanup-security-events`, `expire-trials`) fire at distinct minutes across the 3 AM UTC window — verifiable via `cron.job` schedule rows post-migration.
-  2. Indexes with `idx_scan = 0` over a representative window AND not FK-backing are dropped in a single migration; the migration body documents the idx_scan evidence per dropped index.
-  3. Every FK-supporting index is explicitly kept (enumerated in the migration), and the repo migration is reconciled against the prod-assigned timestamp via `list_migrations`.
-**Plans**: TBD
+  1. The 4 cleanup jobs (`cleanup-cron-history`, `cleanup-pg-net-responses`, `cleanup-security-events`, `expire-trials`) fire at distinct minutes across the 3 AM UTC window (`0/5/10/20 3 * * *`) — verifiable via `cron.job` schedule rows post-migration.
+  2. The single provably-dead index (`idx_properties_property_owner_id`, a btree on the projection-only `properties.stripe_connected_account_id`) is dropped in one migration; the migration body documents the projection-only evidence. No other index is dropped (the broader idx_scan=0 sweep is deferred to a post-launch representative-traffic review).
+  3. Every FK-supporting index is explicitly kept (documented in the migration, spot-checked present in prod), and the repo migration is reconciled against the prod-assigned timestamp via `list_migrations`.
+**Plans**: 1 plan (Wave 1 — author the migration; Task 2 is a [BLOCKING] MCP prod-apply + filename-reconcile checkpoint)
+- [ ] 04-01-PLAN.md — PERF-01, PERF-04: one migration (3 schedule-only `cron.alter_job` reschedules + 1 `DROP INDEX`), [BLOCKING] MCP prod apply + filename reconcile + introspection; no `db:types`
 
 ### Phase 5: Cross-Owner RLS Coverage
 **Goal**: Owner isolation is regression-pinned across the tables that lacked dual-client coverage, and RLS-rejection assertions are hardened to SQLSTATE codes via a single shared helper.
@@ -159,11 +160,11 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 | 1. Security-CI Hardening | v4.0 | 4/4 | Shipped (PR #783) | 2026-06-04 |
 | 2. Typed RPC Boundaries | v4.0 | 4/4 | Shipped (PR #785) | 2026-06-05 |
 | 3. Stats RPC Consolidation | v4.0 | 3/3 | Executed (awaiting PR) | - |
-| 4. Cron Stagger & Index Cleanup | v4.0 | 0/? | Not started | - |
+| 4. Cron Stagger & Index Cleanup | v4.0 | 1/1 | Planned | - |
 | 5. Cross-Owner RLS Coverage | v4.0 | 0/? | Not started | - |
 | 6. Auth & Dollar-Hook Unit Tests | v4.0 | 0/? | Not started | - |
 | 7. Accessibility Labels | v4.0 | 0/? | Not started | - |
 | 8. SEO Recovery | v4.0 | 0/? | Not started | - |
 
 ---
-*Last updated: 2026-06-05 — Phase 3 (Stats RPC Consolidation) planned: 3 plans across 2 waves (PERF-02 + PERF-03). v4.0 Hardening & Hygiene roadmap (8 phases, 21/21 requirements mapped). v3.0 (3 phases, 12/12), v2.0 (7 phases, 34/34), v1.0 (15 phases, 56/56) archived above.*
+*Last updated: 2026-06-06 — Phase 4 (Cron Stagger & Index Cleanup) planned: 1 plan, Wave 1 (PERF-01 + PERF-04). One DB-ops migration: 3 schedule-only `cron.alter_job` reschedules + 1 `DROP INDEX`, applied via Supabase MCP at a [BLOCKING] checkpoint + filename-reconcile; no `db:types`. v4.0 Hardening & Hygiene roadmap (8 phases, 21/21 requirements mapped). v3.0 (3 phases, 12/12), v2.0 (7 phases, 34/34), v1.0 (15 phases, 56/56) archived above.*

--- a/.planning/phases/04-cron-stagger-index-cleanup/04-01-PLAN.md
+++ b/.planning/phases/04-cron-stagger-index-cleanup/04-01-PLAN.md
@@ -1,0 +1,244 @@
+---
+phase: 04-cron-stagger-index-cleanup
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - supabase/migrations/YYYYMMDDHHmmss_cron_stagger_index_cleanup.sql
+autonomous: false
+requirements: [PERF-01, PERF-04]
+
+must_haves:
+  truths:
+    - "The 4 cleanup jobs (cleanup-cron-history, cleanup-pg-net-responses, cleanup-security-events, expire-trials) fire at 4 distinct minutes in the 3 AM UTC window (0/5/10/20 3 * * *)"
+    - "The one provably-dead index idx_properties_property_owner_id no longer exists in prod"
+    - "Every FK/PK/unique index and every structurally-valid index is still present (the drop was surgical)"
+    - "The repo migration filename is reconciled to the prod-assigned timestamp"
+  artifacts:
+    - path: "supabase/migrations/YYYYMMDDHHmmss_cron_stagger_index_cleanup.sql"
+      provides: "3 cron.alter_job reschedules + 1 DROP INDEX + kept-index/deferral rationale block"
+      contains: "cron.alter_job"
+      min_lines: 20
+  key_links:
+    - from: "migration"
+      to: "cron.job"
+      via: "cron.alter_job(job_id := (select jobid from cron.job where jobname = '<name>'), schedule := '<new>')"
+      pattern: "cron\\.alter_job"
+    - from: "migration"
+      to: "pg_indexes"
+      via: "drop index if exists public.idx_properties_property_owner_id"
+      pattern: "drop index if exists public\\.idx_properties_property_owner_id"
+---
+
+<objective>
+One DB-ops migration that (PERF-01) staggers the 4 pg_cron cleanup jobs colliding at `0 3 * * *` onto distinct free minutes, and (PERF-04) drops the single provably-dead index `idx_properties_property_owner_id` while explicitly documenting that all FK/valid indexes are deliberately kept and the broader idx_scan=0 sweep is deferred.
+
+Purpose: Eliminate cron contention at a single timestamp and remove dead-weight index maintenance with zero risk, per the live-DB-verified canonical determination in CONTEXT.md.
+Output: `supabase/migrations/YYYYMMDDHHmmss_cron_stagger_index_cleanup.sql` (authored, then applied to prod via MCP at a blocking checkpoint and filename-reconciled).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-cron-stagger-index-cleanup/04-CONTEXT.md
+@CLAUDE.md
+@supabase/migrations/20260606041458_stats_consolidation_rpcs.sql
+
+<facts>
+<!-- Live-DB-verified facts from 04-CONTEXT.md (binding). The executor must NOT re-derive these. -->
+
+PERF-01 — exactly 4 jobs fire at `0 3 * * *`. Reschedule to distinct FREE minutes
+(:15/:30/:45 are already taken by cleanup-errors / cleanup-webhook-events /
+process-account-deletions — do NOT collide with them):
+  - cleanup-cron-history     → `0 3 * * *`   (UNCHANGED, :00 — no alter_job call needed)
+  - cleanup-pg-net-responses → `5 3 * * *`   (:05)
+  - cleanup-security-events  → `10 3 * * *`   (:10)
+  - expire-trials            → `20 3 * * *`   (:20)
+So only 3 alter_job calls. Reschedule API (NOT `UPDATE cron.job`, NOT `cron.schedule()`):
+  select cron.alter_job(
+    job_id := (select jobid from cron.job where jobname = '<name>'),
+    schedule := '<new>'
+  );
+This changes ONLY the schedule, preserving each job's existing command (each calls a
+named SECURITY DEFINER function per the project's cron convention).
+
+PERF-04 — drop EXACTLY ONE index:
+  drop index if exists public.idx_properties_property_owner_id;
+It is a btree on the vestigial `properties.stripe_connected_account_id` (Stripe-Connect
+residue). That column appears in code ONLY as a SELECT projection
+(property-keys.ts:28 + a test fixture), NEVER in any WHERE/JOIN/ORDER BY, so a btree on
+it can never be used by any query at any traffic level — dead regardless of volume.
+The COLUMN stays (still selected); only the dead index goes.
+Do NOT drop any other index. All FK/PK/unique indexes and all structurally-valid
+idx_scan=0 indexes (incl. idx_documents_search_vector) are deliberately KEPT; the broader
+idx_scan=0 sweep is DEFERRED to a post-launch representative-traffic review.
+
+NO `bun run db:types` — DROP INDEX + cron reschedule do not change generated TS types;
+no `supabase.ts` change is expected.
+</facts>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Author the cron-stagger + index-cleanup migration SQL</name>
+  <files>supabase/migrations/YYYYMMDDHHmmss_cron_stagger_index_cleanup.sql</files>
+  <read_first>
+    - .planning/phases/04-cron-stagger-index-cleanup/04-CONTEXT.md (the LOCKED determination — exact jobnames, exact new schedules, the single index, the kept/deferral rationale)
+    - CLAUDE.md "Cron Jobs (pg_cron)" + "Database" sections (named SECURITY DEFINER functions; reschedule must change ONLY the schedule, never the command; migration naming `YYYYMMDDHHmmss_description.sql`)
+    - supabase/migrations/20260606041458_stats_consolidation_rpcs.sql (recent migration-style precedent — leading comment block documenting intent)
+  </read_first>
+  <action>
+    Create the migration file. Use a real UTC timestamp for `YYYYMMDDHHmmss` (the prod
+    apply in Task 2 may reassign it — reconcile then).
+
+    The migration body, in order:
+
+    1. Leading comment block (precedent: the Phase-3 migration's header) documenting:
+       - PERF-01: the 4 jobs colliding at `0 3 * * *` and the 3 reschedule targets, noting
+         cleanup-cron-history stays at :00 and the :15/:30/:45 slots are already taken.
+       - PERF-04: the projection-only evidence for the ONE dropped index
+         (`idx_properties_property_owner_id` is a btree on the vestigial
+         `properties.stripe_connected_account_id`, which appears only in a SELECT
+         projection — never WHERE/JOIN/ORDER BY — so the index is unusable at any traffic
+         level; the column itself stays).
+       - The deferral rationale: all FK/PK/unique indexes and all structurally-valid
+         idx_scan=0 indexes (incl. idx_documents_search_vector) are deliberately KEPT;
+         idx_scan=0 is meaningless pre-launch (stats span DB lifetime, no representative
+         window), so the broader sweep is deferred to a post-launch traffic review
+         (criterion #3 — keep every FK/valid index).
+
+    2. PERF-01 — exactly 3 `cron.alter_job` reschedule statements (schedule-only, command
+       preserved), one per job:
+         select cron.alter_job(job_id := (select jobid from cron.job where jobname = 'cleanup-pg-net-responses'), schedule := '5 3 * * *');
+         select cron.alter_job(job_id := (select jobid from cron.job where jobname = 'cleanup-security-events'),  schedule := '10 3 * * *');
+         select cron.alter_job(job_id := (select jobid from cron.job where jobname = 'expire-trials'),            schedule := '20 3 * * *');
+       Do NOT emit an alter_job for cleanup-cron-history (it stays at `0 3 * * *`).
+       Do NOT use `UPDATE cron.job` or `cron.schedule(`.
+
+    3. PERF-04 — exactly one drop:
+         drop index if exists public.idx_properties_property_owner_id;
+       Do NOT emit any other `drop index`.
+
+    Do NOT add a `bun run db:types` step or touch `src/types/supabase.ts` — neither a
+    DROP INDEX nor a cron reschedule changes generated TS types.
+  </action>
+  <verify>
+    Greps against the authored migration file:
+    - contains `cron.alter_job` (3 occurrences)
+    - contains `5 3 * * *`, `10 3 * * *`, `20 3 * * *`
+    - contains `drop index if exists public.idx_properties_property_owner_id`
+    - does NOT contain `cron.schedule(`
+    - does NOT contain `UPDATE cron.job` (any case)
+    - `drop index` appears EXACTLY once (the named index only)
+    - does NOT contain `db:types` and the migration is the only file changed (no supabase.ts diff)
+  </verify>
+  <acceptance_criteria>
+    - File exists at supabase/migrations/<ts>_cron_stagger_index_cleanup.sql with a `_description` matching `cron_stagger_index_cleanup`.
+    - Exactly 3 `cron.alter_job(...)` reschedules: cleanup-pg-net-responses→`5 3 * * *`, cleanup-security-events→`10 3 * * *`, expire-trials→`20 3 * * *`. No alter_job for cleanup-cron-history.
+    - Each alter_job uses the `job_id := (select jobid from cron.job where jobname = '<name>'), schedule := '<new>'` form — schedule-only, command untouched.
+    - Exactly 1 `drop index if exists public.idx_properties_property_owner_id;` — no other index dropped.
+    - No `cron.schedule(`, no `UPDATE cron.job`, no `db:types`/`supabase.ts` change.
+    - Leading comment block documents: the 3 reschedule targets, the projection-only evidence for the dropped index, and the kept-FK/valid-index + deferred-sweep rationale.
+  </acceptance_criteria>
+  <done>
+    The migration SQL is fully authored and passes every grep in <verify>: 3 schedule-only
+    alter_job reschedules, exactly 1 named DROP INDEX, documented rationale, and zero
+    forbidden tokens (`cron.schedule(`, `UPDATE cron.job`, `db:types`).
+  </done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: [BLOCKING] Apply migration to prod via Supabase MCP + reconcile filename + introspect</name>
+  <read_first>
+    - .planning/phases/04-cron-stagger-index-cleanup/04-CONTEXT.md ("Migration" + "Verification" notes)
+    - CLAUDE.md "Database" rules + the migration-mcp-prod-drift memory (reconcile repo filename ↔ prod-assigned timestamp via list_migrations after every MCP apply)
+  </read_first>
+  <what-built>
+    Task 1 authored `supabase/migrations/<ts>_cron_stagger_index_cleanup.sql` (3 schedule-only
+    cron.alter_job reschedules + 1 DROP INDEX). Executor subagents have no Supabase MCP, so the
+    orchestrator applies and verifies this migration against prod here.
+  </what-built>
+  <how-to-verify>
+    Run as the orchestrator (you have Supabase MCP):
+
+    1. Apply the migration body via MCP `apply_migration` (name: `cron_stagger_index_cleanup`).
+    2. Reconcile drift: MCP `list_migrations` to read the prod-assigned timestamp, then rename
+       the repo file `supabase/migrations/<repo-ts>_cron_stagger_index_cleanup.sql` →
+       `<prod-ts>_cron_stagger_index_cleanup.sql` so repo ↔ prod match (migration-mcp-prod-drift).
+    3. Post-apply introspection via MCP `execute_sql`:
+       a. CRON — confirm 4 distinct schedules:
+          select jobname, schedule from cron.job
+          where jobname in ('cleanup-cron-history','cleanup-pg-net-responses','cleanup-security-events','expire-trials')
+          order by jobname;
+          EXPECT: cleanup-cron-history=`0 3 * * *`, cleanup-pg-net-responses=`5 3 * * *`,
+                  cleanup-security-events=`10 3 * * *`, expire-trials=`20 3 * * *` (4 distinct minutes).
+       b. CRON command unchanged — confirm none of the 3 rescheduled jobs had its `command`
+          altered (each still calls its named SECURITY DEFINER function; spot-check the `command`
+          column is non-empty and still references the same function name as before).
+       c. DEAD INDEX gone:
+          select 1 from pg_indexes where schemaname='public' and indexname='idx_properties_property_owner_id';
+          EXPECT: 0 rows.
+       d. SURGICAL — FK indexes still present (proves the drop didn't over-reach):
+          select indexname from pg_indexes
+          where schemaname='public' and indexname in ('idx_units_owner_user_id','idx_leases_owner_user_id');
+          EXPECT: both rows present.
+    4. Confirm no `src/types/supabase.ts` change resulted (DROP INDEX + cron reschedule don't
+       alter generated types).
+  </how-to-verify>
+  <acceptance_criteria>
+    - MCP apply succeeded; repo filename reconciled to the prod-assigned timestamp via list_migrations.
+    - `cron.job` shows the 4 jobs at `0/5/10/20 3 * * *` (4 distinct minutes).
+    - None of the 3 rescheduled jobs' `command` changed (still invokes its named SECURITY DEFINER function).
+    - `idx_properties_property_owner_id` returns 0 rows from `pg_indexes`.
+    - `idx_units_owner_user_id` and `idx_leases_owner_user_id` both still exist.
+    - No `supabase.ts` diff.
+  </acceptance_criteria>
+  <resume-signal>Type "approved" once prod introspection confirms 4 distinct cron schedules, the dead index gone, FK indexes intact, commands unchanged, and the filename reconciled — or describe what differs.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| migration SQL → cron.job command column | A cron job's `command` runs as a named SECURITY DEFINER function; altering the command would change what executes with elevated privilege. |
+| migration SQL → prod index set | Dropping the wrong index could remove an FK/PK/unique or feature index and degrade or break queries. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-01 | Elevation of Privilege | cron job `command` (SECURITY DEFINER fn) | mitigate | Reschedule via `cron.alter_job(job_id, schedule := ...)` — schedule-only API that preserves the existing command verbatim. Forbid `cron.schedule(` (would require re-specifying the command) and `UPDATE cron.job`. Task-2 introspection asserts each rescheduled job's `command` is unchanged. |
+| T-04-02 | Denial of Service | prod index set (over-broad DROP) | mitigate | Drop EXACTLY ONE named index (`idx_properties_property_owner_id`) that is provably unusable (projection-only column). Acceptance grep pins `drop index` to a single occurrence; Task-2 spot-checks FK indexes (`idx_units_owner_user_id`, `idx_leases_owner_user_id`) still exist. |
+| T-04-03 | Tampering | migration apply to prod | accept | Single-statement-class DB-ops migration applied via Supabase MCP at a [BLOCKING] human checkpoint with full post-apply introspection; no untrusted input crosses the boundary. No npm/pip/cargo install in this phase. |
+</threat_model>
+
+<verification>
+Phase-level checks (run at the Task-2 blocking checkpoint via Supabase MCP `execute_sql`):
+- `cron.job`: the 4 jobs read `0 3 * * *`, `5 3 * * *`, `10 3 * * *`, `20 3 * * *` — 4 distinct minutes, none colliding with the taken :15/:30/:45 slots.
+- The 3 rescheduled jobs' `command` columns are byte-for-byte unchanged (still invoke their named SECURITY DEFINER functions).
+- `pg_indexes`: `idx_properties_property_owner_id` is absent.
+- `pg_indexes`: `idx_units_owner_user_id` and `idx_leases_owner_user_id` are present (surgical-drop proof).
+- Repo migration filename matches the prod-assigned timestamp (`list_migrations`).
+- No `src/types/supabase.ts` change.
+</verification>
+
+<success_criteria>
+1. The 4 cleanup jobs fire at distinct minutes across the 3 AM UTC window (`0/5/10/20 3 * * *`), verified via `cron.job` schedule rows.
+2. The single provably-dead index `idx_properties_property_owner_id` is dropped in one migration whose body documents the projection-only idx evidence; no other index is dropped.
+3. Every FK-supporting index is explicitly kept (documented in the migration; spot-checked present in prod), and the repo migration is reconciled against the prod-assigned timestamp via `list_migrations`.
+</success_criteria>
+
+<output>
+Create `.planning/phases/04-cron-stagger-index-cleanup/04-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/04-cron-stagger-index-cleanup/04-01-SUMMARY.md
+++ b/.planning/phases/04-cron-stagger-index-cleanup/04-01-SUMMARY.md
@@ -1,0 +1,29 @@
+# Plan 04-01 Summary — Cron Stagger & Index Cleanup (PERF-01, PERF-04)
+
+**Status:** Complete
+**Branch:** gsd/phase-4-cron-stagger-index-cleanup
+**Commit:** `f95424c19`
+
+## What shipped
+`supabase/migrations/20260606205922_cron_stagger_index_cleanup.sql` — applied to prod via Supabase MCP `apply_migration` (prod version `20260606205922`; repo filename reconciled, was authored `...205858`, 24s drift).
+
+- **PERF-01 (cron stagger):** the 4 jobs that all fired at `0 3 * * *` are now at 4 distinct minutes via schedule-only `cron.alter_job` (each job's command preserved — never re-specified/inlined):
+  - `cleanup-cron-history` → `0 3 * * *` (unchanged)
+  - `cleanup-pg-net-responses` → `5 3 * * *`
+  - `cleanup-security-events` → `10 3 * * *`
+  - `expire-trials` → `20 3 * * *`
+  (:15/:30/:45 remain held by cleanup-errors / cleanup-webhook-events / process-account-deletions — no collision.)
+- **PERF-04 (index cleanup):** dropped EXACTLY ONE index — `idx_properties_property_owner_id` (btree on `properties.stripe_connected_account_id`, Stripe-Connect residue from demolished rent-facilitation). Verified dead: that column appears in code only as a SELECT projection (`property-keys.ts:28`), never in WHERE/JOIN/ORDER BY — a btree index is unusable by a projection-only column at any traffic level.
+
+## Verification (prod introspection — this is a DB-ops phase; the proof is prod state, not a unit test)
+MCP `execute_sql` post-apply confirmed:
+- The 4 jobs at `0/5/10/20 3 * * *` (distinct). ✓
+- `to_regclass('public.idx_properties_property_owner_id')` IS NULL (gone). ✓
+- Surgical-drop proof — `idx_units_owner_user_id`, `idx_leases_owner_user_id`, `tenants_owner_user_id_idx`, AND `idx_documents_search_vector` (the vault GIN full-text index) all still present. ✓
+
+## Canonical determination (why the broader index sweep was DEFERRED, not executed)
+The roadmap's PERF-04 success criterion #2 says "idx_scan=0 over a REPRESENTATIVE window." There is none: the DB is pre-launch low-traffic (8 users, ~1 property, near-empty business tables, ~42 req/hr). On small/low-row tables Postgres prefers seq scans, so `idx_scan=0` is GUARANTEED for essential indexes until tables grow — canonically meaningless here despite `stats_reset=never`. Of ~73 idx_scan=0 indexes, ~36 back FK columns (keep permanently) and ~37 are valid feature indexes (incl. the documents GIN search index) unused only for lack of volume. Zero exact-duplicate indexes exist. So the only unconditionally-safe drop was the one projection-only dead index. The broader sweep is deferred to a post-launch `pg_stat_user_indexes` review against representative traffic — the audit's own "re-check after a representative window first" caveat. This was the user's explicit ask ("research canonically and comprehensively then you make the determination").
+
+## Notes
+- No `supabase.ts` change (DROP INDEX + cron reschedule don't alter generated TS types) — no `db:types` run needed.
+- Applied via MCP because the env `SUPABASE_ACCESS_TOKEN` (CLI path) is expired.

--- a/.planning/phases/04-cron-stagger-index-cleanup/04-CONTEXT.md
+++ b/.planning/phases/04-cron-stagger-index-cleanup/04-CONTEXT.md
@@ -1,0 +1,64 @@
+# Phase 4: Cron Stagger & Index Cleanup - Context
+
+**Gathered:** 2026-06-06
+**Status:** Ready for planning
+**Source:** Live-DB-grounded (Supabase MCP) + canonical Postgres index-drop analysis. User directive: "research canonically and comprehensively then you make the determination." This CONTEXT IS that determination.
+
+<domain>
+## Phase Boundary
+Pure DB-ops migration: (PERF-01) stagger the 4 pg_cron jobs colliding at `0 3 * * *`; (PERF-04) drop ONLY provably-dead indexes, keeping every FK/PK/unique index and every structurally-valid index.
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED — canonical determination)
+
+### PERF-01 — Cron stagger (verified live)
+Exactly 4 jobs fire at `0 3 * * *`: `cleanup-cron-history`, `cleanup-pg-net-responses`, `cleanup-security-events`, `expire-trials`. The 3 AM window already has `:15` (cleanup-errors), `:30` (cleanup-webhook-events), `:45` (process-account-deletions) taken. Reschedule the 4 to distinct FREE minutes:
+- `cleanup-cron-history` → `0 3 * * *` (unchanged, :00)
+- `cleanup-pg-net-responses` → `5 3 * * *` (:05)
+- `cleanup-security-events` → `10 3 * * *` (:10)
+- `expire-trials` → `20 3 * * *` (:20)
+
+Reschedule via the canonical pg_cron API, NOT a direct `UPDATE cron.job`: for each, `select cron.alter_job(job_id := (select jobid from cron.job where jobname = '<name>'), schedule := '<new>');`. This changes only the schedule, preserving each job's existing command (which calls a named SECURITY DEFINER function per the project's cron convention — do NOT inline SQL). Verify post-migration via `cron.job` schedule rows.
+
+### PERF-04 — Index cleanup (canonical determination: drop ONE provably-dead index; DEFER the rest)
+**Canonical analysis (why idx_scan=0 is NOT trustworthy here):**
+- `pg_stat_database.stats_reset = never` (stats span the whole DB lifetime) — but the DB is pre-launch low-traffic (8 users, ~1 property, near-empty business tables; ~42 req/hr). On small/low-row tables Postgres prefers seq scans, so `idx_scan=0` is GUARANTEED for essential indexes until tables grow — the textbook "idx_scan=0 is meaningless on small tables / without a representative workload window" case. The phase's own criterion #2 says "idx_scan=0 over a REPRESENTATIVE window"; no representative window exists.
+- Of ~73 idx_scan=0 indexes: ~36 back FK columns (KEEP — FK-check/locking, criterion #3), and ~37 are non-FK but are valid feature indexes unused only for lack of volume — including `idx_documents_search_vector` (the document-vault GIN full-text-search index). Dropping these would be actively harmful (recreated-later + seq scans at scale).
+- Exact-duplicate indexes: NONE (verified — no redundant-index category to drop).
+
+**The ONLY unconditionally-safe drop (dead regardless of traffic):**
+- **`idx_properties_property_owner_id`** — a btree on `properties.stripe_connected_account_id` (misnamed; Stripe-Connect residue from demolished rent-facilitation). Verified: `stripe_connected_account_id` appears in code ONLY as a SELECT projection column (`property-keys.ts:28`) + a test fixture — NEVER in any WHERE/JOIN/ORDER BY. A btree index is never used by a column that only appears in a projection, so this index can NEVER be used by any query at any traffic level. Drop it. (The COLUMN stays — it's still selected; only the dead index goes.)
+
+**DEFER (do NOT drop this phase):** all other idx_scan=0 indexes. They're either FK-backing (keep permanently) or structurally-valid feature indexes whose idx_scan=0 reflects pre-launch traffic, not uselessness. Re-evaluate PERF-04's broader sweep AFTER representative production traffic accumulates (a post-launch `pg_stat_user_indexes` review) — the audit's own "re-check after a representative window first" caveat.
+
+### Migration
+One migration `supabase/migrations/YYYYMMDDHHmmss_cron_stagger_index_cleanup.sql`: the 3 `cron.alter_job` reschedules + `DROP INDEX IF EXISTS public.idx_properties_property_owner_id;`. Apply via Supabase MCP `apply_migration`; reconcile the repo filename vs the prod-assigned timestamp via `list_migrations` (migration-mcp-prod-drift). The migration body must document the idx_scan + projection-only evidence for the one dropped index, and a comment enumerating that all FK/valid indexes are deliberately KEPT (criterion #3) with the deferral rationale.
+
+### Claude's Discretion
+- Exact comment wording. Whether to also `comment on` the kept-index rationale inline vs a leading block (leading block is fine).
+</decisions>
+
+<canonical_refs>
+## Canonical References
+- The project's pg_cron convention (CLAUDE.md "Cron Jobs"): named SECURITY DEFINER functions, `SET search_path=public`, never inline SQL in `cron.schedule()`. The reschedule must NOT change the command, only the schedule → `cron.alter_job(jobid, schedule)`.
+- migration-mcp-prod-drift memory: reconcile repo filename ↔ prod-assigned timestamp after MCP apply.
+- Phase-3 migration (`20260606041458_stats_consolidation_rpcs.sql`) as the recent migration-style precedent.
+- Verified live facts (this CONTEXT): the 4 colliding jobs + free slots; idx def of `idx_properties_property_owner_id`; zero duplicate indexes; `stats_reset=never`; `stripe_connected_account_id` projection-only usage.
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+- This is a no-frontend, no-type-regen phase (no RPC signatures change, so `bun run db:types` is NOT needed — `DROP INDEX` + cron reschedule don't alter the generated TS types). Confirm: no `supabase.ts` change expected.
+- Verification: post-apply, query `cron.job` (4 distinct schedules) + `pg_class`/`pg_stat_user_indexes` (the dead index is gone; spot-check a few FK indexes still exist).
+</specifics>
+
+<deferred>
+## Deferred Ideas
+- The broader idx_scan=0 index sweep (~37 non-FK valid indexes) — defer to a post-launch representative-traffic review. NOT a regression or gap; a canonical-correctness deferral.
+- `cron.job_run_details` 34MB bloat VACUUM (flagged during the billing-banner diagnosis) — could fold here as a one-time maintenance, but VACUUM FULL takes a lock and isn't a migration concern; leave out of this phase unless trivially safe.
+</deferred>
+
+---
+*Phase: 04-cron-stagger-index-cleanup*
+*Context gathered: 2026-06-06 — canonical determination: cron stagger (4 jobs) + drop 1 provably-dead index; defer the idx_scan=0-but-valid sweep to a representative-traffic window.*

--- a/supabase/migrations/20260606205922_cron_stagger_index_cleanup.sql
+++ b/supabase/migrations/20260606205922_cron_stagger_index_cleanup.sql
@@ -1,0 +1,42 @@
+-- Phase 4 (v4.0): Cron stagger + surgical index cleanup (PERF-01, PERF-04).
+--
+-- PERF-01 — Stagger the 4 pg_cron cleanup jobs that all fired at `0 3 * * *`
+-- (cleanup-cron-history, cleanup-pg-net-responses, cleanup-security-events,
+-- expire-trials). The 3 AM window already has :15 (cleanup-errors), :30
+-- (cleanup-webhook-events), :45 (process-account-deletions) taken, so the
+-- three movers go to the free :05/:10/:20 slots; cleanup-cron-history stays
+-- at :00. Rescheduled via cron.alter_job (SCHEDULE-ONLY) so each job's
+-- existing command (a named SECURITY DEFINER function) is preserved exactly
+-- — never re-specified, never inlined.
+--
+-- PERF-04 — Drop ONE provably-dead index: idx_properties_property_owner_id
+-- is a btree on properties.stripe_connected_account_id (a misnamed index;
+-- Stripe-Connect residue from the demolished rent-facilitation feature).
+-- That column appears in code only as a SELECT projection (property-keys.ts),
+-- never in a WHERE/JOIN/ORDER BY, so the index can never be used by any query
+-- at any traffic level — safe to drop regardless of workload.
+--
+-- DELIBERATELY KEPT (NOT dropped): every FK-backing, PK, and unique index,
+-- and every other idx_scan=0 index. On this pre-launch low-traffic DB
+-- (near-empty business tables) idx_scan=0 is canonically meaningless —
+-- Postgres prefers seq scans on tiny tables, so essential indexes (incl. the
+-- documents GIN full-text-search index) read as "unused" until tables grow.
+-- The broader idx_scan=0 sweep is DEFERRED to a post-launch review against a
+-- representative-traffic pg_stat_user_indexes window.
+
+-- PERF-01: schedule-only reschedules (command preserved).
+select cron.alter_job(
+  job_id := (select jobid from cron.job where jobname = 'cleanup-pg-net-responses'),
+  schedule := '5 3 * * *'
+);
+select cron.alter_job(
+  job_id := (select jobid from cron.job where jobname = 'cleanup-security-events'),
+  schedule := '10 3 * * *'
+);
+select cron.alter_job(
+  job_id := (select jobid from cron.job where jobname = 'expire-trials'),
+  schedule := '20 3 * * *'
+);
+
+-- PERF-04: drop the single provably-dead index (projection-only column).
+drop index if exists public.idx_properties_property_owner_id;

--- a/supabase/migrations/20260606205922_cron_stagger_index_cleanup.sql
+++ b/supabase/migrations/20260606205922_cron_stagger_index_cleanup.sql
@@ -9,12 +9,18 @@
 -- existing command (a named SECURITY DEFINER function) is preserved exactly
 -- — never re-specified, never inlined.
 --
--- PERF-04 — Drop ONE provably-dead index: idx_properties_property_owner_id
--- is a btree on properties.stripe_connected_account_id (a misnamed index;
--- Stripe-Connect residue from the demolished rent-facilitation feature).
--- That column appears in code only as a SELECT projection (property-keys.ts),
--- never in a WHERE/JOIN/ORDER BY, so the index can never be used by any query
--- at any traffic level — safe to drop regardless of workload.
+-- PERF-04 — Drop ONE provably-dead index: idx_properties_property_owner_id.
+-- Residue of the demolished ownership model: it was created in base_schema on
+-- the old properties.property_owner_id column (since migrated out in favour of
+-- owner_user_id), and a later column rename carried it onto
+-- properties.stripe_connected_account_id — which is what live pg_get_indexdef
+-- reported for it pre-drop. Either way it backs no live query: the only
+-- column it could cover (stripe_connected_account_id) appears in code solely
+-- as a SELECT projection (property-keys.ts), never in a WHERE/JOIN/ORDER BY,
+-- and owner_user_id has its own dedicated index. So this index can never be
+-- used by any query at any traffic level — safe to drop regardless of
+-- workload. (The stripe_connected_account_id COLUMN stays; only the dead
+-- index goes.)
 --
 -- DELIBERATELY KEPT (NOT dropped): every FK-backing, PK, and unique index,
 -- and every other idx_scan=0 index. On this pre-launch low-traffic DB


### PR DESCRIPTION
## Summary

**v4.0 Phase 4 — Cron Stagger & Index Cleanup (PERF-01, PERF-04).** A single DB-ops migration (`20260606205922_cron_stagger_index_cleanup.sql`), applied to prod via Supabase MCP and verified by introspection.

- **PERF-01 — cron stagger:** the 4 pg_cron jobs that all fired at `0 3 * * *` now run at 4 distinct minutes (`0 / 5 / 10 / 20 3 * * *`), rescheduled via **schedule-only `cron.alter_job`** so each job's existing command (a named SECURITY DEFINER function) is preserved untouched.
- **PERF-04 — index cleanup:** dropped **exactly one** provably-dead index, `idx_properties_property_owner_id` (a btree on `properties.stripe_connected_account_id` — Stripe-Connect residue from demolished rent-facilitation; that column is only ever a SELECT projection, never a WHERE/JOIN/ORDER BY, so the index is unusable at any traffic level).

## The canonical determination (you asked me to make the call)

The roadmap's PERF-04 said "drop idx_scan=0 non-FK indexes over a **representative window**." There is no representative window — this is a pre-launch low-traffic DB (8 users, ~1 property, near-empty business tables). On small tables Postgres prefers seq scans, so `idx_scan=0` is **canonically meaningless** here (it flags essential indexes — including the document-vault GIN full-text-search index — as "unused"). Of ~73 idx_scan=0 indexes: ~36 back FK columns (keep permanently), ~37 are valid feature indexes unused only for lack of volume, and **0 are exact duplicates**. So the only unconditionally-safe drop was the one projection-only dead index. **The broader sweep is deferred** to a post-launch `pg_stat_user_indexes` review against representative traffic (the audit's own "re-check after a representative window first" caveat).

## Verification (prod introspection — DB-ops phase, proof is prod state)
MCP `execute_sql` post-apply confirmed: the 4 jobs at `0/5/10/20 3 * * *`; `idx_properties_property_owner_id` gone; `idx_units_owner_user_id` / `idx_leases_owner_user_id` / `tenants_owner_user_id_idx` / **`idx_documents_search_vector`** all still present (surgical drop). No `supabase.ts`/type change (DROP INDEX + cron reschedule don't alter generated types).

## Notes
Applied via Supabase MCP (the env `SUPABASE_ACCESS_TOKEN` CLI path is expired). The Free-tier quota banner does not affect DDL — the project is healthy/serving.

[hudsor01]
