### PR TITLE
v4.0 Phase 5: Cross-Owner RLS Coverage (TEST-01/02/04)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -32,7 +32,7 @@
 - [x] **TEST-01**: Cross-owner RLS integration tests (dual-client ownerA/ownerB) cover `reports`, `expenses`, and `document_template_definitions`.
 - [ ] **TEST-02**: Cross-owner RLS tests cover the join-policy child tables `inspection_photos`, `inspection_rooms`, `maintenance_request_photos`, `property_images`.
 - [ ] **TEST-03**: Unit tests cover the auth-critical hooks `use-auth-mutations`, `use-mfa`, `use-sessions`, and the dollar-amount hooks `use-expense-mutations` / `use-report-mutations` / `use-reports`.
-- [ ] **TEST-04**: RLS-rejection tests assert SQLSTATE / `error.code` (not message strings), and the `REVOKED_CODES` literal is extracted to one shared test helper consumed by all 4 call sites.
+- [x] **TEST-04**: RLS-rejection tests assert SQLSTATE / `error.code` (not message strings), and the `REVOKED_CODES` literal is extracted to one shared test helper consumed by all 4 call sites.
 
 ### A11Y — programmatic labels
 
@@ -84,7 +84,7 @@ Deferred follow-ups (small, optional, non-blocking — fold into a later milesto
 | PERF-04 | Phase 4 — Cron Stagger & Index Cleanup | Pending |
 | TEST-01 | Phase 5 — Cross-Owner RLS Coverage | Complete |
 | TEST-02 | Phase 5 — Cross-Owner RLS Coverage | Pending |
-| TEST-04 | Phase 5 — Cross-Owner RLS Coverage | Pending |
+| TEST-04 | Phase 5 — Cross-Owner RLS Coverage | Complete |
 | TEST-03 | Phase 6 — Auth & Dollar-Hook Unit Tests | Pending |
 | A11Y-01 | Phase 7 — Accessibility Labels | Pending |
 | A11Y-02 | Phase 7 — Accessibility Labels | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -29,7 +29,7 @@
 
 ### TEST — owner-isolation + auth coverage
 
-- [ ] **TEST-01**: Cross-owner RLS integration tests (dual-client ownerA/ownerB) cover `reports`, `expenses`, and `document_template_definitions`.
+- [x] **TEST-01**: Cross-owner RLS integration tests (dual-client ownerA/ownerB) cover `reports`, `expenses`, and `document_template_definitions`.
 - [ ] **TEST-02**: Cross-owner RLS tests cover the join-policy child tables `inspection_photos`, `inspection_rooms`, `maintenance_request_photos`, `property_images`.
 - [ ] **TEST-03**: Unit tests cover the auth-critical hooks `use-auth-mutations`, `use-mfa`, `use-sessions`, and the dollar-amount hooks `use-expense-mutations` / `use-report-mutations` / `use-reports`.
 - [ ] **TEST-04**: RLS-rejection tests assert SQLSTATE / `error.code` (not message strings), and the `REVOKED_CODES` literal is extracted to one shared test helper consumed by all 4 call sites.
@@ -82,7 +82,7 @@ Deferred follow-ups (small, optional, non-blocking — fold into a later milesto
 | PERF-03 | Phase 3 — Stats RPC Consolidation | Pending |
 | PERF-01 | Phase 4 — Cron Stagger & Index Cleanup | Pending |
 | PERF-04 | Phase 4 — Cron Stagger & Index Cleanup | Pending |
-| TEST-01 | Phase 5 — Cross-Owner RLS Coverage | Pending |
+| TEST-01 | Phase 5 — Cross-Owner RLS Coverage | Complete |
 | TEST-02 | Phase 5 — Cross-Owner RLS Coverage | Pending |
 | TEST-04 | Phase 5 — Cross-Owner RLS Coverage | Pending |
 | TEST-03 | Phase 6 — Auth & Dollar-Hook Unit Tests | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -119,7 +119,10 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   2. Dual-client tests cover the join-policy child tables `inspection_photos`, `inspection_rooms`, `maintenance_request_photos`, and `property_images`, failing on any cross-owner read/write.
   3. RLS-rejection tests assert `error.code` / SQLSTATE (not message strings), insulating them from the chai-6 / message-drift fragility.
   4. The `REVOKED_CODES` literal is extracted to one shared test helper consumed by all 4 call sites (no duplicated code-list literals remain).
-**Plans**: TBD
+**Plans**: 3 plans (all Wave 1 — parallel, zero files_modified overlap)
+- [ ] 05-01-PLAN.md — TEST-01: dual-client RLS for reports + document_template_definitions (direct owner_user_id) + expenses (indirect via maintenance_request chain)
+- [ ] 05-02-PLAN.md — TEST-02: dual-client RLS for the 4 join-policy child tables (property_images, inspection_rooms S/I/U/D; inspection_photos, maintenance_request_photos S/I/D only)
+- [ ] 05-03-PLAN.md — TEST-04: shared REVOKED_CODES/DENIED_CODES helper consumed by all 5 dup sites + SQLSTATE (P0001) migration of the dashboard/bulk-import ownership-guard assertions
 
 ### Phase 6: Auth & Dollar-Hook Unit Tests
 **Goal**: The auth-critical hooks and the dollar-amount mutation/read hooks have vitest unit coverage, raising confidence on the highest-risk untested surfaces without touching their behavior.
@@ -161,7 +164,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 | 2. Typed RPC Boundaries | v4.0 | 4/4 | Shipped (PR #785) | 2026-06-05 |
 | 3. Stats RPC Consolidation | v4.0 | 3/3 | Executed (awaiting PR) | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 1/1 | Planned | - |
-| 5. Cross-Owner RLS Coverage | v4.0 | 0/? | Not started | - |
+| 5. Cross-Owner RLS Coverage | v4.0 | 0/3 | Planned | - |
 | 6. Auth & Dollar-Hook Unit Tests | v4.0 | 0/? | Not started | - |
 | 7. Accessibility Labels | v4.0 | 0/? | Not started | - |
 | 8. SEO Recovery | v4.0 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -120,7 +120,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   3. RLS-rejection tests assert `error.code` / SQLSTATE (not message strings), insulating them from the chai-6 / message-drift fragility.
   4. The `REVOKED_CODES` literal is extracted to one shared test helper consumed by all 4 call sites (no duplicated code-list literals remain).
 **Plans**: 3 plans (all Wave 1 — parallel, zero files_modified overlap)
-- [ ] 05-01-PLAN.md — TEST-01: dual-client RLS for reports + document_template_definitions (direct owner_user_id) + expenses (indirect via maintenance_request chain)
+- [x] 05-01-PLAN.md — TEST-01: dual-client RLS for reports + document_template_definitions (direct owner_user_id) + expenses (indirect via maintenance_request chain)
 - [ ] 05-02-PLAN.md — TEST-02: dual-client RLS for the 4 join-policy child tables (property_images, inspection_rooms S/I/U/D; inspection_photos, maintenance_request_photos S/I/D only)
 - [ ] 05-03-PLAN.md — TEST-04: shared REVOKED_CODES/DENIED_CODES helper consumed by all 5 dup sites + SQLSTATE (P0001) migration of the dashboard/bulk-import ownership-guard assertions
 
@@ -164,7 +164,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 | 2. Typed RPC Boundaries | v4.0 | 4/4 | Shipped (PR #785) | 2026-06-05 |
 | 3. Stats RPC Consolidation | v4.0 | 3/3 | Executed (awaiting PR) | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 1/1 | Planned | - |
-| 5. Cross-Owner RLS Coverage | v4.0 | 0/3 | Planned | - |
+| 5. Cross-Owner RLS Coverage | v4.0 | 1/3 | In Progress|  |
 | 6. Auth & Dollar-Hook Unit Tests | v4.0 | 0/? | Not started | - |
 | 7. Accessibility Labels | v4.0 | 0/? | Not started | - |
 | 8. SEO Recovery | v4.0 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -121,8 +121,8 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
   4. The `REVOKED_CODES` literal is extracted to one shared test helper consumed by all 4 call sites (no duplicated code-list literals remain).
 **Plans**: 3 plans (all Wave 1 — parallel, zero files_modified overlap)
 - [x] 05-01-PLAN.md — TEST-01: dual-client RLS for reports + document_template_definitions (direct owner_user_id) + expenses (indirect via maintenance_request chain)
-- [ ] 05-02-PLAN.md — TEST-02: dual-client RLS for the 4 join-policy child tables (property_images, inspection_rooms S/I/U/D; inspection_photos, maintenance_request_photos S/I/D only)
-- [ ] 05-03-PLAN.md — TEST-04: shared REVOKED_CODES/DENIED_CODES helper consumed by all 5 dup sites + SQLSTATE (P0001) migration of the dashboard/bulk-import ownership-guard assertions
+- [x] 05-02-PLAN.md — TEST-02: dual-client RLS for the 4 join-policy child tables (property_images, inspection_rooms S/I/U/D; inspection_photos, maintenance_request_photos S/I/D only)
+- [x] 05-03-PLAN.md — TEST-04: shared REVOKED_CODES/DENIED_CODES helper consumed by all 5 dup sites + SQLSTATE (P0001) migration of the dashboard/bulk-import ownership-guard assertions
 
 ### Phase 6: Auth & Dollar-Hook Unit Tests
 **Goal**: The auth-critical hooks and the dollar-amount mutation/read hooks have vitest unit coverage, raising confidence on the highest-risk untested surfaces without touching their behavior.
@@ -164,7 +164,7 @@ Closed at 34/34 requirements. Full detail in [milestones/v2.0-ROADMAP.md](milest
 | 2. Typed RPC Boundaries | v4.0 | 4/4 | Shipped (PR #785) | 2026-06-05 |
 | 3. Stats RPC Consolidation | v4.0 | 3/3 | Executed (awaiting PR) | - |
 | 4. Cron Stagger & Index Cleanup | v4.0 | 1/1 | Planned | - |
-| 5. Cross-Owner RLS Coverage | v4.0 | 1/3 | In Progress|  |
+| 5. Cross-Owner RLS Coverage | v4.0 | 3/3 | Complete   | 2026-06-06 |
 | 6. Auth & Dollar-Hook Unit Tests | v4.0 | 0/? | Not started | - |
 | 7. Accessibility Labels | v4.0 | 0/? | Not started | - |
 | 8. SEO Recovery | v4.0 | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v4.0
 milestone_name: Hardening & Hygiene
 status: executing
-last_updated: "2026-06-06T22:10:49.355Z"
+last_updated: "2026-06-06T22:27:38.715Z"
 last_activity: 2026-06-06
 progress:
   total_phases: 8
-  completed_phases: 4
+  completed_phases: 5
   total_plans: 15
-  completed_plans: 13
-  percent: 50
+  completed_plans: 15
+  percent: 63
 ---
 
 # Project State
@@ -25,9 +25,9 @@ See: .planning/PROJECT.md (updated 2026-06-04 — v4.0 Hardening & Hygiene activ
 ## Current Position
 
 Phase: 5 of 8 (Cross-Owner RLS Coverage) — v4.0
-Plan: 1 of 03 complete (05-02, 05-03 pending)
-Status: Executing — 05-01 (TEST-01) complete
-Progress: [█████████░] 87%
+Plan: 2 of 03 complete (05-02, 05-03 pending)
+Status: Ready to execute
+Progress: [██████████] 100%
 Last activity: 2026-06-06
 
 ## Roadmap Summary (v4.0)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v4.0
 milestone_name: Hardening & Hygiene
-status: planning
-last_updated: "2026-06-05T21:43:54.948Z"
-last_activity: 2026-06-05 — executed Phase 2 plan 02-03 (TYPE-02 maintenance boundary → mapMaintenanceRow)
+status: executing
+last_updated: "2026-06-06T22:10:49.355Z"
+last_activity: 2026-06-06
 progress:
   total_phases: 8
-  completed_phases: 1
-  total_plans: 8
-  completed_plans: 7
-  percent: 88
+  completed_phases: 4
+  total_plans: 15
+  completed_plans: 13
+  percent: 50
 ---
 
 # Project State
@@ -24,11 +24,11 @@ See: .planning/PROJECT.md (updated 2026-06-04 — v4.0 Hardening & Hygiene activ
 
 ## Current Position
 
-Phase: 2 of 8 (Typed RPC Boundaries) — v4.0
-Plan: 03 of 04 complete (02-04 pending)
-Status: 02-03 executed — TYPE-02 maintenance boundary routed through validated mapMaintenanceRow
-Progress: [█████████░] 88%
-Last activity: 2026-06-05 — executed Phase 2 plan 02-03 (TYPE-02 maintenance boundary → mapMaintenanceRow)
+Phase: 5 of 8 (Cross-Owner RLS Coverage) — v4.0
+Plan: 1 of 03 complete (05-02, 05-03 pending)
+Status: Executing — 05-01 (TEST-01) complete
+Progress: [█████████░] 87%
+Last activity: 2026-06-06
 
 ## Roadmap Summary (v4.0)
 
@@ -56,13 +56,13 @@ None.
 
 ## Next Action
 
-**Roadmap created.** Plan the first phase:
+**Phase 5 plan 05-01 (TEST-01) complete.** Execute the remaining Phase 5 plans:
 
 ```
-/gsd-plan-phase 1
+/gsd-execute-phase 5
 ```
 
-Phase 1 (Security-CI Hardening) closes CISEC-01..04: edge-function/Stripe-webhook test gate in CI, CSP per-request nonce + `strict-dynamic` (drop `unsafe-inline`), constant-time secret compare in `auth-email-send`, and SHA-pinned GitHub Actions. (CodeQL + gitleaks gates already shipped via PR #781 — out of scope.)
+05-01 added three dual-client cross-owner RLS tests (`reports`, `document_template_definitions`, `expenses`) — commits `1ddb532ef`, `3a67ca52f`. Remaining: 05-02 (TEST-02, four join-policy child tables) and 05-03 (TEST-04, SQLSTATE assertions + shared `REVOKED_CODES` helper). 05-03 is independent of 05-01/02 and can parallelize.
 
 ## Overrides
 

--- a/.planning/phases/05-cross-owner-rls-coverage/05-01-PLAN.md
+++ b/.planning/phases/05-cross-owner-rls-coverage/05-01-PLAN.md
@@ -1,0 +1,166 @@
+---
+phase: 05-cross-owner-rls-coverage
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/integration/rls/reports.rls.test.ts
+  - tests/integration/rls/document-template-definitions.rls.test.ts
+  - tests/integration/rls/expenses.rls.test.ts
+autonomous: true
+requirements: [TEST-01]
+
+must_haves:
+  truths:
+    - "ownerB cannot SELECT ownerA's reports / document_template_definitions / expenses (0 rows)"
+    - "ownerB cannot INSERT a reports / document_template_definitions row carrying ownerA's owner_user_id (rejected)"
+    - "ownerB cannot UPDATE or DELETE ownerA's reports / document_template_definitions row (USING clause hides it: error null + data [])"
+    - "ownerB cannot SELECT/UPDATE/DELETE ownerA's expense (the expense is reached only via maintenance_request_id -> maintenance_requests.owner_user_id)"
+    - "ownerA sees only their own rows for all three tables"
+    - "the new tests fail (not error-skip) if isolation were broken — each cross-owner read asserts 0 rows AND each cross-owner write asserts rejection/no-op"
+  artifacts:
+    - path: "tests/integration/rls/reports.rls.test.ts"
+      provides: "dual-client S/I/U/D isolation for reports (direct owner_user_id)"
+      contains: "describe("
+    - path: "tests/integration/rls/document-template-definitions.rls.test.ts"
+      provides: "dual-client S/I/U/D isolation for document_template_definitions (direct owner_user_id)"
+      contains: "describe("
+    - path: "tests/integration/rls/expenses.rls.test.ts"
+      provides: "dual-client S/I/U/D isolation for expenses via the property->unit->maintenance_request->expense chain"
+      contains: "maintenance_request_id"
+  key_links:
+    - from: "tests/integration/rls/expenses.rls.test.ts"
+      to: "maintenance_requests.owner_user_id"
+      via: "fixture chain property->unit->maintenance_request->expense built under ownerA"
+      pattern: "maintenance_request_id"
+    - from: "all three new test files"
+      to: "tests/integration/setup/supabase-client.ts"
+      via: "createTestClient + getTestCredentials import (reused, not reinvented)"
+      pattern: "from \"../setup/supabase-client\""
+---
+
+<objective>
+Add dual-client (ownerA/ownerB) RLS integration tests pinning cross-owner isolation for the three owner-scoped tables that lacked it: `reports`, `document_template_definitions` (both DIRECT `owner_user_id`), and `expenses` (INDIRECT — owner is reached only through `maintenance_request_id` -> `maintenance_requests.owner_user_id`; expenses have NO direct owner column).
+
+Purpose: TEST-01. These tests run in the `rls-security` CI gate and become the regression proof that a future RLS refactor cannot silently leak one owner's reports/templates/expenses to another.
+Output: three new test files under `tests/integration/rls/`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md
+
+<interfaces>
+<!-- Reused setup helpers — import these directly; do NOT build a new auth client. -->
+
+From tests/integration/setup/supabase-client.ts:
+- `createTestClient(email: string, password: string): Promise<SupabaseClient>` — signs in a synthetic owner.
+- `getTestCredentials(): { ownerA: {email,password}, ownerB: {email,password} }` — throws if the four E2E_OWNER_* env vars are unset (CI supplies via secrets).
+
+Verified column shapes (from src/types/supabase.ts — source of truth):
+- reports (DIRECT owner): owner_user_id (NOT NULL), title (NOT NULL), report_type (NOT NULL), description, is_active, schedule_cron, next_run_at, created_at, updated_at, id.
+- document_template_definitions (DIRECT owner): owner_user_id (NOT NULL), template_key (NOT NULL), custom_fields (Json, NOT NULL, defaults), created_at, updated_at, id.
+- expenses (INDIRECT owner): maintenance_request_id (NOT NULL FK -> maintenance_requests), amount (NOT NULL numeric), expense_date (NOT NULL date), status (defaults), vendor_name, created_at, updated_at, id. NO owner column.
+- maintenance_requests Insert (for the expense chain): owner_user_id (NOT NULL), unit_id (NOT NULL), tenant_id (NOT NULL), description (NOT NULL). INSERT policy `maintenance_requests_insert_owner` requires `owner_user_id = caller AND unit_id IN (caller's units)` — so ownerA CAN create the MR through the authenticated client (it is NOT tenant-only anymore; the base-schema tenant-only policy was superseded by migration 20260506013951).
+- units Insert: property_id, unit_number, bedrooms, bathrooms, rent_amount, status, owner_user_id.
+- properties Insert: name, address_line1, city, state, postal_code, country, property_type, owner_user_id.
+- tenants Insert: email, first_name, last_name, status, owner_user_id.
+</interfaces>
+
+# Sibling templates to mirror (dual-client harness + S/I/U/D assertion shapes):
+@tests/integration/rls/properties.rls.test.ts
+@tests/integration/rls/stats-rpcs.rls.test.ts
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: reports + document_template_definitions dual-client tests (direct owner_user_id)</name>
+  <files>tests/integration/rls/reports.rls.test.ts, tests/integration/rls/document-template-definitions.rls.test.ts</files>
+  <read_first>
+    - tests/integration/rls/properties.rls.test.ts (the canonical direct-owner S/I/U/D dual-client shape — mirror its beforeAll/afterAll, testInsertedIds tracking, and the four isolation blocks)
+    - .planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md (TEST-01 LOCKED decision: reports + document_template_definitions are DIRECT owner_user_id, full S/I/U/D policies)
+  </read_first>
+  <action>
+    Create reports.rls.test.ts mirroring properties.rls.test.ts exactly: import createTestClient + getTestCredentials from "../setup/supabase-client"; sign in clientA/clientB in beforeAll, capture ownerAId/ownerBId via auth.getUser(); track inserted ids and FK-safe-delete them in afterAll. Cover all four policy classes for `reports` (a DIRECT owner_user_id table): SELECT — ownerA reads only rows where owner_user_id === ownerAId; assert ownerB's id set is disjoint from ownerA's. INSERT (positive) — ownerA inserts a row with owner_user_id=ownerAId, title="RLS Test Report A", report_type="financial_summary" (any non-null report_type string), capture id. INSERT (negative) — ownerB inserts with owner_user_id=ownerAId; assert error not null AND data null (WITH CHECK blocks the hijack). UPDATE (negative) — ownerB updates ownerA's report id with .select("id"); assert error null AND data toEqual [] (USING clause hides the row). DELETE (negative) — ownerB deletes ownerA's report id with .select("id"); assert error null AND data toEqual [], then re-read as ownerA and assert the row still exists. Include an ownerA-positive UPDATE+restore and an ownerA-positive DELETE (on a throwaway inserted row) to prove the policy rejects only the cross-owner case, not every call. Repeat the identical structure in document-template-definitions.rls.test.ts for `document_template_definitions`: insert uses owner_user_id + template_key (e.g. `rls-test-template-${Date.now()}`); custom_fields can be omitted (it defaults). Do NOT add an UPDATE field mutation that violates the unique template_key per owner — mutate a safe field or use a distinct template_key on the positive update. No `any`; type rows via the generated client or a narrow local interface. No barrel files / index re-exports.
+  </action>
+  <verify>
+    <automated>bun run typecheck 2>&1 | tail -5; bunx vitest run --no-coverage tests/integration/rls/reports.rls.test.ts tests/integration/rls/document-template-definitions.rls.test.ts 2>&1 | tail -25</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/integration/rls/reports.rls.test.ts exists and asserts cross-owner denial on every policy reports has (S/I/U/D): negative INSERT asserts error+null data; negative UPDATE/DELETE assert error null + data [] + row-still-exists-for-ownerA.
+    - tests/integration/rls/document-template-definitions.rls.test.ts exists with the same four-policy isolation shape.
+    - Both files import createTestClient + getTestCredentials from "../setup/supabase-client" (no reinvented auth client).
+    - `bun run typecheck` is clean; no `any`, no `as unknown as`, no `.toThrow("string")`.
+    - afterAll deletes every inserted id (FK-safe — these are leaf tables, simple delete by id under ownerA).
+  </acceptance_criteria>
+  <done>Two new dual-client direct-owner RLS test files exist, covering S/I/U/D cross-owner denial for reports + document_template_definitions, typecheck clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: expenses dual-client test via the maintenance_request chain (indirect owner)</name>
+  <files>tests/integration/rls/expenses.rls.test.ts</files>
+  <read_first>
+    - tests/integration/rls/stats-rpcs.rls.test.ts (the canonical multi-step fixture-chain builder under ownerA — property -> unit -> tenant — and the FK-safe afterAll teardown order; mirror this for the deeper expense chain)
+    - tests/integration/rls/maintenance.rls.test.ts (how cross-owner maintenance_request denial is asserted)
+    - .planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md (TEST-01 LOCKED: expenses are INDIRECT via maintenance_request_id -> maintenance_requests.owner_user_id; NO direct owner column)
+  </read_first>
+  <action>
+    Create expenses.rls.test.ts. In beforeAll, sign in clientA/clientB, capture owner ids, then build ownerA's full chain through the authenticated client (NOT service-role): insert a property (owner_user_id=ownerAId) -> a unit on that property (owner_user_id=ownerAId, status="available", a rent_amount, unit_number unique per run) -> a maintenance_request (owner_user_id=ownerAId, unit_id=that unit, tenant_id=an ownerA tenant, description set). Note: the maintenance_request INSERT policy `maintenance_requests_insert_owner` requires owner_user_id=caller AND unit_id IN caller's units — so insert the unit first and reference it. For tenant_id, insert an ownerA tenant in the chain (email unique per run, first_name/last_name/status="active", owner_user_id=ownerAId) — the MR requires a non-null tenant_id FK. Then insert one expense (maintenance_request_id=that MR id, amount=123.45, expense_date a valid date string, status omitted/defaulted) as ownerA; capture expenseId. Guard each step: if any insert returns null data, console.warn and set the chain ref null so dependent tests skip gracefully (mirror stats-rpcs.rls.test.ts skip pattern) — BUT the cross-owner denial tests must still run whenever the expense fixture exists. Tests: SELECT — ownerB selects the expense by id (or selects all expenses and asserts ownerA's expense id is absent from ownerB's set); assert ownerB sees 0 rows for that id. UPDATE (negative) — ownerB updates the expense id (e.g. amount=999) with .select("id"); assert error null + data toEqual [] (the expenses_update_owner USING clause keys on the parent MR's owner via EXISTS). DELETE (negative) — ownerB deletes the expense id with .select("id"); assert error null + data toEqual [], then re-read as ownerA and assert still exists. INSERT (negative) — ownerB inserts an expense referencing ownerA's MR id; assert error not null AND data null (expenses_insert_owner WITH CHECK requires the parent MR to be owned by the caller). Positive control: ownerA selects the expense and finds it. afterAll FK-safe teardown under ownerA in child-before-parent order: delete expense -> maintenance_request -> unit -> property -> tenant. No `any`; narrow types via generated client or local interface. No barrel files.
+  </action>
+  <verify>
+    <automated>bun run typecheck 2>&1 | tail -5; bunx vitest run --no-coverage tests/integration/rls/expenses.rls.test.ts 2>&1 | tail -25</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/integration/rls/expenses.rls.test.ts exists and builds the property->unit->tenant->maintenance_request->expense chain under ownerA via the authenticated client (the string "maintenance_request_id" appears in the insert).
+    - Cross-owner denial asserted on every expenses policy (S/I/U/D): negative INSERT asserts error+null data; negative UPDATE/DELETE assert error null + data [] + the expense still exists for ownerA.
+    - The test is false-green-proof: the negative read asserts the expense id is ABSENT from ownerB's result (0 rows), not merely that no error was thrown.
+    - afterAll deletes in child-before-parent order (expense, maintenance_request, unit, property, tenant) so reruns don't leak rows or hit FK violations.
+    - `bun run typecheck` clean; no `any`, no `as unknown as`, no `.toThrow("string")`.
+  </acceptance_criteria>
+  <done>expenses.rls.test.ts exists, pins cross-owner S/I/U/D denial through the indirect maintenance_request_id ownership path with FK-safe teardown, typecheck clean.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| ownerB authenticated client -> PostgREST/RLS on reports/templates/expenses | ownerB is a legitimately authenticated owner attempting to read/mutate ownerA's rows; RLS is the only boundary stopping cross-owner access |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-05-01 | Information Disclosure | reports / document_template_definitions / expenses SELECT RLS | mitigate | This plan adds the dual-client SELECT-isolation tests that fail if ownerB can read ownerA's rows (regression pin in the `rls-security` CI gate) |
+| T-05-02 | Tampering | reports / templates / expenses INSERT/UPDATE/DELETE RLS | mitigate | Negative INSERT (WITH CHECK), UPDATE/DELETE (USING) assertions fail if cross-owner writes were possible |
+| T-05-03 | Elevation of Privilege | expenses indirect-owner path (maintenance_request_id) | mitigate | Negative INSERT against ownerA's MR id pins the expenses_insert_owner EXISTS-on-parent-MR guard |
+| T-05-FG | (false-green test risk) | the new tests themselves | mitigate | Every cross-owner read asserts 0 rows AND every cross-owner write asserts rejection/no-op + row-still-present, so a broken-isolation refactor fails the assertion rather than silently passing |
+</threat_model>
+
+<verification>
+- `bun run typecheck` clean.
+- One structural local run is acceptable (`bunx vitest run --no-coverage tests/integration/rls/{reports,document-template-definitions,expenses}.rls.test.ts`). Do NOT loop the full suite — Supabase auth rate-limits sign-ins ~45/min; rely on the `rls-security` CI gate for the authoritative pass.
+- Manually confirm each cross-owner negative case would FAIL if the policy were removed (read asserts 0 rows; write asserts rejection/no-op + parent row still present).
+</verification>
+
+<success_criteria>
+- Three new dual-client RLS test files exist: reports, document_template_definitions, expenses.
+- All assert cross-owner S/I/U/D denial; the expenses test reaches owner only via maintenance_request_id.
+- No schema/migration/frontend/type changes (test-only).
+- typecheck clean; no `any` / `as unknown as` / `.toThrow("string")`; FK-safe afterAll.
+</success_criteria>
+
+<output>
+Create `.planning/phases/05-cross-owner-rls-coverage/05-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/05-cross-owner-rls-coverage/05-01-SUMMARY.md
+++ b/.planning/phases/05-cross-owner-rls-coverage/05-01-SUMMARY.md
@@ -1,0 +1,105 @@
+---
+phase: 05-cross-owner-rls-coverage
+plan: 01
+subsystem: testing
+tags: [rls, postgrest, supabase, integration-tests, owner-isolation, security]
+
+# Dependency graph
+requires:
+  - phase: 03-stats-rpc-consolidation
+    provides: "dual-client ownerA/ownerB harness template (stats-rpcs.rls.test.ts)"
+provides:
+  - "Dual-client cross-owner RLS isolation tests for reports (direct owner_user_id, S/I/U/D)"
+  - "Dual-client cross-owner RLS isolation tests for document_template_definitions (direct owner_user_id, S/I/U/D)"
+  - "Dual-client cross-owner RLS isolation tests for expenses (indirect via maintenance_request_id -> maintenance_requests.owner_user_id, S/I/U/D)"
+  - "Regression proof in the rls-security CI gate that a future RLS refactor cannot leak reports/templates/expenses across owners"
+affects: [05-02-child-table-rls, 05-03-sqlstate-helper-extract, rls-security-ci-gate]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "False-green-proof RLS test: cross-owner read asserts 0 rows; cross-owner write asserts rejection/no-op + re-read confirms parent row survives"
+    - "Indirect-owner RLS test: build the full parent chain under ownerA via the authenticated client, then assert ownerB is denied through the EXISTS-on-parent guard"
+
+key-files:
+  created:
+    - tests/integration/rls/reports.rls.test.ts
+    - tests/integration/rls/document-template-definitions.rls.test.ts
+    - tests/integration/rls/expenses.rls.test.ts
+  modified: []
+
+key-decisions:
+  - "document_template_definitions.template_key has a CHECK limiting it to 5 fixed values + UNIQUE(owner_user_id, template_key); the test uses real keys and clears leftover rows in beforeAll to avoid CHECK/UNIQUE violations on rerun"
+  - "expenses fixture chain built via the authenticated ownerA client (not service-role) so the owner-insert MR policy (migration 20260506013951) is exercised end-to-end"
+  - "Authoritative integration run deferred to the rls-security CI gate: .env.local secrets are sandbox-blocked locally; typecheck validated the tests compile"
+
+patterns-established:
+  - "Cross-owner denial assertion shape: SELECT -> data [] / id absent; INSERT hijack -> error not null + data null; UPDATE/DELETE -> error null + data [] + ownerA re-read shows row unchanged"
+  - "Positive controls (ownerA self S/I/U/D) prove the policy rejects only the mismatch, not every call"
+
+requirements-completed: [TEST-01]
+
+# Metrics
+duration: 18min
+completed: 2026-06-06
+---
+
+# Phase 5 Plan 01: Cross-Owner RLS Coverage (TEST-01) Summary
+
+**Three new dual-client RLS integration tests pin cross-owner isolation (S/I/U/D) for `reports` and `document_template_definitions` (direct `owner_user_id`) and `expenses` (indirect via `maintenance_request_id` -> `maintenance_requests.owner_user_id`), each asserting the DENIAL side so a broken-isolation refactor fails CI rather than silently passing.**
+
+## Performance
+
+- **Duration:** ~18 min
+- **Tasks:** 2 of 2 completed
+- **Files created:** 3
+- **Files modified:** 0 (test-only plan; no schema/type/frontend changes)
+
+## Accomplishments
+
+- `reports.rls.test.ts` — direct-owner S/I/U/D isolation: ownerB cannot SELECT (0 rows), INSERT-hijack (error + null data via WITH CHECK), UPDATE/DELETE (data `[]` via USING + ownerA re-read confirms survival). OwnerA positive controls for every operation.
+- `document-template-definitions.rls.test.ts` — same four-policy shape, honoring the `template_key` CHECK (5 valid values) and `UNIQUE(owner_user_id, template_key)` constraints; UPDATE mutates the safe `custom_fields` column rather than the unique `template_key`.
+- `expenses.rls.test.ts` — indirect-owner S/I/U/D isolation built on a fresh ownerA chain (property -> unit -> tenant -> maintenance_request -> expense) created via the authenticated client; cross-owner INSERT references ownerA's MR id to pin the `expenses_insert_owner` EXISTS-on-parent guard; FK-safe child-before-parent teardown.
+- All three import `createTestClient` + `getTestCredentials` from `../setup/supabase-client` (reused harness, no reinvented auth client).
+
+## Task Commits
+
+1. **Task 1: reports + document_template_definitions dual-client tests** - `1ddb532ef` (test)
+2. **Task 2: expenses dual-client test via the maintenance_request chain** - `3a67ca52f` (test)
+
+## Files Created/Modified
+
+- `tests/integration/rls/reports.rls.test.ts` - Dual-client S/I/U/D cross-owner isolation for `reports` (direct `owner_user_id`).
+- `tests/integration/rls/document-template-definitions.rls.test.ts` - Dual-client S/I/U/D cross-owner isolation for `document_template_definitions` (direct `owner_user_id`), constraint-aware.
+- `tests/integration/rls/expenses.rls.test.ts` - Dual-client S/I/U/D cross-owner isolation for `expenses` through the indirect `maintenance_request_id` ownership path, with FK-safe chain fixtures + teardown.
+
+## Verification
+
+- `bun run typecheck` — clean (`tsc --noEmit`, no errors). No `any`, no `as unknown as`, no `.toThrow("string")`. Verified twice (after each task).
+- Full lefthook gate passed on both commits (gitleaks, lockfile-verify, lint, typecheck, unit-tests, commitlint). No `--no-verify`.
+- **Integration tests NOT run locally.** `.env.local` (carrying the `E2E_OWNER_*` secrets) is sandbox-blocked from read/grep access in this environment, and bare `vitest` did not populate `process.env` for the integration `globalSetup` (which throws when the four credentials are unset). Per the plan's execution rule, the authoritative pass is delegated to the `rls-security` CI gate, which supplies the secrets via repo secrets and fails hard if they are missing.
+- **False-green guard (manual reasoning):** each cross-owner read asserts `data` is `[]` / the id is absent (would fail if SELECT leaked the row); each cross-owner write asserts rejection (INSERT) or `data []` + an ownerA re-read showing the row unchanged (would fail if UPDATE/DELETE mutated the row). A refactor that dropped any policy would flip at least one of these assertions.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Constraint correctness] document_template_definitions.template_key CHECK + UNIQUE**
+- **Found during:** Task 1 (schema verification against migration 20260311200000).
+- **Issue:** The plan suggested inserting `template_key = rls-test-template-${Date.now()}`, but the live schema has `CHECK (template_key IN ('lease','maintenance-request','property-inspection','rental-application','tenant-notice'))` plus `UNIQUE(owner_user_id, template_key)`. The suggested value would fail the CHECK, and a fixed valid key could collide with a leftover row from a prior run (UNIQUE violation).
+- **Fix:** Used real CHECK-valid keys (distinct per fixture / insert-positive / delete-positive case), cleared any pre-existing owned-key rows for ownerA in `beforeAll`, and made the UPDATE positive control mutate `custom_fields` (a safe column) instead of `template_key`.
+- **Files modified:** tests/integration/rls/document-template-definitions.rls.test.ts.
+- **Commit:** `1ddb532ef`.
+
+## Threat Flags
+
+None — test-only plan; no new network endpoints, auth paths, file access, or schema changes were introduced. The threat register's `mitigate` dispositions (T-05-01/02/03/FG) are satisfied by the assertions described above.
+
+## Self-Check: PASSED
+
+- tests/integration/rls/reports.rls.test.ts — FOUND
+- tests/integration/rls/document-template-definitions.rls.test.ts — FOUND
+- tests/integration/rls/expenses.rls.test.ts — FOUND
+- Commit `1ddb532ef` — FOUND
+- Commit `3a67ca52f` — FOUND

--- a/.planning/phases/05-cross-owner-rls-coverage/05-02-PLAN.md
+++ b/.planning/phases/05-cross-owner-rls-coverage/05-02-PLAN.md
@@ -1,0 +1,173 @@
+---
+phase: 05-cross-owner-rls-coverage
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/integration/rls/property-images.rls.test.ts
+  - tests/integration/rls/inspection-rooms.rls.test.ts
+  - tests/integration/rls/inspection-photos.rls.test.ts
+  - tests/integration/rls/maintenance-request-photos.rls.test.ts
+autonomous: true
+requirements: [TEST-02]
+
+must_haves:
+  truths:
+    - "ownerB cannot SELECT/INSERT/UPDATE/DELETE a property_images row whose property_id belongs to ownerA (join policy via property_id)"
+    - "ownerB cannot SELECT/INSERT/UPDATE/DELETE an inspection_rooms row whose inspection_id belongs to ownerA (join policy via inspection_id)"
+    - "ownerB cannot SELECT/INSERT/DELETE an inspection_photos row owned via ownerA's inspection (S/I/D only — NO UPDATE policy exists; do NOT test UPDATE)"
+    - "ownerB cannot SELECT/INSERT/DELETE a maintenance_request_photos row owned via ownerA's maintenance_request (S/I/D only — NO UPDATE policy exists; do NOT test UPDATE)"
+    - "Each test builds ownerA's full parent chain, inserts the child as ownerA, then asserts ownerB denied on every policy THAT EXISTS for that table"
+  artifacts:
+    - path: "tests/integration/rls/property-images.rls.test.ts"
+      provides: "dual-client cross-owner RLS for property_images via property_id (S/I/U/D)"
+      contains: "describe("
+    - path: "tests/integration/rls/inspection-rooms.rls.test.ts"
+      provides: "dual-client cross-owner RLS for inspection_rooms via inspection_id (S/I/U/D)"
+      contains: "describe("
+    - path: "tests/integration/rls/inspection-photos.rls.test.ts"
+      provides: "dual-client cross-owner RLS for inspection_photos via inspection_id/inspection_room_id (S/I/D only)"
+      contains: "describe("
+    - path: "tests/integration/rls/maintenance-request-photos.rls.test.ts"
+      provides: "dual-client cross-owner RLS for maintenance_request_photos via maintenance_request_id (S/I/D only)"
+      contains: "describe("
+  key_links:
+    - from: "tests/integration/rls/inspection-photos.rls.test.ts"
+      to: "inspection_rooms / inspections (ownerA chain)"
+      via: "inspection_id + inspection_room_id parent chain"
+      pattern: "inspection_room_id"
+    - from: "all four test files"
+      to: "../setup/supabase-client"
+      via: "createTestClient + getTestCredentials (reuse the sibling helpers)"
+      pattern: "createTestClient.*getTestCredentials"
+---
+
+<objective>
+Add dual-client (ownerA/ownerB) RLS integration tests for the four join-policy child tables whose isolation is enforced through a parent chain (not a direct owner column): `property_images` (via property_id), `inspection_rooms` (via inspection_id), `inspection_photos` (via inspection_id/inspection_room_id), and `maintenance_request_photos` (via maintenance_request_id).
+
+Purpose: regression-pin owner isolation on the join-policy children (success criterion 2). The two photos tables have S/I/D policies ONLY (no UPDATE policy) — testing UPDATE there would be a false test, so cover S/I/D only for them and full S/I/U/D for property_images + inspection_rooms.
+Output: four new test files under `tests/integration/rls/`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md
+@CLAUDE.md
+
+<interfaces>
+<!-- Reuse the sibling tests' chain-builders + auth-client helpers. Do not reinvent. -->
+
+From tests/integration/setup/supabase-client.ts:
+- `createTestClient(email, password): Promise<SupabaseClient>`, `getTestCredentials()` — same harness as every sibling RLS test.
+
+Parent-chain builders to mirror (read these for the exact insert column sets, not just structure):
+- properties → units: stats-rpcs.rls.test.ts beforeAll (property insert column set: name, address_line1, city, state, postal_code, country, property_type, owner_user_id; unit insert: property_id, unit_number, bedrooms, bathrooms, rent_amount, status, owner_user_id).
+- inspections (+ rooms/photos): inspections.rls.test.ts builds an inspection from an ownerA lease+unit (owner_user_id, lease_id, property_id, unit_id, inspection_type, status). It gracefully `return`s when no lease/unit exists — mirror that skip pattern.
+- maintenance_requests: maintenance.rls.test.ts — owners cannot INSERT maintenance_requests (INSERT policy requires tenant_id = get_current_tenant_id()); the test selects an EXISTING ownerA maintenance_request instead. Mirror that (select-or-skip).
+
+Child-table INSERT column shapes (verified):
+- property_images — via property_id → properties.owner. Confirm the live image columns (storage/url/path + property_id + any NOT NULL) by reading src/hooks/api/query-keys/property-keys.ts (upload/insert + deleteImage paths) and the property_images Insert type in src/types/supabase.ts before writing the insert.
+- inspection_rooms — insert: inspection_id, room_name, room_type, condition_rating, notes? (from src/lib/validation/inspections.ts createInspectionRoomSchema).
+- inspection_photos — insert: inspection_id, inspection_room_id, storage_path, file_name, file_size?, mime_type, caption? (createInspectionPhotoSchema). Policies S/I/D ONLY.
+- maintenance_request_photos — insert: maintenance_request_id, storage_path, file_name, file_size?, mime_type?, uploaded_by? (src/hooks/api/query-keys/maintenance-keys.ts photos select). Policies S/I/D ONLY.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: property_images + inspection_rooms dual-client RLS tests (S/I/U/D via parent chain)</name>
+  <files>tests/integration/rls/property-images.rls.test.ts, tests/integration/rls/inspection-rooms.rls.test.ts</files>
+  <read_first>
+    - tests/integration/rls/properties.rls.test.ts (S/I/U/D dual-client assertion shape)
+    - tests/integration/rls/inspections.rls.test.ts (inspection→room chain builder + graceful-skip pattern)
+    - tests/integration/rls/stats-rpcs.rls.test.ts (property→unit fixture-build + FK-safe afterAll)
+    - src/hooks/api/query-keys/property-keys.ts AND src/types/supabase.ts (property_images Insert type — confirm live image insert columns)
+    - src/lib/validation/inspections.ts (createInspectionRoomSchema for room insert columns)
+    - .planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md (TEST-02 LOCKED decision — join scoping + which policies exist)
+  </read_first>
+  <action>
+    Create `property-images.rls.test.ts`. beforeAll: sign in clientA/clientB, resolve ownerAId/ownerBId. Build ownerA's parent: insert a property under clientA (reuse the stats-rpcs property column set); insert a property_images row under clientA referencing that property_id (use the confirmed live image columns from property-keys.ts + src/types/supabase.ts). Assert join-policy isolation (property_images has S/I/U/D): SELECT — ownerB select of that image id returns 0 rows; INSERT — ownerB inserting a property_images row referencing ownerA's property_id is rejected by WITH CHECK EXISTS(property owned by caller) (error not null, data null); UPDATE — ownerB updating the image by id with `.select()` returns empty array + error null, row unchanged for ownerA; DELETE — ownerB deleting the image by id with `.select()` returns empty array + error null, row survives for ownerA. afterAll FK-safe: delete the image then the property under clientA.
+    Create `inspection-rooms.rls.test.ts`. beforeAll: build ownerA's inspection using the inspections.rls.test.ts builder (lease+unit→inspection; graceful `return` if no ownerA lease/unit). Insert an inspection_rooms row under clientA referencing that inspection_id (room_name, room_type, condition_rating, notes optional). Assert S/I/U/D cross-owner isolation against inspection_rooms (join via inspection_id → inspections.owner): SELECT 0 rows for ownerB; INSERT referencing ownerA's inspection_id rejected for ownerB; UPDATE/DELETE by ownerB return empty `.select()` + error null with the row surviving for ownerA. afterAll FK-safe: delete the room then the inspection this test created.
+    Vitest-4/chai-6 tuple assertions; no `any`; no schema/frontend changes (test-only). Skip cleanly (console.warn + return) when a required parent fixture can't be built, matching the sibling tests.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/integration/rls/property-images.rls.test.ts exists, builds ownerA's property parent, and asserts ownerB-denied on SELECT (0 rows) + INSERT (rejected) + UPDATE (empty .select(), survives) + DELETE (empty .select(), survives)
+    - tests/integration/rls/inspection-rooms.rls.test.ts exists, builds ownerA's inspection parent (or gracefully skips), and asserts the same four-policy cross-owner denial via inspection_id
+    - both import createTestClient + getTestCredentials from ../setup/supabase-client (no reinvented chain-builder/auth)
+    - both have FK-safe afterAll deleting only fixtures this test created (child before parent)
+    - no `.toThrow(` and no `any`; `bun run typecheck` and `bun run lint` pass
+  </acceptance_criteria>
+  <done>property_images + inspection_rooms pin S/I/U/D cross-owner isolation through their parent chains; typecheck + lint clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: inspection_photos + maintenance_request_photos dual-client RLS tests (S/I/D ONLY — no UPDATE)</name>
+  <files>tests/integration/rls/inspection-photos.rls.test.ts, tests/integration/rls/maintenance-request-photos.rls.test.ts</files>
+  <read_first>
+    - tests/integration/rls/inspections.rls.test.ts (inspection→room chain; inspection_photos needs inspection_id AND inspection_room_id)
+    - tests/integration/rls/maintenance.rls.test.ts (select-existing-ownerA-maintenance_request-or-skip pattern)
+    - src/lib/validation/inspections.ts (createInspectionPhotoSchema — inspection_photos insert columns)
+    - src/hooks/api/query-keys/maintenance-keys.ts (maintenance_request_photos column set)
+    - src/hooks/api/query-keys/inspection-mutation-options.ts (createRoom + recordPhoto inserts for the room→photo chain)
+    - .planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md (TEST-02 LOCKED decision — these two tables are S/I/D ONLY, NO UPDATE policy)
+  </read_first>
+  <action>
+    Create `inspection-photos.rls.test.ts`. beforeAll: build ownerA's full chain — inspection (via inspections.rls.test.ts builder; graceful skip if no lease/unit), then an inspection_rooms row under clientA, then an inspection_photos row under clientA referencing BOTH inspection_id and inspection_room_id (columns: inspection_id, inspection_room_id, storage_path, file_name, mime_type; file_size/caption optional). Assert S/I/D ONLY (do NOT write any UPDATE assertion — there is no UPDATE policy; testing it would be a false test): SELECT — ownerB select of the photo id returns 0 rows; INSERT — ownerB inserting an inspection_photos row referencing ownerA's inspection_id/inspection_room_id is rejected (error not null, data null); DELETE — ownerB deleting the photo by id with `.select()` returns empty array + error null, photo survives for ownerA. Add an inline comment stating S/I/D-only and that NO UPDATE policy exists for this table (so a future reader doesn't add a false UPDATE test). afterAll FK-safe: delete photo → room → inspection (only fixtures this test created).
+    Create `maintenance-request-photos.rls.test.ts`. beforeAll: obtain an ownerA maintenance_request (select existing under clientA `.limit(1).single()`; console.warn + skip if none, matching maintenance.rls.test.ts — owners cannot insert maintenance_requests). Insert a maintenance_request_photos row under clientA referencing that maintenance_request_id (storage_path, file_name; mime_type/file_size/uploaded_by optional per the column set). Assert S/I/D ONLY: SELECT 0 rows for ownerB; INSERT referencing ownerA's maintenance_request_id rejected for ownerB; DELETE by ownerB returns empty `.select()` + error null with the photo surviving for ownerA. Inline comment: S/I/D-only, no UPDATE policy. afterAll: delete only the photo this test created; never delete the pre-existing selected maintenance_request.
+    Vitest-4/chai-6 tuple assertions; no `any`; test-only.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/integration/rls/inspection-photos.rls.test.ts exists, builds ownerA's inspection→room→photo chain, asserts ownerB-denied on SELECT (0 rows) + INSERT (rejected) + DELETE (empty .select(), survives), and contains NO UPDATE assertion (with an inline comment noting S/I/D-only / no UPDATE policy)
+    - tests/integration/rls/maintenance-request-photos.rls.test.ts exists, references an ownerA maintenance_request_id (select-or-skip), asserts the same S/I/D cross-owner denial, and contains NO UPDATE assertion (inline comment noting S/I/D-only)
+    - both import createTestClient + getTestCredentials from ../setup/supabase-client
+    - inspection-photos child insert references BOTH inspection_id and inspection_room_id
+    - FK-safe afterAll deletes only fixtures this test created; never deletes a pre-existing selected maintenance_request
+    - no `.toThrow(`, no `any`, and no `.update(` cross-owner assertion in either photos file; `bun run typecheck` and `bun run lint` pass
+  </acceptance_criteria>
+  <done>Both photos tables pin S/I/D cross-owner isolation (no false UPDATE test); typecheck + lint clean.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| ownerB JWT → PostgREST (join-policy children) | ownerB attempting to reach a child row through a parent chain owned by ownerA; the EXISTS(parent owned by caller) join policy is the only barrier |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-05-04 | Information Disclosure | property_images / inspection_rooms / inspection_photos / maintenance_request_photos SELECT | mitigate | dual-client test asserts ownerB SELECT of ownerA's child returns 0 rows (fails if the join USING clause regresses) |
+| T-05-05 | Tampering | join-policy children INSERT/UPDATE/DELETE | mitigate | ownerB INSERT referencing ownerA's parent id is rejected; UPDATE/DELETE (where the policy exists) affect 0 rows with the row surviving |
+| T-05-06 | (false-policy risk) | inspection_photos / maintenance_request_photos UPDATE | accept | these tables have NO UPDATE policy by design; the plan explicitly forbids an UPDATE assertion so the suite does not encode a false test |
+| T-05-FG | (false-green risk) | new tests | mitigate | every cross-owner assertion checks BOTH the empty result AND (for writes) rejection/empty-affected-rows + post-state survival |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint` clean for the four new files.
+- Structural sanity only: at most ONE local run of `bun run test:integration -- --run tests/integration/rls/property-images.rls.test.ts tests/integration/rls/inspection-rooms.rls.test.ts tests/integration/rls/inspection-photos.rls.test.ts tests/integration/rls/maintenance-request-photos.rls.test.ts` (auth rate-limit ~45 sign-ins/min — do NOT loop). Otherwise rely on the `rls-security` CI gate.
+- inspection_photos + maintenance_request_photos contain NO UPDATE assertions.
+</verification>
+
+<success_criteria>
+The `rls-security` suite includes dual-client tests covering the join-policy child tables `inspection_photos`, `inspection_rooms`, `maintenance_request_photos`, and `property_images`, FAILING on any cross-owner read/write (ROADMAP Phase 5 success criterion 2). The two photos tables are tested S/I/D only (no UPDATE policy exists). No schema/frontend/type changes.
+</success_criteria>
+
+<output>
+Create `.planning/phases/05-cross-owner-rls-coverage/05-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/05-cross-owner-rls-coverage/05-02-SUMMARY.md
+++ b/.planning/phases/05-cross-owner-rls-coverage/05-02-SUMMARY.md
@@ -1,0 +1,123 @@
+---
+phase: 05-cross-owner-rls-coverage
+plan: 02
+subsystem: testing
+tags: [rls, postgrest, supabase, integration-tests, owner-isolation, security, join-policy]
+
+# Dependency graph
+requires:
+  - phase: 03-stats-rpc-consolidation
+    provides: "dual-client ownerA/ownerB harness template (stats-rpcs.rls.test.ts)"
+  - phase: 05-cross-owner-rls-coverage
+    plan: 01
+    provides: "false-green-proof cross-owner denial assertion shape (reports.rls.test.ts)"
+provides:
+  - "Dual-client cross-owner RLS isolation tests for property_images (join via property_id -> properties.owner, S/I/U/D)"
+  - "Dual-client cross-owner RLS isolation tests for inspection_rooms (join via inspection_id -> inspections.owner, S/I/U/D)"
+  - "Dual-client cross-owner RLS isolation tests for inspection_photos (join via inspection_id + inspection_room_id, S/I/D only)"
+  - "Dual-client cross-owner RLS isolation tests for maintenance_request_photos (join via maintenance_request_id -> maintenance_requests.owner, S/I/D only)"
+  - "Regression proof in the rls-security CI gate that a future RLS refactor cannot leak join-policy child rows across owners"
+affects: [05-03-sqlstate-helper-extract, rls-security-ci-gate]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Join-policy child RLS test: build ownerA's full parent chain via the authenticated client, insert the child as ownerA, assert ownerB denied through the EXISTS-on-parent guard on every policy THAT EXISTS"
+    - "Policy-set-honest testing: tables with no UPDATE policy (inspection_photos, maintenance_request_photos) are tested S/I/D only; an UPDATE assertion against a non-existent policy would be a false test and is deliberately omitted with an inline warning comment"
+
+key-files:
+  created:
+    - tests/integration/rls/property-images.rls.test.ts
+    - tests/integration/rls/inspection-rooms.rls.test.ts
+    - tests/integration/rls/inspection-photos.rls.test.ts
+    - tests/integration/rls/maintenance-request-photos.rls.test.ts
+  modified: []
+
+key-decisions:
+  - "property_images + inspection_rooms have the full S/I/U/D policy set, so all four policies are tested; inspection_photos + maintenance_request_photos have S/I/D ONLY (no UPDATE policy by design, LOCKED in 05-CONTEXT.md TEST-02), so NO UPDATE assertion is written for them"
+  - "inspection_photos child insert references BOTH inspection_id AND inspection_room_id (the FK chain inspection -> room -> photo is built fully under ownerA)"
+  - "maintenance_request_photos selects a pre-existing ownerA maintenance_request (owners cannot INSERT maintenance_requests — the INSERT policy is tenant-scoped per migration 20260506013951/restore-landlord-only) and skips gracefully when none exist; afterAll deletes only the inserted photo, NEVER the pre-existing request"
+  - "Authoritative integration run deferred to the rls-security CI gate: the local .env.local could not be loaded by vitest.config.ts's naive line-parser in this shell (a multi-line value at line 11 breaks the parser), so the synthetic-owner credentials never reached process.env locally; typecheck + lint validated the tests compile and conform"
+
+patterns-established:
+  - "Cross-owner denial assertion shape (join-policy children): SELECT -> data [] / id absent; INSERT hijack referencing ownerA's parent id -> error not null + data null; UPDATE/DELETE (only where the policy exists) -> error null + data [] + ownerA re-read shows the child row unchanged/surviving"
+  - "Positive controls (ownerA self S/I/(U)/D on each existing policy) prove the policy rejects only the cross-owner mismatch, not every call — guarding against false-greens"
+  - "FK-safe afterAll deletes children before parents and touches only fixtures the test created"
+
+requirements-completed: [TEST-02]
+
+# Metrics
+duration: 22min
+completed: 2026-06-06
+---
+
+# Phase 5 Plan 02: Cross-Owner RLS Coverage (TEST-02) Summary
+
+**Four new dual-client RLS integration tests pin cross-owner isolation on the join-policy child tables whose isolation flows only through a parent chain: `property_images` (via `property_id`) and `inspection_rooms` (via `inspection_id`) get full S/I/U/D coverage, while `inspection_photos` (via `inspection_id` + `inspection_room_id`) and `maintenance_request_photos` (via `maintenance_request_id`) get S/I/D coverage only — because neither has an UPDATE policy, so an UPDATE assertion would be a false test. Every cross-owner case asserts the DENIAL side so a broken-isolation refactor fails the `rls-security` CI gate rather than silently passing.**
+
+## Performance
+
+- **Duration:** ~22 min
+- **Tasks:** 2 of 2 completed
+- **Files created:** 4
+- **Files modified:** 0 (test-only plan; no schema/type/frontend changes)
+
+## Accomplishments
+
+### Task 1 — property_images + inspection_rooms (S/I/U/D via parent chain)
+
+- `property-images.rls.test.ts`: beforeAll builds an ownerA property, inserts a `property_images` row (`image_url` + `property_id`). Asserts all four policies cross-owner:
+  - SELECT: ownerB select of the image id returns `[]`.
+  - INSERT: ownerB inserting referencing ownerA's `property_id` → `error` not null + `data` null (WITH CHECK EXISTS(property owned by caller) fails).
+  - UPDATE: ownerB `.update().select()` → `data []`, then ownerA re-read confirms `display_order` unchanged.
+  - DELETE: ownerB `.delete().select()` → `data []`, then ownerA re-read confirms the row survives.
+  - ownerA positive controls on SELECT/INSERT/UPDATE/DELETE.
+- `inspection-rooms.rls.test.ts`: beforeAll builds an ownerA inspection from an active lease+unit (graceful skip if none), inserts an `inspection_rooms` row. Same four-policy cross-owner denial via `inspection_id` → `inspections.owner`.
+
+### Task 2 — inspection_photos + maintenance_request_photos (S/I/D ONLY — no UPDATE)
+
+- `inspection-photos.rls.test.ts`: beforeAll builds the full chain inspection → room → photo under ownerA; the photo insert references BOTH `inspection_id` and `inspection_room_id`. Asserts S/I/D cross-owner denial only. An inline comment block in the DELETE section documents that S/I/D are the only policies and warns against adding a false UPDATE test. afterAll deletes photo → room → inspection (FK-safe).
+- `maintenance-request-photos.rls.test.ts`: beforeAll SELECTS a pre-existing ownerA `maintenance_request` (owners cannot INSERT them) and skips gracefully if none; inserts a `maintenance_request_photos` row. Asserts S/I/D cross-owner denial only, same inline no-UPDATE warning. afterAll deletes only the inserted photo and NEVER the pre-existing request.
+
+## Verification
+
+- `bun run typecheck` — clean (`tsc --noEmit`, no errors) across both commits.
+- `bun run lint` — clean (biome; the single `info` is a pre-existing biome-config version-migration notice, out of scope).
+- Full lefthook gate ran on both commits (gitleaks, lockfile-verify, lint, typecheck, unit-tests, commitlint) — NEVER `--no-verify`.
+- No `.toThrow(`, no `any`, no barrel files in any of the four files. Confirmed via grep that neither photos file contains a `.update(` cross-owner assertion.
+- **Local vs CI:** The single permitted structural local run could NOT execute — `vitest.config.ts`'s naive `.env.local` line-parser fails to load the synthetic-owner credentials in this shell (a multi-line value at line 11 breaks parsing; the file itself is also read-restricted in this sandbox), so `globalSetup` threw "E2E owner credentials missing." Authoritative verification is therefore the `rls-security` CI gate, which supplies `E2E_OWNER_*` as proper repo secrets and fails hard if missing. This matches the plan's stated fallback ("else rely on the rls-security CI gate") and the same limitation noted in the 05-01 sibling summary.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None affecting test logic. Two mechanical adjustments during commit:
+
+1. **[Rule 3 - Blocking] Biome auto-format of long single-line `if` cleanup statements.** The initial Task 1 files had single-line `if (x) await ...delete()...` afterAll statements the formatter wanted wrapped; ran `biome check --write` to conform. No logic change.
+2. **[Rule 3 - Blocking] Commitlint header length.** Task 2's first commit header was 102 chars (limit 100); shortened the header (kept the full body) and recommitted. No content change.
+
+### Environment Limitation (not a code deviation)
+
+- Local integration run blocked by the env-loader / read-restricted `.env.local` interaction (documented under Verification). Deferred to the `rls-security` CI gate per the plan's explicit fallback.
+
+## Confirmation: Photos Tables Are S/I/D Only
+
+Both `inspection_photos` and `maintenance_request_photos` tests assert SELECT / INSERT / DELETE isolation ONLY. Neither file contains any `.update(` cross-owner assertion (grep-verified). Each carries an inline comment in its DELETE section stating S/I/D-only / NO UPDATE policy exists, to stop a future reader from adding a false UPDATE test.
+
+## Known Stubs
+
+None. All four test files are fully wired against the live PostgREST/RLS surface via the shared dual-client harness.
+
+## Threat Flags
+
+None. No new security surface introduced (test-only; no schema/endpoint/type changes). The four files directly mitigate threat-register entries T-05-04 (Information Disclosure) and T-05-05 (Tampering) for the join-policy children and honor T-05-06 (false-policy accept) by omitting UPDATE on the two S/I/D tables.
+
+## Commits
+
+- `9a35e496c` — `test(05-02): cross-owner RLS isolation for property_images + inspection_rooms`
+- `4d78a0577` — `test(05-02): cross-owner RLS for inspection_photos + maintenance_request_photos (S/I/D)`
+
+## Self-Check: PASSED
+
+All four test files and the SUMMARY exist on disk; both task commits (`9a35e496c`, `4d78a0577`) are reachable in the branch history.

--- a/.planning/phases/05-cross-owner-rls-coverage/05-03-PLAN.md
+++ b/.planning/phases/05-cross-owner-rls-coverage/05-03-PLAN.md
@@ -1,0 +1,182 @@
+---
+phase: 05-cross-owner-rls-coverage
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/integration/rls/_helpers/revoked-codes.ts
+  - tests/integration/rls/funnel-admin-rpc.test.ts
+  - tests/integration/rls/admin-rpc-grants.rls.test.ts
+  - tests/integration/rls/rls-no-policy-lockdown.rls.test.ts
+  - tests/integration/rls/anon-rpc-grants.rls.test.ts
+  - tests/integration/rls/users-privileged-columns.rls.test.ts
+  - tests/integration/rls/dashboard-rpc-revenue-6mo.test.ts
+  - tests/integration/rls/dashboard-rpc-open-maintenance.test.ts
+  - tests/integration/rls/bulk-import-create-lease.test.ts
+autonomous: true
+requirements: [TEST-04]
+
+must_haves:
+  truths:
+    - "A single shared helper exports the EXECUTE-revoke code set (REVOKED_CODES = ['42501','42883','PGRST202']) consumed by all 5 dup sites"
+    - "No duplicated REVOKED_CODES code-list literal ['42501','42883','PGRST202'] remains in any of the 5 sites — each imports the shared constant"
+    - "The RLS row-deny set (DENIED_CODES = ['42501','PGRST301','PGRST302','PGRST116']) used by rls-no-policy-lockdown is also sourced from the shared helper (no inline code-list literal remains)"
+    - "Message-string RLS/ownership-rejection assertions at the named sites assert error.code/SQLSTATE (P0001 for the bulk + dashboard ownership guards) instead of fragile message-substring matches"
+    - "All migrated/refactored sites still pass typecheck + lint and assert the rejection still fails if isolation were broken"
+  artifacts:
+    - path: "tests/integration/rls/_helpers/revoked-codes.ts"
+      provides: "single source for REVOKED_CODES (EXECUTE-revoke set) + DENIED_CODES (RLS row-deny set)"
+      exports: ["REVOKED_CODES", "DENIED_CODES"]
+    - path: "tests/integration/rls/anon-rpc-grants.rls.test.ts"
+      provides: "imports shared REVOKED_CODES (no local literal)"
+      contains: "revoked-codes"
+    - path: "tests/integration/rls/bulk-import-create-lease.test.ts"
+      provides: "ownership-guard rejections assert error.code (P0001) instead of message substrings"
+      contains: "error?.code"
+  key_links:
+    - from: "the 5 dup sites"
+      to: "tests/integration/rls/_helpers/revoked-codes.ts"
+      via: "import { REVOKED_CODES } (and DENIED_CODES for rls-no-policy-lockdown)"
+      pattern: "revoked-codes"
+    - from: "dashboard-rpc-revenue-6mo / dashboard-rpc-open-maintenance / bulk-import-create-lease"
+      to: "error.code (SQLSTATE)"
+      via: "assert error?.code === 'P0001' for the bare raise exception ownership/overlap guards"
+      pattern: "error.*code"
+---
+
+<objective>
+TEST-04: (a) extract the duplicated `REVOKED_CODES` literal to ONE shared helper consumed by all 5 dup sites so no duplicated code-list literal remains; (b) migrate the message-string RLS/ownership-rejection assertions at the audit-named sites to assert `error.code` / SQLSTATE — insulating them from chai-6 / message-drift fragility.
+
+Purpose: ROADMAP Phase 5 success criteria 3 (assert SQLSTATE not message strings) and 4 (single shared `REVOKED_CODES` helper). Reference style: `funnel-admin-rpc.test.ts:81` (`expect(REVOKED_CODES).toContain(error?.code)`).
+Output: one new shared helper file + edits to 8 existing test files.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md
+@CLAUDE.md
+
+<interfaces>
+<!-- Exact current literal forms at each site (verified). -->
+
+The 5 REVOKED_CODES dup sites and their CURRENT forms:
+- anon-rpc-grants.rls.test.ts:53 — `const REVOKED_CODES = ["42501", "42883", "PGRST202"];` (named local literal; used at :224, :234, :257). Replace the local declaration with an import of the shared constant.
+- funnel-admin-rpc.test.ts:81 — inline `expect(["42501", "42883", "PGRST202"]).toContain(error?.code);` (the canonical reference). Replace the inline array with the shared constant.
+- admin-rpc-grants.rls.test.ts:50,56,64,72 — inline `["42501", "42883", "PGRST202"]` ×4. Replace each with the shared constant.
+- users-privileged-columns.rls.test.ts:314 — inline `["42501", "42883", "PGRST202"]` ×1. Replace with the shared constant. NOTE: the many `expect(error!.code).toBe("42501")` sites in this file assert a SINGLE specific code (not the revoked set) — LEAVE those unchanged; they are not the duplicated literal.
+- rls-no-policy-lockdown.rls.test.ts:47 — `const DENIED_CODES = ["42501", "PGRST301", "PGRST302", "PGRST116"];` — a DIFFERENT 4-code set (RLS row-deny, not EXECUTE-revoke). It is NOT a copy of REVOKED_CODES. Move this constant into the shared helper too (as a named export DENIED_CODES) and import it, so no inline code-list literal remains here either.
+
+The message-string migration sites (verified: all are bare `raise exception` with NO `using errcode` → SQLSTATE 'P0001'):
+- dashboard-rpc-revenue-6mo.test.ts:175,180,197,198 — `get_dashboard_data_v2` "Access denied: cannot request data for another user" guard. The exception is bare `raise exception` (migration 20260524012602) → error.code = 'P0001'. Add `expect(error?.code).toBe("P0001")` as the PRIMARY rejection assertion. The `.toMatch(/access denied/i)` and `.toContain("cannot request data for another user")` may be KEPT as defense-in-depth (the code is the drift-insulated pin; the message phrasing is the semantic-change canary) — keeping them is fine, but the code assertion must be present.
+- dashboard-rpc-open-maintenance.test.ts:240 — same `get_dashboard_data_v2` "access denied" guard → add `expect(error?.code).toBe("P0001")` as the primary pin (keep the message regex as defense-in-depth).
+- bulk-import-create-lease.test.ts:229,248,328 — `bulk_import_create_lease` ownership + overlap guards: "Unit % is not yours or does not exist" (:229), "Tenant % is not yours or does not exist" (:248), "Unit % already has an active or pending lease overlapping..." (:328). All are bare `raise exception` (migration 20260423120000) → error.code = 'P0001'. Replace the `error!.message.toMatch(...)` rejection assertions with `expect(error!.code).toBe("P0001")` as the primary pin. The input-range validation `it.each` block at :255-292 also uses message regexes against bare `raise exception` ('Payment day must be between...', etc.) — those are ALSO P0001 but are application input-validation, NOT RLS/ownership rejections; LEAVE them (out of TEST-04's named scope — note them in the SUMMARY rather than migrating).
+
+IMPORTANT (false-migration guard): do NOT change any of these to '42501'. These ownership/overlap guards do NOT use `using errcode` so they raise the DEFAULT 'P0001' (raise_exception). Asserting '42501' here would make the test fail against prod. '42501' is only correct for the EXECUTE-revoke / grant-denial sites (the REVOKED_CODES set).
+
+Helper convention: the suite has no `_helpers` dir yet; shared setup currently lives in `tests/integration/setup/`. Create `tests/integration/rls/_helpers/revoked-codes.ts` (CONTEXT.md's suggested path) exporting both named const arrays. No barrel file / no re-export index (zero-tolerance rule #2) — import directly from this file.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create the shared code-set helper and rewire all 5 dup sites to import it</name>
+  <files>tests/integration/rls/_helpers/revoked-codes.ts, tests/integration/rls/anon-rpc-grants.rls.test.ts, tests/integration/rls/funnel-admin-rpc.test.ts, tests/integration/rls/admin-rpc-grants.rls.test.ts, tests/integration/rls/users-privileged-columns.rls.test.ts, tests/integration/rls/rls-no-policy-lockdown.rls.test.ts</files>
+  <read_first>
+    - tests/integration/rls/anon-rpc-grants.rls.test.ts (lines ~40-60 + the three usage sites ~224/234/257 — the canonical REVOKED_CODES declaration)
+    - tests/integration/rls/funnel-admin-rpc.test.ts (line ~81 — reference inline form)
+    - tests/integration/rls/admin-rpc-grants.rls.test.ts (lines ~47-73 — four inline arrays)
+    - tests/integration/rls/users-privileged-columns.rls.test.ts (line ~314 — the one revoked-set inline array; confirm the .toBe("42501") sites are single-code, leave them)
+    - tests/integration/rls/rls-no-policy-lockdown.rls.test.ts (line ~47 — DENIED_CODES; the different 4-code set)
+    - .planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md (TEST-04 LOCKED decision)
+  </read_first>
+  <action>
+    Create `tests/integration/rls/_helpers/revoked-codes.ts` exporting two named readonly arrays with explanatory comments: `REVOKED_CODES` = ['42501','42883','PGRST202'] (PostgREST surfaces a revoked EXECUTE on a SECURITY DEFINER fn as 42501 in current versions; older variants 42883/PGRST202) and `DENIED_CODES` = ['42501','PGRST301','PGRST302','PGRST116'] (PostgREST surfaces a missing table grant / RLS row-deny as one of these). Use `as const` or a typed `readonly string[]` so the values stay literal and immutable. No `any`, no default export, no re-export barrel.
+    Rewire each dup site:
+    - anon-rpc-grants.rls.test.ts: delete the local `const REVOKED_CODES = [...]` at ~:53 and add `import { REVOKED_CODES } from "./_helpers/revoked-codes";`. Usage sites at :224/:234/:257 stay as `expect(REVOKED_CODES).toContain(error?.code)`.
+    - funnel-admin-rpc.test.ts: replace the inline `["42501","42883","PGRST202"]` at ~:81 with `REVOKED_CODES` and add the import.
+    - admin-rpc-grants.rls.test.ts: replace all four inline `["42501","42883","PGRST202"]` (:50/:56/:64/:72) with `REVOKED_CODES` and add the import.
+    - users-privileged-columns.rls.test.ts: replace the single inline `["42501","42883","PGRST202"]` at ~:314 with `REVOKED_CODES` and add the import. Leave every `expect(error!.code).toBe("42501")` site untouched (single-code, not the duplicated set).
+    - rls-no-policy-lockdown.rls.test.ts: delete the local `const DENIED_CODES = [...]` at ~:47 and import `DENIED_CODES` from the helper; the `expectDenied` helper usage at ~:69 stays `expect(DENIED_CODES).toContain(error.code)`.
+    After rewiring, grep to confirm zero remaining inline `["42501", "42883", "PGRST202"]` literals and zero remaining inline `["42501", "PGRST301", "PGRST302", "PGRST116"]` literals across tests/integration/rls/ (excluding the helper file). Keep import paths correct (`./_helpers/revoked-codes` — the dup sites live in tests/integration/rls/, the helper is one dir deeper).
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint && grep -rL "revoked-codes" tests/integration/rls/anon-rpc-grants.rls.test.ts tests/integration/rls/funnel-admin-rpc.test.ts tests/integration/rls/admin-rpc-grants.rls.test.ts tests/integration/rls/users-privileged-columns.rls.test.ts tests/integration/rls/rls-no-policy-lockdown.rls.test.ts; test -z "$(grep -rn '\[\"42501\", \"42883\", \"PGRST202\"\]\|\[\"42501\", \"PGRST301\", \"PGRST302\", \"PGRST116\"\]' tests/integration/rls/ | grep -v _helpers/revoked-codes.ts)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/integration/rls/_helpers/revoked-codes.ts exists and exports REVOKED_CODES (['42501','42883','PGRST202']) + DENIED_CODES (['42501','PGRST301','PGRST302','PGRST116'])
+    - all 5 dup sites import from ./_helpers/revoked-codes (grep -rL "revoked-codes" returns none of the 5 files)
+    - zero remaining inline literal ["42501", "42883", "PGRST202"] and zero inline ["42501", "PGRST301", "PGRST302", "PGRST116"] anywhere under tests/integration/rls/ except the helper file
+    - the single-code `expect(error!.code).toBe("42501")` assertions in users-privileged-columns are left unchanged
+    - no barrel/re-export index created; no `any`; `bun run typecheck` and `bun run lint` pass
+  </acceptance_criteria>
+  <done>One shared helper sources both code sets; all 5 dup sites import it; no duplicated code-list literal remains; typecheck + lint clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Migrate message-string RLS/ownership-rejection assertions to error.code (SQLSTATE P0001)</name>
+  <files>tests/integration/rls/dashboard-rpc-revenue-6mo.test.ts, tests/integration/rls/dashboard-rpc-open-maintenance.test.ts, tests/integration/rls/bulk-import-create-lease.test.ts</files>
+  <read_first>
+    - tests/integration/rls/funnel-admin-rpc.test.ts (line ~81 — the reference error.code assertion style)
+    - tests/integration/rls/dashboard-rpc-revenue-6mo.test.ts (lines ~160-200 — the two access-denied guard blocks)
+    - tests/integration/rls/dashboard-rpc-open-maintenance.test.ts (lines ~225-242 — the access-denied guard)
+    - tests/integration/rls/bulk-import-create-lease.test.ts (lines ~218-329 — the ownership + overlap guards; note the input-range it.each block is OUT of scope)
+    - .planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md (TEST-04 migration-sites LOCKED decision)
+  </read_first>
+  <action>
+    All three RPCs raise their ownership/overlap guards via bare `raise exception` (NO `using errcode`) → SQLSTATE 'P0001'. Migrate the message-string rejection assertions to assert `error.code` as the PRIMARY pin. Do NOT use '42501' (these are not grant/EXECUTE denials).
+    dashboard-rpc-revenue-6mo.test.ts: at the A→B guard block (~:169-181) and the symmetric B→A block (~:195-199), add `expect(error?.code).toBe("P0001")` as the primary rejection assertion. Keep the existing `.toMatch(/access denied/i)` and `.toContain("cannot request data for another user")` as defense-in-depth (the code is the drift-insulated pin; the message lines remain a semantic-change canary).
+    dashboard-rpc-open-maintenance.test.ts: at the access-denied guard (~:233-240), add `expect(error?.code).toBe("P0001")` as the primary pin; keep the `.toMatch(/access denied/i)` as defense-in-depth.
+    bulk-import-create-lease.test.ts: replace the three ownership/overlap message-substring assertions with the code pin — :229 (`expect(error!.message).toMatch(/unit.*not yours|access denied/i)` → `expect(error!.code).toBe("P0001")`), :248 (tenant-not-yours → `expect(error!.code).toBe("P0001")`), :328 (overlap → `expect(error!.code).toBe("P0001")`). Keep the preceding `expect(error).not.toBeNull()` / `expect(error!.message)...` only if you want the message as defense-in-depth; at minimum the primary assertion becomes the code. LEAVE the input-range `it.each` validation block (~:255-292) untouched — it is application input-validation, not an RLS/ownership rejection (note this scoping in the SUMMARY).
+    If any site already asserts a code (none do here, per the read), leave it and note it in the SUMMARY. Vitest-4/chai-6: assert `{ data, error }` / `error.code`; never `.toThrow('string')`. No schema/frontend changes (test-only).
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint && grep -c 'error?.code).toBe("P0001")\|error!.code).toBe("P0001")' tests/integration/rls/dashboard-rpc-revenue-6mo.test.ts tests/integration/rls/dashboard-rpc-open-maintenance.test.ts tests/integration/rls/bulk-import-create-lease.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - dashboard-rpc-revenue-6mo.test.ts asserts error.code === 'P0001' at BOTH the A→B and B→A access-denied guard blocks (4 message-string sites :175/:180/:197/:198 now backed by a code pin)
+    - dashboard-rpc-open-maintenance.test.ts asserts error.code === 'P0001' at the access-denied guard (:240)
+    - bulk-import-create-lease.test.ts asserts error.code === 'P0001' at the three ownership/overlap rejections (:229 unit-not-yours, :248 tenant-not-yours, :328 overlap)
+    - NO assertion was changed to '42501' for these bare-raise-exception guards
+    - the bulk-import input-range it.each validation block is left unchanged
+    - no `.toThrow(` introduced; `bun run typecheck` and `bun run lint` pass
+  </acceptance_criteria>
+  <done>The named RLS/ownership-rejection sites assert SQLSTATE 'P0001' as the primary, drift-insulated pin; typecheck + lint clean.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| test assertion ↔ shipped SQLSTATE contract | the test must pin the rejection by a stable code, not a message string that can drift under chai-6 / wording changes |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-05-07 | Tampering (test integrity) | duplicated REVOKED_CODES literals drifting apart | mitigate | single shared helper is the only source; grep gate proves no inline duplicate remains |
+| T-05-08 | Repudiation (false-green) | message-substring assertions silently passing after wording drift | mitigate | primary assertion is error.code (P0001 for ownership/overlap guards; REVOKED_CODES set for EXECUTE-revoke), insulated from message drift |
+| T-05-09 | (false-migration risk) | swapping P0001 guards to 42501 | accept→mitigate | plan explicitly forbids 42501 for the bare-raise-exception ownership/overlap guards; acceptance criteria pin P0001 |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint` clean for the helper + 8 edited files.
+- Grep gates: no inline REVOKED_CODES/DENIED_CODES literal remains outside the helper; the three migrated files contain the P0001 code assertions.
+- Structural sanity only: at most ONE local run of the affected files via `bun run test:integration -- --run <files>` (auth rate-limit ~45 sign-ins/min — do NOT loop). Otherwise rely on the `rls-security` CI gate.
+</verification>
+
+<success_criteria>
+RLS-rejection tests assert `error.code` / SQLSTATE (not message strings) at the named sites (ROADMAP Phase 5 success criterion 3), and the `REVOKED_CODES` literal is extracted to one shared helper consumed by all dup sites with no duplicated code-list literal remaining (success criterion 4). No schema/frontend/type changes.
+</success_criteria>
+
+<output>
+Create `.planning/phases/05-cross-owner-rls-coverage/05-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/05-cross-owner-rls-coverage/05-03-SUMMARY.md
+++ b/.planning/phases/05-cross-owner-rls-coverage/05-03-SUMMARY.md
@@ -1,0 +1,97 @@
+---
+phase: 05-cross-owner-rls-coverage
+plan: 03
+subsystem: testing/rls-integration
+tags: [test-only, rls, sqlstate, refactor, dedup]
+requires: []
+provides:
+  - "tests/integration/rls/_helpers/revoked-codes.ts (single source for REVOKED_CODES + DENIED_CODES)"
+  - "SQLSTATE-pinned RLS/ownership rejection assertions (P0001) at the audit-named sites"
+affects:
+  - tests/integration/rls (rls-security CI gate)
+tech-stack:
+  added: []
+  patterns:
+    - "Shared code-set helper imported directly (no barrel) by all dup sites"
+    - "Primary assertion on error.code (SQLSTATE) with message-substring kept only as defense-in-depth canary"
+key-files:
+  created:
+    - tests/integration/rls/_helpers/revoked-codes.ts
+  modified:
+    - tests/integration/rls/funnel-admin-rpc.test.ts
+    - tests/integration/rls/admin-rpc-grants.rls.test.ts
+    - tests/integration/rls/anon-rpc-grants.rls.test.ts
+    - tests/integration/rls/rls-no-policy-lockdown.rls.test.ts
+    - tests/integration/rls/users-privileged-columns.rls.test.ts
+    - tests/integration/rls/dashboard-rpc-revenue-6mo.test.ts
+    - tests/integration/rls/dashboard-rpc-open-maintenance.test.ts
+    - tests/integration/rls/bulk-import-create-lease.test.ts
+decisions:
+  - "Migrated bare-raise-exception ownership/overlap guards assert P0001 (PostgreSQL default for raise_exception with no `using errcode`), NOT 42501 — 42501 is reserved for EXECUTE-revoke/grant denials"
+  - "Message-substring assertions kept as defense-in-depth semantic-change canaries alongside the new code pin (not deleted)"
+  - "REVOKED_CODES and DENIED_CODES exported as two SEPARATE named consts — they are different sets (EXECUTE-revoke vs RLS row-deny)"
+metrics:
+  duration: ~12m
+  completed: 2026-06-06
+  tasks: 2
+  files: 9
+---
+
+# Phase 5 Plan 03: SQLSTATE Assertions + Shared REVOKED_CODES Helper Summary
+
+Extracted the duplicated `REVOKED_CODES` literal (and the distinct `DENIED_CODES` set) to one shared helper consumed by all 5 dup sites, and migrated the message-string RLS/ownership-rejection assertions at the audit-named sites to pin SQLSTATE `P0001` — insulating them from chai-6 / message-drift fragility while keeping the message lines as defense-in-depth canaries.
+
+## What Was Built
+
+### Task 1: Shared code-set helper + rewire 5 dup sites (commit `e1ed304f4`)
+- Created `tests/integration/rls/_helpers/revoked-codes.ts` exporting two `readonly string[]` named consts:
+  - `REVOKED_CODES = ["42501","42883","PGRST202"]` — EXECUTE-revoke set (revoked EXECUTE on a SECURITY DEFINER fn surfaces as one of these).
+  - `DENIED_CODES = ["42501","PGRST301","PGRST302","PGRST116"]` — RLS row-deny / missing-table-grant set (a DIFFERENT set, used only by rls-no-policy-lockdown).
+- Rewired all 5 dup sites to import directly (no barrel / no re-export index, per zero-tolerance rule #2):
+  - `anon-rpc-grants.rls.test.ts` — deleted local `const REVOKED_CODES`, imports the shared const (usage at :224/:234/:257 unchanged).
+  - `funnel-admin-rpc.test.ts` — inline `["42501","42883","PGRST202"]` at the canonical reference site replaced with `REVOKED_CODES`.
+  - `admin-rpc-grants.rls.test.ts` — all four inline arrays replaced with `REVOKED_CODES`.
+  - `users-privileged-columns.rls.test.ts` — the single 3-code inline array replaced with `REVOKED_CODES`. The 9 single-code `expect(error!.code).toBe("42501")` pins (legitimate EXECUTE-revoke / column-grant denials) were LEFT UNTOUCHED.
+  - `rls-no-policy-lockdown.rls.test.ts` — deleted local `const DENIED_CODES`, imports the shared `DENIED_CODES` (the `expectDenied` helper usage unchanged).
+
+### Task 2: Migrate message-string rejection assertions to SQLSTATE P0001 (commit `1b5148161`)
+All three RPCs raise their ownership/overlap guards via bare `raise exception` (NO `using errcode`) → PostgreSQL default SQLSTATE `P0001` (raise_exception). The primary assertion is now `error.code === "P0001"`; the message-substring checks were kept as defense-in-depth semantic-change canaries.
+- `dashboard-rpc-revenue-6mo.test.ts` — added `expect(error?.code).toBe("P0001")` at BOTH the A→B and B→A access-denied guard blocks (2 code pins).
+- `dashboard-rpc-open-maintenance.test.ts` — added `expect(error?.code).toBe("P0001")` at the access-denied guard (1 code pin).
+- `bulk-import-create-lease.test.ts` — added `expect(error!.code).toBe("P0001")` at the three ownership/overlap rejections: unit-not-yours, tenant-not-yours, overlap (3 code pins).
+
+## Verification
+
+| Gate | Result |
+|------|--------|
+| `bun run typecheck` | PASS (`tsc --noEmit`, clean) |
+| `bun run lint` (biome) | PASS (No fixes applied; the `biome.json` schema-version info note is pre-existing and unrelated) |
+| Inline `["42501","42883","PGRST202"]` outside helper | NONE |
+| Inline `["42501","PGRST301","PGRST302","PGRST116"]` outside helper | NONE |
+| All 5 sites import `./_helpers/revoked-codes` | YES (grep -L returns none) |
+| P0001 code pins: revenue-6mo / open-maintenance / bulk-import | 2 / 1 / 3 |
+| `42501` introduced on the bare-raise guards | NONE (forbidden — would fail against prod) |
+| `.toThrow(` introduced | NONE |
+| users-privileged-columns single-code `.toBe("42501")` pins | 9, untouched |
+| Pre-commit lefthook gate (gitleaks, lint, typecheck, unit-tests) | PASS both commits |
+
+Both commits passed the full lefthook gate (NEVER `--no-verify`). No integration suite was run locally (auth rate-limit ~45 sign-ins/min) — the `rls-security` CI gate is the runtime proof per the plan's execution rules; typecheck + grep gates are the local proof.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. Both tasks followed the LOCKED decisions and the false-migration guard (P0001 not 42501 on the bare-raise guards).
+
+## Out-of-Scope (noted per plan)
+
+- `bulk-import-create-lease.test.ts` input-range `it.each` validation block (~:255-292) and the NULL-guard `it.each` block (~:360-391): these use message regexes against bare `raise exception` (also P0001) but are application INPUT-validation, not RLS/ownership rejections. LEFT UNCHANGED per the plan's explicit scoping.
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+
+- `tests/integration/rls/_helpers/revoked-codes.ts` — FOUND
+- Commit `e1ed304f4` (Task 1) — FOUND
+- Commit `1b5148161` (Task 2) — FOUND
+- All 8 modified test files present on branch `gsd/phase-5-cross-owner-rls-coverage`

--- a/.planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md
+++ b/.planning/phases/05-cross-owner-rls-coverage/05-CONTEXT.md
@@ -1,0 +1,61 @@
+# Phase 5: Cross-Owner RLS Coverage - Context
+
+**Gathered:** 2026-06-06
+**Status:** Ready for planning
+**Source:** Live-DB-grounded (Supabase MCP RLS-policy introspection). Test-only phase — no schema/frontend/type changes.
+
+<domain>
+## Phase Boundary
+Add dual-client (ownerA/ownerB) RLS integration tests for the owner-scoped tables that lacked cross-owner coverage, harden RLS-rejection assertions to SQLSTATE codes, and extract the duplicated `REVOKED_CODES` literal to one shared helper. All under `tests/integration/rls/`, running in the `rls-security` CI gate.
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED)
+
+### TEST-01 — dual-client tests for reports / expenses / document_template_definitions
+All RLS-enabled with full S/I/U/D owner policies (verified). Scoping:
+- **reports** — DIRECT `owner_user_id`. Simple: ownerA inserts a report; ownerB cannot SELECT/UPDATE/DELETE it (0 rows / rejection); ownerA sees only their own.
+- **document_template_definitions** — DIRECT `owner_user_id`. Same shape.
+- **expenses** — INDIRECT via `maintenance_request_id` → `maintenance_requests.owner_user_id` (verified: the RLS + the expense RPCs all join `mr.owner_user_id = p_user_id`; expenses have NO direct owner column). So the fixture must create ownerA's chain: property → unit → maintenance_request → expense, then assert ownerB can't read/mutate the expense.
+
+### TEST-02 — dual-client tests for the 4 join-policy child tables
+All RLS-enabled; owner isolation is enforced via the parent chain (verified scoping cols):
+- **property_images** — via `property_id` → properties.owner. Policies S/I/U/D.
+- **inspection_rooms** — via `inspection_id` → inspections.owner. Policies S/I/U/D.
+- **inspection_photos** — via `inspection_id` + `inspection_room_id`. Policies S/I/D only (NO UPDATE policy — do NOT test UPDATE; test SELECT/INSERT/DELETE isolation).
+- **maintenance_request_photos** — via `maintenance_request_id` → maintenance_requests.owner. Policies S/I/D only (NO UPDATE — same).
+Each test builds ownerA's full parent chain, inserts the child row as ownerA, then asserts ownerB is denied on every policy that exists for that table (read returns 0 rows; write rejected). Reuse the parent-chain fixture helpers from the sibling tests (properties/inspections/maintenance) — don't reinvent the chain setup.
+
+### TEST-04 — SQLSTATE assertions + shared REVOKED_CODES helper
+- **Extract `REVOKED_CODES`** (`["42501","42883","PGRST202"]` — or the exact current literal) to ONE shared test helper (e.g. `tests/integration/rls/_helpers/revoked-codes.ts` or the existing shared-helpers location — match the suite's convention). Consumed by ALL current duplicate sites — there are **5** (not 4): `funnel-admin-rpc.test.ts`, `admin-rpc-grants.rls.test.ts`, `rls-no-policy-lockdown.rls.test.ts`, `anon-rpc-grants.rls.test.ts`, `users-privileged-columns.rls.test.ts`. No duplicated code-list literal may remain.
+- **Migrate message-string RLS-rejection assertions to `error.code` / SQLSTATE** at the audit-named sites: `dashboard-rpc-revenue-6mo.test.ts` (~:175/:180/:197/:198), `dashboard-rpc-open-maintenance.test.ts` (~:240), `bulk-import-create-lease.test.ts` (~:229/:248/:328). Read each: where it asserts on `error.message`/a message string for an RLS/permission rejection, switch to asserting `error.code` (SQLSTATE, e.g. `42501`) or membership in the shared `REVOKED_CODES`. If a site already asserts codes, leave it (note it). Goal: insulate from chai-6 / message-drift fragility (the canonical `funnel-admin-rpc.test.ts:81` code-assertion is the reference style).
+
+### Constraints
+- Integration tests authenticate two synthetic owners against PROD (`e2e-owner-a@tenantflow.app` / `e2e-owner-b@tenantflow.app` — NEVER personal creds). Supabase auth rate-limits sign-ins ~45/min — do NOT run the full suite repeatedly locally; one structural local run at most, else rely on the `rls-security` CI gate (which fails hard on missing secrets). Mirror the existing harness exactly.
+- `afterAll` FK-safe cleanup (delete children before parents) so reruns don't accumulate rows or hit FK violations.
+- Vitest-4/chai-6 gotcha: assert on `{ data, error }` tuples / `error.code`, not `.toThrow('string')`.
+</decisions>
+
+<canonical_refs>
+## Canonical References
+- **Dual-client harness + parent-chain fixtures:** `tests/integration/rls/stats-rpcs.rls.test.ts` (Phase-3, the recent dual-client template), `properties.rls.test.ts`, `inspections.rls.test.ts`, `maintenance.rls.test.ts`, `bulk-import-create-lease.test.ts` (the ownerA/ownerB client setup + chain builders).
+- **SQLSTATE-code assertion reference:** `funnel-admin-rpc.test.ts:81` (asserts `error.code` membership).
+- **The 5 REVOKED_CODES duplicate sites** (listed above) + wherever the suite keeps shared helpers (check for an existing `_helpers`/`setup` dir under `tests/integration/`).
+- CLAUDE.md "Integration Test Coverage" + "RLS integration" sections.
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+- Probable plan split: 05-01 (TEST-01 direct+expense tests), 05-02 (TEST-02 four child-table tests), 05-03 (TEST-04 helper extract + SQLSTATE migration). 05-03 is independent of 05-01/02 (touches different files) → can parallelize.
+- For photos tables (S/I/D-only), assert isolation on SELECT/INSERT/DELETE only — asserting a non-existent UPDATE policy would be a false test.
+- Reuse, don't duplicate, the synthetic-owner auth client factory the sibling tests already import.
+</specifics>
+
+<deferred>
+## Deferred Ideas
+None — TEST-03 (auth/dollar-hook UNIT tests) is the SEPARATE Phase 6, not this phase.
+</deferred>
+
+---
+*Phase: 05-cross-owner-rls-coverage*
+*Context gathered: 2026-06-06 — live RLS-policy scoping paths verified; 7 target tables + 5 REVOKED_CODES dup sites + 3 message-string migration sites identified.*

--- a/tests/integration/rls/_helpers/revoked-codes.ts
+++ b/tests/integration/rls/_helpers/revoked-codes.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared SQLSTATE/PostgREST error-code sets for RLS integration tests.
+ *
+ * Single source of truth so the duplicated code-list literals across the
+ * suite cannot drift apart (TEST-04). Import the named set directly — do
+ * NOT add a barrel/re-export index (zero-tolerance rule #2).
+ */
+
+/**
+ * EXECUTE-revoke set: PostgREST surfaces a revoked EXECUTE on a SECURITY
+ * DEFINER function as `42501` (insufficient_privilege) in current versions;
+ * older variants returned `42883` (undefined_function) or `PGRST202`
+ * (function not found via the PostgREST schema cache). Accept any of the
+ * three so a test pins "function is unreachable from this role", not a
+ * specific code string.
+ *
+ * Consumed by: anon-rpc-grants, funnel-admin-rpc, admin-rpc-grants,
+ * users-privileged-columns.
+ */
+export const REVOKED_CODES: readonly string[] = ["42501", "42883", "PGRST202"];
+
+/**
+ * RLS row-deny / missing-table-grant set: PostgREST surfaces a missing table
+ * grant or an RLS row-level denial as `42501` (insufficient_privilege),
+ * `PGRST301` / `PGRST302` (JWT / authorization failures), or `PGRST116`
+ * (no rows / not found). This is a DIFFERENT set from REVOKED_CODES — it
+ * covers table-level row-deny, not function EXECUTE-revoke.
+ *
+ * Consumed by: rls-no-policy-lockdown.
+ */
+export const DENIED_CODES: readonly string[] = [
+	"42501",
+	"PGRST301",
+	"PGRST302",
+	"PGRST116",
+];

--- a/tests/integration/rls/admin-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/admin-rpc-grants.rls.test.ts
@@ -27,6 +27,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+import { REVOKED_CODES } from "./_helpers/revoked-codes";
 
 describe("admin RPC grants — authenticated cannot reach revoked admin functions", () => {
 	let clientA: SupabaseClient;
@@ -47,13 +48,13 @@ describe("admin RPC grants — authenticated cannot reach revoked admin function
 	it("check_stripe_sync_status: revoked from ownerA", async () => {
 		const { error } = await clientA.rpc("check_stripe_sync_status");
 		expect(error).not.toBeNull();
-		expect(["42501", "42883", "PGRST202"]).toContain(error!.code);
+		expect(REVOKED_CODES).toContain(error!.code);
 	});
 
 	it("check_stripe_sync_status: revoked from ownerB", async () => {
 		const { error } = await clientB.rpc("check_stripe_sync_status");
 		expect(error).not.toBeNull();
-		expect(["42501", "42883", "PGRST202"]).toContain(error!.code);
+		expect(REVOKED_CODES).toContain(error!.code);
 	});
 
 	it("get_user_id_by_stripe_customer: revoked from ownerA", async () => {
@@ -61,7 +62,7 @@ describe("admin RPC grants — authenticated cannot reach revoked admin function
 			p_stripe_customer_id: "cus_does_not_matter",
 		});
 		expect(error).not.toBeNull();
-		expect(["42501", "42883", "PGRST202"]).toContain(error!.code);
+		expect(REVOKED_CODES).toContain(error!.code);
 	});
 
 	it("get_user_id_by_stripe_customer: revoked from ownerB", async () => {
@@ -69,6 +70,6 @@ describe("admin RPC grants — authenticated cannot reach revoked admin function
 			p_stripe_customer_id: "cus_does_not_matter",
 		});
 		expect(error).not.toBeNull();
-		expect(["42501", "42883", "PGRST202"]).toContain(error!.code);
+		expect(REVOKED_CODES).toContain(error!.code);
 	});
 });

--- a/tests/integration/rls/anon-rpc-grants.rls.test.ts
+++ b/tests/integration/rls/anon-rpc-grants.rls.test.ts
@@ -39,6 +39,7 @@
 
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+import { REVOKED_CODES } from "./_helpers/revoked-codes";
 
 const SUPABASE_URL = process.env["NEXT_PUBLIC_SUPABASE_URL"];
 const SUPABASE_PUBLISHABLE_KEY =
@@ -49,8 +50,6 @@ if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
 		"Missing required env vars: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
 	);
 }
-
-const REVOKED_CODES = ["42501", "42883", "PGRST202"];
 
 /** Functions revoked from anon (22 total: 2 IDOR + 19 defense-in-depth + is_admin via pass 3). */
 const REVOKED_FROM_ANON: Array<{

--- a/tests/integration/rls/bulk-import-create-lease.test.ts
+++ b/tests/integration/rls/bulk-import-create-lease.test.ts
@@ -226,6 +226,12 @@ describe("bulk_import_create_lease RPC", () => {
 			p_payment_day: 1,
 		});
 		expect(error).not.toBeNull();
+		// PRIMARY pin: SQLSTATE. The ownership guard is a bare `raise
+		// exception` (no `using errcode`, migration 20260423120000) →
+		// PostgreSQL default 'P0001' (raise_exception). NOT '42501' (that is
+		// only for EXECUTE-revoke / grant denials, which this is not).
+		expect(error!.code).toBe("P0001");
+		// Defense-in-depth: message as semantic-change canary.
 		expect(error!.message).toMatch(/unit.*not yours|access denied/i);
 	});
 
@@ -245,6 +251,10 @@ describe("bulk_import_create_lease RPC", () => {
 			p_payment_day: 1,
 		});
 		expect(error).not.toBeNull();
+		// PRIMARY pin: SQLSTATE 'P0001' (bare `raise exception`, no `using
+		// errcode`). Same drift-insulated contract as the unit-ownership block.
+		expect(error!.code).toBe("P0001");
+		// Defense-in-depth: message as semantic-change canary.
 		expect(error!.message).toMatch(/tenant.*not yours|access denied/i);
 	});
 
@@ -325,6 +335,11 @@ describe("bulk_import_create_lease RPC", () => {
 			p_payment_day: 1,
 		});
 		expect(error).not.toBeNull();
+		// PRIMARY pin: SQLSTATE 'P0001'. The overlap guard is a bare `raise
+		// exception` (no `using errcode`, migration 20260423120000) →
+		// PostgreSQL default 'P0001'.
+		expect(error!.code).toBe("P0001");
+		// Defense-in-depth: message as semantic-change canary.
 		expect(error!.message).toMatch(/overlap/i);
 	});
 

--- a/tests/integration/rls/dashboard-rpc-open-maintenance.test.ts
+++ b/tests/integration/rls/dashboard-rpc-open-maintenance.test.ts
@@ -232,7 +232,12 @@ describe("get_dashboard_data_v2 — open_maintenance per-property RLS isolation"
 		// ownerA, the original P0 leak).
 		expect(data).toBeNull();
 		expect(error).not.toBeNull();
-		// Strict regex against the project-standard message
+		// PRIMARY pin: SQLSTATE. The guard is a bare `raise exception` (no
+		// `using errcode`, migration 20260524012602) → PostgreSQL default
+		// 'P0001' (raise_exception). The code is the drift-insulated pin; NOT
+		// '42501' (that is only for EXECUTE-revoke / grant denials).
+		expect(error?.code).toBe("P0001");
+		// Defense-in-depth: strict regex against the project-standard message
 		// "Access denied: cannot request data for another user" used by
 		// 20+ other stats RPCs and asserted by
 		// tests/integration/rls/rpc-auth.test.ts. Migration

--- a/tests/integration/rls/dashboard-rpc-revenue-6mo.test.ts
+++ b/tests/integration/rls/dashboard-rpc-revenue-6mo.test.ts
@@ -168,15 +168,21 @@ describe("get_dashboard_data_v2 — monthly_revenue_6mo (Phase 4 CHART-01) RLS i
 		// migration `20260524001408` was added to prevent).
 		expect(data).toBeNull();
 		expect(error).not.toBeNull();
+		// PRIMARY pin: SQLSTATE. The guard is a bare `raise exception` (no
+		// `using errcode`, migration 20260524012602) → PostgreSQL default
+		// 'P0001' (raise_exception). Asserting the code insulates this test
+		// from chai-6 / message-string drift. NOT '42501' — that is only for
+		// EXECUTE-revoke / grant denials, which this is not.
+		expect(error?.code).toBe("P0001");
+		// Defense-in-depth: the message lines remain a semantic-change canary.
 		// Regex matches the SHIPPED project-standard message — used by 20+
 		// other stats RPCs and asserted by `rpc-auth.test.ts`. Do NOT use
 		// the older empty-array contract from the pre-cycle-10 Phase 2
 		// plan (RESEARCH.md Pitfall 1).
 		expect(error?.message).toMatch(/access denied/i);
-		// Defense-in-depth: pin the full cycle-10 message phrasing so a
-		// future refactor that swaps the wording to a different
-		// "access denied" phrase still passes the regex but flags here
-		// that something semantic changed.
+		// Pin the full cycle-10 message phrasing so a future refactor that
+		// swaps the wording to a different "access denied" phrase still passes
+		// the regex but flags here that something semantic changed.
 		expect(error?.message).toContain("cannot request data for another user");
 	});
 
@@ -194,6 +200,10 @@ describe("get_dashboard_data_v2 — monthly_revenue_6mo (Phase 4 CHART-01) RLS i
 		// test fails immediately.
 		expect(data).toBeNull();
 		expect(error).not.toBeNull();
+		// PRIMARY pin: SQLSTATE 'P0001' (bare `raise exception`, no `using
+		// errcode`). Same drift-insulated contract as the A→B block above.
+		expect(error?.code).toBe("P0001");
+		// Defense-in-depth: message lines as semantic-change canary.
 		expect(error?.message).toMatch(/access denied/i);
 		expect(error?.message).toContain("cannot request data for another user");
 	});

--- a/tests/integration/rls/document-template-definitions.rls.test.ts
+++ b/tests/integration/rls/document-template-definitions.rls.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Dual-client (ownerA / ownerB) RLS isolation tests for
+ * `document_template_definitions`.
+ *
+ * This is a DIRECT-owner table: `owner_user_id` references `users.id` and all
+ * four policies key on `(select auth.uid()) = owner_user_id`. This file is the
+ * regression proof (TEST-01 / threats T-05-01, T-05-02) that a future RLS
+ * refactor cannot leak one owner's template definitions to another. Runs in the
+ * `rls-security` CI gate.
+ *
+ * Schema constraints honored here (verified against migration
+ * 20260311200000_document_template_definitions.sql):
+ *  - `template_key` has a CHECK limiting it to exactly five values
+ *    ('lease', 'maintenance-request', 'property-inspection',
+ *    'rental-application', 'tenant-notice') — arbitrary keys would violate the
+ *    CHECK, so the test uses real keys.
+ *  - UNIQUE (owner_user_id, template_key) — only one row per owner per key, so
+ *    each fixture/throwaway row uses a distinct key and beforeAll first clears
+ *    any pre-existing rows for the keys this test owns (synthetic accounts may
+ *    carry leftovers from prior runs).
+ *
+ * Every cross-owner case asserts the DENIAL side, not merely "no error":
+ *  - SELECT: ownerA's row id ABSENT from ownerB's result (0 rows).
+ *  - INSERT: ownerB hijack -> error not null + data null (WITH CHECK).
+ *  - UPDATE/DELETE: ownerB -> error null + data [] (USING hides the row), then a
+ *    re-read as ownerA confirms the row survives unchanged.
+ * Positive controls prove the policy rejects only the cross-owner case.
+ *
+ * Mirrors `tests/integration/rls/properties.rls.test.ts`.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+// Valid template_key values (CHECK-allowed). Distinct keys per role so the
+// UNIQUE(owner_user_id, template_key) constraint never collides across the
+// fixture, the insert positive control, and the delete positive control.
+const FIXTURE_KEY = "lease";
+const INSERT_POSITIVE_KEY = "maintenance-request";
+const DELETE_POSITIVE_KEY = "property-inspection";
+// All keys this test owns for ownerA — cleared up-front and torn down after.
+const OWNED_KEYS = [FIXTURE_KEY, INSERT_POSITIVE_KEY, DELETE_POSITIVE_KEY];
+
+describe("Document Template Definitions RLS — cross-owner isolation", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+	let ownerAId: string;
+	let ownerBId: string;
+
+	// ownerA's fixture row the cross-owner denial tests target.
+	let definitionA: { id: string } | null = null;
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		const {
+			data: { user: userA },
+		} = await clientA.auth.getUser();
+		const {
+			data: { user: userB },
+		} = await clientB.auth.getUser();
+		ownerAId = userA!.id;
+		ownerBId = userB!.id;
+
+		// Clear any leftover rows for the keys this test owns so the inserts below
+		// don't trip the UNIQUE(owner_user_id, template_key) constraint on rerun.
+		for (const key of OWNED_KEYS) {
+			await clientA
+				.from("document_template_definitions")
+				.delete()
+				.eq("owner_user_id", ownerAId)
+				.eq("template_key", key);
+		}
+
+		const { data: dA } = await clientA
+			.from("document_template_definitions")
+			.insert({
+				owner_user_id: ownerAId,
+				template_key: FIXTURE_KEY,
+				custom_fields: [{ label: "RLS Test Field A" }],
+			})
+			.select("id")
+			.single();
+		definitionA = dA ? { id: dA.id } : null;
+	});
+
+	afterAll(async () => {
+		// Leaf table — delete every owned key under ownerA (covers fixture + the
+		// insert/delete positive-control rows whichever survived).
+		for (const key of OWNED_KEYS) {
+			await clientA
+				.from("document_template_definitions")
+				.delete()
+				.eq("owner_user_id", ownerAId)
+				.eq("template_key", key);
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// SELECT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can only read their own template definitions", async () => {
+		const { data, error } = await clientA
+			.from("document_template_definitions")
+			.select("id, owner_user_id");
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		data!.forEach((row) => {
+			expect(row.owner_user_id).toBe(ownerAId);
+		});
+	});
+
+	it("owner A finds the fixture definition (positive control)", async () => {
+		if (!definitionA) {
+			console.warn("Skipping: ownerA template definition fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("document_template_definitions")
+			.select("id")
+			.eq("id", definitionA.id);
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: definitionA.id }]);
+	});
+
+	it("owner B cannot SELECT owner A's template definition (0 rows)", async () => {
+		if (!definitionA) {
+			console.warn("Skipping: ownerA template definition fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("document_template_definitions")
+			.select("id")
+			.eq("id", definitionA.id);
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+	});
+
+	it("owner B results contain no rows from owner A", async () => {
+		const { data: dataA } = await clientA
+			.from("document_template_definitions")
+			.select("id, owner_user_id");
+		const { data: dataB } = await clientB
+			.from("document_template_definitions")
+			.select("id, owner_user_id");
+
+		const ownerAIds = new Set((dataA ?? []).map((r) => r.id as string));
+		const ownerBIds = new Set((dataB ?? []).map((r) => r.id as string));
+
+		ownerBIds.forEach((id) => {
+			expect(ownerAIds.has(id)).toBe(false);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can insert a template definition with their own owner_user_id (positive control)", async () => {
+		const { data, error } = await clientA
+			.from("document_template_definitions")
+			.insert({
+				owner_user_id: ownerAId,
+				template_key: INSERT_POSITIVE_KEY,
+			})
+			.select("id")
+			.single();
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+	});
+
+	it("owner B cannot INSERT a template definition carrying owner A's owner_user_id", async () => {
+		const { data, error } = await clientB
+			.from("document_template_definitions")
+			.insert({
+				owner_user_id: ownerAId,
+				template_key: "tenant-notice",
+			})
+			.select("id")
+			.single();
+
+		// WITH CHECK blocks the hijack — ownerB's auth.uid() != ownerAId.
+		expect(error).not.toBeNull();
+		expect(data).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// UPDATE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can update their own template definition (positive control)", async () => {
+		if (!definitionA) {
+			console.warn("Skipping: ownerA template definition fixture not created");
+			return;
+		}
+		// Mutate a safe field (custom_fields) — never template_key, which is
+		// UNIQUE-constrained per owner.
+		const { data, error } = await clientA
+			.from("document_template_definitions")
+			.update({ custom_fields: [{ label: "RLS Updated Field A" }] })
+			.eq("id", definitionA.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: definitionA.id }]);
+
+		// Restore original custom_fields.
+		await clientA
+			.from("document_template_definitions")
+			.update({ custom_fields: [{ label: "RLS Test Field A" }] })
+			.eq("id", definitionA.id);
+	});
+
+	it("owner B cannot UPDATE owner A's template definition (USING hides it: data [])", async () => {
+		if (!definitionA) {
+			console.warn("Skipping: ownerA template definition fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("document_template_definitions")
+			.update({ custom_fields: [{ label: "RLS Hijack Field" }] })
+			.eq("id", definitionA.id)
+			.select("id");
+
+		// USING clause prevents ownerB from seeing/updating the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Row survives unchanged for ownerA.
+		const { data: stillExists } = await clientA
+			.from("document_template_definitions")
+			.select("id")
+			.eq("id", definitionA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can delete their own throwaway template definition (positive control)", async () => {
+		const { data: inserted } = await clientA
+			.from("document_template_definitions")
+			.insert({
+				owner_user_id: ownerAId,
+				template_key: DELETE_POSITIVE_KEY,
+			})
+			.select("id")
+			.single();
+		expect(inserted).not.toBeNull();
+
+		const { data, error } = await clientA
+			.from("document_template_definitions")
+			.delete()
+			.eq("id", inserted!.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: inserted!.id }]);
+	});
+
+	it("owner B cannot DELETE owner A's template definition (USING hides it: data []), row survives", async () => {
+		if (!definitionA) {
+			console.warn("Skipping: ownerA template definition fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("document_template_definitions")
+			.delete()
+			.eq("id", definitionA.id)
+			.select("id");
+
+		// USING clause prevents ownerB from seeing/deleting the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Verify the row still exists for ownerA.
+		const { data: stillExists } = await clientA
+			.from("document_template_definitions")
+			.select("id")
+			.eq("id", definitionA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+});

--- a/tests/integration/rls/expenses.rls.test.ts
+++ b/tests/integration/rls/expenses.rls.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Dual-client (ownerA / ownerB) RLS isolation tests for `expenses`.
+ *
+ * `expenses` is an INDIRECT-owner table: it has NO direct owner column. Owner
+ * isolation is reached only through `maintenance_request_id` ->
+ * `maintenance_requests.owner_user_id`. All four policies
+ * (expenses_{select,insert,update,delete}_owner) wrap an
+ * `EXISTS (SELECT 1 FROM maintenance_requests mr WHERE mr.id =
+ * expenses.maintenance_request_id AND mr.owner_user_id = caller)` guard.
+ *
+ * This file is the regression proof (TEST-01 / threats T-05-01, T-05-02,
+ * T-05-03) that a future RLS refactor cannot leak one owner's expenses to
+ * another through the indirect ownership path. Runs in the `rls-security` CI
+ * gate.
+ *
+ * Fixture chain (built under ownerA via the AUTHENTICATED client, not
+ * service-role): property -> unit -> tenant -> maintenance_request -> expense.
+ * The maintenance_request INSERT policy `maintenance_requests_insert_owner`
+ * (migration 20260506013951) requires owner_user_id = caller AND unit_id IN
+ * caller's units — so the unit is inserted first and referenced. The MR also
+ * requires a non-null tenant_id FK, so an ownerA tenant is inserted into the
+ * chain.
+ *
+ * Every cross-owner case asserts the DENIAL side, not merely "no error":
+ *  - SELECT: ownerA's expense id ABSENT from ownerB's result (0 rows).
+ *  - INSERT: ownerB referencing ownerA's MR -> error not null + data null
+ *    (WITH CHECK EXISTS-on-parent-MR fails for ownerB).
+ *  - UPDATE/DELETE: ownerB -> error null + data [] (USING hides the row), then a
+ *    re-read as ownerA confirms the expense survives unchanged.
+ * Positive control: ownerA SELECTs the expense and finds it.
+ *
+ * Mirrors the multi-step chain builder + FK-safe teardown of
+ * `tests/integration/rls/stats-rpcs.rls.test.ts`.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+const FIXTURE_AMOUNT = 123.45;
+const FIXTURE_EXPENSE_DATE = "2026-01-15";
+
+describe("Expenses RLS — cross-owner isolation (indirect via maintenance_request_id)", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+	let ownerAId: string;
+	let ownerBId: string;
+
+	// Fixture chain under ownerA. FK-safe teardown deletes child-before-parent.
+	let propertyA: { id: string } | null = null;
+	let unitA: { id: string } | null = null;
+	let tenantA: { id: string } | null = null;
+	let maintenanceRequestA: { id: string } | null = null;
+	let expenseA: { id: string } | null = null;
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		const {
+			data: { user: userA },
+		} = await clientA.auth.getUser();
+		const {
+			data: { user: userB },
+		} = await clientB.auth.getUser();
+		ownerAId = userA!.id;
+		ownerBId = userB!.id;
+
+		// Build ownerA's chain through the authenticated client. Each step guards
+		// on the previous one so a partial failure surfaces as a graceful skip
+		// rather than a misleading FK error in a later step.
+		const stamp = Date.now();
+
+		const { data: pA } = await clientA
+			.from("properties")
+			.insert({
+				name: "Expenses RLS Test Property A",
+				address_line1: "1 Expenses St",
+				city: "Testville",
+				state: "TX",
+				postal_code: "00000",
+				country: "US",
+				property_type: "single_family",
+				owner_user_id: ownerAId,
+			})
+			.select("id")
+			.single();
+		propertyA = pA ? { id: pA.id } : null;
+		if (!propertyA) console.warn("Skipping chain: property insert failed");
+
+		if (propertyA) {
+			const { data: uA } = await clientA
+				.from("units")
+				.insert({
+					property_id: propertyA.id,
+					unit_number: `EXP-A-${stamp}`,
+					bedrooms: 1,
+					bathrooms: 1,
+					rent_amount: 1000,
+					status: "available",
+					owner_user_id: ownerAId,
+				})
+				.select("id")
+				.single();
+			unitA = uA ? { id: uA.id } : null;
+			if (!unitA) console.warn("Skipping chain: unit insert failed");
+		}
+
+		const { data: tA } = await clientA
+			.from("tenants")
+			.insert({
+				email: `expenses-rls-test-tenant-a-${stamp}@example.com`,
+				first_name: "Expenses",
+				last_name: "TestA",
+				status: "active",
+				owner_user_id: ownerAId,
+			})
+			.select("id")
+			.single();
+		tenantA = tA ? { id: tA.id } : null;
+		if (!tenantA) console.warn("Skipping chain: tenant insert failed");
+
+		if (unitA && tenantA) {
+			const { data: mrA } = await clientA
+				.from("maintenance_requests")
+				.insert({
+					owner_user_id: ownerAId,
+					unit_id: unitA.id,
+					tenant_id: tenantA.id,
+					description: "Expenses RLS Test Maintenance Request A",
+				})
+				.select("id")
+				.single();
+			maintenanceRequestA = mrA ? { id: mrA.id } : null;
+			if (!maintenanceRequestA)
+				console.warn("Skipping chain: maintenance_request insert failed");
+		}
+
+		if (maintenanceRequestA) {
+			const { data: eA } = await clientA
+				.from("expenses")
+				.insert({
+					maintenance_request_id: maintenanceRequestA.id,
+					amount: FIXTURE_AMOUNT,
+					expense_date: FIXTURE_EXPENSE_DATE,
+				})
+				.select("id")
+				.single();
+			expenseA = eA ? { id: eA.id } : null;
+			if (!expenseA) console.warn("Skipping chain: expense insert failed");
+		}
+	});
+
+	afterAll(async () => {
+		// FK-safe child-before-parent teardown under ownerA:
+		// expense -> maintenance_request -> unit -> property -> tenant.
+		if (expenseA) await clientA.from("expenses").delete().eq("id", expenseA.id);
+		if (maintenanceRequestA)
+			await clientA
+				.from("maintenance_requests")
+				.delete()
+				.eq("id", maintenanceRequestA.id);
+		if (unitA) await clientA.from("units").delete().eq("id", unitA.id);
+		if (propertyA)
+			await clientA.from("properties").delete().eq("id", propertyA.id);
+		if (tenantA) await clientA.from("tenants").delete().eq("id", tenantA.id);
+	});
+
+	// -------------------------------------------------------------------------
+	// SELECT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can SELECT the fixture expense (positive control)", async () => {
+		if (!expenseA) {
+			console.warn("Skipping: ownerA expense fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("expenses")
+			.select("id, maintenance_request_id")
+			.eq("id", expenseA.id);
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		expect(data).toHaveLength(1);
+		expect(data![0]!.id).toBe(expenseA.id);
+		expect(data![0]!.maintenance_request_id).toBe(maintenanceRequestA!.id);
+	});
+
+	it("owner B cannot SELECT owner A's expense (0 rows)", async () => {
+		if (!expenseA) {
+			console.warn("Skipping: ownerA expense fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("expenses")
+			.select("id")
+			.eq("id", expenseA.id);
+		// The EXISTS-on-parent-MR USING clause hides ownerA's expense from ownerB.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+	});
+
+	it("owner B's expense set excludes owner A's fixture expense", async () => {
+		if (!expenseA) {
+			console.warn("Skipping: ownerA expense fixture not created");
+			return;
+		}
+		const { data: dataB } = await clientB
+			.from("expenses")
+			.select("id")
+			.limit(1000);
+		const ownerBIds = new Set((dataB ?? []).map((r) => r.id as string));
+		expect(ownerBIds.has(expenseA.id)).toBe(false);
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner B cannot INSERT an expense referencing owner A's maintenance_request", async () => {
+		if (!maintenanceRequestA) {
+			console.warn("Skipping: ownerA maintenance_request fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("expenses")
+			.insert({
+				maintenance_request_id: maintenanceRequestA.id,
+				amount: 999,
+				expense_date: FIXTURE_EXPENSE_DATE,
+			})
+			.select("id")
+			.single();
+
+		// WITH CHECK requires the parent MR to be owned by the caller; ownerB does
+		// not own ownerA's MR, so the EXISTS guard fails.
+		expect(error).not.toBeNull();
+		expect(data).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// UPDATE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner B cannot UPDATE owner A's expense (USING hides it: data []), value survives", async () => {
+		if (!expenseA) {
+			console.warn("Skipping: ownerA expense fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("expenses")
+			.update({ amount: 999 })
+			.eq("id", expenseA.id)
+			.select("id");
+
+		// USING clause prevents ownerB from seeing/updating the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Re-read as ownerA: the expense survives unchanged.
+		const { data: stillExists } = await clientA
+			.from("expenses")
+			.select("id, amount")
+			.eq("id", expenseA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+		expect(Number(stillExists!.amount)).toBe(FIXTURE_AMOUNT);
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner B cannot DELETE owner A's expense (USING hides it: data []), row survives", async () => {
+		if (!expenseA) {
+			console.warn("Skipping: ownerA expense fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("expenses")
+			.delete()
+			.eq("id", expenseA.id)
+			.select("id");
+
+		// USING clause prevents ownerB from seeing/deleting the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Verify the expense still exists for ownerA.
+		const { data: stillExists } = await clientA
+			.from("expenses")
+			.select("id")
+			.eq("id", expenseA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+});

--- a/tests/integration/rls/funnel-admin-rpc.test.ts
+++ b/tests/integration/rls/funnel-admin-rpc.test.ts
@@ -29,6 +29,7 @@ import {
 	getAdminTestCredentials,
 	getTestCredentials,
 } from "../setup/supabase-client";
+import { REVOKED_CODES } from "./_helpers/revoked-codes";
 
 const adminCreds = getAdminTestCredentials();
 const SUPABASE_URL = process.env["NEXT_PUBLIC_SUPABASE_URL"];
@@ -78,7 +79,7 @@ describe("get_funnel_stats — non-admin callers rejected", () => {
 		// `IF NOT is_admin() THEN RAISE 'Unauthorized'` runs. The role-level revoke
 		// is the canonical lockdown (see tests/integration/rls/anon-rpc-grants.rls.test.ts
 		// for the full set); the in-body `is_admin()` gate is now defense-in-depth.
-		expect(["42501", "42883", "PGRST202"]).toContain(error?.code);
+		expect(REVOKED_CODES).toContain(error?.code);
 	});
 });
 

--- a/tests/integration/rls/inspection-photos.rls.test.ts
+++ b/tests/integration/rls/inspection-photos.rls.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Dual-client (ownerA / ownerB) RLS isolation tests for `inspection_photos`.
+ *
+ * `inspection_photos` is a JOIN-POLICY child table: it has NO direct owner
+ * column. Owner isolation is enforced through the parent chain
+ * `inspection_id` / `inspection_room_id` → `inspections.owner_user_id`
+ * (every policy keys on `inspection_id IN (SELECT id FROM inspections WHERE
+ * owner_user_id = auth.uid())`). This file is the regression proof (TEST-02 /
+ * threats T-05-04, T-05-05) that a future RLS refactor cannot silently leak one
+ * owner's inspection photos to another through the parent chain. It runs in the
+ * `rls-security` CI gate.
+ *
+ * IMPORTANT — S/I/D ONLY: inspection_photos has SELECT, INSERT, and DELETE
+ * policies but **NO UPDATE policy** (verified, LOCKED in 05-CONTEXT.md TEST-02).
+ * There is intentionally NO UPDATE assertion in this file — asserting isolation
+ * on a non-existent UPDATE policy would be a false test. Do NOT add one.
+ *
+ * The full parent chain (inspection → room → photo) is built under ownerA. When
+ * ownerA has no active lease/unit the inspection cannot be built, so every test
+ * skips gracefully (console.warn + return), matching the sibling tests.
+ *
+ * Every cross-owner case asserts the DENIAL side, not merely "no error":
+ *  - SELECT: ownerA's photo id is ABSENT from ownerB's result (0 rows).
+ *  - INSERT: ownerB referencing ownerA's inspection_id/inspection_room_id ->
+ *    error not null + data null (WITH CHECK EXISTS(inspection owned) fails).
+ *  - DELETE: ownerB -> error null + data [] (USING hides the row), then a re-read
+ *    as ownerA confirms the photo survives.
+ * Positive controls (ownerA self-SELECT/INSERT/DELETE) guard against a
+ * false-green test that would pass even if isolation were broken.
+ *
+ * Reuses the shared `createTestClient` / `getTestCredentials` harness — no
+ * reinvented chain-builder or auth.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+describe("inspection_photos RLS — cross-owner isolation (S/I/D only, join via inspection chain)", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+	let ownerAId: string;
+
+	// ownerA's parent chain (inspection → room) + the photo row the cross-owner
+	// tests target. Built in beforeAll, torn down FK-safe (photo → room →
+	// inspection) in afterAll.
+	let inspectionA: { id: string } | null = null;
+	let roomA: { id: string } | null = null;
+	let photoA: { id: string } | null = null;
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		const {
+			data: { user: userA },
+		} = await clientA.auth.getUser();
+		ownerAId = userA!.id;
+
+		// Build ownerA's inspection from an active lease + its unit/property.
+		const { data: leaseA } = await clientA
+			.from("leases")
+			.select("id, unit_id")
+			.neq("lease_status", "inactive")
+			.limit(1)
+			.single();
+		if (!leaseA) return;
+
+		const { data: unitA } = await clientA
+			.from("units")
+			.select("id, property_id")
+			.eq("id", leaseA.unit_id)
+			.single();
+		if (!unitA) return;
+
+		const { data: insp } = await clientA
+			.from("inspections")
+			.insert({
+				owner_user_id: ownerAId,
+				lease_id: leaseA.id,
+				property_id: unitA.property_id,
+				unit_id: unitA.id,
+				inspection_type: "move_in",
+				status: "pending",
+			})
+			.select("id")
+			.single();
+		inspectionA = insp ? { id: insp.id } : null;
+		if (!inspectionA) return;
+
+		// Room (intermediate parent — inspection_photos needs inspection_room_id).
+		const { data: room } = await clientA
+			.from("inspection_rooms")
+			.insert({
+				inspection_id: inspectionA.id,
+				room_name: "RLS Photos Room A",
+				room_type: "bedroom",
+				condition_rating: "good",
+			})
+			.select("id")
+			.single();
+		roomA = room ? { id: room.id } : null;
+		if (!roomA) return;
+
+		// Child: an ownerA inspection_photos row referencing BOTH inspection_id
+		// and inspection_room_id (required cols: storage_path, file_name).
+		const { data: photo } = await clientA
+			.from("inspection_photos")
+			.insert({
+				inspection_id: inspectionA.id,
+				inspection_room_id: roomA.id,
+				storage_path: "rls-test/owner-a-photo.jpg",
+				file_name: "owner-a-photo.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		photoA = photo ? { id: photo.id } : null;
+	});
+
+	afterAll(async () => {
+		// FK-safe: photo → room → inspection, under ownerA only.
+		if (photoA)
+			await clientA.from("inspection_photos").delete().eq("id", photoA.id);
+		if (roomA)
+			await clientA.from("inspection_rooms").delete().eq("id", roomA.id);
+		if (inspectionA)
+			await clientA.from("inspections").delete().eq("id", inspectionA.id);
+	});
+
+	// -------------------------------------------------------------------------
+	// SELECT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can read their own inspection photo (positive control)", async () => {
+		if (!photoA) {
+			console.warn("Skipping: ownerA inspection_photos fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("inspection_photos")
+			.select("id")
+			.eq("id", photoA.id);
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: photoA.id }]);
+	});
+
+	it("owner B cannot SELECT owner A's inspection photo (0 rows)", async () => {
+		if (!photoA) {
+			console.warn("Skipping: ownerA inspection_photos fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("inspection_photos")
+			.select("id")
+			.eq("id", photoA.id);
+		// Join USING clause hides ownerA's photo from ownerB entirely.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can insert a photo for their own inspection/room (positive control)", async () => {
+		if (!inspectionA || !roomA) {
+			console.warn("Skipping: ownerA inspection/room fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("inspection_photos")
+			.insert({
+				inspection_id: inspectionA.id,
+				inspection_room_id: roomA.id,
+				storage_path: "rls-test/owner-a-insert-photo.jpg",
+				file_name: "owner-a-insert-photo.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		// Clean up this extra control row immediately.
+		if (data)
+			await clientA.from("inspection_photos").delete().eq("id", data.id);
+	});
+
+	it("owner B cannot INSERT a photo referencing owner A's inspection_id/inspection_room_id", async () => {
+		if (!inspectionA || !roomA) {
+			console.warn("Skipping: ownerA inspection/room fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("inspection_photos")
+			.insert({
+				inspection_id: inspectionA.id,
+				inspection_room_id: roomA.id,
+				storage_path: "rls-test/owner-b-hijack-photo.jpg",
+				file_name: "owner-b-hijack-photo.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		// WITH CHECK EXISTS(inspection owned by caller) fails — ownerB owns nothing here.
+		expect(error).not.toBeNull();
+		expect(data).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE isolation
+	//
+	// NOTE: inspection_photos has S/I/D policies ONLY — there is NO UPDATE policy
+	// on this table. An UPDATE cross-owner assertion is deliberately omitted; a
+	// test against a non-existent policy would be a false test. Do NOT add one.
+	// -------------------------------------------------------------------------
+
+	it("owner A can delete their own throwaway inspection photo (positive control)", async () => {
+		if (!inspectionA || !roomA) {
+			console.warn("Skipping: ownerA inspection/room fixture not created");
+			return;
+		}
+		const { data: inserted } = await clientA
+			.from("inspection_photos")
+			.insert({
+				inspection_id: inspectionA.id,
+				inspection_room_id: roomA.id,
+				storage_path: "rls-test/owner-a-delete-photo.jpg",
+				file_name: "owner-a-delete-photo.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		expect(inserted).not.toBeNull();
+
+		const { data, error } = await clientA
+			.from("inspection_photos")
+			.delete()
+			.eq("id", inserted!.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: inserted!.id }]);
+	});
+
+	it("owner B cannot DELETE owner A's inspection photo (USING hides it: data []), photo survives", async () => {
+		if (!photoA) {
+			console.warn("Skipping: ownerA inspection_photos fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("inspection_photos")
+			.delete()
+			.eq("id", photoA.id)
+			.select("id");
+		// USING clause prevents ownerB from seeing/deleting the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Verify the photo still exists for ownerA.
+		const { data: stillExists } = await clientA
+			.from("inspection_photos")
+			.select("id")
+			.eq("id", photoA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+});

--- a/tests/integration/rls/inspection-rooms.rls.test.ts
+++ b/tests/integration/rls/inspection-rooms.rls.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Dual-client (ownerA / ownerB) RLS isolation tests for `inspection_rooms`.
+ *
+ * `inspection_rooms` is a JOIN-POLICY child table: it has NO direct owner column.
+ * Owner isolation is enforced entirely through `inspection_id` →
+ * `inspections.owner_user_id` (every policy keys on `inspection_id IN
+ * (SELECT id FROM inspections WHERE owner_user_id = auth.uid())`). This file is
+ * the regression proof (TEST-02 / threats T-05-04, T-05-05) that a future RLS
+ * refactor cannot silently leak one owner's inspection rooms to another through
+ * the parent chain. It runs in the `rls-security` CI gate.
+ *
+ * inspection_rooms has the full S/I/U/D policy set, so all four are tested.
+ *
+ * The inspection parent is built from an ownerA lease+unit (mirroring
+ * inspections.rls.test.ts). When ownerA has no active lease/unit, the fixture
+ * cannot be built and every test skips gracefully (console.warn + return),
+ * matching the sibling tests.
+ *
+ * Every cross-owner case asserts the DENIAL side, not merely "no error":
+ *  - SELECT: ownerA's room id is ABSENT from ownerB's result (0 rows).
+ *  - INSERT: ownerB referencing ownerA's inspection_id -> error not null + data
+ *    null (WITH CHECK EXISTS(inspection owned by caller) fails).
+ *  - UPDATE/DELETE: ownerB -> error null + data [] (USING hides the row), then a
+ *    re-read as ownerA confirms the row survives unchanged.
+ * Positive controls (ownerA self-SELECT/INSERT/UPDATE/DELETE) guard against a
+ * false-green test that would pass even if isolation were broken.
+ *
+ * Reuses the shared `createTestClient` / `getTestCredentials` harness — no
+ * reinvented chain-builder or auth.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+describe("inspection_rooms RLS — cross-owner isolation (join via inspection_id)", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+	let ownerAId: string;
+
+	// ownerA's parent inspection + the room row the cross-owner tests target.
+	// Built in beforeAll, torn down FK-safe (room before inspection) in afterAll.
+	let inspectionA: { id: string } | null = null;
+	let roomA: { id: string } | null = null;
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		const {
+			data: { user: userA },
+		} = await clientA.auth.getUser();
+		ownerAId = userA!.id;
+
+		// Build ownerA's inspection parent from an active lease + its unit/property
+		// (mirrors inspections.rls.test.ts). Graceful skip if no lease/unit exists.
+		const { data: leaseA } = await clientA
+			.from("leases")
+			.select("id, unit_id")
+			.neq("lease_status", "inactive")
+			.limit(1)
+			.single();
+		if (!leaseA) return;
+
+		const { data: unitA } = await clientA
+			.from("units")
+			.select("id, property_id")
+			.eq("id", leaseA.unit_id)
+			.single();
+		if (!unitA) return;
+
+		const { data: insp } = await clientA
+			.from("inspections")
+			.insert({
+				owner_user_id: ownerAId,
+				lease_id: leaseA.id,
+				property_id: unitA.property_id,
+				unit_id: unitA.id,
+				inspection_type: "move_in",
+				status: "pending",
+			})
+			.select("id")
+			.single();
+		inspectionA = insp ? { id: insp.id } : null;
+
+		// Child: an ownerA inspection_rooms row.
+		if (inspectionA) {
+			const { data: room } = await clientA
+				.from("inspection_rooms")
+				.insert({
+					inspection_id: inspectionA.id,
+					room_name: "RLS Test Room A",
+					room_type: "bedroom",
+					condition_rating: "good",
+				})
+				.select("id")
+				.single();
+			roomA = room ? { id: room.id } : null;
+		}
+	});
+
+	afterAll(async () => {
+		// FK-safe: child (room) before parent (inspection), under ownerA only.
+		if (roomA)
+			await clientA.from("inspection_rooms").delete().eq("id", roomA.id);
+		if (inspectionA)
+			await clientA.from("inspections").delete().eq("id", inspectionA.id);
+	});
+
+	// -------------------------------------------------------------------------
+	// SELECT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can read their own inspection room (positive control)", async () => {
+		if (!roomA) {
+			console.warn("Skipping: ownerA inspection_rooms fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("inspection_rooms")
+			.select("id")
+			.eq("id", roomA.id);
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: roomA.id }]);
+	});
+
+	it("owner B cannot SELECT owner A's inspection room (0 rows)", async () => {
+		if (!roomA) {
+			console.warn("Skipping: ownerA inspection_rooms fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("inspection_rooms")
+			.select("id")
+			.eq("id", roomA.id);
+		// Join USING clause hides ownerA's room from ownerB entirely.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can insert a room for their own inspection (positive control)", async () => {
+		if (!inspectionA) {
+			console.warn("Skipping: ownerA inspection fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("inspection_rooms")
+			.insert({
+				inspection_id: inspectionA.id,
+				room_name: "RLS Insert Room A",
+				room_type: "kitchen",
+				condition_rating: "excellent",
+			})
+			.select("id")
+			.single();
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		// Clean up this extra control row immediately.
+		if (data) await clientA.from("inspection_rooms").delete().eq("id", data.id);
+	});
+
+	it("owner B cannot INSERT a room referencing owner A's inspection_id", async () => {
+		if (!inspectionA) {
+			console.warn("Skipping: ownerA inspection fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("inspection_rooms")
+			.insert({
+				inspection_id: inspectionA.id,
+				room_name: "RLS Hijack Room",
+				room_type: "bedroom",
+				condition_rating: "good",
+			})
+			.select("id")
+			.single();
+		// WITH CHECK EXISTS(inspection owned by caller) fails — ownerB owns nothing here.
+		expect(error).not.toBeNull();
+		expect(data).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// UPDATE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can update their own inspection room and restore it (positive control)", async () => {
+		if (!roomA) {
+			console.warn("Skipping: ownerA inspection_rooms fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("inspection_rooms")
+			.update({ notes: "RLS update test" })
+			.eq("id", roomA.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: roomA.id }]);
+		// Restore original (null notes).
+		await clientA
+			.from("inspection_rooms")
+			.update({ notes: null })
+			.eq("id", roomA.id);
+	});
+
+	it("owner B cannot UPDATE owner A's inspection room (USING hides it: data []), row survives", async () => {
+		if (!roomA) {
+			console.warn("Skipping: ownerA inspection_rooms fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("inspection_rooms")
+			.update({ notes: "RLS hijack update" })
+			.eq("id", roomA.id)
+			.select("id");
+		// USING clause prevents ownerB from seeing/updating the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Row survives unchanged for ownerA.
+		const { data: stillExists } = await clientA
+			.from("inspection_rooms")
+			.select("id, notes")
+			.eq("id", roomA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+		expect(stillExists!.notes).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can delete their own throwaway inspection room (positive control)", async () => {
+		if (!inspectionA) {
+			console.warn("Skipping: ownerA inspection fixture not created");
+			return;
+		}
+		const { data: inserted } = await clientA
+			.from("inspection_rooms")
+			.insert({
+				inspection_id: inspectionA.id,
+				room_name: "RLS Delete Room A",
+				room_type: "bathroom",
+				condition_rating: "fair",
+			})
+			.select("id")
+			.single();
+		expect(inserted).not.toBeNull();
+
+		const { data, error } = await clientA
+			.from("inspection_rooms")
+			.delete()
+			.eq("id", inserted!.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: inserted!.id }]);
+	});
+
+	it("owner B cannot DELETE owner A's inspection room (USING hides it: data []), row survives", async () => {
+		if (!roomA) {
+			console.warn("Skipping: ownerA inspection_rooms fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("inspection_rooms")
+			.delete()
+			.eq("id", roomA.id)
+			.select("id");
+		// USING clause prevents ownerB from seeing/deleting the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Verify the row still exists for ownerA.
+		const { data: stillExists } = await clientA
+			.from("inspection_rooms")
+			.select("id")
+			.eq("id", roomA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+});

--- a/tests/integration/rls/maintenance-request-photos.rls.test.ts
+++ b/tests/integration/rls/maintenance-request-photos.rls.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Dual-client (ownerA / ownerB) RLS isolation tests for
+ * `maintenance_request_photos`.
+ *
+ * `maintenance_request_photos` is a JOIN-POLICY child table: it has NO direct
+ * owner column. Owner isolation is enforced through `maintenance_request_id` →
+ * `maintenance_requests.owner_user_id` (every policy keys on
+ * `maintenance_request_id IN (SELECT id FROM maintenance_requests WHERE
+ * owner_user_id = auth.uid())`). This file is the regression proof (TEST-02 /
+ * threats T-05-04, T-05-05) that a future RLS refactor cannot silently leak one
+ * owner's maintenance photos to another through the parent chain. It runs in the
+ * `rls-security` CI gate.
+ *
+ * IMPORTANT — S/I/D ONLY: maintenance_request_photos has SELECT, INSERT, and
+ * DELETE policies but **NO UPDATE policy** (verified, LOCKED in 05-CONTEXT.md
+ * TEST-02). There is intentionally NO UPDATE assertion in this file — asserting
+ * isolation on a non-existent UPDATE policy would be a false test. Do NOT add one.
+ *
+ * The maintenance_request parent is SELECTED (not inserted): owners cannot INSERT
+ * maintenance_requests (the INSERT policy requires tenant_id =
+ * get_current_tenant_id()), so this test reuses a pre-existing ownerA request
+ * (`.limit(1).single()`) and skips gracefully when ownerA has none — mirroring
+ * maintenance.rls.test.ts. The pre-existing request is NEVER deleted; only the
+ * photo rows this test inserts are cleaned up.
+ *
+ * Every cross-owner case asserts the DENIAL side, not merely "no error":
+ *  - SELECT: ownerA's photo id is ABSENT from ownerB's result (0 rows).
+ *  - INSERT: ownerB referencing ownerA's maintenance_request_id -> error not null
+ *    + data null (WITH CHECK EXISTS(request owned by caller) fails).
+ *  - DELETE: ownerB -> error null + data [] (USING hides the row), then a re-read
+ *    as ownerA confirms the photo survives.
+ * Positive controls (ownerA self-SELECT/INSERT/DELETE) guard against a
+ * false-green test that would pass even if isolation were broken.
+ *
+ * Reuses the shared `createTestClient` / `getTestCredentials` harness — no
+ * reinvented chain-builder or auth.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+describe("maintenance_request_photos RLS — cross-owner isolation (S/I/D only, join via maintenance_request_id)", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+
+	// ownerA's pre-existing maintenance_request parent (SELECTED, never created /
+	// deleted) + the photo row the cross-owner tests target (inserted/cleaned up).
+	let requestA: { id: string } | null = null;
+	let photoA: { id: string } | null = null;
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		// Owners cannot INSERT maintenance_requests (INSERT policy is tenant-scoped),
+		// so SELECT an existing ownerA request as the parent. Skip if none exist.
+		const { data: mr } = await clientA
+			.from("maintenance_requests")
+			.select("id")
+			.limit(1)
+			.single();
+		requestA = mr ? { id: mr.id } : null;
+		if (!requestA) return;
+
+		// Child: an ownerA maintenance_request_photos row (required cols:
+		// storage_path, file_name).
+		const { data: photo } = await clientA
+			.from("maintenance_request_photos")
+			.insert({
+				maintenance_request_id: requestA.id,
+				storage_path: "rls-test/owner-a-mr-photo.jpg",
+				file_name: "owner-a-mr-photo.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		photoA = photo ? { id: photo.id } : null;
+	});
+
+	afterAll(async () => {
+		// Delete ONLY the photo this test inserted. NEVER delete the pre-existing
+		// maintenance_request (it belongs to ownerA's real data, not this test).
+		if (photoA)
+			await clientA
+				.from("maintenance_request_photos")
+				.delete()
+				.eq("id", photoA.id);
+	});
+
+	// -------------------------------------------------------------------------
+	// SELECT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can read their own maintenance request photo (positive control)", async () => {
+		if (!photoA) {
+			console.warn(
+				"Skipping: ownerA maintenance_request_photos fixture not created",
+			);
+			return;
+		}
+		const { data, error } = await clientA
+			.from("maintenance_request_photos")
+			.select("id")
+			.eq("id", photoA.id);
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: photoA.id }]);
+	});
+
+	it("owner B cannot SELECT owner A's maintenance request photo (0 rows)", async () => {
+		if (!photoA) {
+			console.warn(
+				"Skipping: ownerA maintenance_request_photos fixture not created",
+			);
+			return;
+		}
+		const { data, error } = await clientB
+			.from("maintenance_request_photos")
+			.select("id")
+			.eq("id", photoA.id);
+		// Join USING clause hides ownerA's photo from ownerB entirely.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can insert a photo for their own maintenance request (positive control)", async () => {
+		if (!requestA) {
+			console.warn("Skipping: ownerA maintenance_request fixture not found");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("maintenance_request_photos")
+			.insert({
+				maintenance_request_id: requestA.id,
+				storage_path: "rls-test/owner-a-mr-insert.jpg",
+				file_name: "owner-a-mr-insert.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		// Clean up this extra control row immediately.
+		if (data)
+			await clientA
+				.from("maintenance_request_photos")
+				.delete()
+				.eq("id", data.id);
+	});
+
+	it("owner B cannot INSERT a photo referencing owner A's maintenance_request_id", async () => {
+		if (!requestA) {
+			console.warn("Skipping: ownerA maintenance_request fixture not found");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("maintenance_request_photos")
+			.insert({
+				maintenance_request_id: requestA.id,
+				storage_path: "rls-test/owner-b-mr-hijack.jpg",
+				file_name: "owner-b-mr-hijack.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		// WITH CHECK EXISTS(request owned by caller) fails — ownerB owns nothing here.
+		expect(error).not.toBeNull();
+		expect(data).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE isolation
+	//
+	// NOTE: maintenance_request_photos has S/I/D policies ONLY — there is NO
+	// UPDATE policy on this table. An UPDATE cross-owner assertion is deliberately
+	// omitted; a test against a non-existent policy would be a false test. Do NOT
+	// add one.
+	// -------------------------------------------------------------------------
+
+	it("owner A can delete their own throwaway maintenance request photo (positive control)", async () => {
+		if (!requestA) {
+			console.warn("Skipping: ownerA maintenance_request fixture not found");
+			return;
+		}
+		const { data: inserted } = await clientA
+			.from("maintenance_request_photos")
+			.insert({
+				maintenance_request_id: requestA.id,
+				storage_path: "rls-test/owner-a-mr-delete.jpg",
+				file_name: "owner-a-mr-delete.jpg",
+				mime_type: "image/jpeg",
+			})
+			.select("id")
+			.single();
+		expect(inserted).not.toBeNull();
+
+		const { data, error } = await clientA
+			.from("maintenance_request_photos")
+			.delete()
+			.eq("id", inserted!.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: inserted!.id }]);
+	});
+
+	it("owner B cannot DELETE owner A's maintenance request photo (USING hides it: data []), photo survives", async () => {
+		if (!photoA) {
+			console.warn(
+				"Skipping: ownerA maintenance_request_photos fixture not created",
+			);
+			return;
+		}
+		const { data, error } = await clientB
+			.from("maintenance_request_photos")
+			.delete()
+			.eq("id", photoA.id)
+			.select("id");
+		// USING clause prevents ownerB from seeing/deleting the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Verify the photo still exists for ownerA.
+		const { data: stillExists } = await clientA
+			.from("maintenance_request_photos")
+			.select("id")
+			.eq("id", photoA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+});

--- a/tests/integration/rls/property-images.rls.test.ts
+++ b/tests/integration/rls/property-images.rls.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Dual-client (ownerA / ownerB) RLS isolation tests for `property_images`.
+ *
+ * `property_images` is a JOIN-POLICY child table: it has NO direct owner column.
+ * Owner isolation is enforced entirely through `property_id` → `properties.owner`
+ * (every policy keys on `property_id IN (SELECT id FROM properties WHERE
+ * owner_user_id = auth.uid())`). This file is the regression proof (TEST-02 /
+ * threats T-05-04, T-05-05) that a future RLS refactor cannot silently leak one
+ * owner's images to another through the parent chain. It runs in the
+ * `rls-security` CI gate.
+ *
+ * property_images has the full S/I/U/D policy set, so all four are tested.
+ *
+ * Every cross-owner case asserts the DENIAL side, not merely "no error":
+ *  - SELECT: ownerA's image id is ABSENT from ownerB's result (0 rows).
+ *  - INSERT: ownerB referencing ownerA's property_id -> error not null + data
+ *    null (WITH CHECK EXISTS(property owned by caller) fails).
+ *  - UPDATE/DELETE: ownerB -> error null + data [] (USING hides the row), then a
+ *    re-read as ownerA confirms the row survives unchanged.
+ * Positive controls (ownerA self-SELECT/INSERT/UPDATE/DELETE on the existing
+ * policy) prove the policy rejects only the cross-owner case, guarding against a
+ * false-green test that would pass even if isolation were broken.
+ *
+ * Mirrors `tests/integration/rls/reports.rls.test.ts` style and reuses the
+ * shared `createTestClient` / `getTestCredentials` harness — no reinvented
+ * chain-builder or auth. `getTestCredentials()` throws when the four E2E_OWNER_*
+ * env vars are unset; CI provides them via repo secrets, local runs require
+ * `.env.local`.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+describe("property_images RLS — cross-owner isolation (join via property_id)", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+	let ownerAId: string;
+
+	// ownerA's parent property + the image row the cross-owner tests target.
+	// Built in beforeAll, torn down FK-safe (image before property) in afterAll.
+	let propertyA: { id: string } | null = null;
+	let imageA: { id: string } | null = null;
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		const {
+			data: { user: userA },
+		} = await clientA.auth.getUser();
+		ownerAId = userA!.id;
+
+		// Parent: a fresh ownerA property (mirrors properties.rls.test.ts columns).
+		const { data: pA } = await clientA
+			.from("properties")
+			.insert({
+				owner_user_id: ownerAId,
+				name: "RLS Test Property (images)",
+				address_line1: "999 Image Street",
+				city: "Testville",
+				state: "TX",
+				postal_code: "00000",
+				property_type: "single_family",
+				country: "US",
+			})
+			.select("id")
+			.single();
+		propertyA = pA ? { id: pA.id } : null;
+
+		// Child: an ownerA property_images row (required cols: image_url + property_id).
+		if (propertyA) {
+			const { data: imgA } = await clientA
+				.from("property_images")
+				.insert({
+					property_id: propertyA.id,
+					image_url: "rls-test/owner-a-image.jpg",
+					display_order: 0,
+				})
+				.select("id")
+				.single();
+			imageA = imgA ? { id: imgA.id } : null;
+		}
+	});
+
+	afterAll(async () => {
+		// FK-safe: child (image) before parent (property), under ownerA only.
+		if (imageA)
+			await clientA.from("property_images").delete().eq("id", imageA.id);
+		if (propertyA)
+			await clientA.from("properties").delete().eq("id", propertyA.id);
+	});
+
+	// -------------------------------------------------------------------------
+	// SELECT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can read their own property image (positive control)", async () => {
+		if (!imageA) {
+			console.warn("Skipping: ownerA property_images fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("property_images")
+			.select("id")
+			.eq("id", imageA.id);
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: imageA.id }]);
+	});
+
+	it("owner B cannot SELECT owner A's property image (0 rows)", async () => {
+		if (!imageA) {
+			console.warn("Skipping: ownerA property_images fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("property_images")
+			.select("id")
+			.eq("id", imageA.id);
+		// Join USING clause hides ownerA's image from ownerB entirely.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can insert an image for their own property (positive control)", async () => {
+		if (!propertyA) {
+			console.warn("Skipping: ownerA property fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("property_images")
+			.insert({
+				property_id: propertyA.id,
+				image_url: "rls-test/owner-a-insert.jpg",
+				display_order: 1,
+			})
+			.select("id")
+			.single();
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		// Clean up this extra control row immediately.
+		if (data) await clientA.from("property_images").delete().eq("id", data.id);
+	});
+
+	it("owner B cannot INSERT an image referencing owner A's property_id", async () => {
+		if (!propertyA) {
+			console.warn("Skipping: ownerA property fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("property_images")
+			.insert({
+				property_id: propertyA.id,
+				image_url: "rls-test/owner-b-hijack.jpg",
+				display_order: 0,
+			})
+			.select("id")
+			.single();
+		// WITH CHECK EXISTS(property owned by caller) fails — ownerB owns nothing here.
+		expect(error).not.toBeNull();
+		expect(data).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// UPDATE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can update their own property image and restore it (positive control)", async () => {
+		if (!imageA) {
+			console.warn("Skipping: ownerA property_images fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("property_images")
+			.update({ display_order: 5 })
+			.eq("id", imageA.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: imageA.id }]);
+		// Restore original display_order.
+		await clientA
+			.from("property_images")
+			.update({ display_order: 0 })
+			.eq("id", imageA.id);
+	});
+
+	it("owner B cannot UPDATE owner A's property image (USING hides it: data []), row survives", async () => {
+		if (!imageA) {
+			console.warn("Skipping: ownerA property_images fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("property_images")
+			.update({ display_order: 999 })
+			.eq("id", imageA.id)
+			.select("id");
+		// USING clause prevents ownerB from seeing/updating the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Row survives unchanged for ownerA.
+		const { data: stillExists } = await clientA
+			.from("property_images")
+			.select("id, display_order")
+			.eq("id", imageA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+		expect(stillExists!.display_order).toBe(0);
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can delete their own throwaway property image (positive control)", async () => {
+		if (!propertyA) {
+			console.warn("Skipping: ownerA property fixture not created");
+			return;
+		}
+		const { data: inserted } = await clientA
+			.from("property_images")
+			.insert({
+				property_id: propertyA.id,
+				image_url: "rls-test/owner-a-delete.jpg",
+				display_order: 2,
+			})
+			.select("id")
+			.single();
+		expect(inserted).not.toBeNull();
+
+		const { data, error } = await clientA
+			.from("property_images")
+			.delete()
+			.eq("id", inserted!.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: inserted!.id }]);
+	});
+
+	it("owner B cannot DELETE owner A's property image (USING hides it: data []), row survives", async () => {
+		if (!imageA) {
+			console.warn("Skipping: ownerA property_images fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("property_images")
+			.delete()
+			.eq("id", imageA.id)
+			.select("id");
+		// USING clause prevents ownerB from seeing/deleting the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Verify the row still exists for ownerA.
+		const { data: stillExists } = await clientA
+			.from("property_images")
+			.select("id")
+			.eq("id", imageA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+});

--- a/tests/integration/rls/reports.rls.test.ts
+++ b/tests/integration/rls/reports.rls.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Dual-client (ownerA / ownerB) RLS isolation tests for `reports`.
+ *
+ * `reports` is a DIRECT-owner table: `owner_user_id` references `users.id`
+ * and all four policies (reports_{select,insert,update,delete}_owner) key on
+ * `owner_user_id = get_current_owner_user_id()`. This file is the regression
+ * proof (TEST-01 / threats T-05-01, T-05-02) that a future RLS refactor cannot
+ * silently leak one owner's reports to another. It runs in the `rls-security`
+ * CI gate.
+ *
+ * Every cross-owner case asserts the DENIAL side, not merely "no error":
+ *  - SELECT: ownerA's report id is ABSENT from ownerB's result (0 rows).
+ *  - INSERT: ownerB hijack -> error not null + data null (WITH CHECK).
+ *  - UPDATE/DELETE: ownerB -> error null + data [] (USING hides the row), then
+ *    a re-read as ownerA confirms the row survives unchanged.
+ * Positive controls (ownerA self-SELECT/UPDATE/DELETE) prove the policy rejects
+ * only the cross-owner case, not every call — guarding against a false-green
+ * test that would pass even if isolation were broken.
+ *
+ * Mirrors `tests/integration/rls/properties.rls.test.ts`. `getTestCredentials()`
+ * throws when the four E2E_OWNER_* env vars are unset; CI provides them via repo
+ * secrets, local runs require `.env.local`.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+
+describe("Reports RLS — cross-owner isolation", () => {
+	let clientA: SupabaseClient;
+	let clientB: SupabaseClient;
+	let ownerAId: string;
+	let ownerBId: string;
+
+	// ownerA's report that the cross-owner denial tests target. Created in
+	// beforeAll, removed in afterAll.
+	let reportA: { id: string } | null = null;
+
+	// Any extra ids inserted by individual tests (e.g. throwaway delete rows).
+	const testInsertedIds: string[] = [];
+
+	beforeAll(async () => {
+		const { ownerA, ownerB } = getTestCredentials();
+		clientA = await createTestClient(ownerA.email, ownerA.password);
+		clientB = await createTestClient(ownerB.email, ownerB.password);
+
+		const {
+			data: { user: userA },
+		} = await clientA.auth.getUser();
+		const {
+			data: { user: userB },
+		} = await clientB.auth.getUser();
+		ownerAId = userA!.id;
+		ownerBId = userB!.id;
+
+		// Fresh ownerA report the cross-owner tests target.
+		const { data: rA } = await clientA
+			.from("reports")
+			.insert({
+				owner_user_id: ownerAId,
+				title: "RLS Test Report A",
+				report_type: "financial_summary",
+			})
+			.select("id")
+			.single();
+		reportA = rA ? { id: rA.id } : null;
+	});
+
+	afterAll(async () => {
+		// Leaf table — simple delete by id under ownerA (the row's owner).
+		if (reportA) await clientA.from("reports").delete().eq("id", reportA.id);
+		for (const id of testInsertedIds) {
+			await clientA.from("reports").delete().eq("id", id);
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// SELECT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can only read their own reports", async () => {
+		const { data, error } = await clientA
+			.from("reports")
+			.select("id, owner_user_id");
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		data!.forEach((row) => {
+			expect(row.owner_user_id).toBe(ownerAId);
+		});
+	});
+
+	it("owner A finds the fixture report (positive control)", async () => {
+		if (!reportA) {
+			console.warn("Skipping: ownerA report fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("reports")
+			.select("id")
+			.eq("id", reportA.id);
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: reportA.id }]);
+	});
+
+	it("owner B cannot SELECT owner A's report (0 rows)", async () => {
+		if (!reportA) {
+			console.warn("Skipping: ownerA report fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("reports")
+			.select("id")
+			.eq("id", reportA.id);
+		// USING clause hides ownerA's row from ownerB entirely.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+	});
+
+	it("owner B results contain no rows from owner A", async () => {
+		const { data: dataA } = await clientA
+			.from("reports")
+			.select("id, owner_user_id");
+		const { data: dataB } = await clientB
+			.from("reports")
+			.select("id, owner_user_id");
+
+		const ownerAIds = new Set((dataA ?? []).map((r) => r.id as string));
+		const ownerBIds = new Set((dataB ?? []).map((r) => r.id as string));
+
+		ownerBIds.forEach((id) => {
+			expect(ownerAIds.has(id)).toBe(false);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can insert a report with their own owner_user_id (positive control)", async () => {
+		const { data, error } = await clientA
+			.from("reports")
+			.insert({
+				owner_user_id: ownerAId,
+				title: "RLS Insert Test Report A",
+				report_type: "financial_summary",
+			})
+			.select("id")
+			.single();
+
+		expect(error).toBeNull();
+		expect(data).not.toBeNull();
+		testInsertedIds.push(data!.id);
+	});
+
+	it("owner B cannot INSERT a report carrying owner A's owner_user_id", async () => {
+		const { data, error } = await clientB
+			.from("reports")
+			.insert({
+				owner_user_id: ownerAId,
+				title: "RLS Hijack Report",
+				report_type: "financial_summary",
+			})
+			.select("id")
+			.single();
+
+		// WITH CHECK blocks the hijack — ownerB's auth.uid() != ownerAId.
+		expect(error).not.toBeNull();
+		expect(data).toBeNull();
+	});
+
+	// -------------------------------------------------------------------------
+	// UPDATE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can update their own report and restore it (positive control)", async () => {
+		if (!reportA) {
+			console.warn("Skipping: ownerA report fixture not created");
+			return;
+		}
+		const { data, error } = await clientA
+			.from("reports")
+			.update({ title: "RLS Update Test Report" })
+			.eq("id", reportA.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: reportA.id }]);
+
+		// Restore original title.
+		await clientA
+			.from("reports")
+			.update({ title: "RLS Test Report A" })
+			.eq("id", reportA.id);
+	});
+
+	it("owner B cannot UPDATE owner A's report (USING hides it: data [])", async () => {
+		if (!reportA) {
+			console.warn("Skipping: ownerA report fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("reports")
+			.update({ title: "RLS Hijack Update" })
+			.eq("id", reportA.id)
+			.select("id");
+
+		// USING clause prevents ownerB from seeing/updating the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Row survives unchanged for ownerA.
+		const { data: stillExists } = await clientA
+			.from("reports")
+			.select("id, title")
+			.eq("id", reportA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+		expect(stillExists!.title).toBe("RLS Test Report A");
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE isolation
+	// -------------------------------------------------------------------------
+
+	it("owner A can delete their own throwaway report (positive control)", async () => {
+		const { data: inserted } = await clientA
+			.from("reports")
+			.insert({
+				owner_user_id: ownerAId,
+				title: "RLS Delete Test Report",
+				report_type: "financial_summary",
+			})
+			.select("id")
+			.single();
+		expect(inserted).not.toBeNull();
+
+		const { data, error } = await clientA
+			.from("reports")
+			.delete()
+			.eq("id", inserted!.id)
+			.select("id");
+		expect(error).toBeNull();
+		expect(data).toEqual([{ id: inserted!.id }]);
+	});
+
+	it("owner B cannot DELETE owner A's report (USING hides it: data []), row survives", async () => {
+		if (!reportA) {
+			console.warn("Skipping: ownerA report fixture not created");
+			return;
+		}
+		const { data, error } = await clientB
+			.from("reports")
+			.delete()
+			.eq("id", reportA.id)
+			.select("id");
+
+		// USING clause prevents ownerB from seeing/deleting the row.
+		expect(error).toBeNull();
+		expect(data).toEqual([]);
+
+		// Verify the row still exists for ownerA.
+		const { data: stillExists } = await clientA
+			.from("reports")
+			.select("id")
+			.eq("id", reportA.id)
+			.single();
+		expect(stillExists).not.toBeNull();
+	});
+});

--- a/tests/integration/rls/rls-no-policy-lockdown.rls.test.ts
+++ b/tests/integration/rls/rls-no-policy-lockdown.rls.test.ts
@@ -32,6 +32,7 @@
 
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+import { DENIED_CODES } from "./_helpers/revoked-codes";
 
 const SUPABASE_URL = process.env["NEXT_PUBLIC_SUPABASE_URL"];
 const SUPABASE_PUBLISHABLE_KEY =
@@ -42,9 +43,6 @@ if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
 		"Missing required env vars: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
 	);
 }
-
-// PostgREST surfaces a missing table grant / RLS denial as one of these.
-const DENIED_CODES = ["42501", "PGRST301", "PGRST302", "PGRST116"];
 
 const LOCKED_TABLES = [
 	"app_config",

--- a/tests/integration/rls/users-privileged-columns.rls.test.ts
+++ b/tests/integration/rls/users-privileged-columns.rls.test.ts
@@ -48,6 +48,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createTestClient, getTestCredentials } from "../setup/supabase-client";
+import { REVOKED_CODES } from "./_helpers/revoked-codes";
 
 const PROBE_PROPERTY_NAME_PREFIX = "RLS-probe-users-priv-";
 
@@ -311,7 +312,7 @@ describe("P0 security hardening — public.users + sign_lease + property-images 
 			// 42883 / PGRST202. Accept any of the three so the test pins
 			// "function is no longer reachable from authenticated", not a
 			// specific error-code string.
-			expect(["42501", "42883", "PGRST202"]).toContain(error!.code);
+			expect(REVOKED_CODES).toContain(error!.code);
 		});
 	});
 


### PR DESCRIPTION
## Summary

**v4.0 Phase 5 — Cross-Owner RLS Coverage (TEST-01, TEST-02, TEST-04).** Regression-pins owner isolation across the tables that lacked dual-client coverage and hardens RLS-rejection assertions to SQLSTATE codes via a single shared helper. **Test-only** — no schema/frontend/type changes.

| Plan | Req | What |
|------|-----|------|
| 05-01 | TEST-01 | Dual-client (ownerA/ownerB) RLS tests: `reports` + `document_template_definitions` (direct `owner_user_id`, S/I/U/D) and `expenses` (indirect via property→unit→maintenance_request chain, S/I/U/D) |
| 05-02 | TEST-02 | Dual-client tests for the 4 join-policy child tables: `property_images` + `inspection_rooms` (S/I/U/D), `inspection_photos` + `maintenance_request_photos` (S/I/D only — those tables have no UPDATE policy) |
| 05-03 | TEST-04 | Extract `REVOKED_CODES` + `DENIED_CODES` to one shared `_helpers/revoked-codes.ts` (5 dup sites now import it, zero inline literals); migrate message-string RLS-rejection assertions to `error.code` SQLSTATE |

## Correctness highlights (verified during planning + by the plan-checker)
- **No false-greens:** every cross-owner case asserts the *denial* side — SELECT returns 0 rows (id absent), INSERT rejected (error≠null), UPDATE/DELETE return `[]` AND a re-read as ownerA confirms the row survived. ownerA positive controls included. A test would fail if isolation broke.
- **Correct SQLSTATE:** the migrated ownership/overlap guards (`bulk_import_create_lease`, `get_dashboard_data_v2`) raise via bare `raise exception` → **`P0001`**, not `42501`. Verified against the actual RPC bodies. The legit `42501` EXECUTE-revoke pins in `users-privileged-columns` are **left untouched**; `DENIED_CODES` (RLS row-deny) is kept distinct from `REVOKED_CODES` (EXECUTE-revoke) — both separate exports.
- **No phantom-policy tests:** the two photos tables are tested S/I/D only (grep-verified no cross-owner `.update(` assertion) since they have no UPDATE policy.
- A real CHECK-constraint issue was caught + fixed (`document_template_definitions.template_key` only allows a fixed enum — the test uses valid keys).

## Tests
The new + migrated tests run in the **`rls-security` CI gate** (authenticates two synthetic owners against prod — the authoritative run; local runs lack the repo-secret credentials by design). `bun run typecheck` clean; full pre-commit lefthook gate green on every commit.

[hudsor01]
