### PR TITLE
Phase 14: Cadence, Dedupe & Monitoring — slug dedup + evergreen source + alerts (BLOG-09)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -17,7 +17,7 @@
 - [x] **BLOG-06**: Quality + brand guardrails — E-E-A-T-hardened system prompt (first-hand framing, specific depth, RAG-grounding-only), Organization "TenantFlow Team" byline (regression-locked in article-schema.test.ts), and a Mistral LLM-as-judge self-critique gate scoring 4 dimensions that regenerates/fails-closed on thin/off-brand drafts before in-review.
 - [x] **BLOG-07**: Human approve/reject surface at `/admin/blog` (is_admin-walled (admin) group): in-review list + sanitized preview → Approve (→published + revalidate) / Reject (→archived) via the authenticated admin client (blogs_update_admin RLS + defense-in-depth is_admin re-check). Nothing publishes without an explicit Approve.
 - [x] **BLOG-08**: SEO-01 reclaim — a topic queue seeded from the deleted high-impression ghost slugs (top-10 first) generates posts at the exact original slugs; on publish, the entry is removed from `src/lib/seo/blog-redirects.ts` and the collision-guard test stays green. (Closes the carried-over v4.0 SEO-01 item.)
-- [ ] **BLOG-09**: Cadence + observability — a sustainable schedule with slug dedupe, execution monitoring, and failure alerts (reuse the critical-error notify path); runaway/cost guards documented.
+- [x] **BLOG-09**: Cadence + observability — a pre-POST `public.blogs` slug-dedup check in the generator (existing slug → clean skip, exit 0, no 409 waste), greppable `BLOG-GEN-FAIL: <reason>` failure output, an `EVERGREEN_TOPICS` secondary topic source after `RECLAIM_QUEUE`, and the n8n/README.md documents the sustainable few-posts/week cadence + the Error-Trigger notify wiring (reusing the `app_config`/`notify_critical_error` path, no secret in source) + runaway/cost guards.
 
 ## Out of Scope
 
@@ -40,7 +40,7 @@
 | BLOG-06 | Phase 12 — Quality & Brand Guardrails | Done |
 | BLOG-07 | Phase 12 — Quality & Brand Guardrails | Done |
 | BLOG-08 | Phase 13 — SEO-01 Reclaim Integration | Complete |
-| BLOG-09 | Phase 14 — Cadence, Dedupe & Monitoring | Pending |
+| BLOG-09 | Phase 14 — Cadence, Dedupe & Monitoring | Done |
 
 **Coverage:** 9 requirements mapped to 6 phases (9-14), no orphans.
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -91,6 +91,10 @@ Plans:
 **Success Criteria**:
   1. A schedule (e.g., a few posts/week) generates drafts without duplicating existing/published slugs.
   2. Execution monitoring + failure alerts are in place (reuse the critical-error notify path); runaway/cost guards documented.
+**Plans:** 2 plans
+Plans:
+- [ ] 14-01-PLAN.md — generator pre-POST slug-dedup check (existing slug → clean-skip exit 0, no 409 waste; 409 stays backstop) + structured `BLOG-GEN-FAIL: <reason>` failure output + unit tests for both dedup branches + the failure line (BLOG-09)
+- [ ] 14-02-PLAN.md — committed EVERGREEN_TOPICS const (secondary topic source after RECLAIM_QUEUE) + drift-guard test, and n8n/README.md refined cadence (few posts/week, reclaim-then-evergreen) + Error-Trigger notify wiring (app_config `blog_factory_alert_url`, no secret in source) + runaway/cost guard docs (BLOG-09)
 
 ## Progress
 
@@ -101,4 +105,4 @@ Plans:
 | 11 — Generation Pipeline | Complete | real in-review draft produced e2e (201, MCP-verified); ingest EF fixed |
 | 12 — Quality & Brand Guardrails | Complete | judge gate + /admin/blog approve-reject + byline lock + E2E; 30 unit tests |
 | 13 — SEO-01 Reclaim Integration | Complete | 2 plans (--slug override + reclaim-queue; reclaim-finalize codemod + guard); 19+ unit tests |
-| 14 — Cadence, Dedupe & Monitoring | Not started | TBD |
+| 14 — Cadence, Dedupe & Monitoring | Planned | 2 plans (generator dedup + BLOG-GEN-FAIL output; evergreen const + n8n cadence/error-workflow/guard docs) |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -17,7 +17,7 @@
 - [x] **Phase 11: Generation Pipeline** — DONE: generate-blog-draft.ts (topic→RAG→Mistral→validate/repair+banlist-sanitizer→HMAC→ingest) produced a real 1,410-word in-review draft (HTTP 201, MCP-verified). Fixed the ingest EF's dead legacy key (→INGEST_DB_KEY) + N8N_WEBHOOK_SECRET (BLOG-04, BLOG-05)
 - [x] **Phase 12: Quality & Brand Guardrails** — DONE: Mistral LLM-as-judge self-critique gate (4-dim score, regenerate/fail-closed) + E-E-A-T prompt hardening + /admin/blog approve-reject surface (is_admin-walled, RLS, revalidate) + Organization byline regression-lock + E2E. 30 unit tests (BLOG-06, BLOG-07)
 - [x] **Phase 13: SEO-01 Reclaim Integration** — ghost-slug queue, generate-at-slug, auto-drop redirect on publish; closes SEO-01 (BLOG-08) (completed 2026-06-10)
-- [ ] **Phase 14: Cadence, Dedupe & Monitoring** — schedule, dedupe, observability + failure alerts (BLOG-09)
+- [x] **Phase 14: Cadence, Dedupe & Monitoring** — DONE: pre-POST slug dedup (clean-skip, no 409 waste) + greppable BLOG-GEN-FAIL output + EVERGREEN_TOPICS secondary source + n8n/README cadence/error-workflow/cost-guard docs. CLOSES v5.0 (BLOG-09)
 
 ## Phase Details (v5.0 AI Blog Content Engine)
 
@@ -105,4 +105,4 @@ Plans:
 | 11 — Generation Pipeline | Complete | real in-review draft produced e2e (201, MCP-verified); ingest EF fixed |
 | 12 — Quality & Brand Guardrails | Complete | judge gate + /admin/blog approve-reject + byline lock + E2E; 30 unit tests |
 | 13 — SEO-01 Reclaim Integration | Complete | 2 plans (--slug override + reclaim-queue; reclaim-finalize codemod + guard); 19+ unit tests |
-| 14 — Cadence, Dedupe & Monitoring | Planned | 2 plans (generator dedup + BLOG-GEN-FAIL output; evergreen const + n8n cadence/error-workflow/guard docs) |
+| 14 — Cadence, Dedupe & Monitoring | Complete | dedup skip + BLOG-GEN-FAIL output + EVERGREEN_TOPICS + n8n cadence/alert/guard docs |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v5.0
 milestone_name: AI Blog Content Engine
-status: "Phases 9-11 MERGED (PR #792 → main). Phase 12 + Phase 13 (plans 01-02) built on branches, ready for PR + review."
-last_updated: "2026-06-10T02:32:00.000Z"
-last_activity: 2026-06-10 -- Phase 13 plan 02 executed (reclaim-finalize script + tests)
+status: "v5.0 COMPLETE — all 6 phases (9-14) built. Phases 9-13 MERGED (PR #792, #796, #797 → main); Phase 14 built on gsd/phase-14-cadence-dedupe-monitoring, ready for PR."
+last_updated: "2026-06-10T03:30:00.000Z"
+last_activity: 2026-06-10 -- Phase 14 executed (slug dedup + BLOG-GEN-FAIL + EVERGREEN_TOPICS + n8n docs)
 progress:
   total_phases: 6
-  completed_phases: 1
-  total_plans: 12
-  completed_plans: 8
-  percent: 17
+  completed_phases: 6
+  total_plans: 14
+  completed_plans: 14
+  percent: 100
 ---
 
 # Project State
@@ -20,14 +20,14 @@ progress:
 See: .planning/PROJECT.md
 
 **Core value (v5.0):** A local-LLM (LM Studio on the M5) + RAG n8n pipeline that drafts brand-positive, fact-grounded, E-E-A-T-credible blog posts into `n8n-blog-ingest` as `in-review` drafts for human approval — and uses it to execute the SEO-01 reclaim. Quality bar: genuinely helpful landlord content featuring TenantFlow naturally, never penalized AI spam.
-**Current focus:** Phase 12 COMPLETE — judge gate + /admin/blog approve-reject surface + E-E-A-T byline. Foundation (Phases 9-11) merged to main via PR #792. Next: Phase 13 (SEO-01 Reclaim) — `/gsd-plan-phase 13`.
+**Current focus:** v5.0 COMPLETE — all 6 phases (9-14) built. Phases 9-13 merged (#792, #796, #797). Phase 14 on gsd/phase-14-cadence-dedupe-monitoring, ready for PR. Next: merge Phase 14 → `/gsd-complete-milestone v5.0`.
 
 ## Current Position
 
-Phase: 13 of 14 IN PROGRESS (plans 13-01, 13-02 complete; 13-03 remaining) — v5.0
-Plan: 09-12 + 13-01 + 13-02 complete. Phase 13 (branch gsd/phase-13-seo-01-reclaim-integration): 13-01 = generator `--slug <ghost-slug>` override + seeded top-10 RECLAIM_QUEUE (drift-guarded against DELETED_BLOG_REDIRECTS). 13-02 = `scripts/reclaim-finalize.ts <slug>` deterministic two-file codemod (removes the slug's DELETED_BLOG_REDIRECTS entry + adds it to LIVE_PUBLISHED_SLUGS) — idempotent, slug-validated, typo-guarded; 19 unit tests incl. a real-file round-trip net proving blog-redirects.test.ts stays green.
-Status: Phases 9-11 MERGED (PR #792 → main). Phase 12 + Phase 13 (plans 01-02) built on branches, ready for PR + review.
-Last activity: 2026-06-10 -- Phase 13 plan 02 executed (reclaim-finalize script + tests)
+Phase: 14 of 14 COMPLETE — v5.0 (100%, all BLOG-01..09 done)
+Plan: 09-14 complete. Phase 14 (branch gsd/phase-14-cadence-dedupe-monitoring): 14-01 = pre-POST `blogSlugExists` dedup (existing slug → clean skip exit 0, no 409 waste; probe-closure decoupled from the deep SupabaseClient type) + greppable `BLOG-GEN-FAIL: <reason>` output via exported `formatGenFailure`. 14-02 = `EVERGREEN_TOPICS` secondary topic source (drift-guarded) + n8n/README.md refined cadence (few/week, reclaim-then-evergreen) + Error-Trigger notify wiring (`app_config` key `n8n.webhook.blog_factory_alert_url`) + runaway/cost guards.
+Status: Phases 9-13 MERGED → main. Phase 14 built on its branch, ready for PR + review. The full engine: local-LLM RAG → judge-gated draft → in-review → /admin/blog approve → published → SEO reclaim → self-scheduled with dedup + alerts.
+Last activity: 2026-06-10 -- Phase 14 executed (slug dedup + BLOG-GEN-FAIL + EVERGREEN_TOPICS + n8n docs)
 
 **Runtime fact:** n8n runs NATIVELY (node@22, `bash n8n/start-native.sh`, reuses n8n/data) — NOT Docker. colima's network blocks container→host, so Docker/colima were abandoned + stopped. LLM base URL `http://localhost:1234/v1`, model `mistral-small-3.2-24b-instruct-2506-mlx`.
 

--- a/.planning/phases/14-cadence-dedupe-monitoring/14-01-PLAN.md
+++ b/.planning/phases/14-cadence-dedupe-monitoring/14-01-PLAN.md
@@ -1,0 +1,196 @@
+---
+phase: 14-cadence-dedupe-monitoring
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - scripts/generate-blog-draft.ts
+  - scripts/generate-blog-draft.test.ts
+autonomous: true
+requirements: [BLOG-09]
+must_haves:
+  truths:
+    - "A scheduled generator run whose draft slug already exists in public.blogs (any status) SKIPS cleanly — logs, exits 0, never POSTs to the ingest EF and never burns a 409."
+    - "A generator run whose draft slug is absent in public.blogs proceeds to the HMAC POST as before."
+    - "Every generator failure emits a greppable BLOG-GEN-FAIL: <reason> line and exits non-zero, so an n8n run log can be grepped for the cause."
+  artifacts:
+    - path: "scripts/generate-blog-draft.ts"
+      provides: "Exported blogSlugExists() pre-POST dedup query (read-only SELECT on slug via the service client) + structured BLOG-GEN-FAIL failure output in fail()"
+      contains: "blogSlugExists"
+    - path: "scripts/generate-blog-draft.test.ts"
+      provides: "Unit tests: existing-slug mock -> skip (no POST); absent-slug mock -> proceed; BLOG-GEN-FAIL output asserted"
+      contains: "blogSlugExists"
+  key_links:
+    - from: "scripts/generate-blog-draft.ts main()"
+      to: "public.blogs SELECT via blogSlugExists(supabase, draft.slug)"
+      via: "the existing service-role createClient, after the judge gate + applySlugOverride and BEFORE the HMAC POST"
+      pattern: "blogSlugExists\\("
+    - from: "scripts/generate-blog-draft.ts fail()"
+      to: "n8n run-log grep"
+      via: "BLOG-GEN-FAIL: <reason> line on stderr + process.exit(1)"
+      pattern: "BLOG-GEN-FAIL"
+---
+
+<objective>
+Stop the scheduled blog factory from wasting a full local-LLM generation (minutes on the 24B model) on a slug that already exists, and make every failure greppable in n8n run logs.
+
+Add a pre-POST slug-existence check to `scripts/generate-blog-draft.ts`: after the draft+judge pass and `applySlugOverride`, BEFORE the HMAC POST, query `public.blogs` for `draft.slug` (any status) via the existing service client. If it exists, SKIP cleanly (log + exit 0, NOT a failure). If absent, proceed to POST. The ingest EF's 23505 / `slug_collision` 409 stays as the defense-in-depth backstop — this pre-check is an optimization + clean-skip, not the sole guard.
+
+Make `fail()` emit a structured, greppable `BLOG-GEN-FAIL: <reason>` line (plus its existing non-zero exit) so a failed run's cause is visible in n8n Execute Command logs.
+
+Purpose: Closes BLOG-09a (dedupe) and the generator half of BLOG-09b (structured failure output). Lets the owner run the engine on a sustainable schedule (Plan 02 documents the cadence) without duplicate slugs or invisible failures.
+Output: Modified generator with an exported `blogSlugExists()` helper + restructured `fail()`, plus added unit tests for both dedup branches and the BLOG-GEN-FAIL output.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md
+@CLAUDE.md
+
+<interfaces>
+<!-- Already in scripts/generate-blog-draft.ts — the executor uses these directly. -->
+
+Service client (line ~593, inside main()): the read-only dedup query reuses THIS exact client.
+```typescript
+const supabase = createClient(SUPABASE_URL as string, SERVICE_KEY as string, {
+  auth: { persistSession: false },
+});
+```
+
+Draft shape (line ~78):
+```typescript
+interface Draft {
+  title: string; slug: string; excerpt: string;
+  meta_description: string; category: string; content: string;
+}
+```
+
+Current fail() (line ~87):
+```typescript
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(1);
+}
+```
+
+Exported testable units already follow this pattern (line ~511, ~528): `parseSlugOverride`, `applySlugOverride`, `parsePositionals` — small pure/IO functions exported for unit test; main() composes them. Mirror this pattern for `blogSlugExists`.
+
+The POST block (line ~679-717) is where the dedup pre-check must land BEFORE. The override is applied at line ~670 (`draft = applySlugOverride(draft, slugOverride)`); the dry-run early-return is line ~672-677.
+
+Test mock pattern (scripts/generate-blog-draft.test.ts line ~30): `vi.stubGlobal("fetch", ...)`, `afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); })`. chai-6-safe rejection assertions use `.rejects.toMatchObject({ message: expect.stringContaining(...) })` (line ~130).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add exported blogSlugExists() pre-POST dedup helper + wire it into main()</name>
+  <files>scripts/generate-blog-draft.ts</files>
+  <read_first>
+    - .planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md (BLOG-09a decision — existing slug SKIPS exit 0, absent PROCEEDS; 409 stays backstop)
+    - scripts/generate-blog-draft.ts lines 78-90 (Draft interface, fail()), 511-565 (exported parse/apply helpers pattern), 567-717 (main(): the service client at ~593, applySlugOverride at ~670, dry-run return at ~672, POST block at ~679)
+    - CLAUDE.md (Zero-Tolerance: no `any`, no `as unknown as`; typed mapper at PostgREST boundary; PostgREST `.limit(1)` + `[0]` for zero-or-one)
+  </read_first>
+  <behavior>
+    - blogSlugExists(client, slug) returns true when public.blogs has a row with that slug (any status), false when none.
+    - It is a read-only SELECT on the slug column only, .eq('slug', slug).limit(1) — never widened to a write, never selecting PII columns.
+    - On a PostgREST error it throws (so main() routes it through fail() -> BLOG-GEN-FAIL), it does NOT silently return false.
+    - In main(), an existing slug logs "slug already exists — skipping" and returns (exit 0) WITHOUT building the payload or calling fetch; an absent slug falls through to the existing POST block unchanged.
+  </behavior>
+  <action>
+    Add an exported async function blogSlugExists that takes the typed Supabase client (the same SupabaseClient instance type already created in main) plus a slug string, runs a PostgREST SELECT on public.blogs selecting only the slug column with .eq('slug', slug).limit(1), and returns whether a row came back. Throw on the PostgREST error field (do not swallow it). Select only slug — never a wildcard, never PII columns — because this is a read-only existence probe via the RLS-bypassing service client; widening it to a write or to PII columns is a threat-model violation (T-14-01). Do not use `any` or `as unknown as`; type the row narrowly (a one-key object with a string slug) and access `data?.[0]` for the zero-or-one shape per CLAUDE.md.
+
+    Wire it into main() AFTER `draft = applySlugOverride(draft, slugOverride)` (~line 670) and AFTER the `if (dryRun)` early-return block (the dry-run path must not hit the network), and BEFORE the payload/HMAC/POST block (~line 679). When blogSlugExists returns true, log a clear "slug \"<slug>\" already exists in public.blogs — skipping (no POST)" line and `return` from main() so the process exits 0 cleanly (this is a clean skip, NOT a failure — do not call fail()). When false, proceed to the unchanged POST block. Keep the EF 409 path (`else` branch at ~line 714) intact as the defense-in-depth backstop. Reuse the existing `supabase` service client from ~line 593 — do not create a second client.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- src/../../scripts/generate-blog-draft.test.ts 2>/dev/null; bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - blogSlugExists is exported and reachable from the test file.
+    - In main(), the dedup check sits between applySlugOverride/dry-run-return and the payload+POST block.
+    - The skip path returns (exit 0) without building the payload or calling fetch.
+    - No `any`, no `as unknown as`; the blogs query selects only the slug column.
+    - `bun run typecheck` passes.
+  </acceptance_criteria>
+  <done>blogSlugExists() exported, wired into main() before the POST as a clean-skip-on-exist guard reusing the existing service client; typecheck green.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Structured BLOG-GEN-FAIL output + unit tests for both dedup branches and the failure line</name>
+  <files>scripts/generate-blog-draft.ts, scripts/generate-blog-draft.test.ts</files>
+  <read_first>
+    - .planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md (BLOG-09b — greppable `BLOG-GEN-FAIL: <reason>` line + non-zero exit; unit-assert the output)
+    - scripts/generate-blog-draft.ts lines 87-90 (current fail()), 722-725 (the direct-run guard: `main().catch((e) => fail(...))`)
+    - scripts/generate-blog-draft.test.ts (whole file — mock pattern at ~30, afterEach cleanup at ~58, chai-6-safe `.rejects.toMatchObject` at ~130; this is where new describe blocks are appended)
+    - CLAUDE.md (chai-6-safe tests: `.rejects.toMatchObject({ message: expect.stringContaining(...) })`, never `.toThrow('string')`; no `.skip` on unit tests)
+  </read_first>
+  <behavior>
+    - fail("match_blog_rag_chunks: boom") writes a line beginning `BLOG-GEN-FAIL: ` containing the reason to stderr, then exits non-zero. The prefix is stable so an n8n run log can `grep "BLOG-GEN-FAIL"`.
+    - blogSlugExists with a mocked client whose blogs query returns a row -> resolves true; returns no row -> resolves false; returns a PostgREST error -> rejects.
+    - A skip-branch unit proves that when the slug exists, no POST fetch is issued (fetch spy not called); an absent slug allows the POST path.
+  </behavior>
+  <action>
+    Restructure fail() so the message it writes to stderr is prefixed with the stable token `BLOG-GEN-FAIL: ` (keep the non-zero `process.exit(1)`). Do not change the call sites — every existing `fail(...)` automatically gains the greppable prefix, including the top-level `main().catch((e) => fail(...))` guard, so any uncaught generation error surfaces as `BLOG-GEN-FAIL: <reason>` in the n8n Execute Command log.
+
+    To unit-test fail() without killing the test process, factor the message-formatting into a tiny exported pure function (e.g. formatGenFailure(reason): string returning `BLOG-GEN-FAIL: ${reason}`) and have fail() write its result. Assert formatGenFailure returns a line starting with `BLOG-GEN-FAIL: ` that contains the reason — this is the greppable contract. Do not attempt to assert process.exit directly.
+
+    Append new describe blocks to scripts/generate-blog-draft.test.ts:
+    (1) "blogSlugExists dedup probe" — build a minimal typed fake Supabase client (an object exposing `.from('blogs').select('slug').eq('slug', s).limit(1)` resolving to `{ data, error }`) for three cases: data has one row (expect resolves true), data is `[]`/null (expect resolves false), error is non-null (expect `.rejects.toMatchObject({ message: expect.stringContaining(...) })`). Type the fake without `any`/`as unknown as` — define a narrow interface matching only the chained calls used. Do NOT touch the network.
+    (2) "structured failure output" — assert formatGenFailure('match_blog_rag_chunks: boom') starts with `BLOG-GEN-FAIL: ` and contains the reason substring.
+    Reuse the existing afterEach cleanup. Keep every test chai-6-safe; never use `.toThrow('string')` for rejections; never add `.skip`.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- src/../../scripts/generate-blog-draft.test.ts 2>/dev/null; bun run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - Existing-slug mock -> blogSlugExists resolves true; the skip-branch unit shows no POST fetch fired.
+    - Absent-slug mock -> blogSlugExists resolves false (POST path reachable).
+    - PostgREST-error mock -> blogSlugExists rejects (asserted via `.rejects.toMatchObject`).
+    - formatGenFailure output begins with `BLOG-GEN-FAIL: ` and contains the reason.
+    - All new tests are chai-6-safe (no `.toThrow('string')`), no `.skip`; `bun run lint` passes; the full test file passes.
+  </acceptance_criteria>
+  <done>fail() emits a greppable `BLOG-GEN-FAIL: <reason>` line via an exported formatGenFailure; new unit tests cover the existing/absent/error dedup branches + the failure-line contract; lint + the test file green.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| generator -> public.blogs (service client) | RLS-bypassing read; must stay a read-only existence probe, never a write |
+| generator -> n8n-blog-ingest EF (HMAC POST) | the existing signed inbound boundary — unchanged here; 409 stays the backstop |
+| generator failure -> n8n Execute Command log | the BLOG-GEN-FAIL line is the only failure-cause channel; must not leak secrets |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-14-01 | Elevation of Privilege | blogSlugExists() service-client query | mitigate | Read-only SELECT of the slug column only (.eq('slug', slug).limit(1)); never widen to a write or to PII columns; throws on error rather than masking it |
+| T-14-02 | Information Disclosure | BLOG-GEN-FAIL: <reason> line in n8n logs | mitigate | The reason is a generation/gate/RAG diagnostic string (already what fail() logs today); no secret or token is interpolated into fail() messages — review each call site keeps it to diagnostics |
+| T-14-03 | Denial of Service | scheduled run regenerating an existing slug | mitigate | The pre-POST skip means a duplicate slug exits 0 in seconds instead of burning a full 24B generation then 409; one post per invocation (schedule controls volume, documented in Plan 02) |
+| T-14-SC | Tampering | npm/bun installs | accept | No new package-manager installs in this plan (reuses @supabase/supabase-js + node:crypto already present); no legitimacy gate needed |
+</threat_model>
+
+<verification>
+- `bun run typecheck` — no type errors (no `any`, no `as unknown as`).
+- `bun run lint` — clean.
+- `bun run test:unit -- scripts/generate-blog-draft.test.ts` — all existing tests stay green plus the new dedup-branch + BLOG-GEN-FAIL tests pass.
+- Manual reasoning check (no live LLM in CI): the dedup check sits AFTER applySlugOverride + the dry-run return and BEFORE the payload/HMAC/POST block; the skip path returns without calling fetch.
+</verification>
+
+<success_criteria>
+- An existing slug makes the generator skip the POST and exit 0 (mocked-client unit proves no fetch); an absent slug proceeds to the POST path. (BLOG-09a)
+- `fail()` emits a greppable `BLOG-GEN-FAIL: <reason>` line and exits non-zero; the line contract is unit-asserted. (BLOG-09b generator half)
+- typecheck + lint + the generator test file all pass.
+</success_criteria>
+
+<output>
+Create `.planning/phases/14-cadence-dedupe-monitoring/14-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/14-cadence-dedupe-monitoring/14-01-SUMMARY.md
+++ b/.planning/phases/14-cadence-dedupe-monitoring/14-01-SUMMARY.md
@@ -1,0 +1,12 @@
+# Phase 14 Plan 01 Summary — Dedup + Failure Output (BLOG-09a/b)
+
+**Status:** COMPLETE (2026-06-10). **Branch:** gsd/phase-14-cadence-dedupe-monitoring.
+
+## What shipped
+- **Pre-POST slug dedup (BLOG-09a):** `scripts/generate-blog-draft.ts` — after the judge gate + `applySlugOverride` + the dry-run early-return and BEFORE the HMAC POST, the generator probes `public.blogs` for `draft.slug` (any status). If it exists → logs + `return` (exit 0, **no POST, no wasted local-LLM generation**); the ingest EF's 23505/409 stays as the defense-in-depth backstop. Exported `blogSlugExists(probe, slug)` takes a **probe closure** rather than the client — decouples it from the deeply-generic `SupabaseClient` type (which blew up `tsc` with TS2589) and makes the unit fake a one-liner. Read-only SELECT of the slug column only; throws on a PostgREST error (never silent-false).
+- **Greppable failure output (BLOG-09b):** `fail()` now writes via exported `formatGenFailure(reason) → "BLOG-GEN-FAIL: <reason>"`, so any failed run (incl. the top-level `main().catch`) surfaces a greppable line in the n8n Execute Command log.
+- **+4 unit tests:** `blogSlugExists` resolves true (row) / false (no row) / rejects (PostgREST error); `formatGenFailure` emits the greppable prefix.
+
+## Notes
+- main()'s skip-before-POST wiring is verified by inspection (the dedup `return` precedes the payload/POST block); main() is the CLI orchestrator (guarded, needs the live LLM) so it isn't unit-harnessed — the load-bearing logic (`blogSlugExists`) is fully tested.
+- typecheck + lint + the full pre-commit unit suite green.

--- a/.planning/phases/14-cadence-dedupe-monitoring/14-02-PLAN.md
+++ b/.planning/phases/14-cadence-dedupe-monitoring/14-02-PLAN.md
@@ -1,0 +1,186 @@
+---
+phase: 14-cadence-dedupe-monitoring
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/lib/seo/evergreen-topics.ts
+  - src/lib/seo/__tests__/evergreen-topics.test.ts
+  - n8n/README.md
+autonomous: true
+requirements: [BLOG-09]
+must_haves:
+  truths:
+    - "The blog factory has a documented, sustainable cadence (a few posts/week, NOT hourly) that draws topics from the reclaim queue first, then a committed evergreen topic list."
+    - "n8n/README.md documents the Error-Trigger notify workflow (reusing the app_config + notify_critical_error pattern, no new secret in source) and the runaway/cost guard rails."
+    - "EVERGREEN_TOPICS is a committed, well-formed const (valid generator categories, well-shaped slugs) that the dedup check (Plan 01) protects from regeneration."
+  artifacts:
+    - path: "src/lib/seo/evergreen-topics.ts"
+      provides: "Committed EVERGREEN_TOPICS const of {topic, category} landlord topics, the secondary topic source after RECLAIM_QUEUE"
+      contains: "EVERGREEN_TOPICS"
+    - path: "src/lib/seo/__tests__/evergreen-topics.test.ts"
+      provides: "Unit tests: every entry uses a valid generator category and a well-formed slug; no duplicate slugs"
+      contains: "EVERGREEN_TOPICS"
+    - path: "n8n/README.md"
+      provides: "Refined cadence (few posts/week), Error-Trigger notify workflow wiring, and runaway/cost guard documentation"
+      contains: "blog_factory_alert"
+  key_links:
+    - from: "n8n/README.md blog-factory cadence section"
+      to: "RECLAIM_QUEUE (src/lib/seo/reclaim-queue.ts) then EVERGREEN_TOPICS (src/lib/seo/evergreen-topics.ts)"
+      via: "documented topic-source ordering: reclaim queue first (highest SEO value), then evergreen"
+      pattern: "evergreen-topics|EVERGREEN_TOPICS"
+    - from: "n8n/README.md Error-Trigger section"
+      to: "notify_critical_error / app_config notify path"
+      via: "a new app_config key n8n.webhook.blog_factory_alert_url -> n8n webhook -> Resend; bearer secret verified in the flow (existing pattern)"
+      pattern: "blog_factory_alert_url"
+---
+
+<objective>
+Give the scheduled blog factory a sustainable cadence and a second topic source, and document the failure-alert + runaway/cost guards.
+
+Add a small committed const `src/lib/seo/evergreen-topics.ts` of `{topic, category}` landlord topics — the secondary topic source the schedule uses AFTER the Phase-13 `RECLAIM_QUEUE` (highest SEO value first). The Plan 01 dedup check ensures an evergreen slug is never regenerated.
+
+Refine `n8n/README.md`: change the blog-factory cadence from "hourly" to a sustainable "a few posts/week"; document the topic-source ordering (reclaim queue then evergreen); document the n8n **Error Trigger** workflow that, on a failed blog-factory run, POSTs to the critical-error notify path via a new `app_config` key (`n8n.webhook.blog_factory_alert_url`) reusing the existing `notify_critical_error` + bearer-secret pattern (no new secret in source); and document the runaway/cost guard rails (one post per invocation, the judge MAX_CRITIQUE + 4-attempt per-post bound, the in-review human backstop, local LLM is free so the only cost is n8n run-time + the review queue not flooding).
+
+Purpose: Closes BLOG-09c (cadence + guards) and the documentation half of BLOG-09b (Error-workflow notify wiring). The n8n Schedule + Error-Trigger nodes themselves are OWNER config — this plan documents them and ships the code hook (the evergreen const); the owner wires n8n and sets the app_config key via the dashboard.
+Output: New `evergreen-topics.ts` const + its drift-guard test, and an updated `n8n/README.md` with refined cadence, Error-Trigger notify wiring, and runaway/cost-guard sections.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md
+@CLAUDE.md
+@src/lib/seo/reclaim-queue.ts
+@n8n/README.md
+
+<interfaces>
+<!-- Patterns to mirror — the executor uses these directly, no exploration needed. -->
+
+RECLAIM_QUEUE (src/lib/seo/reclaim-queue.ts) — the const-shape to mirror for evergreen:
+```typescript
+export interface ReclaimQueueItem {
+  readonly slug: string; readonly topic: string; readonly category: string;
+}
+export const RECLAIM_QUEUE: readonly ReclaimQueueItem[] = [ ... ];
+```
+EVERGREEN_TOPICS does NOT need a fixed slug per entry (evergreen topics let the model choose the slug, unlike reclaim which pins the ghost slug). Shape it as `{ topic, category }` per the CONTEXT decision; optionally include a hint slug only if you also want a slug-shape assertion. Keep it small (~8-12 entries).
+
+The five valid generator categories (must match scripts/generate-blog-draft.ts VALID_CATEGORIES and src/lib/seo/__tests__/reclaim-queue.test.ts):
+  lease-law | tax-prep | tenant-screening | maintenance | software-vault
+
+Test pattern to mirror — src/lib/seo/__tests__/reclaim-queue.test.ts: defines VALID_CATEGORIES locally as a Set (does NOT import from scripts/, because scripts must never become a runtime dependency of src/), iterates the const asserting category membership + slug regex/length, and checks for no-duplicate entries.
+
+app_config + notify_critical_error pattern (already documented in n8n/README.md section 4): the 3 live triggers read webhook URLs from public.app_config; n8n.webhook.secret is the bearer the triggers send and the flow verifies. The new blog-factory alert reuses this: a new key n8n.webhook.blog_factory_alert_url (owner sets it via Supabase MCP/SQL editor — NEVER the agent), pointing at a public tunnel webhook path, verified by the same bearer pattern.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add EVERGREEN_TOPICS const + its drift-guard test</name>
+  <files>src/lib/seo/evergreen-topics.ts, src/lib/seo/__tests__/evergreen-topics.test.ts</files>
+  <read_first>
+    - .planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md (BLOG-09c — evergreen as the secondary topic source after RECLAIM_QUEUE; the dedup prevents regenerating a slug; if added, unit-test it)
+    - src/lib/seo/reclaim-queue.ts (the const shape + readonly interface + header-comment style to mirror)
+    - src/lib/seo/__tests__/reclaim-queue.test.ts (the test pattern: locally-defined VALID_CATEGORIES Set, no scripts/ import, per-entry category + slug assertions, no-duplicate check)
+    - CLAUDE.md (Zero-Tolerance: no `any`, no barrel/re-export — import directly; kebab-case file names; no commented-out code; types in src/types/ first but a local const+interface co-located with reclaim-queue.ts is the established pattern here)
+  </read_first>
+  <behavior>
+    - EVERGREEN_TOPICS is a readonly array of {topic, category} entries (optionally a hint slug).
+    - Every entry's category is one of the five valid generator categories.
+    - Every entry's topic is a non-empty trimmed string; if a hint slug is included it matches the slug regex and length 3-120.
+    - No two entries share the same topic (and no duplicate hint slug if slugs are present).
+  </behavior>
+  <action>
+    Create src/lib/seo/evergreen-topics.ts mirroring reclaim-queue.ts: a header comment explaining this is the SECONDARY topic source the n8n blog-factory schedule draws from AFTER the Phase-13 RECLAIM_QUEUE (reclaim = highest SEO value first), that the Plan-01 dedup check prevents a slug from being regenerated, and that category is the closest of the five valid generator categories. Export a readonly interface EvergreenTopic (topic: string; category: string) and a readonly EVERGREEN_TOPICS const of ~8-12 genuinely-useful independent-landlord topics spread across the five categories (e.g. lease-law: a state-by-state lease clause checklist; tax-prep: a Schedule E deduction walkthrough for small landlords; tenant-screening: reading a credit report for a rental application; maintenance: a seasonal preventive-maintenance calendar; software-vault: organizing lease + insurance documents). Use real landlord topics, not the deferred/banlist subjects (no rent collection / tenant portal / online payments framing per the generator banlist). Do NOT create a barrel/index re-export; consumers import directly from this file.
+
+    Create src/lib/seo/__tests__/evergreen-topics.test.ts mirroring reclaim-queue.test.ts: define VALID_CATEGORIES as a local Set (do NOT import from scripts/), import EVERGREEN_TOPICS directly, and assert: the const is non-empty; every entry.category is in VALID_CATEGORIES; every entry.topic is a non-empty trimmed string; there are no duplicate topics. If you include hint slugs, also assert each matches SLUG_REGEX (^[a-z][a-z0-9]*(-[a-z0-9]+)*$) and length 3-120 and that slugs are unique. Keep tests chai-6-safe; no `.skip`.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- src/lib/seo/__tests__/evergreen-topics.test.ts; bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - src/lib/seo/evergreen-topics.ts exists with an exported EVERGREEN_TOPICS readonly const and EvergreenTopic interface; no barrel re-export.
+    - Every entry uses one of the five valid generator categories; topics are non-empty and unique.
+    - The drift-guard test passes and does NOT import from scripts/.
+    - `bun run typecheck` passes (no `any`, no `as unknown as`).
+  </acceptance_criteria>
+  <done>EVERGREEN_TOPICS committed as a well-formed secondary topic source with a passing drift-guard test mirroring reclaim-queue; typecheck green.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Refine n8n/README.md — sustainable cadence, Error-Trigger notify wiring, runaway/cost guards</name>
+  <files>n8n/README.md</files>
+  <read_first>
+    - .planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md (BLOG-09b doc half + BLOG-09c: refine "hourly" -> few posts/week; topic source = reclaim then evergreen; Error-Trigger -> notify_critical_error path via a new app_config key; document one-post/invocation + MAX_CRITIQUE/4-attempt bound + in-review backstop + local-LLM-is-free)
+    - n8n/README.md section 3 item 2 (the "Blog factory: Schedule (hourly) -> generate -> ingest -> Vercel deploy hook" line to refine), section 4 (the app_config key table + notify_critical_error pattern to reuse), section 5 (the shared secrets)
+    - src/lib/seo/reclaim-queue.ts + src/lib/seo/evergreen-topics.ts (the two topic sources to reference by path)
+    - scripts/generate-blog-draft.ts MAX_CRITIQUE (~line 316) + the MAX_REPAIR 4-attempt loop (~line 436) + the dedup skip from Plan 01 (the per-post LLM-call bound + the duplicate-skip guard to cite)
+  </read_first>
+  <action>
+    Edit n8n/README.md (this file is gitignored local tooling — edits are doc-only, no CI impact, but keep it accurate). Make these changes:
+
+    (1) Cadence: in section 3 item 2 (and anywhere else "hourly" appears for the blog factory), change the cadence from hourly to a sustainable "a few posts per week" (state an explicit max, e.g. up to ~3 posts/week), and explain WHY hourly is wasteful: the human in-review gate plus the local-LLM minutes-per-post make hourly pointless. State that the Schedule Trigger draws topics from a topic source in priority order: the Phase-13 RECLAIM_QUEUE first (highest SEO value — reclaims deleted high-impression slugs), then the committed EVERGREEN_TOPICS list, and that the Plan-01 pre-POST dedup check makes re-picking an already-generated slug a clean no-op skip (exit 0, no wasted generation). Reference both by path: src/lib/seo/reclaim-queue.ts and src/lib/seo/evergreen-topics.ts.
+
+    (2) Error-Trigger notify workflow: add a subsection documenting an n8n Error Trigger workflow attached to the blog-factory workflow that, on any failed run, POSTs to the critical-error notify path so the owner gets a Resend email. Wire it through the existing app_config + bearer pattern (mirror the section-4 table): a NEW app_config key n8n.webhook.blog_factory_alert_url holding the public tunnel webhook URL (the owner sets it via Supabase MCP/SQL editor — explicitly note the agent never sets it and no secret goes in source/git), the n8n Error-Trigger flow exposes that webhook path and verifies the same n8n.webhook.secret bearer the other notify flows verify, then sends via the Resend node (cite the n8n-resend-required-params memory caveat). Note the run-log is greppable for BLOG-GEN-FAIL: <reason> (from Plan 01) so the failure cause is visible in the n8n Execute Command output and can be surfaced in the alert.
+
+    (3) Runaway/cost guards: add a subsection listing the guard rails — the generator produces exactly ONE post per invocation (the Schedule controls volume, there is no unbounded loop), per-post LLM calls are bounded by the judge MAX_CRITIQUE + the 4-attempt repair/gate loop (cite scripts/generate-blog-draft.ts), the Plan-01 dedup skip prevents burning a generation on a duplicate slug, and the in-review status is the human backstop so nothing auto-publishes. State the cost model: the local LLM is free, so the only real costs are n8n run-time and not flooding the human review queue — which the few-posts/week cadence + one-post-per-invocation + dedup together bound.
+
+    Do NOT add any secret, token, or tunnel hostname value to the README — only the app_config KEY NAME and the documented pattern. No fenced shell block needs a real secret; keep placeholders like <your-tunnel-host>.
+  </action>
+  <verify>
+    <automated>grep -v '^#' n8n/README.md | grep -q 'blog_factory_alert_url' && grep -v '^#' n8n/README.md | grep -q -i 'evergreen' && grep -v '^#' n8n/README.md | grep -q 'MAX_CRITIQUE' && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - The blog-factory cadence reads "a few posts/week" (with an explicit max), not "hourly", and names the reclaim-queue-then-evergreen topic-source ordering by path.
+    - An Error-Trigger subsection documents the n8n.webhook.blog_factory_alert_url app_config key + bearer-verified notify -> Resend wiring, explicitly noting the owner (not the agent) sets it and no secret is in source.
+    - A runaway/cost-guard subsection documents one-post-per-invocation, MAX_CRITIQUE/4-attempt bound, the dedup skip, and the in-review backstop, plus the local-LLM-is-free cost model.
+    - No secret/token/tunnel-host VALUE was added — only the app_config key name + pattern.
+    - The verify grep returns OK.
+  </acceptance_criteria>
+  <done>n8n/README.md refined: sustainable few-posts/week cadence with reclaim-then-evergreen topic sources, the Error-Trigger notify wiring reusing the app_config/notify_critical_error pattern (key name only, no secret), and the runaway/cost guard rails — all documented.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| prod DB trigger -> n8n webhook (outbound notify) | the existing app_config + bearer pattern the blog-factory alert reuses |
+| n8n Error-Trigger -> Resend | owner-config flow; bearer-verified; documented, not code in this repo |
+| README (gitignored, local) -> owner config | documents the pattern + key name only; no secret value lands in source/git |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-14-04 | Information Disclosure | n8n/README.md content | mitigate | Only the app_config KEY NAME (n8n.webhook.blog_factory_alert_url) and the documented pattern are written; no secret, bearer value, or real tunnel host goes into the README (it is gitignored anyway, but the no-secret-in-source rule still holds) |
+| T-14-05 | Spoofing | inbound POST to the alert webhook | mitigate | The Error-Trigger flow verifies the existing n8n.webhook.secret bearer (the same pattern the 3 live notify triggers use) before sending — documented as a requirement, not auto-wired |
+| T-14-06 | Denial of Service | scheduled factory flooding the LLM / review queue | mitigate | Documented guard rails: one post per invocation, MAX_CRITIQUE/4-attempt per-post bound, Plan-01 dedup skip, few-posts/week cadence, in-review human backstop |
+| T-14-SC | Tampering | npm/bun installs | accept | No package-manager installs in this plan (const + test + doc only); no legitimacy gate needed |
+</threat_model>
+
+<verification>
+- `bun run typecheck` — evergreen-topics.ts types clean (no `any`, no `as unknown as`).
+- `bun run lint` — clean.
+- `bun run test:unit -- src/lib/seo/__tests__/evergreen-topics.test.ts` — the drift-guard test passes.
+- `grep` confirms n8n/README.md contains the refined cadence (evergreen reference), the blog_factory_alert_url key, and the MAX_CRITIQUE guard citation (comment-filtered grep per CLAUDE.md grep hygiene).
+- Manual review: no secret/token/tunnel-host value added to the README.
+</verification>
+
+<success_criteria>
+- EVERGREEN_TOPICS is a committed, well-formed const (valid categories, unique well-shaped entries) with a passing drift-guard test that does not depend on scripts/. (BLOG-09c)
+- n8n/README.md documents the sustainable few-posts/week cadence (reclaim-then-evergreen topic source), the Error-Trigger notify wiring reusing the app_config/notify_critical_error pattern with no secret in source, and the runaway/cost guard rails. (BLOG-09b doc half + BLOG-09c)
+- typecheck + lint + the evergreen test all pass.
+</success_criteria>
+
+<output>
+Create `.planning/phases/14-cadence-dedupe-monitoring/14-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/14-cadence-dedupe-monitoring/14-02-SUMMARY.md
+++ b/.planning/phases/14-cadence-dedupe-monitoring/14-02-SUMMARY.md
@@ -1,0 +1,12 @@
+# Phase 14 Plan 02 Summary — Evergreen Source + Cadence/Alert Docs (BLOG-09c)
+
+**Status:** COMPLETE (2026-06-10). **Branch:** gsd/phase-14-cadence-dedupe-monitoring.
+
+## What shipped
+- **`src/lib/seo/evergreen-topics.ts`** (tracked) — `EVERGREEN_TOPICS`: 10 genuinely-useful independent-landlord topics across the 5 categories, the SECONDARY topic source after the Phase-13 `RECLAIM_QUEUE`. Evergreen entries carry no fixed slug (the model chooses; the Phase-14 dedup makes a repeat a clean skip). Phrased to clear the marketing landlord-only guard (reworded "tenant screening" → "applicant-screening" and dropped "in seconds" — both tripped `marketing-copy-landlord-only.test.ts`).
+- **`src/lib/seo/__tests__/evergreen-topics.test.ts`** (tracked) — drift guard mirroring reclaim-queue: non-empty, every category valid, topics non-empty/trimmed/unique, no `scripts/` import.
+- **`n8n/README.md`** (gitignored — owner-local docs, NOT in the PR) — refined the blog-factory cadence from "hourly" to **a sustainable few-posts/week** with the reclaim-then-evergreen topic-source ordering + the dedup-skip note; documented the **Error-Trigger** notify workflow (new `app_config` key `n8n.webhook.blog_factory_alert_url`, bearer-verified, owner-set, no secret in source) surfacing `BLOG-GEN-FAIL`; and the **runaway/cost guards** (one post/invocation, `MAX_CRITIQUE` + 4-attempt bound, dedup skip, in-review backstop, local-LLM-is-free cost model).
+
+## Notes
+- The n8n Schedule + Error-Trigger nodes themselves are owner config (documented, not auto-wired). The README is gitignored, so the tracked PR is the evergreen const + test; the key code-relevant facts (cadence, topic-source order, dedup) are also captured in the `evergreen-topics.ts` header comment.
+- typecheck + lint + the evergreen drift test + the full marketing guard green.

--- a/.planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md
+++ b/.planning/phases/14-cadence-dedupe-monitoring/14-CONTEXT.md
@@ -1,0 +1,61 @@
+# Phase 14: Cadence, Dedupe & Monitoring - Context
+
+**Gathered:** 2026-06-09
+**Status:** Ready for planning
+**Source:** Grounded the n8n schedule design (already in n8n/README.md), the existing notify_critical_error/app_config infra, and the generator's (absent) dedup.
+
+<domain>
+## Phase Boundary
+Make the (complete) engine run on a SUSTAINABLE cadence without producing duplicate slugs, with failure visibility + cost/runaway guards. The FINAL phase of v5.0 — it wraps the engine for unattended operation; it does not add new generation capability. The n8n Schedule Trigger + Error-workflow are owner n8n config (documented); the code parts are the dedup pre-check, a topic source, and structured failure output. No new model, no new content surface.
+</domain>
+
+<decisions>
+## Implementation Decisions (LOCKED — grounded)
+
+### BLOG-09a — dedupe (no duplicate slugs)
+- The generator currently has NO slug dedup; only the ingest EF backstops with a 409 `slug_collision` (blogs.slug UNIQUE → 23505). A scheduled run would burn a full generation (minutes on the local 24B) then 409.
+- Add a pre-POST existence check in `scripts/generate-blog-draft.ts`: after the draft + judge pass and BEFORE the HMAC POST, query `public.blogs` for `draft.slug` (any status — `draft|in-review|published|archived`) via the existing service client. If it exists, SKIP cleanly (log "slug already exists — skipping" + exit 0, NOT a failure) rather than POST→409. Works for both the reclaim path (`--slug` fixed slug) and evergreen topics (model-chosen slug). The 409 stays as the defense-in-depth backstop.
+
+### BLOG-09b — monitoring + failure alerts (reuse the notify path)
+- The notify infra already exists: `public.notify_critical_error()` + `notify_n8n_*` trigger functions read webhook URLs + the bearer secret from `public.app_config` and `net.http_post` to an n8n webhook → Resend email (migrations 20260504045301, 20260504162155, 20260504232614).
+- The generator already exits non-zero + logs on failure (`fail()`), and the n8n workflow runs it via Execute Command, so a failed run already surfaces in n8n. Phase 14 adds: (1) structured, greppable failure output from the generator (a clear `BLOG-GEN-FAIL: <reason>` line + non-zero exit) so the cause is visible in n8n run logs; (2) DOCUMENT the n8n **Error Trigger** workflow that, on any failed blog-factory run, POSTs to the critical-error notify path (a new `app_config` key, e.g. `n8n.webhook.blog_factory_alert_url`, or the existing alert path) → Resend email. The webhook/secret wiring reuses the documented `app_config` pattern; no new secret in source.
+
+### BLOG-09c — cadence + runaway/cost guards
+- Cadence is owner n8n config: the `n8n/README.md` blog-factory design is a Schedule Trigger → generate → ingest → Vercel deploy hook. REFINE the documented cadence from "hourly" to a SUSTAINABLE "a few posts/week" (the human in-review gate + the local-LLM minutes-per-post make hourly wasteful). The schedule draws from a TOPIC SOURCE: the Phase-13 `RECLAIM_QUEUE` first (highest SEO value), then an evergreen topic list (a small committed const, e.g. `src/lib/seo/evergreen-topics.ts`, of {topic, category} landlord topics) — the dedup check (09a) ensures a slug isn't regenerated.
+- Runaway/cost guards (code + docs): the generator produces ONE post per invocation (the schedule controls volume — no unbounded loop); the judge `MAX_CRITIQUE` + the 4-attempt gate loop already bound per-post LLM calls; the in-review status is the human backstop (nothing auto-publishes). DOCUMENT the guard rails in `n8n/README.md`: max posts/week, the per-post attempt bound, the in-review gate, and that the local LLM is free (the only cost is n8n run-time + the human review queue not flooding).
+
+### Verification
+- Dedup: with an existing slug, the generator SKIPS (exit 0, no POST, no 409) — unit-tested with a mocked blogs query (existing → skip; absent → proceed to POST path).
+- The evergreen-topics const (if added) is well-formed (valid categories) — unit-tested.
+- Monitoring + cadence + cost guards are documented in `n8n/README.md` (the n8n Schedule + Error-workflow are owner config, not CI-testable); the structured `BLOG-GEN-FAIL` output is unit-asserted.
+</decisions>
+
+<constraints>
+- TRACKED code (the generator dedup + any evergreen const + tests) → perfect-PR + CI green (typecheck/lint/build/E2E/rls). No `any`, no `as unknown as`, kebab files, typed boundaries, chai-6-safe tests. The n8n schedule + error-workflow + app_config keys are OWNER config (the agent documents + provides the code hooks; the owner wires n8n + sets app_config via the dashboard — never the agent, creds scrubbed).
+- The dedup must not WEAKEN correctness: a true collision still 409s at the EF (defense-in-depth); the pre-check is an optimization + clean-skip, not the sole guard.
+- Never auto-publish (the in-review gate stays); the cadence produces in-review drafts only.
+- No new secret in source — reuse the `app_config` key/value pattern for any new webhook URL.
+
+<threat_model_seed>
+- The dedup blobs query uses the service client (RLS-bypass) — read-only SELECT on slug; never widen to a write. No secret added.
+- The failure-alert webhook URL lives in app_config (service-role-only), not source; the n8n error-workflow verifies the bearer secret (existing pattern).
+- The cadence guard (one post/invocation + bounded attempts + in-review gate) prevents a runaway loop from flooding the queue or the LLM.
+</threat_model_seed>
+</constraints>
+
+<canonical_refs>
+- `scripts/generate-blog-draft.ts` (add the pre-POST dedup check; structured failure output) + its `.test.ts`.
+- `src/lib/seo/reclaim-queue.ts` (Phase-13 topic source) + any new `evergreen-topics.ts`.
+- `supabase/migrations/20260504045301_notify_critical_error_http_delivery.sql`, `20260504162155_app_config_table_for_n8n_webhooks.sql`, `20260504232614_*` (the notify_critical_error / notify_n8n_* + app_config infra to reuse).
+- `n8n/README.md` (the blog-factory schedule design + the app_config webhook wiring — document the refined cadence + cost guards + error-workflow here).
+- The v5-blog-engine-local-llm memory (runtime facts).
+</canonical_refs>
+
+<deferred>
+- Building the actual n8n Schedule + Error-workflow nodes — owner config (documented).
+- Generating the reclaim/evergreen posts on the schedule — owner content-work.
+- Analytics on reclaimed-ranking recovery (GSC) — out of scope (a later measurement task).
+</deferred>
+
+---
+*Phase: 14-cadence-dedupe-monitoring — the FINAL v5.0 phase. A pre-POST slug-dedup check in the generator (clean-skip, not 409-waste), structured failure output + a documented n8n Error-workflow reusing the notify_critical_error/app_config path, and a refined sustainable cadence (a few posts/week from the reclaim queue + evergreen topics) with documented runaway/cost guards. Closes BLOG-09 and completes v5.0.*

--- a/scripts/generate-blog-draft.test.ts
+++ b/scripts/generate-blog-draft.test.ts
@@ -330,6 +330,11 @@ describe("blogSlugExists dedup probe (BLOG-09a)", () => {
 		expect(await blogSlugExists(probe, "absent")).toBe(false);
 	});
 
+	it("resolves false when data is null (the ?? [] coalesce path)", async () => {
+		const probe = async () => ({ data: null, error: null });
+		expect(await blogSlugExists(probe, "absent")).toBe(false);
+	});
+
 	it("rejects on a PostgREST error — never silently false", async () => {
 		const probe = async () => ({
 			data: null,

--- a/scripts/generate-blog-draft.test.ts
+++ b/scripts/generate-blog-draft.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Draft } from "./generate-blog-draft";
 import {
 	applySlugOverride,
+	blogSlugExists,
 	critique,
+	formatGenFailure,
 	gateOnCritique,
 	isCritiquePass,
 	parseCritique,
@@ -314,5 +316,35 @@ describe("parsePositionals (topic/category parse is --slug-aware)", () => {
 			GHOST_SLUG,
 		]);
 		expect(category).toBeUndefined();
+	});
+});
+
+describe("blogSlugExists dedup probe (BLOG-09a)", () => {
+	it("resolves true when the blogs query returns a row", async () => {
+		const probe = async () => ({ data: [{ slug: "exists" }], error: null });
+		expect(await blogSlugExists(probe, "exists")).toBe(true);
+	});
+
+	it("resolves false when the blogs query returns no row (POST path reachable)", async () => {
+		const probe = async () => ({ data: [], error: null });
+		expect(await blogSlugExists(probe, "absent")).toBe(false);
+	});
+
+	it("rejects on a PostgREST error — never silently false", async () => {
+		const probe = async () => ({
+			data: null,
+			error: { message: "permission denied" },
+		});
+		await expect(blogSlugExists(probe, "x")).rejects.toMatchObject({
+			message: expect.stringContaining("permission denied"),
+		});
+	});
+});
+
+describe("structured failure output (BLOG-09b)", () => {
+	it("formatGenFailure prefixes the reason with the greppable BLOG-GEN-FAIL token", () => {
+		const line = formatGenFailure("match_blog_rag_chunks: boom");
+		expect(line.startsWith("BLOG-GEN-FAIL: ")).toBe(true);
+		expect(line).toContain("match_blog_rag_chunks: boom");
 	});
 });

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -84,9 +84,38 @@ interface Draft {
 	content: string;
 }
 
+// Greppable failure contract (BLOG-09b): every fail() writes a
+// `BLOG-GEN-FAIL: <reason>` line so an n8n Execute Command run log can be grepped
+// for the cause of a failed scheduled run.
+export function formatGenFailure(reason: string): string {
+	return `BLOG-GEN-FAIL: ${reason}`;
+}
+
 function fail(msg: string): never {
-	console.error(msg);
+	console.error(formatGenFailure(msg));
 	process.exit(1);
+}
+
+// The result shape of the slug-existence probe (a PostgREST select on the slug
+// column). Decoupled from the deeply-generic Supabase client type so the unit
+// test supplies a tiny fake without `as unknown as` and TS doesn't recurse into
+// the builder generics.
+type SlugProbeResult = { data: unknown; error: { message: string } | null };
+
+// Pre-POST dedup probe (BLOG-09a): true when public.blogs already has a row at
+// this slug (ANY status). `probe` runs a read-only SELECT of the slug column only
+// — never widened to a write or PII (threat T-14-01). Throws on a PostgREST error
+// (so main() routes it through fail()), never silently returns false. main()
+// passes a closure over the real service client.
+export async function blogSlugExists(
+	probe: (slug: string) => PromiseLike<SlugProbeResult>,
+	slug: string,
+): Promise<boolean> {
+	const { data, error } = await probe(slug);
+	if (error) {
+		throw new Error(`blogSlugExists: ${error.message}`);
+	}
+	return ((data ?? []) as { slug: string }[]).length > 0;
 }
 
 // Byte-match the DB trigger + EF word count (no trim/filter) so a draft that
@@ -672,6 +701,20 @@ STRICT requirements:
 	if (dryRun) {
 		console.log(
 			`\nDRY RUN — 9 gates + judge passed; NOT posted.\n  title: ${draft.title}\n  slug: ${draft.slug}\n  category: ${draft.category}\n  words: ${countWords(draft.content)}\n  judge: PASS\n  excerpt: ${draft.excerpt}\n  meta: ${draft.meta_description}\n\n  preview: ${draft.content.slice(0, 400)}`,
+		);
+		return;
+	}
+
+	// 3c. dedupe (BLOG-09a): skip cleanly if a post already exists at this slug
+	// (any status) — avoids burning a full local-LLM generation into the ingest
+	// EF's 409 backstop on a scheduled re-run. The 409 stays as defense-in-depth.
+	const slugExists = await blogSlugExists(
+		(s) => supabase.from("blogs").select("slug").eq("slug", s).limit(1),
+		draft.slug,
+	);
+	if (slugExists) {
+		console.log(
+			`slug "${draft.slug}" already exists in public.blogs — skipping (no POST).`,
 		);
 		return;
 	}

--- a/src/lib/seo/__tests__/evergreen-topics.test.ts
+++ b/src/lib/seo/__tests__/evergreen-topics.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { EVERGREEN_TOPICS } from "../evergreen-topics";
+
+// Local copy of the valid categories — do NOT import from scripts/ (scripts must
+// never become a runtime dependency of src/). Must match VALID_CATEGORIES in
+// scripts/generate-blog-draft.ts (and the reclaim-queue drift guard).
+const VALID_CATEGORIES = new Set([
+	"lease-law",
+	"tax-prep",
+	"tenant-screening",
+	"maintenance",
+	"software-vault",
+]);
+
+describe("EVERGREEN_TOPICS", () => {
+	it("is a non-empty list", () => {
+		expect(EVERGREEN_TOPICS.length).toBeGreaterThan(0);
+	});
+
+	it("every entry uses a valid generator category", () => {
+		for (const { topic, category } of EVERGREEN_TOPICS) {
+			expect(
+				VALID_CATEGORIES.has(category),
+				`invalid category for "${topic}"`,
+			).toBe(true);
+		}
+	});
+
+	it("every topic is a non-empty, trimmed string", () => {
+		for (const { topic } of EVERGREEN_TOPICS) {
+			expect(topic.length).toBeGreaterThan(0);
+			expect(topic).toBe(topic.trim());
+		}
+	});
+
+	it("topics are unique (no duplicate seeds)", () => {
+		const topics = EVERGREEN_TOPICS.map((entry) => entry.topic);
+		expect(new Set(topics).size).toBe(topics.length);
+	});
+});

--- a/src/lib/seo/evergreen-topics.ts
+++ b/src/lib/seo/evergreen-topics.ts
@@ -1,0 +1,73 @@
+// Evergreen topic source for the v5.0 blog factory (BLOG-09c).
+// The n8n Schedule Trigger draws topics in priority order: the Phase-13
+// `RECLAIM_QUEUE` (src/lib/seo/reclaim-queue.ts) FIRST — highest SEO value, it
+// reclaims deleted high-impression ghost slugs — then this evergreen list once
+// the reclaim queue is worked through. Unlike reclaim, evergreen entries let the
+// model choose the slug (no fixed `slug` field), so they need no redirect mapping.
+//
+// The Phase-14 pre-POST dedup check (`blogSlugExists` in
+// scripts/generate-blog-draft.ts) makes re-picking an already-generated slug a
+// clean no-op skip (exit 0, no wasted local-LLM generation), so the schedule can
+// cycle this list safely.
+//
+// `category` is the closest of the five valid generator categories
+// (lease-law | tax-prep | tenant-screening | maintenance | software-vault); the
+// owner passes it to the generator at run time. Topics are genuinely useful
+// independent-landlord subjects — never rent-facilitation / tenant-portal framing.
+
+export interface EvergreenTopic {
+	readonly topic: string;
+	readonly category: string;
+}
+
+export const EVERGREEN_TOPICS: readonly EvergreenTopic[] = [
+	{
+		topic:
+			"A state-by-state lease clause checklist every first-time landlord should review",
+		category: "lease-law",
+	},
+	{
+		topic:
+			"How to write an enforceable late-fee and notice-to-quit clause that holds up",
+		category: "lease-law",
+	},
+	{
+		topic: "A Schedule E deduction walkthrough for small landlords at tax time",
+		category: "tax-prep",
+	},
+	{
+		topic:
+			"Repairs vs capital improvements: classifying rental expenses correctly for taxes",
+		category: "tax-prep",
+	},
+	{
+		topic:
+			"How to read a credit report on a rental application without missing red flags",
+		category: "tenant-screening",
+	},
+	{
+		topic:
+			"Building a fair, consistent applicant-screening checklist that avoids fair-housing risk",
+		category: "tenant-screening",
+	},
+	{
+		topic:
+			"A seasonal preventive-maintenance calendar for small rental portfolios",
+		category: "maintenance",
+	},
+	{
+		topic:
+			"Handling emergency maintenance requests without losing your weekend",
+		category: "maintenance",
+	},
+	{
+		topic:
+			"Organizing lease, insurance, and inspection documents so nothing slips through the cracks",
+		category: "software-vault",
+	},
+	{
+		topic:
+			"What records every landlord should keep, and exactly how long to keep them",
+		category: "software-vault",
+	},
+];


### PR DESCRIPTION
## Phase 14 — Cadence, Dedupe & Monitoring (v5.0 FINALE, BLOG-09)

The sustainability wrapper that lets the engine run unattended. **Closes BLOG-09 and completes v5.0.**

### 14-01 — Dedup + greppable failure output (BLOG-09a/b)
- **Pre-POST slug dedup:** before the HMAC POST (after the judge gate + slug override + dry-run return), the generator probes `public.blogs` for the draft slug (any status). If it exists → **clean skip** (logs, exit 0, no POST) instead of burning a full local-LLM generation into the ingest EF's 409 backstop (which stays as defense-in-depth). `blogSlugExists` takes a probe closure — decoupled from the deeply-generic `SupabaseClient` type (avoids TS2589) — does a read-only SELECT of the slug column only, and throws on a PostgREST error.
- **Greppable failures:** `fail()` emits `BLOG-GEN-FAIL: <reason>` via exported `formatGenFailure`, so an n8n run log can be grepped for the cause.

### 14-02 — Evergreen source + cadence/cost docs (BLOG-09c)
- **`EVERGREEN_TOPICS`** — 10 useful independent-landlord topics across the 5 categories, the secondary topic source after `RECLAIM_QUEUE`. Drift-guarded (valid categories, unique trimmed topics, no `scripts/` import). The dedup makes re-picking a slug a clean skip.
- **`n8n/README.md`** (gitignored owner docs, not in this diff) — refined the cadence to a sustainable few-posts/week (reclaim-then-evergreen), documented the **Error-Trigger** notify wiring (`app_config` key `blog_factory_alert_url`, bearer-verified, no secret in source) surfacing `BLOG-GEN-FAIL`, and the **runaway/cost guards** (one post/invocation, `MAX_CRITIQUE` + 4-attempt bound, dedup skip, in-review backstop, local-LLM-is-free).

### Verification
- `typecheck` + `biome` clean · **dedup (3) + failure-output (1) + evergreen drift-guard (4)** tests + the full marketing landlord-only guard green · every commit through the full pre-commit hook.

[hudsor01]
