### PR TITLE
v4.0 Phase 8: SEO Recovery (SEO-02 verified, SEO-03 done, SEO-01 content-dependent)

### DIFF
--- a/.planning/phases/08-seo-recovery/08-CONTEXT.md
+++ b/.planning/phases/08-seo-recovery/08-CONTEXT.md
@@ -1,0 +1,45 @@
+# Phase 8: SEO Recovery - Context
+
+**Gathered:** 2026-06-07
+**Status:** Executed (code-doable scope); SEO-01 content-dependency surfaced
+**Source:** Direct source-read of /pricing structured data, the blog category page, and the blog-redirect map + its collision-guard test.
+
+<domain>
+## Phase Boundary
+The three SEO requirements split cleanly by what is code-resolvable vs. content-dependent:
+- **SEO-02** — already fixed in code (verify + it has a regression-guard test).
+- **SEO-03** — code-doable (noindex empty category pages).
+- **SEO-01** — content-dependent (republishing requires real article content via the n8n pipeline; cannot be fabricated).
+</domain>
+
+<decisions>
+## Determinations (LOCKED)
+
+### SEO-02 — /pricing JSON-LD validates clean — ALREADY DONE (verify + close)
+The Product schema was already removed from `/pricing` (`src/app/pricing/page.tsx:38-44` documents why: Product forced the page into Google's Merchant-listings validation, which requires `shippingDetails` + `hasMerchantReturnPolicy` — meaningless for SaaS — producing the GSC "Merchant listings: invalid item" error). The page now emits only FAQ + Breadcrumb JSON-LD; the SoftwareApplication + AggregateOffer are emitted sitewide by `SeoJsonLd` (`src/lib/generate-metadata.ts:167-188`). A regression-guard test already exists and passes: `src/app/pricing/__tests__/page.test.ts:97-106` asserts `schemaTypes === ["FAQPage","BreadcrumbList"]` and `not.toContain("Product")`. Nothing to change — SEO-02 is satisfied. (Google's live rich-results-test is an external check the owner can re-run; the code emits no merchant-listing-eligible node, which is the fix.)
+
+### SEO-03 — empty category pages don't bleed crawl signal — IMPLEMENT (noindex)
+`src/app/blog/category/[category]/page.tsx` validated categories (notFound for invalid) and rendered `BlogEmptyState` for zero posts, but `generateMetadata` only set `noindex: page > 1` — so page 1 of an empty valid category (e.g. `financial-management`, `maintenance`) served an indexable thin page. Fix: a `cache()`-deduped `getCategoryPublishedCount(name)` (HEAD count) drives `noindex: page > 1 || publishedCount === 0`. The page stays reachable for users; Google won't index it until it has content (self-healing — once a post is published the count flips and it becomes indexable). Pinned by 3 new `generateMetadata` tests (empty → `robots: "noindex, follow"`; non-empty page 1 → no robots; page 2 → noindex).
+
+### SEO-01 — republish highest-impression deleted posts — CONTENT-DEPENDENT (surfaced, not code-completed)
+The requirement is "republished at their original slugs (**content via the n8n pipeline**), and each republished slug's entry removed from `blog-redirects.ts`." This has a hard external dependency: real, quality, ranking-equivalent article CONTENT must be authored + published to `public.blogs` via the n8n pipeline. It cannot be fabricated by the agent (fake content would harm SEO and is not honest), and removing a redirect entry BEFORE the post exists would turn the slug into a 404 (the slug 404s without content AND without the redirect — `dynamicParams=false` on `/blog/[slug]`). So the code-side is already prepared and correct:
+- The 301 redirect map (`DELETED_BLOG_REDIRECTS`, 144 entries) transfers ranking signal today.
+- The collision-guard test (`src/lib/seo/__tests__/blog-redirects.test.ts`) already enforces the reclaim invariant: a source may never collide with a live published slug, and destinations must be live paths.
+- The documented reclaim runbook is in the `blog-redirects.ts` header: "when a quality replacement is published at one of these slugs, DELETE that entry so the new post serves instead of redirecting."
+**Owner action required:** run the n8n pipeline to publish the top-impression posts (top-10 first per the Hybrid plan), then delete their entries from `blog-redirects.ts` (the collision-guard test will keep it honest). This is the only v4.0 item that cannot be closed in code.
+</decisions>
+
+<canonical_refs>
+- `src/app/pricing/page.tsx` + `src/app/pricing/__tests__/page.test.ts` (SEO-02 fix + guard, already in place).
+- `src/lib/generate-metadata.ts` (sitewide SoftwareApplication + AggregateOffer).
+- `src/app/blog/category/[category]/page.tsx` + `.test.tsx` (SEO-03).
+- `src/lib/seo/blog-redirects.ts` + `__tests__/blog-redirects.test.ts` (SEO-01 mechanics + collision guard).
+- `seo-deleted-blog-catalogue` memory (the ~126 ghost slugs, top-10 republish candidates).
+</canonical_refs>
+
+<deferred>
+- SEO-01 content republishing — owner's n8n pipeline. The redirect map keeps transferring signal in the meantime; reclaim is per-post and incremental (delete one entry as each post lands).
+</deferred>
+
+---
+*Phase: 08-seo-recovery — SEO-02 verified-done, SEO-03 implemented (noindex empty categories), SEO-01 surfaced as content-dependent on the n8n pipeline.*

--- a/.planning/phases/08-seo-recovery/08-SUMMARY.md
+++ b/.planning/phases/08-seo-recovery/08-SUMMARY.md
@@ -1,0 +1,21 @@
+# Phase 8 Summary — SEO Recovery (SEO-01/02/03)
+
+**Status:** Code-doable scope complete; SEO-01 surfaced as content-dependent
+**Branch:** gsd/phase-8-seo-recovery
+
+## Outcomes
+| Req | Status | What |
+|-----|--------|------|
+| SEO-02 | ✅ Verified done | `/pricing` already emits no Product/merchant-listing schema (only FAQ + Breadcrumb; SoftwareApplication+AggregateOffer are sitewide). Regression guard `pricing/__tests__/page.test.ts:97-106` (`schemaTypes === ["FAQPage","BreadcrumbList"]`, `not.toContain("Product")`) passing. The GSC "Merchant listings: invalid item" cause is removed. |
+| SEO-03 | ✅ Implemented | Empty valid category pages (`financial-management`, `maintenance`) now `noindex` so they don't bleed crawl signal. `cache()`-deduped `getCategoryPublishedCount` HEAD query drives `noindex: page>1 \|\| count===0`. Self-healing — flips indexable once a post lands. 3 new `generateMetadata` tests. |
+| SEO-01 | ⚠ Content-dependent (owner action) | Republishing the top-impression deleted posts requires real article content via the **n8n pipeline** — cannot be fabricated, and removing a redirect entry before content exists would 404. Code-side is ready: 301 map transfers signal today, collision-guard test enforces the reclaim invariant, runbook documented in `blog-redirects.ts`. Reclaim is incremental: publish a post via n8n → delete its entry. |
+
+## Verification
+- Full unit suite: **207 files / 106,567 tests** green. Typecheck + biome clean.
+- SEO-02 guard + SEO-03 noindex tests + redirect collision-guard all pass (21 tests across the 3 SEO files).
+
+## Why SEO-01 is not code-closed
+The requirement explicitly sources content from the n8n pipeline. Authoring fake "ranked-equivalent" articles would be dishonest and SEO-harmful, and prematurely deleting redirect entries (`dynamicParams=false` on `/blog/[slug]`) would replace a 301 with a 404. The correct, honest completion is: keep the signal-transferring 301s + collision guard in place (done) and hand the content step to the owner's pipeline. This is the only v4.0 requirement that cannot close in code.
+
+## Notes
+- No DB writes; no migration. The SEO-03 count query is a cheap per-request HEAD count, request-deduped via React `cache()`.

--- a/src/app/blog/category/[category]/page.test.tsx
+++ b/src/app/blog/category/[category]/page.test.tsx
@@ -81,7 +81,7 @@ vi.mock("#components/seo/json-ld-script", () => ({
 }));
 
 import type { BlogListItem } from "#hooks/api/query-keys/blog-keys";
-import BlogCategoryPage from "./page";
+import BlogCategoryPage, { generateMetadata } from "./page";
 
 const mockCategories = [
 	{ name: "Software Comparisons", slug: "software-comparisons", post_count: 5 },
@@ -136,6 +136,15 @@ function makeClient({
 		chain.range = vi.fn(() =>
 			Promise.resolve({ data: posts, count: postsCount, error: null }),
 		);
+		// Awaiting the builder directly (the HEAD count path used by
+		// getCategoryPublishedCount) resolves to the same {count} shape.
+		chain.then = (
+			resolve: (v: {
+				data: BlogListItem[];
+				count: number | null;
+				error: null;
+			}) => unknown,
+		) => resolve({ data: posts, count: postsCount, error: null });
 		return chain;
 	});
 
@@ -227,5 +236,42 @@ describe("BlogCategoryPage (server component)", () => {
 	it("renders NewsletterSignup", async () => {
 		render(await renderPage("software-comparisons"));
 		expect(screen.getByTestId("newsletter-signup")).toBeInTheDocument();
+	});
+});
+
+describe("BlogCategoryPage generateMetadata (SEO-03 empty-category noindex)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	async function metaFor(
+		categorySlug: string,
+		opts?: MockBuilderOpts,
+	): Promise<import("next").Metadata> {
+		mockCreateClient.mockResolvedValue(makeClient(opts));
+		return generateMetadata({
+			params: Promise.resolve({ category: categorySlug }),
+			searchParams: Promise.resolve({}),
+		});
+	}
+
+	it("noindexes an empty category (zero published posts) so it does not bleed crawl signal", async () => {
+		const meta = await metaFor("software-comparisons", { postsCount: 0 });
+		expect(meta.robots).toBe("noindex, follow");
+	});
+
+	it("leaves a non-empty category indexable (page 1)", async () => {
+		const meta = await metaFor("software-comparisons", { postsCount: 5 });
+		// createPageMetadata omits robots when indexable.
+		expect(meta.robots).toBeUndefined();
+	});
+
+	it("noindexes paginated pages regardless of count", async () => {
+		mockCreateClient.mockResolvedValue(makeClient({ postsCount: 5 }));
+		const meta = await generateMetadata({
+			params: Promise.resolve({ category: "software-comparisons" }),
+			searchParams: Promise.resolve({ page: "2" }),
+		});
+		expect(meta.robots).toBe("noindex, follow");
 	});
 });

--- a/src/app/blog/category/[category]/page.tsx
+++ b/src/app/blog/category/[category]/page.tsx
@@ -48,6 +48,24 @@ const getValidCategory = cache(
 	},
 );
 
+/**
+ * Published-post count for a category — request-deduplicated via cache().
+ * Drives the SEO-03 empty-category noindex: a valid category with zero
+ * published posts (e.g. financial-management, maintenance) would otherwise
+ * serve an indexable thin page and bleed crawl signal. HEAD count only.
+ */
+const getCategoryPublishedCount = cache(
+	async (categoryName: string): Promise<number> => {
+		const supabase = await createClient();
+		const { count } = await supabase
+			.from("blogs")
+			.select("*", { count: "exact", head: true })
+			.eq("status", "published")
+			.eq("category", categoryName);
+		return count ?? 0;
+	},
+);
+
 export async function generateMetadata({
 	params,
 	searchParams,
@@ -61,11 +79,17 @@ export async function generateMetadata({
 		return { title: "Category Not Found | TenantFlow" };
 	}
 
+	// SEO-03: noindex paginated pages AND empty categories (zero published
+	// posts) so a thin/empty category page does not bleed crawl signal. The
+	// page stays reachable for users; Google just won't index it until it has
+	// content (the count is dynamic, so it self-heals once a post is published).
+	const publishedCount = await getCategoryPublishedCount(validCategory.name);
+
 	return createPageMetadata({
 		title: `${validCategory.name} Articles & Guides`,
 		description: `Browse TenantFlow blog posts about ${validCategory.name.toLowerCase()}. Expert insights and practical guides for landlords.`,
 		path: `/blog/category/${category}`,
-		noindex: page > 1,
+		noindex: page > 1 || publishedCount === 0,
 	});
 }
 


### PR DESCRIPTION
## Summary

**v4.0 Phase 8 — SEO Recovery (SEO-01/02/03).** The final v4.0 phase. Two requirements close in code; SEO-01 is content-dependent on the n8n pipeline (surfaced, not fabricated).

| Req | Status | What |
|-----|--------|------|
| **SEO-02** | ✅ verified done | `/pricing` already emits no Product/merchant-listing schema (only FAQ + Breadcrumb; the SoftwareApplication + AggregateOffer are sitewide via `generate-metadata.ts`). The cause of Google's "Merchant listings: 1 invalid item" (Product schema requires `shippingDetails`/`hasMerchantReturnPolicy`, meaningless for SaaS) is removed. Regression guard `pricing/__tests__/page.test.ts:97-106` passing. |
| **SEO-03** | ✅ implemented | Empty valid category pages (`financial-management`, `maintenance`) now `noindex` so they don't bleed crawl signal. A `cache()`-deduped `getCategoryPublishedCount` HEAD query drives `noindex: page>1 \|\| count===0` — self-healing (flips indexable once a post lands). 3 new `generateMetadata` tests. |
| **SEO-01** | ⚠ content-dependent | Republishing the top-impression deleted posts requires real article content via the **n8n pipeline** — the agent will not fabricate ranked content, and removing a redirect entry before its post exists would 404 (`dynamicParams=false`). Code-side is ready: the 301 map transfers ranking signal today, the collision-guard test enforces the reclaim invariant, and the runbook lives in `blog-redirects.ts`. Reclaim is incremental: publish a post via n8n → delete its entry (the test keeps it honest). |

## Verification
- Full unit suite **207 files / 106,567 tests** green; typecheck + biome clean.
- SEO-02 guard + SEO-03 noindex tests + redirect collision-guard all pass.
- No DB writes / no migration; the SEO-03 count is a cheap per-request HEAD count, request-deduped via React `cache()`.

## Note on SEO-01
This is the only v4.0 requirement that cannot close in code — by design it sources content from the owner's n8n pipeline. The signal-preserving 301s + collision guard remain in place so nothing regresses while content is republished incrementally.

[hudsor01]
