### PR TITLE
v4.0 Phase 7: Accessibility Labels (A11Y-01/02/03)

### DIFF
--- a/.planning/phases/07-accessibility-labels/07-CONTEXT.md
+++ b/.planning/phases/07-accessibility-labels/07-CONTEXT.md
@@ -1,0 +1,59 @@
+# Phase 7: Accessibility Labels - Context
+
+**Gathered:** 2026-06-07
+**Status:** Ready for execution (workflow-orchestrated)
+**Source:** Direct source-read of every named component + axe-infra probe. Frontend a11y fixes (real src edits) + deterministic unit a11y tests.
+
+<domain>
+## Phase Boundary
+Programmatic labels + accessible names for the named form/control components (A11Y-01/02), and the `text-muted`→`text-muted-foreground` token fix (A11Y-03). Verified by testing-library `getByLabelText`/`getByRole({name})` unit assertions (the deterministic, local proof of association) — the repo's axe runs via `@axe-core/playwright` E2E (`tests/e2e/tests/owner/dashboard-a11y.e2e.spec.ts`).
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED)
+
+### Shared design call (A11Y-01) — DO NOT modify Field.tsx behavior
+The Field inputs are RAW `<input>` elements rendered inline as siblings of `<FieldLabel>` inside `<Field>` — they are NOT descendant components, so a `FieldContext` cannot auto-wire them, and globally auto-setting `FieldLabel htmlFor` from a context id would point EVERY existing form's label at a nonexistent control id (a NEW app-wide a11y bug). Therefore: **per-field `useId()` + explicit `htmlFor` on `FieldLabel` + matching `id` on the control**, applied ONLY to the named components. `FieldLabel` already forwards `htmlFor` to the underlying radix `<Label>` (it spreads `...props`), so no Field.tsx change is needed. This satisfies "thread useId through Field, auto-associate label/input, no bare <Label>" with ZERO shared-infra regression risk.
+
+### A11Y-01 — programmatic labels (per-field useId + htmlFor/id)
+- `src/components/settings/owner-emergency-contact-section.tsx` — 3 raw inputs (name/relationship/phone) under `<Field><FieldLabel>…</FieldLabel><input/></Field>` with no association. Add `const nameId = useId()` etc.; `<FieldLabel htmlFor={nameId}>` + `<input id={nameId}>`.
+- `src/components/profiles/tenant/personal-information-section.tsx` — same pattern (first/last name + others).
+- `src/components/profiles/tenant/emergency-contact-section.tsx` — same.
+- `src/components/auth/change-password-dialog.tsx` — 3 password fields; the input is WRAPPED (show/hide toggle button already has aria-label). Wire `useId()` + `htmlFor`/`id` on each (current/new/confirm). Keep the existing toggle-button aria-labels.
+- `src/components/profiles/owner/personal-info-section.tsx` — ALREADY compliant (`<Label htmlFor="first_name">` + `<Input id="first_name">` pairs). Verify; no change needed unless a bare label is found. Add a `getByLabelText` test to pin it.
+
+### A11Y-02 — accessible names
+- `src/components/tenants/tenant-toolbar.tsx` — search `<input>` (placeholder-only) → add `aria-label="Search tenants"`; status `<select>` → add `aria-label="Filter by status"`. (The Table/Grid view-toggle buttons already have visible text → accessible names OK; optionally add `aria-pressed`.)
+- `src/components/tenants/tenant-grid.tsx` — the row-select `<input type="checkbox">` (line ~107) → `aria-label={`Select ${tenant name}`}` (per-row, descriptive). The icon action buttons (view/edit/delete) already have aria-labels.
+- `src/components/leases/table/leases-table-columns.tsx` — row-select `<input type="checkbox">` (line ~72) → `aria-label={`Select lease …`}`. Also check `leases-table.tsx` for a header select-all checkbox → `aria-label="Select all leases"`.
+- `src/components/leases/template/clause-selector.tsx` — the `<button>` inside `<TooltipTrigger>` (line ~91) wrapping only an `<Info>` icon → `aria-label="More information about this clause"` (or similar).
+
+### A11Y-03 — token fix (done directly by orchestrator)
+- `src/components/error-boundary/error-boundary.tsx:85` — `className="text-muted font-mono bg-muted p-2 rounded"` → `text-muted-foreground` (bare `text-muted` is not a valid text-color token; breaks muted-text contrast). One-line.
+
+### Verification
+- Add/extend a **unit a11y test** per fixed component (testing-library): `getByLabelText('First Name')` etc. resolves each input (proves htmlFor↔id association — this IS the axe "label" rule, deterministically); `getByRole('checkbox', { name: /select/i })` + `getByRole('button', { name: /more information/i })` + `getByRole('textbox', { name: /search tenants/i })` resolve the A11Y-02 controls. These run locally (jsdom) and fail if association/accessible-name regresses.
+- The existing `@axe-core/playwright` dashboard-a11y E2E remains the integration-level axe gate; extending it to settings/tenant routes needs the running app + auth, so the unit-level assertions are the authoritative local proof this phase.
+</decisions>
+
+<constraints>
+- No inline styles; Tailwind tokens only (`text-muted-foreground`, not bare `text-muted`).
+- No `any`, no barrel files. `useId()` from React (one per field). Match component style (tabs).
+- Icon-only buttons: `aria-label` (CLAUDE.md Accessibility rule). `getByLabelText` is the association proof.
+- Test-files alongside the existing `__tests__` convention; mirror existing component-test patterns (`src/test/utils/test-render.tsx`).
+- Parallel fix agents WRITE files only — orchestrator commits sequentially (no agent git-commits).
+</constraints>
+
+<canonical_refs>
+- CLAUDE.md Accessibility section (aria-label on icon-only buttons; text-muted-foreground; bg-background).
+- `tests/e2e/tests/owner/dashboard-a11y.e2e.spec.ts` (@axe-core/playwright pattern).
+- `src/components/ui/field.tsx` (FieldLabel forwards htmlFor — no change needed).
+- `src/components/profiles/owner/personal-info-section.tsx` (the already-correct htmlFor/id reference pattern).
+</canonical_refs>
+
+<deferred>
+None — A11Y-01/02/03 are the whole phase.
+</deferred>
+
+---
+*Phase: 07-accessibility-labels — source-read 2026-06-07; per-field useId (no Field.tsx regression), aria-labels on named controls, text-muted token fix; getByLabelText/getByRole unit proofs.*

--- a/.planning/phases/07-accessibility-labels/07-SUMMARY.md
+++ b/.planning/phases/07-accessibility-labels/07-SUMMARY.md
@@ -1,0 +1,36 @@
+# Phase 7 Summary — Accessibility Labels (A11Y-01/02/03)
+
+**Status:** Complete (workflow-orchestrated under ultracode)
+**Branch:** gsd/phase-7-accessibility-labels
+
+## What shipped
+Programmatic labels + accessible names across the named form/control components, each pinned by a `getByLabelText`/`getByRole({name})` unit proof (the deterministic, mutation-resistant equivalent of the axe "label"/"button-name" rules). 9 components fixed via fix→adversarial-verify workflow fan-out (all 9 verify verdicts CLEAN). Full suite green: **206 files, 106,561 tests**.
+
+### A11Y-01 — programmatic form labels (per-field `useId()` + `htmlFor`/`id`)
+Design call: the Field inputs are raw inline `<input>` siblings of `<FieldLabel>`, so a FieldContext can't auto-wire them and a global FieldLabel-auto-htmlFor would point every existing form's label at a nonexistent id (a NEW app-wide bug). So per-field `useId()` + explicit `htmlFor`/`id` on the named forms only — `FieldLabel` already forwards `htmlFor`, so **no Field.tsx change, zero shared-infra regression**.
+- `settings/owner-emergency-contact-section.tsx` — 3 inputs associated.
+- `profiles/tenant/personal-information-section.tsx` — 4 inputs associated.
+- `profiles/tenant/emergency-contact-section.tsx` — 3 inputs associated.
+- `auth/change-password-dialog.tsx` — 3 password fields associated (toggle-button aria-labels kept).
+- `profiles/owner/personal-info-section.tsx` — already compliant (htmlFor/id); pinned by a new test, no source change.
+
+### A11Y-02 — accessible names
+- `tenants/tenant-toolbar.tsx` — search input → `aria-label="Search tenants"`; status select → `aria-label`.
+- `tenants/tenant-grid.tsx` — row-select checkbox → descriptive `aria-label`.
+- `leases/table/leases-table-columns.tsx` + `leases-table.tsx` — row-select + select-all checkboxes → `aria-label`s.
+- `leases/template/clause-selector.tsx` — info tooltip button → `aria-label`.
+
+### A11Y-03 — token fix
+- `error-boundary/error-boundary.tsx:85` — bare `text-muted` → `text-muted-foreground` (committed directly).
+
+## Regression caught + fixed (perfect-PR discipline)
+Associating the change-password inputs made the **pre-existing** `profile-page.test.tsx > opens change password dialog` test's loose `queryByLabelText(/current password/i)` ambiguous (it now matched both the labeled input AND the "Show current password" toggle aria-label → "multiple elements"). Tightened that query to exact label text. Per "perfect-PR covers pre-existing failures."
+
+## Verification
+- Full unit suite: 206 files / 106,561 passed. Typecheck + biome clean.
+- Each fixed control has a `getByLabelText`/`getByRole({name})` assertion that fails if the label/accessible-name regresses (mutation-tested by the verify agents).
+- axe integration layer remains the existing `@axe-core/playwright` dashboard-a11y E2E; the unit-level association proofs are this phase's deterministic local gate (extending the E2E to settings/tenant routes needs the running app + auth).
+
+## Notes
+- 9 components, all independent files → workflow fan-out with zero file contention; orchestrator committed (agents wrote only).
+- 2 commits (A11Y-01 forms+regression-fix / A11Y-02 controls) + the earlier A11Y-03 commit.

--- a/src/app/(owner)/profile/__tests__/profile-page.test.tsx
+++ b/src/app/(owner)/profile/__tests__/profile-page.test.tsx
@@ -310,10 +310,13 @@ describe("Owner Profile Page", () => {
 				const changePasswordHeading = dialogHeadings.find(
 					(h) => h.textContent === "Change Password",
 				);
-				// Also try looking for dialog-specific elements
+				// Also try looking for dialog-specific elements. Use exact label
+				// text so the query targets the now-associated password input only
+				// (the show/hide toggle buttons also contain "current/new password"
+				// in their aria-labels, which would make a loose regex ambiguous).
 				const currentPasswordField =
-					screen.queryByLabelText(/current password/i);
-				const newPasswordField = screen.queryByLabelText(/new password/i);
+					screen.queryByLabelText("Current Password *");
+				const newPasswordField = screen.queryByLabelText("New Password *");
 
 				expect(
 					changePasswordHeading || currentPasswordField || newPasswordField,

--- a/src/components/auth/__tests__/change-password-dialog.a11y.test.tsx
+++ b/src/components/auth/__tests__/change-password-dialog.a11y.test.tsx
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the mutation hook so the dialog renders without a live Supabase auth
+// client. The dialog only reads `isPending` and `mutateAsync` from it.
+vi.mock("#hooks/api/use-auth-mutations", () => ({
+	useChangePasswordMutation: () => ({
+		mutate: vi.fn(),
+		mutateAsync: vi.fn(),
+		reset: vi.fn(),
+		isPending: false,
+		isError: false,
+		isSuccess: false,
+		error: null,
+		data: undefined,
+		status: "idle" as const,
+	}),
+}));
+
+vi.mock("#lib/frontend-logger", () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { ChangePasswordDialog } from "../change-password-dialog";
+
+function renderWithClient(ui: ReactNode) {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	return render(
+		createElement(QueryClientProvider, { client: queryClient }, ui),
+	);
+}
+
+describe("ChangePasswordDialog — A11Y-01 programmatic labels", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("associates each password field with its visible label via htmlFor/id", () => {
+		const { getByLabelText } = renderWithClient(
+			createElement(ChangePasswordDialog, {
+				open: true,
+				onOpenChange: vi.fn(),
+			}),
+		);
+
+		// getByLabelText resolves ONLY when the FieldLabel's htmlFor matches the
+		// password input's id (the axe "label" rule, deterministically).
+		const current = getByLabelText("Current Password *");
+		const next = getByLabelText("New Password *");
+		const confirm = getByLabelText("Confirm New Password *");
+
+		expect(current).toBeInstanceOf(HTMLInputElement);
+		expect(current).toHaveAttribute("type", "password");
+		expect(next).toBeInstanceOf(HTMLInputElement);
+		expect(next).toHaveAttribute("type", "password");
+		expect(confirm).toBeInstanceOf(HTMLInputElement);
+		expect(confirm).toHaveAttribute("type", "password");
+
+		// Each input must have a non-empty, unique id (the association anchor).
+		const ids = [current.id, next.id, confirm.id];
+		expect(ids.every((id) => id.length > 0)).toBe(true);
+		expect(new Set(ids).size).toBe(3);
+	});
+
+	it("keeps the icon-only show/hide toggle aria-labels intact", () => {
+		const { getByRole } = renderWithClient(
+			createElement(ChangePasswordDialog, {
+				open: true,
+				onOpenChange: vi.fn(),
+			}),
+		);
+
+		expect(
+			getByRole("button", { name: "Show current password" }),
+		).toBeInTheDocument();
+		expect(
+			getByRole("button", { name: "Show new password" }),
+		).toBeInTheDocument();
+		expect(
+			getByRole("button", { name: "Show confirm password" }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/auth/change-password-dialog.tsx
+++ b/src/components/auth/change-password-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { Eye, EyeOff, Lock } from "lucide-react";
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Button } from "#components/ui/button";
 import {
 	Dialog,
@@ -29,6 +29,10 @@ export function ChangePasswordDialog({
 	onOpenChange,
 }: ChangePasswordDialogProps) {
 	const changePassword = useChangePasswordMutation();
+
+	const currentPasswordId = useId();
+	const newPasswordId = useId();
+	const confirmPasswordId = useId();
 
 	const [formData, setFormData] = useState({
 		currentPassword: "",
@@ -176,9 +180,12 @@ export function ChangePasswordDialog({
 					<DialogBody>
 						{/* Current Password */}
 						<Field>
-							<FieldLabel>Current Password *</FieldLabel>
+							<FieldLabel htmlFor={currentPasswordId}>
+								Current Password *
+							</FieldLabel>
 							<div className="relative">
 								<input
+									id={currentPasswordId}
 									type={showPasswords.current ? "text" : "password"}
 									className="input w-full pr-[var(--spacing-10)]"
 									value={formData.currentPassword}
@@ -211,9 +218,10 @@ export function ChangePasswordDialog({
 
 						{/* New Password */}
 						<Field>
-							<FieldLabel>New Password *</FieldLabel>
+							<FieldLabel htmlFor={newPasswordId}>New Password *</FieldLabel>
 							<div className="relative">
 								<input
+									id={newPasswordId}
 									type={showPasswords.new ? "text" : "password"}
 									className="input w-full pr-[var(--spacing-10)]"
 									value={formData.newPassword}
@@ -249,9 +257,12 @@ export function ChangePasswordDialog({
 
 						{/* Confirm Password */}
 						<Field>
-							<FieldLabel>Confirm New Password *</FieldLabel>
+							<FieldLabel htmlFor={confirmPasswordId}>
+								Confirm New Password *
+							</FieldLabel>
 							<div className="relative">
 								<input
+									id={confirmPasswordId}
 									type={showPasswords.confirm ? "text" : "password"}
 									className="input w-full pr-[var(--spacing-10)]"
 									value={formData.confirmPassword}

--- a/src/components/error-boundary/error-boundary.tsx
+++ b/src/components/error-boundary/error-boundary.tsx
@@ -82,7 +82,7 @@ function DefaultErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
 							An unexpected error occurred. Our team has been notified.
 						</p>
 						{message && (
-							<p className="text-muted font-mono bg-muted p-2 rounded">
+							<p className="text-muted-foreground font-mono bg-muted p-2 rounded">
 								{message}
 							</p>
 						)}

--- a/src/components/leases/table/__tests__/leases-table-columns.a11y.test.tsx
+++ b/src/components/leases/table/__tests__/leases-table-columns.a11y.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ * A11Y-02: row-select checkbox accessible name (LeaseRow)
+ *
+ * Proves the row-select <input type="checkbox"> has an accessible name
+ * derived from aria-label. getByRole('checkbox', { name }) resolves ONLY
+ * if the accessible-name association is correct.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import type { Lease } from "#types/core";
+import type { LeaseDisplay } from "../lease-utils";
+import { LeaseRow } from "../leases-table-columns";
+
+const stubLease: LeaseDisplay = {
+	id: "lease-1",
+	tenantName: "Jane Doe",
+	propertyName: "Maple Apartments",
+	unitNumber: "4B",
+	status: "active",
+	startDate: "2026-01-01",
+	endDate: "2026-12-31",
+	rentAmount: 1500,
+	original: { id: "lease-1" } as Lease,
+};
+
+function renderRow() {
+	return render(
+		<table>
+			<tbody>
+				<LeaseRow
+					lease={stubLease}
+					isSelected={false}
+					onToggleSelect={vi.fn()}
+					onView={vi.fn()}
+					onEdit={vi.fn()}
+					onRenew={vi.fn()}
+					onTerminate={vi.fn()}
+				/>
+			</tbody>
+		</table>,
+	);
+}
+
+describe("LeaseRow a11y (A11Y-02)", () => {
+	test("row-select checkbox has an accessible name", () => {
+		renderRow();
+		const checkbox = screen.getByRole("checkbox", { name: /select/i });
+		expect(checkbox).toBeInTheDocument();
+	});
+
+	test("accessible name includes the lease tenant identifier", () => {
+		renderRow();
+		expect(
+			screen.getByRole("checkbox", { name: /select lease jane doe/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/leases/table/__tests__/leases-table-columns.a11y.test.tsx
+++ b/src/components/leases/table/__tests__/leases-table-columns.a11y.test.tsx
@@ -56,4 +56,22 @@ describe("LeaseRow a11y (A11Y-02)", () => {
 			screen.getByRole("checkbox", { name: /select lease jane doe/i }),
 		).toBeInTheDocument();
 	});
+
+	test("icon-only action buttons expose aria-label accessible names", () => {
+		renderRow();
+		// status:"active" renders all four; each resolves ONLY via its aria-label
+		// (the lucide icons are aria-hidden, so title alone is not a reliable name).
+		expect(
+			screen.getByRole("button", { name: /view lease for jane doe/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /edit lease for jane doe/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /renew lease for jane doe/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /terminate lease for jane doe/i }),
+		).toBeInTheDocument();
+	});
 });

--- a/src/components/leases/table/__tests__/leases-table.a11y.test.tsx
+++ b/src/components/leases/table/__tests__/leases-table.a11y.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ * A11Y-02: select-all checkbox accessible name (LeasesTable header)
+ *
+ * Proves the header "select all" <input type="checkbox"> exposes an accessible
+ * name via aria-label. getByRole('checkbox', { name }) resolves ONLY if the
+ * aria-label is present, so removing it makes this test FAIL.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import type { Lease } from "#types/core";
+import type { LeaseDisplay } from "../lease-utils";
+import { LeasesTable } from "../leases-table";
+
+const stubLease: LeaseDisplay = {
+	id: "lease-1",
+	tenantName: "Jane Doe",
+	propertyName: "Maple Apartments",
+	unitNumber: "4B",
+	status: "active",
+	startDate: "2026-01-01",
+	endDate: "2026-12-31",
+	rentAmount: 1500,
+	original: { id: "lease-1" } as Lease,
+};
+
+describe("LeasesTable a11y (A11Y-02)", () => {
+	test("select-all checkbox has an accessible name", () => {
+		render(
+			<LeasesTable
+				leases={[stubLease]}
+				paginatedLeases={[stubLease]}
+				searchQuery=""
+				statusFilter="all"
+				sortField="tenant"
+				sortDirection="asc"
+				selectedRows={new Set<string>()}
+				currentPage={1}
+				totalPages={1}
+				itemsPerPage={10}
+				onSearchChange={vi.fn()}
+				onStatusFilterChange={vi.fn()}
+				onSort={vi.fn()}
+				onToggleSelectAll={vi.fn()}
+				onToggleSelect={vi.fn()}
+				onPageChange={vi.fn()}
+				onView={vi.fn()}
+				onEdit={vi.fn()}
+				onRenew={vi.fn()}
+				onTerminate={vi.fn()}
+				onClearSelection={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("checkbox", { name: /select all leases/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/leases/table/leases-table-columns.tsx
+++ b/src/components/leases/table/leases-table-columns.tsx
@@ -72,6 +72,7 @@ export function LeaseRow({
 					type="checkbox"
 					checked={isSelected}
 					onChange={() => onToggleSelect(lease.id)}
+					aria-label={`Select lease ${lease.tenantName}`}
 					className="w-4 h-4 rounded border-border text-primary focus:ring-primary focus:ring-offset-0"
 				/>
 			</td>

--- a/src/components/leases/table/leases-table-columns.tsx
+++ b/src/components/leases/table/leases-table-columns.tsx
@@ -104,6 +104,7 @@ export function LeaseRow({
 						onClick={() => onView(lease.id)}
 						className="p-2 rounded-sm hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
 						title="View"
+						aria-label={`View lease for ${lease.tenantName}`}
 					>
 						<Eye className="w-4 h-4" />
 					</button>
@@ -111,6 +112,7 @@ export function LeaseRow({
 						onClick={() => onEdit(lease.id)}
 						className="p-2 rounded-sm hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
 						title="Edit"
+						aria-label={`Edit lease for ${lease.tenantName}`}
 					>
 						<Pencil className="w-4 h-4" />
 					</button>
@@ -120,6 +122,7 @@ export function LeaseRow({
 								onClick={() => onRenew(lease)}
 								className="p-2 rounded-sm hover:bg-muted text-muted-foreground hover:text-primary transition-colors"
 								title="Renew Lease"
+								aria-label={`Renew lease for ${lease.tenantName}`}
 							>
 								<RefreshCw className="w-4 h-4" />
 							</button>
@@ -127,6 +130,7 @@ export function LeaseRow({
 								onClick={() => onTerminate(lease)}
 								className="p-2 rounded-sm hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
 								title="Terminate Lease"
+								aria-label={`Terminate lease for ${lease.tenantName}`}
 							>
 								<XCircle className="w-4 h-4" />
 							</button>

--- a/src/components/leases/table/leases-table.tsx
+++ b/src/components/leases/table/leases-table.tsx
@@ -110,6 +110,7 @@ export function LeasesTable({
 											selectedRows.size === leases.length && leases.length > 0
 										}
 										onChange={onToggleSelectAll}
+										aria-label="Select all leases"
 										className="w-4 h-4 rounded border-border text-primary focus:ring-primary focus:ring-offset-0"
 									/>
 								</th>

--- a/src/components/leases/template/__tests__/clause-selector.test.tsx
+++ b/src/components/leases/template/__tests__/clause-selector.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * A11Y-02 proof for the clause-selector tooltip trigger.
+ *
+ * The icon-only <button> inside <TooltipTrigger> wraps only an <Info> icon, so it
+ * has no visible-text accessible name. `aria-label="More information about this clause"`
+ * supplies the accessible name. `getByRole('button', { name: /more information/i })`
+ * resolves ONLY if that accessible name is wired correctly.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ClauseSelector } from "#components/leases/template/clause-selector";
+
+describe("ClauseSelector a11y", () => {
+	it("exposes an accessible name on each icon-only info tooltip trigger", () => {
+		render(
+			<ClauseSelector
+				selectedClauses={[]}
+				onToggleClause={() => {}}
+				recommendedClauses={new Set<string>()}
+				state="CA"
+			/>,
+		);
+
+		const infoButtons = screen.getAllByRole("button", {
+			name: /more information/i,
+		});
+
+		expect(infoButtons.length).toBeGreaterThan(0);
+		for (const button of infoButtons) {
+			expect(button).toHaveAccessibleName("More information about this clause");
+		}
+	});
+});

--- a/src/components/leases/template/clause-selector.tsx
+++ b/src/components/leases/template/clause-selector.tsx
@@ -90,6 +90,7 @@ export function ClauseSelector({
 												<TooltipTrigger asChild>
 													<button
 														type="button"
+														aria-label="More information about this clause"
 														className="text-muted-foreground"
 													>
 														<Info className="size-4" />

--- a/src/components/profiles/owner/__tests__/personal-info-section.test.tsx
+++ b/src/components/profiles/owner/__tests__/personal-info-section.test.tsx
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PersonalInfoSection } from "#components/profiles/owner/personal-info-section";
+
+const baseProps = {
+	profile: {
+		email: "owner@example.com",
+		phone: "(555) 123-4567",
+		full_name: "Jane Doe",
+		status: "active",
+	},
+	isEditing: true,
+	isPending: false,
+	formData: {
+		first_name: "Jane",
+		last_name: "Doe",
+		phone: "(555) 123-4567",
+	},
+	onEditClick: () => {},
+	onCancelEdit: () => {},
+	onSaveProfile: () => {},
+	onFormChange: () => {},
+};
+
+describe("A11Y-01: owner PersonalInfoSection programmatic labels", () => {
+	// Every edit-mode input must resolve via its visible <Label htmlFor> ↔
+	// <Input id> association. getByLabelText / getByRole({ name }) ONLY match
+	// when the label is programmatically associated with the control — this is
+	// the deterministic local equivalent of the axe "label" rule.
+	it("associates a label with every editable input", () => {
+		const { getByLabelText, getByRole } = render(
+			<PersonalInfoSection {...baseProps} />,
+		);
+
+		// First / Last name + phone are editable textboxes.
+		const firstName = getByLabelText("First Name");
+		expect(firstName).toBeInstanceOf(HTMLInputElement);
+		expect((firstName as HTMLInputElement).value).toBe("Jane");
+
+		const lastName = getByLabelText("Last Name");
+		expect(lastName).toBeInstanceOf(HTMLInputElement);
+		expect((lastName as HTMLInputElement).value).toBe("Doe");
+
+		const phone = getByLabelText("Phone Number");
+		expect(phone).toBeInstanceOf(HTMLInputElement);
+		expect((phone as HTMLInputElement).type).toBe("tel");
+
+		// Email is a disabled (read-only) input — disabled inputs are not in the
+		// "textbox" role tree, so assert the label association directly.
+		const email = getByLabelText("Email Address");
+		expect(email).toBeInstanceOf(HTMLInputElement);
+		expect((email as HTMLInputElement).value).toBe("owner@example.com");
+
+		// Accessible-name proof via the role tree for the enabled controls.
+		expect(getByRole("textbox", { name: "First Name" })).toBe(firstName);
+		expect(getByRole("textbox", { name: "Last Name" })).toBe(lastName);
+		expect(getByRole("textbox", { name: "Phone Number" })).toBe(phone);
+	});
+});

--- a/src/components/profiles/tenant/__tests__/emergency-contact-section.test.tsx
+++ b/src/components/profiles/tenant/__tests__/emergency-contact-section.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "#test/utils/test-render";
+import { EmergencyContactSection } from "../emergency-contact-section";
+
+function renderSection() {
+	return render(
+		<EmergencyContactSection
+			formData={{ name: "", relationship: "", phone: "" }}
+			hasExistingContact={false}
+			isEditing={true}
+			isLoading={false}
+			isSaving={false}
+			onEditToggle={vi.fn()}
+			onChange={vi.fn()}
+			onSave={vi.fn()}
+			onCancel={vi.fn()}
+			onDelete={vi.fn()}
+		/>,
+	);
+}
+
+describe("EmergencyContactSection a11y", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("associates every input with its programmatic label (htmlFor/id)", () => {
+		renderSection();
+
+		// getByLabelText resolves ONLY when the FieldLabel htmlFor matches the input id.
+		expect(screen.getByLabelText("Contact Name *")).toHaveAttribute(
+			"type",
+			"text",
+		);
+		expect(screen.getByLabelText("Relationship")).toHaveAttribute(
+			"type",
+			"text",
+		);
+		expect(screen.getByLabelText("Phone Number *")).toHaveAttribute(
+			"type",
+			"tel",
+		);
+	});
+
+	it("exposes each control via its accessible name (getByRole)", () => {
+		renderSection();
+
+		expect(
+			screen.getByRole("textbox", { name: "Contact Name *" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("textbox", { name: "Relationship" }),
+		).toBeInTheDocument();
+		// Phone label includes an icon; accessible name is still the text "Phone Number *".
+		expect(
+			screen.getByRole("textbox", { name: "Phone Number *" }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/profiles/tenant/__tests__/personal-information-section.test.tsx
+++ b/src/components/profiles/tenant/__tests__/personal-information-section.test.tsx
@@ -1,0 +1,61 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PersonalInformationSection } from "#components/profiles/tenant/personal-information-section";
+
+const baseFormData = {
+	first_name: "Ada",
+	last_name: "Lovelace",
+	email: "ada@example.com",
+	phone: "(555) 123-4567",
+};
+
+function renderSection() {
+	return render(
+		<PersonalInformationSection
+			formData={baseFormData}
+			isEditing={true}
+			isLoading={false}
+			onEditToggle={() => {}}
+			onChange={() => {}}
+			onSave={() => {}}
+			onCancel={() => {}}
+		/>,
+	);
+}
+
+describe("A11Y-01: PersonalInformationSection programmatic labels", () => {
+	// getByLabelText resolves ONLY when the <FieldLabel htmlFor> ↔ <input id>
+	// association is wired correctly — this IS the axe "label" rule, proven
+	// deterministically in jsdom.
+	it("associates every input with its label (htmlFor ↔ id)", () => {
+		const { getByLabelText } = renderSection();
+
+		expect(getByLabelText("First Name *")).toHaveAttribute("type", "text");
+		expect(getByLabelText("Last Name *")).toHaveAttribute("type", "text");
+		expect(getByLabelText("Email Address *")).toHaveAttribute("type", "email");
+		expect(getByLabelText("Phone Number")).toHaveAttribute("type", "tel");
+	});
+
+	it("exposes each control via its accessible name (getByRole name)", () => {
+		const { getByRole } = renderSection();
+
+		// editable controls resolve as textbox by their accessible name
+		expect(getByRole("textbox", { name: "First Name *" })).toBeInTheDocument();
+		expect(getByRole("textbox", { name: "Last Name *" })).toBeInTheDocument();
+		expect(getByRole("textbox", { name: "Phone Number" })).toBeInTheDocument();
+	});
+
+	it("each input id is unique (no duplicate associations)", () => {
+		const { getByLabelText } = renderSection();
+		const ids = [
+			getByLabelText("First Name *").id,
+			getByLabelText("Last Name *").id,
+			getByLabelText("Email Address *").id,
+			getByLabelText("Phone Number").id,
+		];
+		for (const id of ids) {
+			expect(id).not.toBe("");
+		}
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});

--- a/src/components/profiles/tenant/emergency-contact-section.tsx
+++ b/src/components/profiles/tenant/emergency-contact-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Phone } from "lucide-react";
-import type { FormEvent } from "react";
+import { type FormEvent, useId } from "react";
 import { Button } from "#components/ui/button";
 import { CardLayout } from "#components/ui/card-layout";
 import { Field, FieldLabel } from "#components/ui/field";
@@ -38,6 +38,9 @@ export function EmergencyContactSection({
 	onDelete,
 }: EmergencyContactSectionProps) {
 	const isDisabled = !isEditing || isLoading || isSaving;
+	const nameId = useId();
+	const relationshipId = useId();
+	const phoneId = useId();
 
 	return (
 		<CardLayout
@@ -47,8 +50,9 @@ export function EmergencyContactSection({
 			<form onSubmit={onSave} className="space-y-6">
 				<div className="grid gap-6 md:grid-cols-2">
 					<Field>
-						<FieldLabel>Contact Name *</FieldLabel>
+						<FieldLabel htmlFor={nameId}>Contact Name *</FieldLabel>
 						<input
+							id={nameId}
 							type="text"
 							className="input w-full"
 							placeholder="Full name"
@@ -60,8 +64,9 @@ export function EmergencyContactSection({
 					</Field>
 
 					<Field>
-						<FieldLabel>Relationship</FieldLabel>
+						<FieldLabel htmlFor={relationshipId}>Relationship</FieldLabel>
 						<input
+							id={relationshipId}
 							type="text"
 							className="input w-full"
 							placeholder="e.g., Spouse, Parent"
@@ -73,13 +78,14 @@ export function EmergencyContactSection({
 				</div>
 
 				<Field>
-					<FieldLabel>
+					<FieldLabel htmlFor={phoneId}>
 						<div className="flex items-center gap-2">
 							<Phone className="size-4" />
 							<span>Phone Number *</span>
 						</div>
 					</FieldLabel>
 					<input
+						id={phoneId}
 						type="tel"
 						className="input w-full"
 						placeholder="(555) 123-4567"

--- a/src/components/profiles/tenant/personal-information-section.tsx
+++ b/src/components/profiles/tenant/personal-information-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Mail, Phone } from "lucide-react";
-import type { FormEvent } from "react";
+import { type FormEvent, useId } from "react";
 import { Button } from "#components/ui/button";
 import { CardLayout } from "#components/ui/card-layout";
 import { Field, FieldLabel } from "#components/ui/field";
@@ -32,6 +32,11 @@ export function PersonalInformationSection({
 	onSave,
 	onCancel,
 }: PersonalInformationSectionProps) {
+	const firstNameId = useId();
+	const lastNameId = useId();
+	const emailId = useId();
+	const phoneId = useId();
+
 	return (
 		<CardLayout
 			title="Personal Information"
@@ -40,8 +45,9 @@ export function PersonalInformationSection({
 			<form onSubmit={onSave} className="space-y-6">
 				<div className="grid gap-6 md:grid-cols-2">
 					<Field>
-						<FieldLabel>First Name *</FieldLabel>
+						<FieldLabel htmlFor={firstNameId}>First Name *</FieldLabel>
 						<input
+							id={firstNameId}
 							type="text"
 							className="input w-full"
 							value={formData.first_name}
@@ -52,8 +58,9 @@ export function PersonalInformationSection({
 					</Field>
 
 					<Field>
-						<FieldLabel>Last Name *</FieldLabel>
+						<FieldLabel htmlFor={lastNameId}>Last Name *</FieldLabel>
 						<input
+							id={lastNameId}
 							type="text"
 							className="input w-full"
 							value={formData.last_name}
@@ -65,13 +72,14 @@ export function PersonalInformationSection({
 				</div>
 
 				<Field>
-					<FieldLabel>
+					<FieldLabel htmlFor={emailId}>
 						<div className="flex items-center gap-2">
 							<Mail className="size-4" />
 							<span>Email Address *</span>
 						</div>
 					</FieldLabel>
 					<input
+						id={emailId}
 						type="email"
 						className="input w-full"
 						value={formData.email}
@@ -84,13 +92,14 @@ export function PersonalInformationSection({
 				</Field>
 
 				<Field>
-					<FieldLabel>
+					<FieldLabel htmlFor={phoneId}>
 						<div className="flex items-center gap-2">
 							<Phone className="size-4" />
 							<span>Phone Number</span>
 						</div>
 					</FieldLabel>
 					<input
+						id={phoneId}
 						type="tel"
 						className="input w-full"
 						placeholder="(555) 123-4567"

--- a/src/components/settings/__tests__/owner-emergency-contact-section.test.tsx
+++ b/src/components/settings/__tests__/owner-emergency-contact-section.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OwnerEmergencyContactSection } from "../owner-emergency-contact-section";
+
+const mockUseOwnerEmergencyContact = vi.fn();
+const mockUpdateMutation = vi.fn();
+const mockDeleteMutation = vi.fn();
+
+vi.mock("#hooks/api/use-owner-emergency-contact", () => ({
+	useOwnerEmergencyContact: () => mockUseOwnerEmergencyContact(),
+	useUpdateOwnerEmergencyContactMutation: () => mockUpdateMutation(),
+	useDeleteOwnerEmergencyContactMutation: () => mockDeleteMutation(),
+}));
+
+describe("OwnerEmergencyContactSection a11y (A11Y-01)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockUseOwnerEmergencyContact.mockReturnValue({
+			data: null,
+			isLoading: false,
+		});
+		mockUpdateMutation.mockReturnValue({
+			mutateAsync: vi.fn(),
+			isPending: false,
+		});
+		mockDeleteMutation.mockReturnValue({
+			mutateAsync: vi.fn(),
+			isPending: false,
+		});
+	});
+
+	it("associates each input with its label via htmlFor/id (programmatic labels)", () => {
+		render(<OwnerEmergencyContactSection />);
+
+		// getByLabelText resolves ONLY when FieldLabel htmlFor === input id.
+		// Each assertion proves the label↔input association exists.
+		expect(screen.getByLabelText("Contact Name")).toBeInTheDocument();
+		expect(screen.getByLabelText("Contact Name").tagName).toBe("INPUT");
+
+		expect(screen.getByLabelText("Relationship")).toBeInTheDocument();
+		expect(screen.getByLabelText("Relationship").tagName).toBe("INPUT");
+
+		// Phone label wraps an icon + visible "Phone Number" text node.
+		expect(screen.getByLabelText("Phone Number")).toBeInTheDocument();
+		expect(screen.getByLabelText("Phone Number").tagName).toBe("INPUT");
+	});
+});

--- a/src/components/settings/owner-emergency-contact-section.tsx
+++ b/src/components/settings/owner-emergency-contact-section.tsx
@@ -2,7 +2,7 @@
 
 import { Phone } from "lucide-react";
 import type { FormEvent } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import { Button } from "#components/ui/button";
 import { CardLayout } from "#components/ui/card-layout";
@@ -29,6 +29,10 @@ export function OwnerEmergencyContactSection() {
 
 	const [isEditing, setIsEditing] = useState(false);
 	const [formData, setFormData] = useState<FormState>(EMPTY_FORM);
+
+	const nameId = useId();
+	const relationshipId = useId();
+	const phoneId = useId();
 
 	useEffect(() => {
 		// Guard against the global refetchOnWindowFocus + onMutate-driven cache
@@ -106,8 +110,9 @@ export function OwnerEmergencyContactSection() {
 			<form onSubmit={handleSave} className="space-y-6">
 				<div className="grid gap-6 md:grid-cols-2">
 					<Field>
-						<FieldLabel>Contact Name</FieldLabel>
+						<FieldLabel htmlFor={nameId}>Contact Name</FieldLabel>
 						<input
+							id={nameId}
 							type="text"
 							className="input w-full"
 							placeholder="Full name"
@@ -119,8 +124,9 @@ export function OwnerEmergencyContactSection() {
 					</Field>
 
 					<Field>
-						<FieldLabel>Relationship</FieldLabel>
+						<FieldLabel htmlFor={relationshipId}>Relationship</FieldLabel>
 						<input
+							id={relationshipId}
 							type="text"
 							className="input w-full"
 							placeholder="e.g., Spouse, Parent"
@@ -132,13 +138,14 @@ export function OwnerEmergencyContactSection() {
 				</div>
 
 				<Field>
-					<FieldLabel>
+					<FieldLabel htmlFor={phoneId}>
 						<div className="flex items-center gap-2">
 							<Phone className="size-4" />
 							<span>Phone Number</span>
 						</div>
 					</FieldLabel>
 					<input
+						id={phoneId}
 						type="tel"
 						className="input w-full"
 						placeholder="(555) 123-4567"

--- a/src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
+++ b/src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
@@ -37,4 +37,24 @@ describe("TenantGrid accessibility (A11Y-02)", () => {
 		expect(checkbox).toBeInTheDocument();
 		expect(checkbox).toHaveAccessibleName("Select Jane Doe");
 	});
+
+	it("exposes an accessible name on the per-row status select", () => {
+		render(
+			<TenantGrid
+				tenants={[stubTenant]}
+				selectedIds={new Set<string>()}
+				onSelectChange={vi.fn()}
+				onView={vi.fn()}
+				onEdit={vi.fn()}
+				onDelete={vi.fn()}
+				onContact={vi.fn()}
+			/>,
+		);
+
+		// Resolves ONLY if the <select> carries aria-label="Lease status for Jane Doe".
+		const statusSelect = screen.getByRole("combobox", {
+			name: /lease status for jane doe/i,
+		});
+		expect(statusSelect).toBeInTheDocument();
+	});
 });

--- a/src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
+++ b/src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Accessibility unit test for TenantGrid (A11Y-02)
+ *
+ * Proves the per-row select checkbox exposes an accessible name via aria-label.
+ * getByRole('checkbox', { name: /select/i }) resolves ONLY if the aria-label
+ * association is correct, so this is the deterministic axe "label" proof.
+ */
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TenantItem } from "#types/sections/tenants";
+import { render } from "../../../test/utils/test-render";
+import { TenantGrid } from "../tenant-grid";
+
+const stubTenant: TenantItem = {
+	id: "tenant-1",
+	fullName: "Jane Doe",
+	email: "jane@example.com",
+	totalPaid: 0,
+};
+
+describe("TenantGrid accessibility (A11Y-02)", () => {
+	it("exposes an accessible name on the row-select checkbox", () => {
+		render(
+			<TenantGrid
+				tenants={[stubTenant]}
+				selectedIds={new Set<string>()}
+				onSelectChange={vi.fn()}
+				onView={vi.fn()}
+				onEdit={vi.fn()}
+				onDelete={vi.fn()}
+				onContact={vi.fn()}
+			/>,
+		);
+
+		const checkbox = screen.getByRole("checkbox", { name: /select/i });
+		expect(checkbox).toBeInTheDocument();
+		expect(checkbox).toHaveAccessibleName("Select Jane Doe");
+	});
+});

--- a/src/components/tenants/__tests__/tenant-toolbar.a11y.test.tsx
+++ b/src/components/tenants/__tests__/tenant-toolbar.a11y.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Accessibility tests for TenantToolbar (A11Y-02)
+ *
+ * Proves the placeholder-only search <input> and the unlabeled status
+ * <select> expose programmatic accessible names via aria-label, so that
+ * assistive tech (and the axe "label" rule) can identify the controls.
+ *
+ * These getByRole({ name }) queries resolve ONLY if the aria-label
+ * association is correct — they fail if the accessible name regresses.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TenantToolbar } from "#components/tenants/tenant-toolbar";
+
+describe("TenantToolbar accessibility (A11Y-02)", () => {
+	function renderToolbar() {
+		return render(
+			<TenantToolbar
+				searchQuery=""
+				onSearchChange={vi.fn()}
+				statusFilter="all"
+				onStatusFilterChange={vi.fn()}
+				viewMode="table"
+				onViewModeChange={vi.fn()}
+				filteredCount={0}
+			/>,
+		);
+	}
+
+	it("exposes an accessible name for the search input", () => {
+		renderToolbar();
+		expect(
+			screen.getByRole("textbox", { name: /search tenants/i }),
+		).toBeInTheDocument();
+	});
+
+	it("exposes an accessible name for the status filter select", () => {
+		renderToolbar();
+		expect(
+			screen.getByRole("combobox", { name: /filter by status/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/tenants/tenant-grid.tsx
+++ b/src/components/tenants/tenant-grid.tsx
@@ -31,9 +31,10 @@ interface TenantGridProps {
 interface StatusDropdownProps {
 	value: LeaseStatus | undefined;
 	onChange: (value: LeaseStatus) => void;
+	ariaLabel: string;
 }
 
-function StatusDropdown({ value, onChange }: StatusDropdownProps) {
+function StatusDropdown({ value, onChange, ariaLabel }: StatusDropdownProps) {
 	const statusLabels: Record<LeaseStatus, string> = {
 		draft: "Draft",
 		pending_signature: "Pending",
@@ -47,6 +48,7 @@ function StatusDropdown({ value, onChange }: StatusDropdownProps) {
 			<select
 				value={value || "active"}
 				onChange={(e) => onChange(e.target.value as LeaseStatus)}
+				aria-label={ariaLabel}
 				className="appearance-none w-full px-2 py-1 text-xs bg-muted border border-transparent hover:border-border focus:border-primary rounded text-foreground focus:outline-none focus:ring-1 focus:ring-primary/20 cursor-pointer transition-all"
 			>
 				{Object.entries(statusLabels).map(([key, label]) => (
@@ -127,6 +129,7 @@ function TenantCard({
 					<div className="w-24">
 						<StatusDropdown
 							value={tenant.leaseStatus}
+							ariaLabel={`Lease status for ${tenant.fullName}`}
 							onChange={(value) =>
 								logger.info("Status change", {
 									tenantId: tenant.id,

--- a/src/components/tenants/tenant-grid.tsx
+++ b/src/components/tenants/tenant-grid.tsx
@@ -107,6 +107,7 @@ function TenantCard({
 							type="checkbox"
 							checked={isSelected}
 							onChange={onSelect}
+							aria-label={`Select ${tenant.fullName ?? "tenant"}`}
 							className="w-4 h-4 rounded border-border text-primary focus:ring-primary focus:ring-offset-0"
 						/>
 						<button

--- a/src/components/tenants/tenant-toolbar.tsx
+++ b/src/components/tenants/tenant-toolbar.tsx
@@ -28,6 +28,7 @@ export function TenantToolbar({
 			<div className="relative w-64">
 				<input
 					type="text"
+					aria-label="Search tenants"
 					placeholder="Search tenants..."
 					value={searchQuery}
 					onChange={(e) => onSearchChange(e.target.value)}
@@ -36,6 +37,7 @@ export function TenantToolbar({
 			</div>
 
 			<select
+				aria-label="Filter by status"
 				value={statusFilter}
 				onChange={(e) =>
 					onStatusFilterChange(e.target.value as TenantStatusFilter)


### PR DESCRIPTION
## Summary

**v4.0 Phase 7 — Accessibility Labels (A11Y-01/02/03).** Programmatic labels + accessible names across the named form/control components, each pinned by a `getByLabelText`/`getByRole({name})` unit proof (the deterministic equivalent of the axe label/button-name rules). Full suite green: **206 files / 106,561 tests**.

### A11Y-01 — programmatic form labels
Per-field `useId()` + `FieldLabel htmlFor` + matching control `id` so label/input auto-associate. `FieldLabel` already forwards `htmlFor`, so **no `Field.tsx` change** — the inline raw `<input>` siblings can't be auto-wired by context, and a global FieldLabel-auto-htmlFor would point every existing form's label at a nonexistent id (an app-wide regression). Scoped to the named forms:
- `settings/owner-emergency-contact-section`, `profiles/tenant/personal-information-section`, `profiles/tenant/emergency-contact-section`, `auth/change-password-dialog` (toggle aria-labels kept). `profiles/owner/personal-info-section` was already compliant — pinned by a test, no source change.

### A11Y-02 — accessible names
`tenant-toolbar` search input (`aria-label="Search tenants"`) + status select; `tenant-grid` + `leases-table`/`leases-table-columns` row-select + select-all checkboxes; `clause-selector` info tooltip button.

### A11Y-03 — token fix
`error-boundary.tsx` bare `text-muted` → `text-muted-foreground`.

## Regression caught + fixed (perfect-PR discipline)
Properly labeling the change-password inputs made the **pre-existing** `profile-page.test.tsx > opens change password dialog` test's loose `queryByLabelText(/current password/i)` ambiguous (now matched the labeled input AND the "Show current password" toggle). Tightened to exact label text. (Per "perfect-PR covers pre-existing failures.")

## Verification
- Full unit suite 206/106,561 green; typecheck + biome clean.
- Each fixed control has a `getByLabelText`/`getByRole({name})` assertion that fails if the label/accessible-name is removed (mutation-tested during review).
- axe integration layer = the existing `@axe-core/playwright` dashboard-a11y E2E; these unit-level association proofs are the deterministic local gate for the affected screens.

[hudsor01]
