### PR TITLE
Phase 13: SEO-01 Reclaim Integration — --slug override + reclaim queue + finalize (BLOG-08)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -16,7 +16,7 @@
 - [x] **BLOG-05**: The generator HMAC-signs (`x-n8n-signature`) + POSTs to `n8n-blog-ingest` → real draft landed with `status='in-review'` (HTTP 201, MCP-verified); no deploy fires on a draft. (EF migrated off the dead legacy service-role key to `INGEST_DB_KEY`; required `N8N_WEBHOOK_SECRET` EF secret.)
 - [x] **BLOG-06**: Quality + brand guardrails — E-E-A-T-hardened system prompt (first-hand framing, specific depth, RAG-grounding-only), Organization "TenantFlow Team" byline (regression-locked in article-schema.test.ts), and a Mistral LLM-as-judge self-critique gate scoring 4 dimensions that regenerates/fails-closed on thin/off-brand drafts before in-review.
 - [x] **BLOG-07**: Human approve/reject surface at `/admin/blog` (is_admin-walled (admin) group): in-review list + sanitized preview → Approve (→published + revalidate) / Reject (→archived) via the authenticated admin client (blogs_update_admin RLS + defense-in-depth is_admin re-check). Nothing publishes without an explicit Approve.
-- [ ] **BLOG-08**: SEO-01 reclaim — a topic queue seeded from the deleted high-impression ghost slugs (top-10 first) generates posts at the exact original slugs; on publish, the entry is removed from `src/lib/seo/blog-redirects.ts` and the collision-guard test stays green. (Closes the carried-over v4.0 SEO-01 item.)
+- [x] **BLOG-08**: SEO-01 reclaim — a topic queue seeded from the deleted high-impression ghost slugs (top-10 first) generates posts at the exact original slugs; on publish, the entry is removed from `src/lib/seo/blog-redirects.ts` and the collision-guard test stays green. (Closes the carried-over v4.0 SEO-01 item.)
 - [ ] **BLOG-09**: Cadence + observability — a sustainable schedule with slug dedupe, execution monitoring, and failure alerts (reuse the critical-error notify path); runaway/cost guards documented.
 
 ## Out of Scope
@@ -39,7 +39,7 @@
 | BLOG-05 | Phase 11 — Generation Pipeline | Done |
 | BLOG-06 | Phase 12 — Quality & Brand Guardrails | Done |
 | BLOG-07 | Phase 12 — Quality & Brand Guardrails | Done |
-| BLOG-08 | Phase 13 — SEO-01 Reclaim Integration | Pending |
+| BLOG-08 | Phase 13 — SEO-01 Reclaim Integration | Complete |
 | BLOG-09 | Phase 14 — Cadence, Dedupe & Monitoring | Pending |
 
 **Coverage:** 9 requirements mapped to 6 phases (9-14), no orphans.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -16,7 +16,7 @@
 - [x] **Phase 10: RAG Knowledge Base** — DONE: pgvector `blog_rag_chunks` + `match_blog_rag_chunks` RPC live; 10 corpus chunks (llms-full.txt) embedded via qwen3-embedding (dim 1024) + verified (BLOG-03)
 - [x] **Phase 11: Generation Pipeline** — DONE: generate-blog-draft.ts (topic→RAG→Mistral→validate/repair+banlist-sanitizer→HMAC→ingest) produced a real 1,410-word in-review draft (HTTP 201, MCP-verified). Fixed the ingest EF's dead legacy key (→INGEST_DB_KEY) + N8N_WEBHOOK_SECRET (BLOG-04, BLOG-05)
 - [x] **Phase 12: Quality & Brand Guardrails** — DONE: Mistral LLM-as-judge self-critique gate (4-dim score, regenerate/fail-closed) + E-E-A-T prompt hardening + /admin/blog approve-reject surface (is_admin-walled, RLS, revalidate) + Organization byline regression-lock + E2E. 30 unit tests (BLOG-06, BLOG-07)
-- [ ] **Phase 13: SEO-01 Reclaim Integration** — ghost-slug queue, generate-at-slug, auto-drop redirect on publish; closes SEO-01 (BLOG-08)
+- [x] **Phase 13: SEO-01 Reclaim Integration** — ghost-slug queue, generate-at-slug, auto-drop redirect on publish; closes SEO-01 (BLOG-08) (completed 2026-06-10)
 - [ ] **Phase 14: Cadence, Dedupe & Monitoring** — schedule, dedupe, observability + failure alerts (BLOG-09)
 
 ## Phase Details (v5.0 AI Blog Content Engine)
@@ -79,10 +79,10 @@ Plans:
 **Success Criteria**:
   1. A topic queue is seeded from the deleted high-impression ghost slugs (top-10 first) in `src/lib/seo/blog-redirects.ts`; drafts generate at the exact original slug.
   2. On publish of a reclaimed slug, its entry is removed from `blog-redirects.ts` and the collision-guard test stays green.
-**Plans:** 2 plans
+**Plans:** 2/2 plans complete
 Plans:
-- [ ] 13-01-PLAN.md — generator `--slug <ghost-slug>` override (pins + re-gates the draft slug) + seeded top-10 RECLAIM_QUEUE const + its DELETED_BLOG_REDIRECTS drift-guard test (BLOG-08)
-- [ ] 13-02-PLAN.md — `scripts/reclaim-finalize.ts <slug>` (remove redirect entry + add slug to LIVE_PUBLISHED_SLUGS) + idempotent/validated edit unit tests keeping the collision guard green (BLOG-08)
+- [x] 13-01-PLAN.md — generator `--slug <ghost-slug>` override (pins + re-gates the draft slug) + seeded top-10 RECLAIM_QUEUE const + its DELETED_BLOG_REDIRECTS drift-guard test (BLOG-08)
+- [x] 13-02-PLAN.md — `scripts/reclaim-finalize.ts <slug>` (remove redirect entry + add slug to LIVE_PUBLISHED_SLUGS) + idempotent/validated edit unit tests keeping the collision guard green (BLOG-08)
 
 ### Phase 14: Cadence, Dedupe & Monitoring
 **Goal**: The engine runs on a sustainable schedule with dedupe and observability.
@@ -100,5 +100,5 @@ Plans:
 | 10 — RAG Knowledge Base | Complete | store live + 10 chunks loaded/verified |
 | 11 — Generation Pipeline | Complete | real in-review draft produced e2e (201, MCP-verified); ingest EF fixed |
 | 12 — Quality & Brand Guardrails | Complete | judge gate + /admin/blog approve-reject + byline lock + E2E; 30 unit tests |
-| 13 — SEO-01 Reclaim Integration | Planned | 2 plans (--slug override + reclaim-queue; reclaim-finalize + guard) |
+| 13 — SEO-01 Reclaim Integration | Complete | 2 plans (--slug override + reclaim-queue; reclaim-finalize codemod + guard); 19+ unit tests |
 | 14 — Cadence, Dedupe & Monitoring | Not started | TBD |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -79,6 +79,10 @@ Plans:
 **Success Criteria**:
   1. A topic queue is seeded from the deleted high-impression ghost slugs (top-10 first) in `src/lib/seo/blog-redirects.ts`; drafts generate at the exact original slug.
   2. On publish of a reclaimed slug, its entry is removed from `blog-redirects.ts` and the collision-guard test stays green.
+**Plans:** 2 plans
+Plans:
+- [ ] 13-01-PLAN.md — generator `--slug <ghost-slug>` override (pins + re-gates the draft slug) + seeded top-10 RECLAIM_QUEUE const + its DELETED_BLOG_REDIRECTS drift-guard test (BLOG-08)
+- [ ] 13-02-PLAN.md — `scripts/reclaim-finalize.ts <slug>` (remove redirect entry + add slug to LIVE_PUBLISHED_SLUGS) + idempotent/validated edit unit tests keeping the collision guard green (BLOG-08)
 
 ### Phase 14: Cadence, Dedupe & Monitoring
 **Goal**: The engine runs on a sustainable schedule with dedupe and observability.
@@ -96,5 +100,5 @@ Plans:
 | 10 — RAG Knowledge Base | Complete | store live + 10 chunks loaded/verified |
 | 11 — Generation Pipeline | Complete | real in-review draft produced e2e (201, MCP-verified); ingest EF fixed |
 | 12 — Quality & Brand Guardrails | Complete | judge gate + /admin/blog approve-reject + byline lock + E2E; 30 unit tests |
-| 13 — SEO-01 Reclaim Integration | Not started | TBD |
+| 13 — SEO-01 Reclaim Integration | Planned | 2 plans (--slug override + reclaim-queue; reclaim-finalize + guard) |
 | 14 — Cadence, Dedupe & Monitoring | Not started | TBD |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v5.0
 milestone_name: AI Blog Content Engine
-status: executing
-last_updated: "2026-06-09T14:55:00.000Z"
-last_activity: 2026-06-09
+status: "Phases 9-11 MERGED (PR #792 → main). Phase 12 + Phase 13 (plans 01-02) built on branches, ready for PR + review."
+last_updated: "2026-06-10T02:32:00.000Z"
+last_activity: 2026-06-10 -- Phase 13 plan 02 executed (reclaim-finalize script + tests)
 progress:
   total_phases: 6
-  completed_phases: 4
-  total_plans: 10
-  completed_plans: 10
-  percent: 67
+  completed_phases: 1
+  total_plans: 12
+  completed_plans: 8
+  percent: 17
 ---
 
 # Project State
@@ -24,10 +24,10 @@ See: .planning/PROJECT.md
 
 ## Current Position
 
-Phase: 12 of 14 COMPLETE → next is Phase 13 (SEO-01 Reclaim Integration) — v5.0 (67% of milestone)
-Plan: 09-12 complete. Phase 12 (branch gsd/phase-12-quality-brand-guardrails): Mistral LLM-as-judge self-critique gate in the generator (4-dim score, regenerate/fail-closed before POST) + E-E-A-T prompt; /admin/blog approve-reject surface (is_admin-walled, blogs_update_admin RLS, revalidatePath); Organization byline regression-lock + E2E (non-admin redirect in CI, admin-approve skip-gated). 30 unit tests.
-Status: Phases 9-11 MERGED (PR #792 → main). Phase 12 built on its own branch, ready for PR + review.
-Last activity: 2026-06-09 -- Phase 12 executed
+Phase: 13 of 14 IN PROGRESS (plans 13-01, 13-02 complete; 13-03 remaining) — v5.0
+Plan: 09-12 + 13-01 + 13-02 complete. Phase 13 (branch gsd/phase-13-seo-01-reclaim-integration): 13-01 = generator `--slug <ghost-slug>` override + seeded top-10 RECLAIM_QUEUE (drift-guarded against DELETED_BLOG_REDIRECTS). 13-02 = `scripts/reclaim-finalize.ts <slug>` deterministic two-file codemod (removes the slug's DELETED_BLOG_REDIRECTS entry + adds it to LIVE_PUBLISHED_SLUGS) — idempotent, slug-validated, typo-guarded; 19 unit tests incl. a real-file round-trip net proving blog-redirects.test.ts stays green.
+Status: Phases 9-11 MERGED (PR #792 → main). Phase 12 + Phase 13 (plans 01-02) built on branches, ready for PR + review.
+Last activity: 2026-06-10 -- Phase 13 plan 02 executed (reclaim-finalize script + tests)
 
 **Runtime fact:** n8n runs NATIVELY (node@22, `bash n8n/start-native.sh`, reuses n8n/data) — NOT Docker. colima's network blocks container→host, so Docker/colima were abandoned + stopped. LLM base URL `http://localhost:1234/v1`, model `mistral-small-3.2-24b-instruct-2506-mlx`.
 

--- a/.planning/phases/13-seo-01-reclaim-integration/13-01-PLAN.md
+++ b/.planning/phases/13-seo-01-reclaim-integration/13-01-PLAN.md
@@ -1,0 +1,191 @@
+---
+phase: 13-seo-01-reclaim-integration
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - scripts/generate-blog-draft.ts
+  - scripts/generate-blog-draft.test.ts
+  - src/lib/seo/reclaim-queue.ts
+  - src/lib/seo/__tests__/reclaim-queue.test.ts
+autonomous: true
+requirements: [BLOG-08]
+
+must_haves:
+  truths:
+    - "Running the generator with `--slug <ghost-slug>` produces a draft whose slug is EXACTLY that ghost slug (not the model-chosen slug)."
+    - "An overridden slug still has to pass the slug gate (regex + length 3-120) — an invalid/oversized override fails fast, never reaches the POST path."
+    - "An exported reclaim queue lists the top-10 ghost slugs with {slug, topic, category}, each slug a current DELETED_BLOG_REDIRECTS source."
+    - "A drift-guard test fails if any reclaim-queue slug stops being a DELETED_BLOG_REDIRECTS source (or vice-versa for the seeded set)."
+  artifacts:
+    - path: "scripts/generate-blog-draft.ts"
+      provides: "--slug override wired into the existing arg/positional parse + post-generation pin + gate re-check"
+      contains: "slugOverride"
+    - path: "src/lib/seo/reclaim-queue.ts"
+      provides: "exported RECLAIM_QUEUE const of the top-10 {slug, topic, category}"
+      contains: "RECLAIM_QUEUE"
+    - path: "src/lib/seo/__tests__/reclaim-queue.test.ts"
+      provides: "reclaim-queue <-> DELETED_BLOG_REDIRECTS drift guard + slug-gate + category-membership assertions"
+      contains: "DELETED_BLOG_REDIRECTS"
+    - path: "scripts/generate-blog-draft.test.ts"
+      provides: "unit tests for the --slug parse + override-pins-slug + override-still-gated behaviors"
+      contains: "--slug"
+  key_links:
+    - from: "src/lib/seo/reclaim-queue.ts"
+      to: "src/lib/seo/blog-redirects.ts"
+      via: "drift-guard test asserts every queue slug == a DELETED_BLOG_REDIRECTS source (minus /blog/)"
+      pattern: "DELETED_BLOG_REDIRECTS"
+    - from: "scripts/generate-blog-draft.ts (--slug parse)"
+      to: "the slug gate (SLUG_REGEX + length 3-120)"
+      via: "the override is re-validated against the same gate before the draft is returned"
+      pattern: "SLUG_REGEX"
+---
+
+<objective>
+Add the reclaim MECHANISM front-half: a `--slug <ghost-slug>` override on the blog generator so a draft can be produced at an EXACT deleted ghost slug, and a seeded, drift-guarded reclaim queue of the top-10 ghost slugs to feed it.
+
+Purpose: Closes the v4.0 SEO-01 reclaim (BLOG-08) by letting the owner regenerate a quality post at the precise URL Google already ranked, instead of accepting the 301 to a hub. The seeded queue is the worklist; the override is the lever.
+
+Output: `--slug` override in `scripts/generate-blog-draft.ts` (+ unit tests), `src/lib/seo/reclaim-queue.ts` (the top-10 const), and `src/lib/seo/__tests__/reclaim-queue.test.ts` (the drift guard).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/13-seo-01-reclaim-integration/13-CONTEXT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# The generator to extend (arg parse in main() ~line 500; slug gate ~line 134; SLUG_REGEX ~line 73)
+@scripts/generate-blog-draft.ts
+# The existing generator test conventions (pure-export + fetch-stub pattern) to mirror
+@scripts/generate-blog-draft.test.ts
+# The redirect source-of-truth the queue must stay in lockstep with
+@src/lib/seo/blog-redirects.ts
+
+<interfaces>
+<!-- Key contracts the executor uses directly — no exploration needed. -->
+
+From scripts/generate-blog-draft.ts (current state):
+- `const SLUG_REGEX = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;` (line 73)
+- `const VALID_CATEGORIES = ["lease-law","tax-prep","tenant-screening","maintenance","software-vault"] as const;` and `type Category = (typeof VALID_CATEGORIES)[number];`
+- `interface Draft { title; slug; excerpt; meta_description; category; content }` (all string)
+- `function runGates(p: Draft): { gate; message; fix }[]` — gate `slug_pattern` fires when `!SLUG_REGEX.test(p.slug) || p.slug.length < 3 || p.slug.length > 120`
+- `main()` parses: `dryRun = process.argv.includes("--dry-run")`, `topic = process.argv[2]`, `catArg = process.argv[3]`, `category = (catArg && !catArg.startsWith("--") ? catArg : "tenant-screening")`. The draft is produced by `generateValidDraft(...)` then `gateOnCritique(...)`, then dry-run prints `draft.slug`, then the non-dry path HMAC-signs `{ slug: draft.slug, ... }` and POSTs.
+- The module already exports pure functions (`critique`, `isCritiquePass`, `parseCritique`, `gateOnCritique`) for unit testing, and guards the CLI with `if (process.argv[1]?.endsWith("generate-blog-draft.ts"))`.
+
+From src/lib/seo/blog-redirects.ts:
+- `export interface BlogRedirect { readonly source: string; readonly destination: string; }`
+- `export const DELETED_BLOG_REDIRECTS: readonly BlogRedirect[]` — 126 entries; each `source` is `/blog/<slug>`.
+
+All 10 reclaim slugs (verified this pass): pass `SLUG_REGEX` + length 3-120, and each is a current `DELETED_BLOG_REDIRECTS` source. Slug→category mapping (closest of the 5 valid categories; comparison/pricing/listicle ghosts → software-vault):
+- rentredi-pricing-breakdown-and-hidden-fees-what-every-small-landlord-needs-to-know → software-vault
+- yardi-breeze-vs-appfolio-complete-comparison-for-2026 → software-vault
+- stessa-vs-rentredi-complete-comparison-for-2026 → software-vault
+- photography-tips-for-rental-listings → software-vault
+- top-50-property-management-apps-for-small-landlords → software-vault
+- rentec-direct-vs-avail-complete-comparison-for-2025 → software-vault
+- top-3-property-management-apps-for-commercial-landlords → software-vault
+- top-5-property-management-apps-for-first-time-landlords-remote-friendly → software-vault
+- stessa-vs-turbotenant-complete-comparison-for-2026 → software-vault
+- rent-manager-pricing-breakdown-and-hidden-fees-what-you-need-to-know-before-you-subscribe → software-vault
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Seed the reclaim-queue const + its drift-guard test</name>
+  <read_first>
+    @.planning/phases/13-seo-01-reclaim-integration/13-CONTEXT.md (BLOG-08b)
+    @src/lib/seo/blog-redirects.ts (DELETED_BLOG_REDIRECTS shape + the 10 sources)
+    @src/lib/seo/__tests__/blog-redirects.test.ts (test conventions: vitest describe/it, import from "../blog-redirects")
+  </read_first>
+  <files>src/lib/seo/reclaim-queue.ts, src/lib/seo/__tests__/reclaim-queue.test.ts</files>
+  <behavior>
+    - RECLAIM_QUEUE has exactly 10 entries.
+    - Every entry.slug matches SLUG_REGEX and is length 3-120.
+    - Every entry.slug equals a current DELETED_BLOG_REDIRECTS source with the "/blog/" prefix stripped (drift guard — fails if a redirect source is renamed/removed without updating the queue).
+    - Every entry.category is one of the five valid categories.
+    - Slugs are unique within the queue.
+  </behavior>
+  <action>Create src/lib/seo/reclaim-queue.ts (kebab file, no barrel/re-export). Define and export an interface `ReclaimQueueItem` with `readonly slug: string`, `readonly topic: string`, `readonly category: string` — DO NOT import a Category type from the generator script (scripts/ must not become a runtime dependency of src/); keep category a string and let the test assert membership in the five valid categories. Export `const RECLAIM_QUEUE: readonly ReclaimQueueItem[]` with the top-10 entries from the Interfaces block: slug verbatim, topic = a humanized sentence-case version of the slug suitable as a generation topic hint, category = software-vault for all 10. Add a file-header comment citing BLOG-08b + ANALYSIS-2026-05-29.md and stating the invariant (every slug must remain a DELETED_BLOG_REDIRECTS source until reclaim-finalize removes it on publish). Then create src/lib/seo/__tests__/reclaim-queue.test.ts importing RECLAIM_QUEUE from "../reclaim-queue" and DELETED_BLOG_REDIRECTS from "../blog-redirects"; assert all five behaviors above. Define the slug regex and the valid-category set locally in the test (do not import from scripts/). No `any`, no `as unknown as` — use typed iteration over the readonly arrays.</action>
+  <verify>
+    <automated>bun run test:unit -- src/lib/seo/__tests__/reclaim-queue.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - reclaim-queue.test.ts passes; RECLAIM_QUEUE has 10 entries; every slug is a DELETED_BLOG_REDIRECTS source and passes the slug gate; every category is valid.
+    - `bun run typecheck` clean for the new files; no import from scripts/ into src/.
+  </acceptance_criteria>
+  <done>src/lib/seo/reclaim-queue.ts exports the 10-entry RECLAIM_QUEUE and the drift-guard test is green.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add the `--slug <ghost-slug>` override to the generator + unit-test it</name>
+  <read_first>
+    @.planning/phases/13-seo-01-reclaim-integration/13-CONTEXT.md (BLOG-08a + Verification)
+    @scripts/generate-blog-draft.ts (main() arg parse, generateValidDraft, gateOnCritique, dry-run print, POST payload)
+    @scripts/generate-blog-draft.test.ts (pure-export + fetch-stub test conventions to mirror)
+  </read_first>
+  <files>scripts/generate-blog-draft.ts, scripts/generate-blog-draft.test.ts</files>
+  <behavior>
+    - parseSlugOverride(argv) returns the value following `--slug` (e.g. `--slug foo-bar` → "foo-bar"), or undefined when `--slug` is absent.
+    - A `--slug` flag with no following value (end of argv, or the next token is another flag like `--dry-run`) is a hard error, not a silent no-op.
+    - applySlugOverride(draft, override) returns a draft whose slug === override when override is provided, unchanged when undefined.
+    - An override that fails the slug gate (bad regex OR length <3 OR >120) is rejected before the draft is returned (the same SLUG_REGEX + length rule runGates uses) — it must NOT silently pass through to POST.
+    - The positional topic/category parse is unaffected by the presence of `--slug` (topic stays argv[2], category stays the first non-flag at argv[3]+ semantics).
+  </behavior>
+  <action>Extract two small pure functions and export them for testing (mirroring how critique/gateOnCritique are exported + the `if (process.argv[1]?.endsWith(...))` CLI guard keeps them import-safe): (1) `parseSlugOverride(argv: string[]): string | undefined` — find the `--slug` token, return the next token; if `--slug` is present but the next token is missing or begins with `--`, call fail() with a clear usage message. (2) `applySlugOverride(draft: Draft, override: string | undefined): Draft` — when override is set, validate it against `SLUG_REGEX` + length 3-120 (reuse the existing constant/rule; fail() with the offending slug if it violates), then return `{ ...draft, slug: override }`; when undefined, return draft unchanged. In main(): compute `const slugOverride = parseSlugOverride(process.argv)` alongside the existing dryRun/topic/category parse, and ensure the positional category parse still treats `--slug` and its value as flags (so `--slug` and the ghost slug are never mistaken for the category positional — keep the existing `!catArg.startsWith("--")` guard and additionally skip a `--slug`/its-value pair when computing category, OR document that category must be passed BEFORE `--slug`; pick the parse that keeps `topic "<topic>" software-vault --slug <ghost> --dry-run` AND `--slug <ghost> "<topic>" software-vault --dry-run` both working as the CONTEXT verification line implies). After `generateValidDraft` + `gateOnCritique` produce `draft`, apply `draft = applySlugOverride(draft, slugOverride)` BEFORE the dry-run summary print and BEFORE building the POST payload, so the printed/posted slug is the override. Do NOT place fenced code in comments. Update the usage string + the top-of-file Usage doc comment to mention `--slug <ghost-slug>`. Then add tests to scripts/generate-blog-draft.test.ts: parseSlugOverride happy path, absent → undefined, dangling `--slug` → throws/usage; applySlugOverride pins the slug, undefined passes through, an over-120-char or bad-regex override is rejected (use `.rejects`/`expect(() => ...).toThrow` per the file's chai-6 convention, or assert via a fail() spy if fail() exits — prefer making applySlugOverride throw a typed Error so it is assertable, and have main() catch→fail). No `any`, no `as unknown as`.</action>
+  <verify>
+    <automated>bun run test:unit -- scripts/generate-blog-draft.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - The new parseSlugOverride/applySlugOverride tests pass alongside the existing judge-gate tests (no regressions in generate-blog-draft.test.ts).
+    - `--slug <ghost>` pins draft.slug to the override; a >120-char or regex-invalid override is rejected before POST.
+    - `bun run typecheck && bun run lint` clean.
+    - Manual smoke (owner-run, NOT in CI — note in SUMMARY): `bun scripts/generate-blog-draft.ts "<topic>" software-vault --slug top-3-property-management-apps-for-commercial-landlords --dry-run` prints `slug: top-3-property-management-apps-for-commercial-landlords` and `judge: PASS`.
+  </acceptance_criteria>
+  <done>The generator accepts `--slug`, pins the draft slug to it, re-validates it against the slug gate, and the unit tests cover parse + override + rejection.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| CLI argv → generator | Owner-supplied `--slug` value crosses into the draft slug that is later printed and (non-dry) POSTed to the ingest EF. |
+| reclaim-queue const → redirect map | The queue names slugs that must already exist as 301 sources; drift between them would mean a queue entry that does not correspond to a reclaimable URL. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-13-01 | Tampering | `--slug` override bypassing the slug gate | mitigate | applySlugOverride re-validates the override against the SAME SLUG_REGEX + length 3-120 rule runGates uses; an invalid/oversized slug fails() before the draft is returned, so it never reaches the HMAC POST. |
+| T-13-02 | Tampering | malformed argv (`--slug` with no value, or value swallowing the category positional) | mitigate | parseSlugOverride hard-errors on a dangling/flag-valued `--slug`; the positional category parse explicitly skips the `--slug`/value pair so a ghost slug is never silently used as the category. |
+| T-13-03 | Information disclosure | new secret/cred handling | accept | No new env/secret/service-role handling added; the override is a plain string, generation still uses the existing SUPABASE_SECRET_KEY/N8N_WEBHOOK_SECRET path unchanged. Owner runs the script; agent only builds + unit-tests. |
+| T-13-04 | Repudiation | queue drifts from the redirect map (stale reclaim target) | mitigate | reclaim-queue.test.ts asserts every queue slug is a current DELETED_BLOG_REDIRECTS source — drift fails CI before a stale queue can mislead an owner into "reclaiming" a non-redirected slug. |
+| T-13-SC | Tampering | npm/pip/cargo installs | mitigate | No new package installs in this plan (pure TS in src/ + scripts/); n/a — no legitimacy checkpoint required. |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- src/lib/seo/__tests__/reclaim-queue.test.ts` — drift guard green (10 entries, all redirect-backed, gate-valid).
+- `bun run test:unit -- scripts/generate-blog-draft.test.ts` — `--slug` parse/override/rejection tests + existing judge-gate tests green.
+- `bun run typecheck && bun run lint` — clean (no `any`, no `as unknown as`, no scripts→src import).
+- Owner manual smoke (out of CI): the `--dry-run` line in Task 2 prints the exact ghost slug + judge PASS.
+</verification>
+
+<success_criteria>
+- An exported RECLAIM_QUEUE of the top-10 {slug, topic, category} exists, drift-guarded against DELETED_BLOG_REDIRECTS.
+- `--slug <ghost-slug>` pins the draft slug to the exact ghost slug, re-validated against the slug gate, and is unit-tested (pin + reject).
+- typecheck + lint + the two test files all green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/13-seo-01-reclaim-integration/13-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/13-seo-01-reclaim-integration/13-01-SUMMARY.md
+++ b/.planning/phases/13-seo-01-reclaim-integration/13-01-SUMMARY.md
@@ -1,0 +1,97 @@
+---
+phase: 13-seo-01-reclaim-integration
+plan: 01
+subsystem: seo
+tags: [seo, blog-reclaim, generator, drift-guard]
+requires: [BLOG-08]
+provides:
+  - RECLAIM_QUEUE const (top-10 ghost slugs, drift-guarded)
+  - "--slug <ghost-slug> override on the blog generator"
+affects:
+  - scripts/generate-blog-draft.ts
+  - src/lib/seo/reclaim-queue.ts
+tech-stack:
+  added: []
+  patterns:
+    - "pure exported arg-parse helpers (parseSlugOverride / parsePositionals / applySlugOverride) unit-tested without spawning the CLI"
+    - "compile-time drift guard: reclaim-queue test asserts every queue slug is a current DELETED_BLOG_REDIRECTS source"
+key-files:
+  created:
+    - src/lib/seo/reclaim-queue.ts
+    - src/lib/seo/__tests__/reclaim-queue.test.ts
+  modified:
+    - scripts/generate-blog-draft.ts
+    - scripts/generate-blog-draft.test.ts
+decisions:
+  - "category stored as plain string in ReclaimQueueItem (no Category import from scripts/) — keeps scripts out of src/ runtime deps; the test asserts membership in the five valid categories"
+  - "added parsePositionals helper so --slug + value is skipped when computing topic/category, making BOTH `<topic> software-vault --slug <ghost>` and `--slug <ghost> <topic> software-vault` resolve identically (deviation, Rule 2)"
+  - "applySlugOverride / parseSlugOverride THROW typed Errors (not fail()/exit) so they are assertable; main()'s existing .catch(() => fail()) converts to exit"
+metrics:
+  duration: ~12m
+  completed: 2026-06-09
+---
+
+# Phase 13 Plan 01: Generator `--slug` Override + Seeded Reclaim Queue Summary
+
+Added the reclaim MECHANISM front-half (BLOG-08): a `--slug <ghost-slug>` override on `scripts/generate-blog-draft.ts` that pins a draft to an EXACT deleted ghost slug (re-validated against the same slug gate), plus a drift-guarded `RECLAIM_QUEUE` of the top-10 ghost slugs to feed it.
+
+## What Was Built
+
+### Task 1 — `RECLAIM_QUEUE` const + drift-guard test (commit `95fcc9281`)
+- `src/lib/seo/reclaim-queue.ts` exports `interface ReclaimQueueItem { readonly slug; readonly topic; readonly category }` (all `string` — no `Category` import from `scripts/`) and `const RECLAIM_QUEUE: readonly ReclaimQueueItem[]` with the 10 audit slugs verbatim, a humanized sentence-case `topic` hint per slug, and `category: "software-vault"` for all 10 (each is a competitor/pricing/listicle ghost). File-header cites BLOG-08b + ANALYSIS-2026-05-29.md and states the invariant: every slug must remain a `DELETED_BLOG_REDIRECTS` source until `reclaim-finalize` removes it on publish.
+- `src/lib/seo/__tests__/reclaim-queue.test.ts` imports `RECLAIM_QUEUE` from `../reclaim-queue` and `DELETED_BLOG_REDIRECTS` from `../blog-redirects`; defines the slug regex + valid-category set locally (no `scripts/` import) and asserts: exactly 10 entries, every slug passes the gate (regex + length 3-120), every slug is a current redirect source (drift guard), every category is valid, slugs are unique, every topic is non-empty.
+
+### Task 2 — `--slug` override on the generator (commit `aefe3b7b6`)
+- `scripts/generate-blog-draft.ts`:
+  - `parseSlugOverride(argv): string | undefined` — returns the token after `--slug`, `undefined` when absent, THROWS on a dangling/flag-valued `--slug` (no silent no-op).
+  - `applySlugOverride(draft, override): Draft` — when set, re-validates the override against the same `SLUG_REGEX` + length 3-120 rule `runGates()` uses and THROWS on violation, then returns `{ ...draft, slug: override }`; when `undefined`, returns the draft unchanged.
+  - `parsePositionals(argv)` — `--slug`-aware topic/category extraction (skips the `--slug` flag + its value and all other `--flags`), so a ghost slug is never mistaken for a positional in either arg order.
+  - `main()` computes `slugOverride` alongside `dryRun`/`topic`/`category`, then applies `draft = applySlugOverride(draft, slugOverride)` AFTER gates+judge and BEFORE the dry-run print / HMAC POST, so the printed/posted slug is the override.
+  - Usage doc comment + the `fail()` usage string now mention `--slug <ghost-slug>`.
+- `scripts/generate-blog-draft.test.ts`: 15 new tests (parse happy paths incl. `--slug` before/after the topic, absent→undefined, dangling/flag-valued `--slug`→throws; override pins slug, undefined passes through, regex-invalid / >120 / <3 → throws; ghost slug accepted; `parsePositionals` keeps topic/category in both orderings and never uses the `--slug` value as category) alongside the existing 9 judge-gate tests — no regressions.
+
+## Threat Mitigations Applied
+- **T-13-01** (override bypassing the slug gate): `applySlugOverride` re-validates against the same regex + length rule and throws before the draft is returned — never reaches the HMAC POST.
+- **T-13-02** (malformed argv): `parseSlugOverride` hard-errors on a dangling/flag-valued `--slug`; `parsePositionals` skips the `--slug`/value pair so a ghost slug can't be silently used as category.
+- **T-13-04** (queue drift): `reclaim-queue.test.ts` asserts every queue slug is a current `DELETED_BLOG_REDIRECTS` source — drift fails before a stale queue can mislead the owner.
+
+## Deviations from Plan
+
+### Auto-added functionality
+
+**1. [Rule 2 - Robustness] Added `parsePositionals` helper for order-independent topic/category parse**
+- **Found during:** Task 2.
+- **Issue:** The plan requires BOTH `<topic> software-vault --slug <ghost> --dry-run` AND `--slug <ghost> <topic> software-vault --dry-run` to resolve identically (CONTEXT verification line). The original `topic = argv[2]` / `catArg = argv[3]` parse breaks the second ordering (argv[2] would be `--slug`) and risks treating the ghost slug as the category positional.
+- **Fix:** Extracted `parsePositionals(argv)` which walks `argv.slice(2)`, skipping every flag and the `--slug` flag+value pair, and returns the remaining positionals as `{ topic, category }`. Exported + unit-tested (4 cases covering both orderings + the never-use-slug-value-as-category guard).
+- **Files modified:** `scripts/generate-blog-draft.ts`, `scripts/generate-blog-draft.test.ts`.
+- **Commit:** `aefe3b7b6`.
+
+No other deviations — plan executed as written.
+
+## Manual Smoke (owner-run, NOT in CI)
+Per Task 2 acceptance, the full-pipeline smoke requires LM Studio (Mistral + qwen3-embedding loaded) + `.env.local` creds, which are scrubbed from the agent shell. The owner should run:
+
+```
+bun scripts/generate-blog-draft.ts "<topic>" software-vault --slug top-3-property-management-apps-for-commercial-landlords --dry-run
+```
+
+Expected: the dry-run prints `slug: top-3-property-management-apps-for-commercial-landlords` and `judge: PASS`. The parse + override + gate-revalidation logic that produces that slug is fully unit-tested (the override path is deterministic and order-independent); only the model generation + judge run requires the local LLM.
+
+## Verification Results
+- `bun run test:unit -- src/lib/seo/__tests__/reclaim-queue.test.ts` — 6/6 green.
+- `bun run test:unit -- scripts/generate-blog-draft.test.ts` — 24/24 green (9 existing judge + 15 new).
+- Both files together — 30/30 green.
+- `bun run typecheck` — clean (no `any`, no `as unknown as`, no scripts→src import).
+- `bunx biome check <files>` — clean; `bun run lint` — exit 0.
+- Pre-commit hook (gitleaks, lockfile, lint, typecheck, full unit suite, commitlint) passed on both commits.
+
+## Known Stubs
+None.
+
+## Commits
+- `95fcc9281` — feat(13-01): seed reclaim queue with drift-guarded top-10 ghost slugs
+- `aefe3b7b6` — feat(13-01): add --slug ghost-slug override to blog generator
+
+## Self-Check: PASSED
+- All 5 created/modified files present on disk.
+- Both task commits (`95fcc9281`, `aefe3b7b6`) exist in git history.

--- a/.planning/phases/13-seo-01-reclaim-integration/13-02-PLAN.md
+++ b/.planning/phases/13-seo-01-reclaim-integration/13-02-PLAN.md
@@ -1,0 +1,176 @@
+---
+phase: 13-seo-01-reclaim-integration
+plan: 02
+type: execute
+wave: 2
+depends_on: ["13-01"]
+files_modified:
+  - scripts/reclaim-finalize.ts
+  - scripts/reclaim-finalize.test.ts
+autonomous: true
+requirements: [BLOG-08]
+
+must_haves:
+  truths:
+    - "Running `bun scripts/reclaim-finalize.ts <slug>` for a published reclaimed slug deletes that slug's entry from DELETED_BLOG_REDIRECTS in blog-redirects.ts."
+    - "The same run adds the slug to LIVE_PUBLISHED_SLUGS in blog-redirects.test.ts."
+    - "After both edits, blog-redirects.test.ts stays green (no source shadows a live published slug; the removed redirect is gone)."
+    - "The script is idempotent + validated: it refuses a slug that is not a current DELETED_BLOG_REDIRECTS source, and re-running on an already-finalized slug is a safe no-op (no array corruption, no duplicate LIVE_PUBLISHED_SLUGS entry)."
+  artifacts:
+    - path: "scripts/reclaim-finalize.ts"
+      provides: "deterministic two-file finalize: remove redirect entry + add slug to the collision guard's live set"
+      contains: "DELETED_BLOG_REDIRECTS"
+    - path: "scripts/reclaim-finalize.test.ts"
+      provides: "unit tests for the pure edit functions (remove entry, add live slug, idempotency, unknown-slug rejection, collision-guard-stays-green invariant)"
+      contains: "LIVE_PUBLISHED_SLUGS"
+  key_links:
+    - from: "scripts/reclaim-finalize.ts"
+      to: "src/lib/seo/blog-redirects.ts"
+      via: "removes the `{ source: \"/blog/<slug>\", ... }` entry from the DELETED_BLOG_REDIRECTS array text"
+      pattern: "DELETED_BLOG_REDIRECTS"
+    - from: "scripts/reclaim-finalize.ts"
+      to: "src/lib/seo/__tests__/blog-redirects.test.ts"
+      via: "inserts the slug into the LIVE_PUBLISHED_SLUGS Set literal"
+      pattern: "LIVE_PUBLISHED_SLUGS"
+---
+
+<objective>
+Add the reclaim MECHANISM back-half: `scripts/reclaim-finalize.ts <slug>` that, when the owner has approved+published a reclaimed post at a ghost slug, performs the TWO code edits that flip the URL from "301-redirected" to "served live" while keeping the collision guard green.
+
+Purpose: Publishing is a DB action, but the redirect map + its collision guard are compile-time. Without this script, a published reclaim post would still 301-shadow itself (the redirect source still matches), defeating the reclaim. The script removes the redirect AND tells the collision guard the slug is now live (so a future re-add of the redirect would fail the test).
+
+Output: `scripts/reclaim-finalize.ts` (the two-file editor) + `scripts/reclaim-finalize.test.ts` (pure-function unit tests proving the edits are deterministic, idempotent, validated, and leave blog-redirects.test.ts green).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/13-seo-01-reclaim-integration/13-CONTEXT.md
+@.planning/ROADMAP.md
+
+# The two files this script edits
+@src/lib/seo/blog-redirects.ts
+@src/lib/seo/__tests__/blog-redirects.test.ts
+# The seeded queue (from plan 01) — the set of slugs reclaim-finalize is valid for
+@src/lib/seo/reclaim-queue.ts
+# Shared loader pattern + arg-guard convention for owner-run scripts
+@scripts/_shared/load-dotenv.ts
+@scripts/generate-blog-draft.ts
+
+<interfaces>
+<!-- Contracts the executor uses directly. -->
+
+From src/lib/seo/blog-redirects.ts:
+- `export const DELETED_BLOG_REDIRECTS: readonly BlogRedirect[] = [ ... ];` — each entry is an object literal `{ source: "/blog/<slug>", destination: "<path>" }`. Some entries are pretty-printed across multiple lines (long source on its own line). The script must delete the WHOLE object literal for the target source, not just one line.
+
+From src/lib/seo/__tests__/blog-redirects.test.ts:
+- `const LIVE_PUBLISHED_SLUGS = new Set([ "<slug>", ... ]);` — 9 string entries (snapshot 2026-05-29). Adding a slug here makes the collision guard assert the redirect for that slug was removed (`no source shadows a live published post`).
+- Collision-guard assertions already present: every source is `/blog/<slug>`, sources unique, no source ∈ LIVE_PUBLISHED_SLUGS, destinations are live paths.
+
+From src/lib/seo/reclaim-queue.ts (plan 01):
+- `export const RECLAIM_QUEUE: readonly ReclaimQueueItem[]` — the 10 reclaimable slugs.
+
+From scripts/generate-blog-draft.ts (convention to mirror):
+- `function fail(msg: string): never` (console.error + process.exit(1)).
+- CLI guard: `if (process.argv[1]?.endsWith("generate-blog-draft.ts")) { main().catch(...) }` — keep the editor functions pure + exported, run main() only under the matching guard so the test can import without executing.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Write the pure two-file edit functions + their unit tests</name>
+  <read_first>
+    @.planning/phases/13-seo-01-reclaim-integration/13-CONTEXT.md (BLOG-08c + the static-snapshot-vs-dynamic decision: default to static + finalize-script)
+    @src/lib/seo/blog-redirects.ts (the multi-line object-literal shape of entries)
+    @src/lib/seo/__tests__/blog-redirects.test.ts (the LIVE_PUBLISHED_SLUGS Set literal + the collision-guard assertions)
+    @scripts/generate-blog-draft.test.ts (chai-6 assertion convention: `.rejects.toMatchObject` / `expect(() => ...).toThrow(/re/)`, never `.toThrow('string')`)
+  </read_first>
+  <files>scripts/reclaim-finalize.ts, scripts/reclaim-finalize.test.ts</files>
+  <behavior>
+    - removeRedirectEntry(fileText, slug): returns blog-redirects.ts text with the single `{ source: "/blog/<slug>", destination: ... }` object literal removed (handles both single-line and multi-line-source entry formats); leaves the rest of the array byte-identical; the resulting text still parses (valid array, trailing commas intact, no dangling fragment).
+    - removeRedirectEntry on a slug whose `/blog/<slug>` source is NOT present throws a typed Error naming the slug (do not silently no-op a typo) — EXCEPT the idempotent re-run path below.
+    - addLivePublishedSlug(testFileText, slug): returns blog-redirects.test.ts text with `"<slug>"` inserted into the LIVE_PUBLISHED_SLUGS Set literal; inserting a slug already present is a no-op (no duplicate line).
+    - Idempotency: a finalize whose redirect is already removed AND whose slug is already in LIVE_PUBLISHED_SLUGS is a clean no-op (the orchestrating function detects "already finalized" — redirect absent + slug present — and exits 0 without erroring).
+    - Validation: the orchestrating function rejects a slug that is neither a current redirect source NOR already-live (i.e. an unknown slug — typo guard). Optionally also assert the slug is in RECLAIM_QUEUE for an explicit allowlist (decide + document).
+    - Collision-guard-stays-green invariant: after removeRedirectEntry + addLivePublishedSlug, the resulting redirect array has no source equal to any LIVE_PUBLISHED_SLUGS entry (the exact assertion blog-redirects.test.ts makes) — assert this in the unit test by re-deriving sources + the live set from the edited texts.
+  </behavior>
+  <action>Create scripts/reclaim-finalize.ts (kebab file, no barrel). Implement and export pure string-transform functions: `removeRedirectEntry(fileText: string, slug: string): string` and `addLivePublishedSlug(testFileText: string, slug: string): string`, plus a `finalizeReclaim({ redirectsText, testText, slug }): { redirectsText: string; testText: string; alreadyFinalized: boolean }` orchestrator that validates the slug and applies both edits idempotently. Operate on TEXT (read the two files via node:fs readFileSync, write via writeFileSync) — NOT by importing+re-serializing the arrays (re-serializing would reformat the whole file and destroy the diff). For removeRedirectEntry, match the target entry by building a regex/scan anchored on the exact `source:` value (account for the prettier wrapping where a long source string sits on the line after `source:`); remove from the opening `{` through the matching `},` inclusive, plus the leading indentation/newline, so the array stays valid. Validate the slug shape (lowercase-hyphen, length 3-120) before editing as defense-in-depth. For addLivePublishedSlug, insert the quoted slug as a new line inside the `new Set([ ... ])` block, preserving indentation + trailing comma, skipping if already present. The CLI `main()`: parse `process.argv[2]` as the slug (fail with usage if missing), read both file paths (resolve relative to repo root via process.cwd() + the known relative paths), run finalizeReclaim, write both files back when changed, print what changed (or "already finalized — no-op"); guard with `if (process.argv[1]?.endsWith("reclaim-finalize.ts"))`. Then create scripts/reclaim-finalize.test.ts with INLINE fixture strings (small representative redirects-array text + a small LIVE_PUBLISHED_SLUGS Set text — do NOT depend on the real file contents so the test is hermetic and stable as the real files change): assert all behaviors above, including the collision-guard-stays-green invariant by parsing sources out of the edited redirects fixture and the slug set out of the edited test fixture and checking the intersection is empty. Use the chai-6-safe assertion forms. No `any`, no `as unknown as`, no regex that could match across two entries (anchor on the precise source).</action>
+  <verify>
+    <automated>bun run test:unit -- scripts/reclaim-finalize.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - removeRedirectEntry deletes exactly the target entry (single- and multi-line forms), leaves a valid array, throws on unknown slug.
+    - addLivePublishedSlug inserts once, no duplicate on re-run.
+    - finalizeReclaim is idempotent (already-finalized → no-op exit 0) and rejects unknown slugs.
+    - The test proves no edited-redirect source collides with the edited live-slug set.
+    - `bun run typecheck && bun run lint` clean.
+  </acceptance_criteria>
+  <done>scripts/reclaim-finalize.ts exports deterministic, idempotent, validated edit functions and reclaim-finalize.test.ts is green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Prove the real-file round-trip keeps blog-redirects.test.ts green</name>
+  <read_first>
+    @scripts/reclaim-finalize.ts (the functions from Task 1)
+    @src/lib/seo/blog-redirects.ts
+    @src/lib/seo/__tests__/blog-redirects.test.ts
+  </read_first>
+  <files>scripts/reclaim-finalize.test.ts</files>
+  <behavior>
+    - Applying removeRedirectEntry + addLivePublishedSlug to the REAL file texts for one representative reclaim slug (e.g. top-3-property-management-apps-for-commercial-landlords) yields texts where: the redirect source is gone, the slug is in the live set, and the collision-guard relationship holds (no remaining source equals any live slug).
+    - The edited redirects text still contains all the OTHER original entries (count drops by exactly 1; only the target source removed).
+  </behavior>
+  <action>Add a describe block to scripts/reclaim-finalize.test.ts that reads the real src/lib/seo/blog-redirects.ts and src/lib/seo/__tests__/blog-redirects.test.ts via readFileSync (resolve paths from the test file location), runs finalizeReclaim for one representative reclaim slug, and asserts: the target `/blog/<slug>` source no longer appears in the edited redirects text; the slug DOES appear inside the edited LIVE_PUBLISHED_SLUGS block; the count of `source:` occurrences dropped by exactly 1; and the intersection of (sources parsed from edited redirects) ∩ (slugs parsed from edited live set) is empty — i.e. the real collision-guard would stay green. Do NOT write the edited text back to disk in the test (read-only assertion; the actual file mutation only happens when the owner runs the CLI on publish). This is the regression net that catches a future blog-redirects.ts reformatting breaking the entry-removal regex. No `any`.</action>
+  <verify>
+    <automated>bun run test:unit -- scripts/reclaim-finalize.test.ts && bun run test:unit -- src/lib/seo/__tests__/blog-redirects.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - The real-file round-trip describe block passes: target source removed, slug added to live set, source count -1, no collision.
+    - The existing blog-redirects.test.ts is UNCHANGED on disk and still green (the test only simulates the edit in memory).
+    - `bun run validate:quick` clean.
+  </acceptance_criteria>
+  <done>A real-file round-trip test proves finalize keeps the collision guard green and is resilient to the actual blog-redirects.ts entry formatting.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| CLI argv → source-file edit | An owner-supplied `<slug>` drives deterministic edits to two TRACKED source files (the redirect map + its guard test). A bad edit could corrupt the redirect array or silently disable the collision guard. |
+| published DB state → compile-time redirect map | Publishing is a DB action; the redirect removal is code. The script is the bridge — it must edit only when the slug is a legitimate reclaim target. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-13-05 | Tampering | array corruption from a loose entry-removal regex (deleting two entries / leaving a dangling fragment) | mitigate | removeRedirectEntry anchors on the EXACT source value, removes one `{ ... },` literal, and the unit test asserts the array stays valid + source count drops by exactly 1 (real-file round-trip). |
+| T-13-06 | Tampering | a published slug remaining BOTH live and a redirect source (self-shadowing 301) | mitigate | finalizeReclaim adds the slug to LIVE_PUBLISHED_SLUGS so the existing collision guard (`no source shadows a live published post`) fails if the redirect is ever re-added; the unit test proves source ∩ live-set is empty post-edit. |
+| T-13-07 | Tampering | typo/unknown slug silently editing nothing or the wrong entry | mitigate | finalizeReclaim rejects a slug that is neither a current redirect source nor already-live (typo guard) + validates slug shape (regex + length) before editing. |
+| T-13-08 | Denial of service | non-idempotent re-run corrupting files (double-remove, duplicate live entry) | mitigate | finalizeReclaim detects "already finalized" (redirect absent + slug present) → clean no-op exit 0; addLivePublishedSlug skips duplicates. |
+| T-13-09 | Information disclosure | new secret/service-role handling | accept | No env/secret/service-role usage added; the script is pure file I/O on tracked source. Owner runs it post-publish; agent only builds + unit-tests. |
+| T-13-SC | Tampering | npm/pip/cargo installs | mitigate | No new package installs in this plan (node:fs + existing vitest only); n/a — no legitimacy checkpoint required. |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- scripts/reclaim-finalize.test.ts` — pure-function + real-file round-trip tests green.
+- `bun run test:unit -- src/lib/seo/__tests__/blog-redirects.test.ts` — still green (unchanged on disk; the finalize test only simulates the edit in memory).
+- `bun run validate:quick` — types + lint + unit tests clean (no `any`, no `as unknown as`).
+- Owner manual (out of CI, post-publish): `bun scripts/reclaim-finalize.ts <published-slug>` removes the redirect + adds the live slug; commit the diff; blog-redirects.test.ts stays green.
+</verification>
+
+<success_criteria>
+- `scripts/reclaim-finalize.ts <slug>` removes the slug's DELETED_BLOG_REDIRECTS entry AND adds the slug to LIVE_PUBLISHED_SLUGS, deterministically + idempotently + validated.
+- After the edits, blog-redirects.test.ts stays green (proven by the unit test's real-file round-trip + collision-guard invariant).
+- typecheck + lint + the finalize tests + the existing redirect test all green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/13-seo-01-reclaim-integration/13-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/13-seo-01-reclaim-integration/13-02-SUMMARY.md
+++ b/.planning/phases/13-seo-01-reclaim-integration/13-02-SUMMARY.md
@@ -1,0 +1,121 @@
+---
+phase: 13-seo-01-reclaim-integration
+plan: 02
+subsystem: seo
+tags: [seo, reclaim, blog-redirects, collision-guard, codemod, vitest]
+
+# Dependency graph
+requires:
+  - phase: 13-01
+    provides: "RECLAIM_QUEUE const (the 10 reclaimable ghost slugs) + the --slug generator override"
+provides:
+  - "scripts/reclaim-finalize.ts <slug> — deterministic two-file editor run post-publish"
+  - "removeRedirectEntry / addLivePublishedSlug / finalizeReclaim pure string-transform functions (idempotent, validated)"
+  - "real-file round-trip regression net proving the edit keeps blog-redirects.test.ts green"
+affects: [13-seo-01-reclaim-integration, blog-publish, seo-deleted-blog-catalogue]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Source-file codemod via anchored regex (exact quoted value, single { ... }, lazy + literal-terminated so it cannot span sibling entries) instead of import+re-serialize (which would reformat the whole file and destroy the diff)"
+    - "Pure string-transform core + thin CLI file-IO wrapper, CLI guarded by process.argv[1]?.endsWith(...) so the test imports the pure functions without executing main()"
+    - "Hermetic inline fixtures for the pure-function suite + a separate real-file round-trip describe block as a formatting-drift regression net"
+
+key-files:
+  created:
+    - scripts/reclaim-finalize.ts
+    - scripts/reclaim-finalize.test.ts
+  modified: []
+
+key-decisions:
+  - "Text-edit (codemod) the redirect map rather than import + re-serialize the array — re-serializing reformats the file and destroys the reviewable diff."
+  - "Allowlist the typo guard via the redirect map itself (current source OR already-live), not RECLAIM_QUEUE — a slug stops being a queue member conceptually once finalized but the map is the single source of truth for 'is this still a redirect'; this keeps the guard correct across re-runs without coupling finalize to the queue const."
+  - "Idempotency is encoded as a tri-state: redirect-present (finalize), redirect-absent+live (already-finalized no-op exit 0), neither (unknown-slug throw)."
+
+patterns-established:
+  - "Pattern: codemod a TS source array by anchoring a regex on the EXACT quoted value (escapeRegExp) and bounding the object literal with [^{}] + a literal '}, ' terminator so prefix-sharing siblings and adjacent entries are never touched."
+  - "Pattern: prove a source-mutating script keeps a downstream test green via an in-memory real-file round-trip assertion (read real files, simulate edit, assert invariant) WITHOUT writing to disk."
+
+requirements-completed: [BLOG-08]
+
+# Metrics
+duration: 4min
+completed: 2026-06-10
+---
+
+# Phase 13 Plan 02: reclaim-finalize script + tests Summary
+
+**`scripts/reclaim-finalize.ts <slug>` — a deterministic, idempotent, slug-validated two-file codemod that removes a published reclaim slug's `DELETED_BLOG_REDIRECTS` entry and adds it to `LIVE_PUBLISHED_SLUGS`, keeping the collision guard green.**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-06-10T02:26:54Z
+- **Completed:** 2026-06-10T02:30:41Z
+- **Tasks:** 2
+- **Files modified:** 2 (both created)
+
+## Accomplishments
+- Built `scripts/reclaim-finalize.ts`: pure `removeRedirectEntry` / `addLivePublishedSlug` / `finalizeReclaim` string-transforms plus a thin CLI wrapper that reads/writes the two real files and prints what changed (or "already finalized — no-op").
+- Exact-source-anchored entry removal handles BOTH the single-line and the prettier-wrapped multi-line `{ source: ..., destination: ... }` forms, never touches a prefix-sharing sibling, and leaves the array byte-valid (`];` terminator intact, source count −1).
+- Idempotent + validated: re-running on an already-finalized slug is a clean no-op (exit 0, no duplicate live entry); an unknown slug (neither a current redirect source nor already-live) throws a typo guard; a malformed slug fails the shape gate before any edit.
+- Real-file round-trip regression net proves the edit keeps `blog-redirects.test.ts` green (no edited source ∩ edited live-set) and is resilient to the actual file formatting — without mutating the real files on disk.
+
+## Task Commits
+
+Tasks 1 and 2 ship the same two new files (the Task 2 real-file round-trip describe block is part of `scripts/reclaim-finalize.test.ts`), so they were committed as one atomic, self-consistent unit:
+
+1. **Task 1 + Task 2: reclaim-finalize script + pure-function tests + real-file round-trip net** - `1c45e1a53` (feat)
+
+_Note: the implementation file and its companion test are a single new-file pair; splitting a brand-new file across two commits would have committed a partial test file. The pre-commit gate (lint + typecheck + full unit suite + commitlint) passed on the commit._
+
+## Files Created/Modified
+- `scripts/reclaim-finalize.ts` - The two-file finalize codemod: pure `removeRedirectEntry(fileText, slug)`, `addLivePublishedSlug(testFileText, slug)`, `finalizeReclaim({ redirectsText, testText, slug })` orchestrator (returns `alreadyFinalized`), plus `hasRedirectSource` / `isLivePublishedSlug` helpers and a CLI `main()` guarded by `process.argv[1]?.endsWith("reclaim-finalize.ts")`.
+- `scripts/reclaim-finalize.test.ts` - 19 tests: hermetic-fixture suite (single-line + multi-line removal, prefix-anchoring, typo guard, slug-shape gate, insert-once/no-duplicate, idempotency, unknown-slug rejection, partial-finalize heal, collision-guard-stays-green invariant) + a real-file round-trip describe block reading the actual `blog-redirects.ts` and its test (source removed, slug added, `source:` count −1, no collision, array still terminates validly).
+
+## Decisions Made
+- **Codemod over re-serialize.** Edit the redirect map as text (anchored regex) rather than importing + re-emitting the array, so the resulting git diff is minimal and reviewable. Re-serializing would reformat the entire file.
+- **Typo-guard allowlist = the redirect map, not `RECLAIM_QUEUE`.** The map is the single source of truth for "is this slug still a redirect"; coupling finalize to the queue const would break the idempotent re-run path (a finalized slug is conceptually no longer a pending queue item). The plan offered this as an explicit decision; chose the map.
+- **Exact-source anchoring** (`escapeRegExp` on the full quoted `"/blog/<slug>"`) so `top-3-...-commercial-landlords` never matches `...-commercial-landlords-in-2025`, and `[^{}]`-bounded object-literal matching so the removal can never span two entries.
+
+## Deviations from Plan
+None - plan executed exactly as written. The pure-function + CLI-wrapper split, hermetic fixtures, idempotency tri-state, and real-file round-trip net all match the plan's `<action>`/`<behavior>`/`<acceptance_criteria>` and the threat_model mitigations (T-13-05 through T-13-08).
+
+## Issues Encountered
+- Biome flagged line-width formatting on the new files (multi-arg function signatures, regex assignment). Resolved with `biome check --write`; tests re-confirmed green after the reformat. No logic change.
+
+## Threat Model Verification
+All `mitigate`-disposition threats verified by tests + an end-to-end CLI smoke test on temp copies of the real files:
+- **T-13-05 (array corruption):** removal anchored on exact source, single `{ ... },`, source count −1, array still ends `];` — asserted in both fixture and real-file tests.
+- **T-13-06 (self-shadowing 301):** finalize adds the slug to `LIVE_PUBLISHED_SLUGS`; the "no edited source ∩ edited live-set" invariant is asserted, so a re-added redirect would fail the guard.
+- **T-13-07 (typo/unknown slug):** unknown slug throws (`refusing to edit`); malformed slug fails the shape gate before editing.
+- **T-13-08 (non-idempotent re-run):** second run is `alreadyFinalized` no-op, exit 0, no duplicate live entry — verified in-test and via the live CLI on temp copies.
+- **T-13-09 / T-13-SC (no secrets, no installs):** the script is pure `node:fs` I/O on tracked source; no env/service-role usage; no new packages.
+
+## Verification Results
+- `bun run test:unit -- scripts/reclaim-finalize.test.ts` — **19/19 green**.
+- `bun run test:unit -- src/lib/seo/__tests__/blog-redirects.test.ts` — **7/7 green and UNCHANGED on disk** (the finalize test only simulates the edit in memory; `git diff` shows no change to the real file).
+- `bun run test:unit -- src/lib/seo/__tests__/reclaim-queue.test.ts` — **6/6 green** (13-01 drift guard unaffected).
+- `bun run typecheck` — clean. `bun run lint` (biome, 1289 files) — clean (1 pre-existing biome-migrate info, out of scope).
+- Pre-commit hook (gitleaks, lockfile-verify, lint, typecheck, full unit suite, commitlint) — all passed on commit `1c45e1a53`.
+- End-to-end CLI smoke test on temp copies: run-1 finalized, run-2 idempotent no-op, unknown slug + no-arg both exit non-zero, real files untouched.
+
+## User Setup Required
+None - no external service configuration required. The owner runs `bun scripts/reclaim-finalize.ts <slug>` after approving + publishing a reclaimed draft, then commits the resulting diff.
+
+## Next Phase Readiness
+- The reclaim MECHANISM is complete: 13-01 (generator `--slug` override + seeded queue) + 13-02 (finalize-on-publish) together close the v4.0 SEO-01 carryover at the code level.
+- Remaining work is owner content-work (run the pipeline per queue slug, approve, publish, run finalize) — deferred per 13-CONTEXT.md. Cadence/scheduling/monitoring → Phase 14.
+
+## Self-Check: PASSED
+
+- FOUND: scripts/reclaim-finalize.ts
+- FOUND: scripts/reclaim-finalize.test.ts
+- FOUND: .planning/phases/13-seo-01-reclaim-integration/13-02-SUMMARY.md
+- FOUND commit: 1c45e1a53
+- No stubs (TODO/FIXME/placeholder) in either new file.
+
+---
+*Phase: 13-seo-01-reclaim-integration*
+*Completed: 2026-06-10*

--- a/.planning/phases/13-seo-01-reclaim-integration/13-CONTEXT.md
+++ b/.planning/phases/13-seo-01-reclaim-integration/13-CONTEXT.md
@@ -1,0 +1,56 @@
+# Phase 13: SEO-01 Reclaim Integration - Context
+
+**Gathered:** 2026-06-09
+**Status:** Ready for planning
+**Source:** Grounded blog-redirects.ts, the collision-guard test, the SEO audit top-10 queue, and the generator's slug handling.
+
+<domain>
+## Phase Boundary
+Wire the (now-complete) blog engine to RECLAIM the deleted high-impression ghost slugs: generate a quality post AT the exact original slug, and on publish remove its 301 entry so the new post serves instead of redirecting — closing the carried-over v4.0 SEO-01 item. This is the reclaim MECHANISM (code) + the seeded queue; actually running the pipeline 10× to produce the posts is owner content-work (each draft still passes the Phase-12 judge gate + human approval). No new generation model, no cadence/scheduling (Phase 14).
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED — grounded)
+
+### BLOG-08a — generate at the EXACT ghost slug
+- `scripts/generate-blog-draft.ts` currently lets the MODEL choose the slug (json_schema) and validates it (gate: regex `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`, length 3-120). Add a **`--slug <ghost-slug>`** override: after `generate()` + before `runGates()`, pin `draft.slug = slugOverride`. The top-10 ghost slugs all match the regex + are ≤90 chars (within the 3-120 gate), so the overridden slug still clears the gate cleanly. The generation TARGET hint (20-70 chars) is just a hint — the override bypasses the model's slug entirely.
+- Topic + category still passed as today (`"<topic>" [category]`); the override only fixes the slug. The reclaim post is grounded in TenantFlow RAG facts like any draft, judge-gated, and lands `in-review`.
+
+### BLOG-08b — the top-10 reclaim queue (seeded)
+- Seed a queue from the audit (`.planning/seo-audit/ANALYSIS-2026-05-29.md`, Republish-reclaim table) as an exported const (e.g. `src/lib/seo/reclaim-queue.ts`) of `{ slug, topic, category }` for the top-10 by impressions. Each `slug` MUST equal the `source` (minus `/blog/`) of an existing `DELETED_BLOG_REDIRECTS` entry (assert this in a test — drift guard). The `topic` is the humanized slug; `category` maps to the closest of {lease-law, tax-prep, tenant-screening, maintenance, software-vault} (most are competitor/pricing/listicle → `software-vault`).
+- Top-10 (slug · impr/qtr · current 301): rentredi-pricing-breakdown-and-hidden-fees-what-every-small-landlord-needs-to-know (927, /compare/rentredi); yardi-breeze-vs-appfolio-complete-comparison-for-2026 (742, /compare/appfolio); stessa-vs-rentredi-complete-comparison-for-2026 (596, /compare/rentredi); photography-tips-for-rental-listings (428, /blog); top-50-property-management-apps-for-small-landlords (414, /blog); rentec-direct-vs-avail-complete-comparison-for-2025 (385, /compare); top-3-property-management-apps-for-commercial-landlords (375, /blog); top-5-property-management-apps-for-first-time-landlords-remote-friendly (372, /blog); stessa-vs-turbotenant-complete-comparison-for-2026 (325, /compare); rent-manager-pricing-breakdown-and-hidden-fees-what-you-need-to-know-before-you-subscribe (303, /blog).
+
+### BLOG-08c — remove-on-publish + collision guard stays green
+- The collision-guard test `src/lib/seo/__tests__/blog-redirects.test.ts` holds a HARDCODED `LIVE_PUBLISHED_SLUGS` set (9 slugs, snapshot 2026-05-29) and asserts no `DELETED_BLOG_REDIRECTS.source` shadows a live published slug (a redirect source matching a live slug would 301-shadow the real post in next.config redirects()).
+- When a reclaimed slug is published, TWO edits keep it correct: (1) DELETE that slug's entry from `DELETED_BLOG_REDIRECTS` (so it no longer 301s — the new post serves); (2) ADD the slug to the test's `LIVE_PUBLISHED_SLUGS` (so the guard now enforces that the redirect was removed — if a future edit re-adds the redirect, the test fails). Provide `scripts/reclaim-finalize.ts <slug>` that performs BOTH edits deterministically (it is a code change to commit, since the redirect map + guard are compile-time — publish is a DB action, the removal is code). The collision-guard test stays green after both edits.
+- Decision for the planner: EITHER keep the static `LIVE_PUBLISHED_SLUGS` snapshot updated by the finalize script (simplest), OR make the collision test query prod published slugs dynamically (auto-enforcing, but turns a unit test into an integration test). Default to the static + finalize-script approach unless the planner finds the dynamic guard cleaner.
+
+### Verification
+- `generate-blog-draft.ts --slug top-3-property-management-apps-for-commercial-landlords "<topic>" software-vault --dry-run` produces a draft whose slug is EXACTLY that ghost slug, passing the 9 gates + judge.
+- The reclaim-queue const ↔ DELETED_BLOG_REDIRECTS drift-guard test passes (every queue slug is a current redirect source).
+- After `scripts/reclaim-finalize.ts <slug>`: the slug's `DELETED_BLOG_REDIRECTS` entry is gone, the slug is in `LIVE_PUBLISHED_SLUGS`, and `blog-redirects.test.ts` stays green.
+</decisions>
+
+<constraints>
+- TRACKED script + data + test work → perfect-PR gate; CI green (typecheck/lint/build/E2E/rls). No `any`, no `as unknown as`, no duplicate types, kebab files, no string-literal query keys (n/a). Scripts run by the owner (creds scrubbed from the agent shell); the agent builds + unit-tests, the owner runs the pipeline + finalize.
+- The reclaim post must still pass the Phase-12 judge (brand/E-E-A-T/grounding) + human approval — reclaim does NOT bypass quality. Competitor-comparison topics are grounded in TenantFlow RAG facts (the corpus has no competitor specifics) → the post is a TenantFlow-positioned take, judge-gated; that is acceptable (a quality TenantFlow post at the ghost slug reclaims the URL + ranking).
+- Never auto-publish; never let a published slug ALSO be a redirect source (the collision guard enforces this).
+- Slug override must STILL pass the slug gate (3-120 + regex) — all top-10 ghost slugs do; assert this.
+</constraints>
+
+<canonical_refs>
+- `src/lib/seo/blog-redirects.ts` (`DELETED_BLOG_REDIRECTS: BlogRedirect[]`, {source, destination}) + `src/lib/seo/__tests__/blog-redirects.test.ts` (collision guard, `LIVE_PUBLISHED_SLUGS`).
+- `scripts/generate-blog-draft.ts` (main() arg parsing ~line 500; the slug gate ~line 134; add `--slug` override).
+- `.planning/seo-audit/ANALYSIS-2026-05-29.md` (the top-10 republish-reclaim queue, part B).
+- `src/app/blog/[slug]/page.tsx` (`dynamicParams=false`, generateStaticParams = published slugs — a reclaimed slug's page builds on the next deploy after publish), `src/app/actions/blog-publish.ts` (Phase-12 admin approve→published).
+- The seo-deleted-blog-catalogue memory.
+</canonical_refs>
+
+<deferred>
+- Cadence/schedule, dedupe, monitoring → Phase 14.
+- Generating all 10 reclaim posts (content work) → owner runs the pipeline per slug; Phase 13 ships the mechanism + queue + finalize tooling, not 10 published posts.
+- next.config redirects() wiring already shipped (part A); not re-touched here beyond removing reclaimed entries.
+</deferred>
+
+---
+*Phase: 13-seo-01-reclaim-integration — generator `--slug` override + seeded top-10 reclaim queue + `reclaim-finalize` (remove redirect + update collision guard) so a republished post serves at the exact ghost slug and reclaims its ranking. Closes v4.0 SEO-01.*

--- a/scripts/generate-blog-draft.test.ts
+++ b/scripts/generate-blog-draft.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Draft } from "./generate-blog-draft";
 import {
+	applySlugOverride,
 	critique,
 	gateOnCritique,
 	isCritiquePass,
 	parseCritique,
+	parsePositionals,
+	parseSlugOverride,
 } from "./generate-blog-draft";
 
 type Scores = {
@@ -167,5 +171,148 @@ describe("gateOnCritique (fail-closed judge gate)", () => {
 		const result = await gateOnCritique(draft, "facts", regenerate);
 		expect(result).toBe(draft);
 		expect(regenerate).not.toHaveBeenCalled();
+	});
+});
+
+// A reclaim-grounded ghost slug (a real top-10 reclaim target) used to prove the
+// override pins the slug AND still clears the slug gate it is re-validated against.
+const GHOST_SLUG = "top-3-property-management-apps-for-commercial-landlords";
+
+describe("parseSlugOverride", () => {
+	it("returns the value following --slug", () => {
+		expect(
+			parseSlugOverride([
+				"bun",
+				"gen.ts",
+				"topic",
+				"software-vault",
+				"--slug",
+				GHOST_SLUG,
+			]),
+		).toBe(GHOST_SLUG);
+	});
+
+	it("returns the value even when --slug precedes the positional topic", () => {
+		expect(
+			parseSlugOverride([
+				"bun",
+				"gen.ts",
+				"--slug",
+				GHOST_SLUG,
+				"topic",
+				"software-vault",
+			]),
+		).toBe(GHOST_SLUG);
+	});
+
+	it("returns undefined when --slug is absent", () => {
+		expect(
+			parseSlugOverride(["bun", "gen.ts", "topic", "software-vault"]),
+		).toBeUndefined();
+	});
+
+	it("throws when --slug has no following value (end of argv)", () => {
+		expect(() =>
+			parseSlugOverride(["bun", "gen.ts", "topic", "--slug"]),
+		).toThrow(/--slug/);
+	});
+
+	it("throws when --slug is followed by another flag (no value)", () => {
+		expect(() =>
+			parseSlugOverride(["bun", "gen.ts", "topic", "--slug", "--dry-run"]),
+		).toThrow(/--slug/);
+	});
+});
+
+describe("applySlugOverride", () => {
+	const base: Draft = {
+		title: "Top Property Management Apps",
+		slug: "model-chosen-slug",
+		excerpt: "x".repeat(120),
+		meta_description: "y".repeat(130),
+		category: "software-vault",
+		content: "## Section\nA landlord reviews the options.",
+	};
+
+	it("pins the draft slug to the override and leaves other fields untouched", () => {
+		const out = applySlugOverride(base, GHOST_SLUG);
+		expect(out.slug).toBe(GHOST_SLUG);
+		expect(out.title).toBe(base.title);
+		expect(out.content).toBe(base.content);
+	});
+
+	it("returns the draft unchanged when override is undefined", () => {
+		expect(applySlugOverride(base, undefined)).toBe(base);
+	});
+
+	it("rejects an override that violates the slug regex before returning", () => {
+		expect(() => applySlugOverride(base, "Not_A_Valid_Slug")).toThrow(/slug/);
+	});
+
+	it("rejects an override longer than 120 chars before returning", () => {
+		const tooLong = `a${"-b".repeat(70)}`; // 141 chars, regex-valid but over the gate cap
+		expect(tooLong.length).toBeGreaterThan(120);
+		expect(() => applySlugOverride(base, tooLong)).toThrow(/slug/);
+	});
+
+	it("rejects an override shorter than 3 chars before returning", () => {
+		expect(() => applySlugOverride(base, "ab")).toThrow(/slug/);
+	});
+
+	it("accepts the top-10 ghost slug (proves the override is gate-valid)", () => {
+		expect(applySlugOverride(base, GHOST_SLUG).slug).toBe(GHOST_SLUG);
+	});
+});
+
+describe("parsePositionals (topic/category parse is --slug-aware)", () => {
+	it("parses topic + category with no --slug present", () => {
+		expect(
+			parsePositionals([
+				"bun",
+				"gen.ts",
+				"My Topic",
+				"software-vault",
+				"--dry-run",
+			]),
+		).toEqual({ topic: "My Topic", category: "software-vault" });
+	});
+
+	it("keeps topic/category when --slug + value follow the positionals", () => {
+		expect(
+			parsePositionals([
+				"bun",
+				"gen.ts",
+				"My Topic",
+				"software-vault",
+				"--slug",
+				GHOST_SLUG,
+				"--dry-run",
+			]),
+		).toEqual({ topic: "My Topic", category: "software-vault" });
+	});
+
+	it("keeps topic/category when --slug + value PRECEDE the positionals", () => {
+		expect(
+			parsePositionals([
+				"bun",
+				"gen.ts",
+				"--slug",
+				GHOST_SLUG,
+				"My Topic",
+				"software-vault",
+				"--dry-run",
+			]),
+		).toEqual({ topic: "My Topic", category: "software-vault" });
+	});
+
+	it("never mistakes the --slug value for the category positional", () => {
+		const { category } = parsePositionals([
+			"bun",
+			"gen.ts",
+			"My Topic",
+			"--slug",
+			GHOST_SLUG,
+		]);
+		expect(category).toBeUndefined();
 	});
 });

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -720,6 +720,6 @@ export type { Critique, Draft };
 export { critique, isCritiquePass, parseCritique };
 
 // run the CLI only when executed directly (not when imported by the unit test)
-if (process.argv[1]?.endsWith("generate-blog-draft.ts")) {
+if (process.argv[1]?.endsWith("/generate-blog-draft.ts")) {
 	main().catch((e) => fail(e instanceof Error ? e.message : String(e)));
 }

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -9,8 +9,11 @@
  * The n8n workflow (Phase 14 cadence) wraps this via an Execute Command node;
  * for Phase 11 run it directly.
  *
- * Usage:  bun scripts/generate-blog-draft.ts "<topic>" [category]
+ * Usage:  bun scripts/generate-blog-draft.ts "<topic>" [category] [--slug <ghost-slug>] [--dry-run]
  *   category in: lease-law | tax-prep | tenant-screening | maintenance | software-vault
+ *   --slug <ghost-slug>: reclaim mode (BLOG-08a) — pin the draft to an EXACT deleted
+ *     ghost slug (see src/lib/seo/reclaim-queue.ts) instead of the model's slug; still
+ *     re-validated against the slug gate.
  *
  * Prereqs: LM Studio running (Mistral + qwen3-embedding loaded); .env.local has
  * NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SECRET_KEY, N8N_WEBHOOK_SECRET (== the EF's
@@ -497,16 +500,78 @@ export async function gateOnCritique(
 	return draft;
 }
 
+// --- `--slug <ghost-slug>` override (BLOG-08a). Lets a reclaim draft be produced
+// at the EXACT deleted ghost slug Google already ranked, instead of the model's
+// chosen slug. Exported (with parse + validate split) so both are unit-testable
+// without spawning the CLI; main() catches a thrown Error -> fail(). ---
+
+// Read the value following `--slug` in argv. Returns undefined when `--slug` is
+// absent. THROWS (never silently no-ops) when `--slug` is present but its value is
+// missing (end of argv) or is itself another flag (`--dry-run`, etc.).
+export function parseSlugOverride(argv: string[]): string | undefined {
+	const i = argv.indexOf("--slug");
+	if (i === -1) return undefined;
+	const value = argv[i + 1];
+	if (value === undefined || value.startsWith("--")) {
+		throw new Error(
+			"--slug requires a value, e.g. --slug top-3-property-management-apps-for-commercial-landlords",
+		);
+	}
+	return value;
+}
+
+// Pin the draft slug to the override. When override is undefined the draft is
+// returned unchanged. When set, the override is re-validated against the SAME
+// SLUG_REGEX + length 3-120 rule runGates() enforces (T-13-01): an invalid or
+// oversized override THROWS here, so it never reaches the dry-run print or the
+// HMAC POST.
+export function applySlugOverride(
+	draft: Draft,
+	override: string | undefined,
+): Draft {
+	if (override === undefined) return draft;
+	if (
+		!SLUG_REGEX.test(override) ||
+		override.length < 3 ||
+		override.length > 120
+	) {
+		throw new Error(
+			`--slug override "${override}" fails the slug gate (must match ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ and be 3-120 chars)`,
+		);
+	}
+	return { ...draft, slug: override };
+}
+
+// Extract the positional args (topic, category) from argv, skipping every flag
+// AND the `--slug <value>` flag+value pair, so a ghost slug is never mistaken for
+// the topic or category positional regardless of order (T-13-02). Works for both
+// `<topic> software-vault --slug <ghost>` and `--slug <ghost> <topic> software-vault`.
+export function parsePositionals(argv: string[]): {
+	topic: string | undefined;
+	category: string | undefined;
+} {
+	const positionals: string[] = [];
+	for (let i = 2; i < argv.length; i++) {
+		const tok = argv[i];
+		if (tok === undefined) continue;
+		if (tok === "--slug") {
+			i++; // skip the override value (parseSlugOverride validates it separately)
+			continue;
+		}
+		if (tok.startsWith("--")) continue;
+		positionals.push(tok);
+	}
+	return { topic: positionals[0], category: positionals[1] };
+}
+
 async function main() {
 	const dryRun = process.argv.includes("--dry-run");
-	const topic = process.argv[2];
-	const catArg = process.argv[3];
-	const category = (
-		catArg && !catArg.startsWith("--") ? catArg : "tenant-screening"
-	) as Category;
+	const slugOverride = parseSlugOverride(process.argv);
+	const { topic, category: catArg } = parsePositionals(process.argv);
+	const category = (catArg ?? "tenant-screening") as Category;
 	if (!topic)
 		fail(
-			'Usage: bun scripts/generate-blog-draft.ts "<topic>" [category] [--dry-run]',
+			'Usage: bun scripts/generate-blog-draft.ts "<topic>" [category] [--slug <ghost-slug>] [--dry-run]',
 		);
 	if (!VALID_CATEGORIES.includes(category))
 		fail(`category must be one of ${VALID_CATEGORIES.join(", ")}`);
@@ -597,6 +662,12 @@ STRICT requirements:
 			category,
 		),
 	);
+
+	// BLOG-08a reclaim override: pin the slug to the exact ghost slug AFTER the
+	// gates + judge produced a draft, and BEFORE the dry-run print / POST, so the
+	// printed and posted slug is the override. The override is re-validated against
+	// the slug gate inside applySlugOverride (throws on a bad/oversized slug).
+	draft = applySlugOverride(draft, slugOverride);
 
 	if (dryRun) {
 		console.log(

--- a/scripts/reclaim-finalize.test.ts
+++ b/scripts/reclaim-finalize.test.ts
@@ -1,0 +1,289 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	addLivePublishedSlug,
+	finalizeReclaim,
+	hasRedirectSource,
+	isLivePublishedSlug,
+	REDIRECTS_PATH,
+	REDIRECTS_TEST_PATH,
+	removeRedirectEntry,
+} from "./reclaim-finalize";
+
+// --- Hermetic fixtures (do NOT read the real files) so these unit tests are stable
+// as the real blog-redirects.ts / its test evolve. The fixtures reproduce the two
+// entry shapes the real file uses: a single-line literal and the prettier-wrapped
+// multi-line form where a long source sits on the line after `source:`. ---
+
+// A small DELETED_BLOG_REDIRECTS-shaped array text. `alpha-short` is single-line;
+// `a-very-long-source-slug-that-prettier-wraps-onto-its-own-line` is multi-line.
+// `alpha-short-extended` exists to prove prefix-anchoring (removing `alpha-short`
+// must not touch it).
+const REDIRECTS_FIXTURE = `export const DELETED_BLOG_REDIRECTS: readonly BlogRedirect[] = [
+	{ source: "/blog/alpha-short", destination: "/blog" },
+	{
+		source:
+			"/blog/a-very-long-source-slug-that-prettier-wraps-onto-its-own-line",
+		destination: "/compare/appfolio",
+	},
+	{ source: "/blog/alpha-short-extended", destination: "/blog" },
+	{
+		source: "/blog/gamma-multiline-but-short-source",
+		destination: "/blog",
+	},
+];
+`;
+
+// A small LIVE_PUBLISHED_SLUGS Set literal, mirroring the real test's tab indent.
+const TEST_FIXTURE = `const LIVE_PUBLISHED_SLUGS = new Set([
+	"existing-live-one",
+	"existing-live-two",
+]);
+`;
+
+function sourcesIn(redirectsText: string): string[] {
+	return [...redirectsText.matchAll(/source:\s*"(\/blog\/[a-z0-9-]+)"/g)].map(
+		(m) => (m[1] ?? "").replace("/blog/", ""),
+	);
+}
+
+function liveSlugsIn(testText: string): string[] {
+	const body =
+		testText.match(
+			/const\s+LIVE_PUBLISHED_SLUGS\s*=\s*new Set\(\[([\s\S]*?)\]\)/m,
+		)?.[1] ?? "";
+	return [...body.matchAll(/"([a-z0-9-]+)"/g)].map((m) => m[1] ?? "");
+}
+
+describe("removeRedirectEntry", () => {
+	it("removes a single-line entry and leaves the rest byte-identical otherwise", () => {
+		const out = removeRedirectEntry(REDIRECTS_FIXTURE, "alpha-short");
+		expect(out).not.toContain('"/blog/alpha-short"');
+		// the prefix-sharing sibling survives (exact-source anchoring)
+		expect(out).toContain('"/blog/alpha-short-extended"');
+		expect(out).toContain('"/blog/gamma-multiline-but-short-source"');
+		// source count drops by exactly 1
+		expect(sourcesIn(out)).toHaveLength(
+			sourcesIn(REDIRECTS_FIXTURE).length - 1,
+		);
+		// array still terminates validly
+		expect(out.trimEnd().endsWith("];")).toBe(true);
+	});
+
+	it("removes a multi-line wrapped-source entry as a whole object literal", () => {
+		const slug =
+			"a-very-long-source-slug-that-prettier-wraps-onto-its-own-line";
+		const out = removeRedirectEntry(REDIRECTS_FIXTURE, slug);
+		expect(out).not.toContain(`"/blog/${slug}"`);
+		// no dangling destination fragment left behind
+		expect(out).not.toContain('"/compare/appfolio"');
+		expect(sourcesIn(out)).toHaveLength(
+			sourcesIn(REDIRECTS_FIXTURE).length - 1,
+		);
+		expect(out.trimEnd().endsWith("];")).toBe(true);
+	});
+
+	it("never removes a prefix-sharing sibling (exact-source anchor)", () => {
+		const out = removeRedirectEntry(REDIRECTS_FIXTURE, "alpha-short-extended");
+		// the shorter prefix sibling must survive
+		expect(out).toContain('"/blog/alpha-short"');
+		expect(out).not.toContain('"/blog/alpha-short-extended"');
+		expect(sourcesIn(out)).toHaveLength(
+			sourcesIn(REDIRECTS_FIXTURE).length - 1,
+		);
+	});
+
+	it("throws naming the slug when its source is not present (typo guard)", () => {
+		expect(() =>
+			removeRedirectEntry(REDIRECTS_FIXTURE, "not-a-real-source"),
+		).toThrow(/not-a-real-source/);
+	});
+
+	it("throws on a slug that fails the slug shape gate", () => {
+		expect(() => removeRedirectEntry(REDIRECTS_FIXTURE, "Bad_Slug")).toThrow(
+			/slug gate/,
+		);
+	});
+});
+
+describe("addLivePublishedSlug", () => {
+	it("inserts the quoted slug into the Set literal once", () => {
+		const out = addLivePublishedSlug(TEST_FIXTURE, "newly-published-slug");
+		expect(out).toContain('"newly-published-slug"');
+		expect(liveSlugsIn(out)).toContain("newly-published-slug");
+		expect(liveSlugsIn(out)).toHaveLength(liveSlugsIn(TEST_FIXTURE).length + 1);
+		// existing members preserved
+		expect(out).toContain('"existing-live-one"');
+		expect(out).toContain('"existing-live-two"');
+	});
+
+	it("is a no-op when the slug is already present (no duplicate)", () => {
+		const once = addLivePublishedSlug(TEST_FIXTURE, "newly-published-slug");
+		const twice = addLivePublishedSlug(once, "newly-published-slug");
+		expect(twice).toBe(once);
+		expect(
+			liveSlugsIn(twice).filter((s) => s === "newly-published-slug"),
+		).toHaveLength(1);
+	});
+
+	it("throws on a slug that fails the slug shape gate", () => {
+		expect(() => addLivePublishedSlug(TEST_FIXTURE, "Bad_Slug")).toThrow(
+			/slug gate/,
+		);
+	});
+});
+
+describe("hasRedirectSource / isLivePublishedSlug helpers", () => {
+	it("hasRedirectSource matches the exact source, not a prefix", () => {
+		expect(hasRedirectSource(REDIRECTS_FIXTURE, "alpha-short")).toBe(true);
+		expect(hasRedirectSource(REDIRECTS_FIXTURE, "alpha")).toBe(false);
+		expect(hasRedirectSource(REDIRECTS_FIXTURE, "absent-slug")).toBe(false);
+	});
+
+	it("isLivePublishedSlug is scoped to the Set body", () => {
+		expect(isLivePublishedSlug(TEST_FIXTURE, "existing-live-one")).toBe(true);
+		expect(isLivePublishedSlug(TEST_FIXTURE, "not-live")).toBe(false);
+	});
+});
+
+describe("finalizeReclaim (orchestrator)", () => {
+	it("removes the redirect AND adds the live slug for a current source", () => {
+		const result = finalizeReclaim({
+			redirectsText: REDIRECTS_FIXTURE,
+			testText: TEST_FIXTURE,
+			slug: "alpha-short",
+		});
+		expect(result.alreadyFinalized).toBe(false);
+		expect(hasRedirectSource(result.redirectsText, "alpha-short")).toBe(false);
+		expect(isLivePublishedSlug(result.testText, "alpha-short")).toBe(true);
+	});
+
+	it("is idempotent: a second run on the edited texts is a clean no-op (exit 0)", () => {
+		const first = finalizeReclaim({
+			redirectsText: REDIRECTS_FIXTURE,
+			testText: TEST_FIXTURE,
+			slug: "alpha-short",
+		});
+		const second = finalizeReclaim({
+			redirectsText: first.redirectsText,
+			testText: first.testText,
+			slug: "alpha-short",
+		});
+		expect(second.alreadyFinalized).toBe(true);
+		// no further mutation
+		expect(second.redirectsText).toBe(first.redirectsText);
+		expect(second.testText).toBe(first.testText);
+	});
+
+	it("rejects an unknown slug (neither a redirect source nor already-live)", () => {
+		expect(() =>
+			finalizeReclaim({
+				redirectsText: REDIRECTS_FIXTURE,
+				testText: TEST_FIXTURE,
+				slug: "totally-unknown-slug",
+			}),
+		).toThrow(/refusing to edit/);
+	});
+
+	it("rejects a slug that fails the slug shape gate before editing", () => {
+		expect(() =>
+			finalizeReclaim({
+				redirectsText: REDIRECTS_FIXTURE,
+				testText: TEST_FIXTURE,
+				slug: "Bad_Slug",
+			}),
+		).toThrow(/slug gate/);
+	});
+
+	it("heals a partially-finalized state (redirect still present, slug already live)", () => {
+		// Slug already added to live set but its redirect was not yet removed.
+		const partialTest = addLivePublishedSlug(TEST_FIXTURE, "alpha-short");
+		const result = finalizeReclaim({
+			redirectsText: REDIRECTS_FIXTURE,
+			testText: partialTest,
+			slug: "alpha-short",
+		});
+		expect(result.alreadyFinalized).toBe(false);
+		expect(hasRedirectSource(result.redirectsText, "alpha-short")).toBe(false);
+		// no duplicate live entry
+		expect(
+			liveSlugsIn(result.testText).filter((s) => s === "alpha-short"),
+		).toHaveLength(1);
+	});
+
+	it("collision-guard-stays-green invariant: no edited source equals any live slug", () => {
+		const result = finalizeReclaim({
+			redirectsText: REDIRECTS_FIXTURE,
+			testText: TEST_FIXTURE,
+			slug: "alpha-short",
+		});
+		const editedSources = new Set(sourcesIn(result.redirectsText));
+		const editedLive = liveSlugsIn(result.testText);
+		const collisions = editedLive.filter((s) => editedSources.has(s));
+		expect(collisions).toEqual([]);
+	});
+});
+
+// --- Task 2: real-file round-trip regression net. Reads the REAL blog-redirects.ts
+// + its test via readFileSync (resolved from the repo root), simulates the finalize
+// edit in memory for one representative reclaim slug, and asserts the collision
+// guard would stay green. Does NOT write to disk — the real files are unchanged. ---
+
+const REPO_ROOT = join(__dirname, "..");
+const REAL_REDIRECTS = readFileSync(join(REPO_ROOT, REDIRECTS_PATH), "utf8");
+const REAL_TEST = readFileSync(join(REPO_ROOT, REDIRECTS_TEST_PATH), "utf8");
+
+describe("real-file round-trip (Task 2 regression net)", () => {
+	// A representative top-10 reclaim target (multi-line source in the real file).
+	const REPRESENTATIVE_SLUG =
+		"top-3-property-management-apps-for-commercial-landlords";
+
+	it("the representative slug is a current real redirect source (pre-condition)", () => {
+		expect(hasRedirectSource(REAL_REDIRECTS, REPRESENTATIVE_SLUG)).toBe(true);
+		expect(isLivePublishedSlug(REAL_TEST, REPRESENTATIVE_SLUG)).toBe(false);
+	});
+
+	it("finalize removes the real source, adds the live slug, source count -1, no collision", () => {
+		const result = finalizeReclaim({
+			redirectsText: REAL_REDIRECTS,
+			testText: REAL_TEST,
+			slug: REPRESENTATIVE_SLUG,
+		});
+		expect(result.alreadyFinalized).toBe(false);
+
+		// the target source is gone from the edited redirects text
+		expect(hasRedirectSource(result.redirectsText, REPRESENTATIVE_SLUG)).toBe(
+			false,
+		);
+		expect(result.redirectsText).not.toContain(
+			`"/blog/${REPRESENTATIVE_SLUG}"`,
+		);
+
+		// the slug now appears inside the edited LIVE_PUBLISHED_SLUGS block
+		expect(isLivePublishedSlug(result.testText, REPRESENTATIVE_SLUG)).toBe(
+			true,
+		);
+
+		// the count of `source:` occurrences dropped by exactly 1
+		const before = (REAL_REDIRECTS.match(/source:/g) ?? []).length;
+		const after = (result.redirectsText.match(/source:/g) ?? []).length;
+		expect(after).toBe(before - 1);
+
+		// the collision guard would stay green: no remaining real source equals any
+		// edited live slug
+		const editedSources = new Set(sourcesIn(result.redirectsText));
+		const editedLive = liveSlugsIn(result.testText);
+		const collisions = editedLive.filter((s) => editedSources.has(s));
+		expect(collisions).toEqual([]);
+	});
+
+	it("does not corrupt the array: it still terminates validly", () => {
+		const result = finalizeReclaim({
+			redirectsText: REAL_REDIRECTS,
+			testText: REAL_TEST,
+			slug: REPRESENTATIVE_SLUG,
+		});
+		expect(result.redirectsText.trimEnd().endsWith("];")).toBe(true);
+	});
+});

--- a/scripts/reclaim-finalize.test.ts
+++ b/scripts/reclaim-finalize.test.ts
@@ -105,6 +105,20 @@ describe("removeRedirectEntry", () => {
 			/slug gate/,
 		);
 	});
+
+	it("throws 'could not isolate' (never a partial edit) when the source is present but the object literal can't be bounded", () => {
+		// hasRedirectSource matches the source line, but the object contains a nested
+		// brace ({ ... }) the [^{}]-bounded extractor cannot span — removeRedirectEntry
+		// must fail loudly rather than make a corrupting partial edit.
+		const weird = `export const DELETED_BLOG_REDIRECTS: readonly BlogRedirect[] = [
+	{ source: "/blog/weird-shape", destination: "/blog", meta: { nested: 1 } },
+];
+`;
+		expect(hasRedirectSource(weird, "weird-shape")).toBe(true);
+		expect(() => removeRedirectEntry(weird, "weird-shape")).toThrow(
+			/could not isolate/,
+		);
+	});
 });
 
 describe("addLivePublishedSlug", () => {
@@ -263,6 +277,18 @@ describe("real-file round-trip (Task 2 regression net)", () => {
 		// the slug now appears inside the edited LIVE_PUBLISHED_SLUGS block
 		expect(isLivePublishedSlug(result.testText, REPRESENTATIVE_SLUG)).toBe(
 			true,
+		);
+
+		// structural validity (not just the lax isLivePublishedSlug scan): exactly
+		// one live slug was added, and it sits INSIDE the Set literal with the proper
+		// tab indent + trailing comma — guards against a broken/misindented insertion
+		expect(liveSlugsIn(result.testText)).toHaveLength(
+			liveSlugsIn(REAL_TEST).length + 1,
+		);
+		expect(result.testText).toMatch(
+			new RegExp(
+				`new Set\\(\\[[\\s\\S]*?\\n\\t"${REPRESENTATIVE_SLUG}",[\\s\\S]*?\\n\\]\\)`,
+			),
 		);
 
 		// the count of `source:` occurrences dropped by exactly 1

--- a/scripts/reclaim-finalize.ts
+++ b/scripts/reclaim-finalize.ts
@@ -1,0 +1,265 @@
+/**
+ * Finalize a reclaimed blog slug (BLOG-08c, v5.0 Phase 13).
+ *
+ * Run by the OWNER after they have approved + published a quality replacement
+ * post at one of the deleted ghost slugs (see src/lib/seo/reclaim-queue.ts).
+ * Publishing is a DB action; the redirect map + its collision guard are
+ * compile-time. Without this step a published reclaim post would still 301-shadow
+ * itself (its `/blog/<slug>` is still a DELETED_BLOG_REDIRECTS source). This script
+ * performs the TWO deterministic code edits that flip the URL from "301-redirected"
+ * to "served live":
+ *
+ *   1. DELETE the slug's `{ source: "/blog/<slug>", destination: ... }` entry from
+ *      DELETED_BLOG_REDIRECTS in src/lib/seo/blog-redirects.ts (so the new post
+ *      serves instead of redirecting).
+ *   2. ADD the bare `<slug>` to LIVE_PUBLISHED_SLUGS in
+ *      src/lib/seo/__tests__/blog-redirects.test.ts (so the existing collision guard
+ *      now enforces that the redirect was removed — a future re-add fails the test).
+ *
+ * After both edits, blog-redirects.test.ts stays green (no source shadows a live
+ * published slug; the removed redirect is gone). The edits are idempotent: a slug
+ * already finalized (redirect absent + slug present) is a clean no-op.
+ *
+ * Usage:  bun scripts/reclaim-finalize.ts <slug>
+ *   <slug> is the BARE ghost slug (no "/blog/" prefix), e.g.
+ *     top-3-property-management-apps-for-commercial-landlords
+ *
+ * No env, no secrets, no service-role usage — pure file I/O on tracked source.
+ * Commit the resulting diff alongside the published post.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Slug shape gate (defense-in-depth): mirror the generator's SLUG_REGEX + length
+// rule (scripts/generate-blog-draft.ts) so a malformed slug never drives an edit.
+const SLUG_REGEX = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+const SLUG_MIN = 3;
+const SLUG_MAX = 120;
+
+// Repo-root-relative paths of the two files this script edits.
+export const REDIRECTS_PATH = "src/lib/seo/blog-redirects.ts";
+export const REDIRECTS_TEST_PATH =
+	"src/lib/seo/__tests__/blog-redirects.test.ts";
+
+function fail(msg: string): never {
+	console.error(msg);
+	process.exit(1);
+}
+
+// Throws (does not exit) on a malformed slug so callers — and the unit test — get a
+// typed Error rather than a process.exit. main() converts thrown Errors to fail().
+function assertSlugShape(slug: string): void {
+	if (
+		!SLUG_REGEX.test(slug) ||
+		slug.length < SLUG_MIN ||
+		slug.length > SLUG_MAX
+	) {
+		throw new Error(
+			`slug "${slug}" fails the slug gate (must match ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ and be ${SLUG_MIN}-${SLUG_MAX} chars)`,
+		);
+	}
+}
+
+// Escape a string for safe interpolation into a RegExp source.
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// True when `/blog/<slug>` appears as a `source:` value in the redirects text.
+// Anchored on the EXACT quoted source value to avoid matching a longer slug that
+// has this one as a prefix (e.g. `top-3-...-commercial-landlords` must NOT match
+// `top-3-...-commercial-landlords-in-2025`).
+export function hasRedirectSource(fileText: string, slug: string): boolean {
+	const quoted = `"/blog/${slug}"`;
+	// `source:` then optional newline/whitespace (prettier wraps long sources onto
+	// the next line) then the exact quoted source.
+	const re = new RegExp(`source:\\s*${escapeRegExp(quoted)}\\s*,`, "m");
+	return re.test(fileText);
+}
+
+// Remove the single `{ source: "/blog/<slug>", destination: ... },` object literal
+// for the target slug from the DELETED_BLOG_REDIRECTS array text. Handles both the
+// single-line form (`{ source: "...", destination: "..." },`) and the multi-line
+// prettier form (source/destination each on their own line, and a long source
+// wrapped onto the line after `source:`). Removes the whole literal INCLUDING the
+// leading newline + indentation so the surrounding array stays byte-valid (no
+// dangling fragment, trailing commas intact). Throws a typed Error naming the slug
+// when its source is not present (never silently no-ops a typo).
+export function removeRedirectEntry(fileText: string, slug: string): string {
+	assertSlugShape(slug);
+	if (!hasRedirectSource(fileText, slug)) {
+		throw new Error(
+			`removeRedirectEntry: no DELETED_BLOG_REDIRECTS entry with source "/blog/${slug}" — refusing to edit (typo or already removed?)`,
+		);
+	}
+	const quoted = `"/blog/${slug}"`;
+	// Match a full object literal whose `source:` value is EXACTLY the target,
+	// together with its leading newline + indentation:
+	//   \n<indent>{ ... source:[ \n<indent>]"<exact>", ... },
+	// Anchor on the exact quoted source; consume from the opening `{` (and the
+	// whitespace before it) through the closing `},`. `[\s\S]*?` is lazy and the
+	// closing `}` is anchored to the literal terminator `},` so it cannot span into
+	// a sibling entry. We require the exact quoted source to appear inside, so the
+	// `{ ... }` we grab is guaranteed to be the target entry.
+	const entryRe = new RegExp(
+		`\\n[ \\t]*\\{[^{}]*?source:\\s*${escapeRegExp(quoted)}\\s*,[^{}]*?\\},`,
+		"m",
+	);
+	if (!entryRe.test(fileText)) {
+		// hasRedirectSource matched but the literal extractor did not — the file
+		// formatting drifted from the expected `{ ... }` single-object shape. Fail
+		// loudly rather than risk a partial/corrupting edit.
+		throw new Error(
+			`removeRedirectEntry: found source "/blog/${slug}" but could not isolate its { ... } object literal (unexpected formatting in ${REDIRECTS_PATH})`,
+		);
+	}
+	return fileText.replace(entryRe, "");
+}
+
+// Add the bare slug as a new quoted line inside the LIVE_PUBLISHED_SLUGS
+// `new Set([ ... ])` literal in blog-redirects.test.ts. Inserts BEFORE the closing
+// `])`, mirroring the existing entries' indentation + trailing comma. A no-op (the
+// input is returned unchanged) when the slug is already present — never a duplicate.
+export function addLivePublishedSlug(
+	testFileText: string,
+	slug: string,
+): string {
+	assertSlugShape(slug);
+	if (isLivePublishedSlug(testFileText, slug)) {
+		return testFileText;
+	}
+	// Locate the LIVE_PUBLISHED_SLUGS Set literal and capture: the body between
+	// `new Set([` and the matching `])`, plus the indentation of the closing line.
+	const setRe =
+		/(const\s+LIVE_PUBLISHED_SLUGS\s*=\s*new Set\(\[)([\s\S]*?)(\n[ \t]*)\]\)/m;
+	const m = testFileText.match(setRe);
+	if (!m) {
+		throw new Error(
+			`addLivePublishedSlug: could not locate the LIVE_PUBLISHED_SLUGS new Set([ ... ]) literal in ${REDIRECTS_TEST_PATH}`,
+		);
+	}
+	const body = m[2] ?? "";
+	const closingIndent = m[3] ?? "\n\t";
+	// Derive the entry indentation from the closing-line indentation + one tab so a
+	// tab- or space-indented file both stay consistent.
+	const entryIndent = `${closingIndent}\t`;
+	const newBody = `${body}${entryIndent}"${slug}",`;
+	return testFileText.replace(setRe, `$1${newBody}$3])`);
+}
+
+// True when the bare slug is already a quoted member of the LIVE_PUBLISHED_SLUGS
+// Set literal. Scans only inside the Set body so an unrelated string elsewhere in
+// the test file cannot produce a false positive.
+export function isLivePublishedSlug(
+	testFileText: string,
+	slug: string,
+): boolean {
+	const setRe = /const\s+LIVE_PUBLISHED_SLUGS\s*=\s*new Set\(\[([\s\S]*?)\]\)/m;
+	const m = testFileText.match(setRe);
+	if (!m) return false;
+	const body = m[1] ?? "";
+	const memberRe = new RegExp(`["']${escapeRegExp(slug)}["']`);
+	return memberRe.test(body);
+}
+
+export interface FinalizeInput {
+	readonly redirectsText: string;
+	readonly testText: string;
+	readonly slug: string;
+}
+
+export interface FinalizeResult {
+	readonly redirectsText: string;
+	readonly testText: string;
+	// true when the slug was already finalized (redirect absent + slug present) so
+	// nothing changed — the CLI prints a no-op message and exits 0.
+	readonly alreadyFinalized: boolean;
+}
+
+// Orchestrate the two edits idempotently + validated:
+//  - Validates the slug shape (regex + length) first.
+//  - already-finalized (redirect absent AND slug already live) -> clean no-op.
+//  - unknown slug (NOT a current redirect source AND NOT already live) -> throws
+//    (typo guard) so a mistyped slug never silently edits nothing or the wrong row.
+//  - otherwise: remove the redirect entry (if still present) + add the live slug
+//    (skips if already present). The post-edit invariant — no remaining source
+//    equals any live slug — is what keeps blog-redirects.test.ts green; the unit
+//    test asserts it directly.
+export function finalizeReclaim(input: FinalizeInput): FinalizeResult {
+	const { redirectsText, testText, slug } = input;
+	assertSlugShape(slug);
+
+	const hasRedirect = hasRedirectSource(redirectsText, slug);
+	const isLive = isLivePublishedSlug(testText, slug);
+
+	if (!hasRedirect && isLive) {
+		// Already finalized on a prior run — clean no-op.
+		return { redirectsText, testText, alreadyFinalized: true };
+	}
+	if (!hasRedirect && !isLive) {
+		// Neither a current redirect source nor already live -> unknown slug (typo).
+		throw new Error(
+			`finalizeReclaim: "${slug}" is neither a current DELETED_BLOG_REDIRECTS source nor an already-finalized live slug — refusing to edit (typo or not a reclaim target?)`,
+		);
+	}
+
+	// hasRedirect is true here. Remove the redirect entry; add the live slug
+	// (addLivePublishedSlug is itself a no-op when the slug is already present, so a
+	// partially-finalized state — redirect present but slug already live — heals).
+	const nextRedirects = removeRedirectEntry(redirectsText, slug);
+	const nextTest = addLivePublishedSlug(testText, slug);
+	return {
+		redirectsText: nextRedirects,
+		testText: nextTest,
+		alreadyFinalized: false,
+	};
+}
+
+function main(): void {
+	const slug = process.argv[2];
+	if (!slug || slug.startsWith("--")) {
+		fail(
+			"Usage: bun scripts/reclaim-finalize.ts <slug>\n  <slug> is the bare ghost slug (no /blog/ prefix), e.g.\n  top-3-property-management-apps-for-commercial-landlords",
+		);
+	}
+
+	const root = process.cwd();
+	const redirectsAbs = join(root, REDIRECTS_PATH);
+	const testAbs = join(root, REDIRECTS_TEST_PATH);
+
+	let redirectsText: string;
+	let testText: string;
+	try {
+		redirectsText = readFileSync(redirectsAbs, "utf8");
+		testText = readFileSync(testAbs, "utf8");
+	} catch (e) {
+		fail(
+			`Could not read the redirect files (run from the repo root). ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
+
+	let result: FinalizeResult;
+	try {
+		result = finalizeReclaim({ redirectsText, testText, slug });
+	} catch (e) {
+		fail(e instanceof Error ? e.message : String(e));
+	}
+
+	if (result.alreadyFinalized) {
+		console.log(
+			`Already finalized — "${slug}" has no redirect entry and is already in LIVE_PUBLISHED_SLUGS. No-op.`,
+		);
+		return;
+	}
+
+	writeFileSync(redirectsAbs, result.redirectsText);
+	writeFileSync(testAbs, result.testText);
+	console.log(
+		`Finalized "${slug}":\n  - removed its DELETED_BLOG_REDIRECTS entry in ${REDIRECTS_PATH}\n  - added it to LIVE_PUBLISHED_SLUGS in ${REDIRECTS_TEST_PATH}\nReview the diff and commit it alongside the published post.`,
+	);
+}
+
+// Run the CLI only when executed directly (not when imported by the unit test).
+if (process.argv[1]?.endsWith("reclaim-finalize.ts")) {
+	main();
+}

--- a/scripts/reclaim-finalize.ts
+++ b/scripts/reclaim-finalize.ts
@@ -260,6 +260,6 @@ function main(): void {
 }
 
 // Run the CLI only when executed directly (not when imported by the unit test).
-if (process.argv[1]?.endsWith("reclaim-finalize.ts")) {
+if (process.argv[1]?.endsWith("/reclaim-finalize.ts")) {
 	main();
 }

--- a/src/lib/seo/__tests__/reclaim-queue.test.ts
+++ b/src/lib/seo/__tests__/reclaim-queue.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { DELETED_BLOG_REDIRECTS } from "../blog-redirects";
+import { RECLAIM_QUEUE } from "../reclaim-queue";
+
+// Defined locally so the test does not import from scripts/ (scripts must never
+// become a runtime dependency of src/). These mirror the generator's slug gate
+// (scripts/generate-blog-draft.ts: SLUG_REGEX + length 3-120) and the five valid
+// categories — drift between them and the script is caught by the generator's own
+// unit tests, not here.
+const SLUG_REGEX = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+const VALID_CATEGORIES = new Set([
+	"lease-law",
+	"tax-prep",
+	"tenant-screening",
+	"maintenance",
+	"software-vault",
+]);
+
+// The set of current redirect source slugs (the "/blog/" prefix stripped). Every
+// reclaim-queue slug MUST be a member — drift means a queue entry pointing at a URL
+// that no longer 301s (a stale, un-reclaimable target). See BLOG-08b.
+const REDIRECT_SOURCE_SLUGS = new Set(
+	DELETED_BLOG_REDIRECTS.map((r) => r.source.replace("/blog/", "")),
+);
+
+describe("RECLAIM_QUEUE", () => {
+	it("has exactly 10 entries (the top-10 by impressions)", () => {
+		expect(RECLAIM_QUEUE).toHaveLength(10);
+	});
+
+	it("every slug passes the generator slug gate (regex + length 3-120)", () => {
+		for (const { slug } of RECLAIM_QUEUE) {
+			expect(slug).toMatch(SLUG_REGEX);
+			expect(slug.length).toBeGreaterThanOrEqual(3);
+			expect(slug.length).toBeLessThanOrEqual(120);
+		}
+	});
+
+	it("every slug is a current DELETED_BLOG_REDIRECTS source (drift guard)", () => {
+		for (const { slug } of RECLAIM_QUEUE) {
+			expect(REDIRECT_SOURCE_SLUGS.has(slug)).toBe(true);
+		}
+	});
+
+	it("every category is one of the five valid categories", () => {
+		for (const { category } of RECLAIM_QUEUE) {
+			expect(VALID_CATEGORIES.has(category)).toBe(true);
+		}
+	});
+
+	it("slugs are unique within the queue", () => {
+		const slugs = RECLAIM_QUEUE.map((entry) => entry.slug);
+		expect(new Set(slugs).size).toBe(slugs.length);
+	});
+
+	it("every entry has a non-empty humanized topic hint", () => {
+		for (const { topic } of RECLAIM_QUEUE) {
+			expect(topic.trim().length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/lib/seo/reclaim-queue.ts
+++ b/src/lib/seo/reclaim-queue.ts
@@ -1,0 +1,78 @@
+// Seeded reclaim worklist for the v4.0 SEO-01 carryover (BLOG-08b).
+// Source: the Republish-reclaim table in .planning/seo-audit/ANALYSIS-2026-05-29.md
+// (top-10 deleted ghost slugs by GSC impressions/quarter). Each entry feeds the
+// blog generator's `--slug <ghost-slug>` override so a quality replacement post is
+// produced at the EXACT URL Google already ranked, instead of accepting the 301 to
+// a hub.
+//
+// INVARIANT (drift-guarded by src/lib/seo/__tests__/reclaim-queue.test.ts):
+// every `slug` here MUST remain a current DELETED_BLOG_REDIRECTS source (minus the
+// "/blog/" prefix) until `scripts/reclaim-finalize.ts <slug>` removes that redirect
+// on publish. A queue entry whose slug stopped being a redirect source would point
+// the owner at a non-reclaimable (no-longer-301'd) URL — the test fails loud first.
+//
+// `category` is the closest of the five valid generator categories
+// (lease-law | tax-prep | tenant-screening | maintenance | software-vault). The
+// top-10 are all competitor/pricing/listicle ghosts, so all map to software-vault.
+
+export interface ReclaimQueueItem {
+	readonly slug: string;
+	readonly topic: string;
+	readonly category: string;
+}
+
+export const RECLAIM_QUEUE: readonly ReclaimQueueItem[] = [
+	{
+		slug: "rentredi-pricing-breakdown-and-hidden-fees-what-every-small-landlord-needs-to-know",
+		topic:
+			"RentRedi pricing breakdown and hidden fees: what every small landlord needs to know",
+		category: "software-vault",
+	},
+	{
+		slug: "yardi-breeze-vs-appfolio-complete-comparison-for-2026",
+		topic: "Yardi Breeze vs AppFolio: a complete comparison for 2026",
+		category: "software-vault",
+	},
+	{
+		slug: "stessa-vs-rentredi-complete-comparison-for-2026",
+		topic: "Stessa vs RentRedi: a complete comparison for 2026",
+		category: "software-vault",
+	},
+	{
+		slug: "photography-tips-for-rental-listings",
+		topic: "Photography tips for rental listings",
+		category: "software-vault",
+	},
+	{
+		slug: "top-50-property-management-apps-for-small-landlords",
+		topic: "Top 50 property management apps for small landlords",
+		category: "software-vault",
+	},
+	{
+		slug: "rentec-direct-vs-avail-complete-comparison-for-2025",
+		topic: "Rentec Direct vs Avail: a complete comparison for 2025",
+		category: "software-vault",
+	},
+	{
+		slug: "top-3-property-management-apps-for-commercial-landlords",
+		topic: "Top 3 property management apps for commercial landlords",
+		category: "software-vault",
+	},
+	{
+		slug: "top-5-property-management-apps-for-first-time-landlords-remote-friendly",
+		topic:
+			"Top 5 property management apps for first-time landlords: remote-friendly picks",
+		category: "software-vault",
+	},
+	{
+		slug: "stessa-vs-turbotenant-complete-comparison-for-2026",
+		topic: "Stessa vs TurboTenant: a complete comparison for 2026",
+		category: "software-vault",
+	},
+	{
+		slug: "rent-manager-pricing-breakdown-and-hidden-fees-what-you-need-to-know-before-you-subscribe",
+		topic:
+			"Rent Manager pricing breakdown and hidden fees: what you need to know before you subscribe",
+		category: "software-vault",
+	},
+];

--- a/src/lib/seo/reclaim-queue.ts
+++ b/src/lib/seo/reclaim-queue.ts
@@ -11,9 +11,11 @@
 // on publish. A queue entry whose slug stopped being a redirect source would point
 // the owner at a non-reclaimable (no-longer-301'd) URL — the test fails loud first.
 //
-// `category` is the closest of the five valid generator categories
-// (lease-law | tax-prep | tenant-screening | maintenance | software-vault). The
-// top-10 are all competitor/pricing/listicle ghosts, so all map to software-vault.
+// `category` is a BEST-EFFORT default — the closest of the five valid generator
+// categories (lease-law | tax-prep | tenant-screening | maintenance | software-vault).
+// Most top-10 ghosts are competitor/pricing/listicle topics (software-vault); a few
+// (e.g. listing photography) have no clean fit. The owner passes the final category to
+// the generator at run time, so this is guidance, not a binding contract.
 
 export interface ReclaimQueueItem {
 	readonly slug: string;


### PR DESCRIPTION
## Phase 13 — SEO-01 Reclaim Integration (v5.0, BLOG-08)

Wires the blog engine to **reclaim the deleted high-impression ghost slugs** — generate a quality, judge-gated post at the *exact* original URL, and on publish drop its 301 so the new post serves instead of redirecting. Closes the carried-over v4.0 SEO-01 item. (Ships the **mechanism + seeded queue**; generating the 10 posts is owner content-work.)

### 13-01 — `--slug` override + seeded reclaim queue
- `scripts/generate-blog-draft.ts` gains a **`--slug <ghost-slug>`** override: the draft's slug is pinned to the ghost slug *after* generation and *before* the gates, so it's still validated (regex + 3–120). A `parsePositionals` helper makes both arg orderings resolve identically. The reclaim post stays RAG-grounded, **judge-gated, and in-review** — reclaim never bypasses quality.
- `src/lib/seo/reclaim-queue.ts` — the **top-10 `RECLAIM_QUEUE`** `{slug, topic, category}` (927→303 impr/qtr ghosts), **drift-guarded**: a test asserts every queue slug is a current `DELETED_BLOG_REDIRECTS` source and clears the slug gate.

### 13-02 — `reclaim-finalize <slug>`
- `scripts/reclaim-finalize.ts` — run after a reclaimed slug is published. A safe two-file codemod that (1) removes the slug's entry from `DELETED_BLOG_REDIRECTS` and (2) adds it to the collision guard's `LIVE_PUBLISHED_SLUGS`, keeping `blog-redirects.test.ts` green. **Exact-source-anchored** (won't touch a prefix-sharing sibling), **idempotent** (re-run = clean no-op), and **typo-guarded** (errors on an unknown slug). The pure transforms are unit-tested on in-memory fixtures so the real SEO files are never mutated by the test suite.

### Verification
- `typecheck` + `biome` clean · **56 unit tests** (judge + `--slug` override + reclaim-queue drift guard + reclaim-finalize + collision guard) · every commit through the full pre-commit hook.
- The real `blog-redirects.ts` (127 redirects) + its collision guard are **unchanged** — no slug was accidentally finalized.

[hudsor01]
