### PR TITLE
feat(blog): 1,000-topic canonical bank + zero-waste scheduled runner

### DIFF
--- a/scripts/blog-topics.json
+++ b/scripts/blog-topics.json
@@ -1,0 +1,6002 @@
+[
+	{
+		"topic": "Apartments.com vs RentRedi: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "apartments-com-vs-rentredi-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "AppFolio alternatives under $20/month for rental property management",
+		"category": "software-vault",
+		"slug": "appfolio-alternatives-under-20-month-for-rental-property-management",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "AppFolio alternatives under $25/month for first-time landlords",
+		"category": "software-vault",
+		"slug": "appfolio-alternatives-under-25-month-for-first-time-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "AppFolio vs Hemlane: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "appfolio-vs-hemlane-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Best property management software for commercial landlords",
+		"category": "software-vault",
+		"slug": "best-property-management-software-for-commercial-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Best property management software for remote landlords",
+		"category": "software-vault",
+		"slug": "best-property-management-software-for-remote-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Blockchain in real estate explained: a level-headed landlord's overview",
+		"category": "software-vault",
+		"slug": "blockchain-in-real-estate-explained-a-landlord-s-guide-to-the-future",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "The BRRRR method explained for multi-family property investors",
+		"category": "software-vault",
+		"slug": "brrrr-method-explained-for-property-investors-a-multi-family-investor-s-guide",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "The BRRRR method explained for remote landlords",
+		"category": "software-vault",
+		"slug": "brrrr-method-explained-for-remote-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Buildium alternatives under $40/month for first-time landlords",
+		"category": "software-vault",
+		"slug": "buildium-alternatives-under-40-month-for-first-time-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Buildium vs Landlord Studio: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "buildium-vs-landlord-studio-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Communication tools for long-distance landlords",
+		"category": "software-vault",
+		"slug": "communication-tools-for-distant-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to document property condition properly: a landlord's guide",
+		"category": "maintenance",
+		"slug": "documenting-property-condition-properly-a-landlord-s-guide-to-smart-rental-management",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "DoorLoop alternatives under $40/month for single-property owners",
+		"category": "software-vault",
+		"slug": "doorloop-alternatives-under-40-month-for-single-property-owners",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "DoorLoop review: is it worth the price for professional landlords?",
+		"category": "software-vault",
+		"slug": "doorloop-review-is-it-worth-the-price-for-professional-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Essential property management tips for small landlords",
+		"category": "software-vault",
+		"slug": "essential-property-management-tips-for-small-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Financial reports every landlord needs",
+		"category": "tax-prep",
+		"slug": "financial-reports-every-landlord-needs",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Free property management software options in 2025",
+		"category": "software-vault",
+		"slug": "free-property-management-software-options-in-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Handling inspection disputes with tenants: a landlord's guide",
+		"category": "maintenance",
+		"slug": "handling-inspection-disputes-with-tenants",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Hemlane alternatives under $25/month: property management software for landlords",
+		"category": "software-vault",
+		"slug": "hemlane-alternatives-under-25-month-best-property-management-software-for-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Hemlane review: is it worth the price for tech-savvy landlords?",
+		"category": "software-vault",
+		"slug": "hemlane-review-is-it-worth-the-price-for-tech-savvy-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to increase rental income by 5% as a single-property owner",
+		"category": "software-vault",
+		"slug": "how-to-increase-rental-income-by-5-as-a-single-property-owner",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to increase rental income by 50%: a realistic look at what it takes",
+		"category": "software-vault",
+		"slug": "how-to-increase-rental-income-by-50-without-losing-your-sanity",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to manage one rental property without expensive software",
+		"category": "software-vault",
+		"slug": "how-to-manage-1-rental-property-without-expensive-software",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to manage three rental properties without expensive property software",
+		"category": "software-vault",
+		"slug": "how-to-manage-3-rental-properties-without-expensive-property-software",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to manage 50 rental properties without expensive software",
+		"category": "software-vault",
+		"slug": "how-to-manage-50-rental-properties-without-expensive-software",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to scale from 10 to 20 rental properties: a commercial landlord's guide",
+		"category": "software-vault",
+		"slug": "how-to-scale-from-10-to-20-rental-properties-a-commercial-landlord-s-guide",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "How to scale from 3 to 6 rental properties",
+		"category": "software-vault",
+		"slug": "how-to-scale-from-3-to-6-rental-properties",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Scaling from 50 to 500 rental properties: what actually has to change",
+		"category": "software-vault",
+		"slug": "how-to-scale-from-50-to-500-rental-properties-without-losing-your-mind",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Innago vs Buildium: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "innago-vs-buildium-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Landlord Studio review: is it worth the price for first-time landlords?",
+		"category": "software-vault",
+		"slug": "landlord-studio-review-is-it-worth-the-price-for-first-time-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Landlord Studio vs ResMan: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "landlord-studio-vs-resman-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Landlord Studio vs SimplifyEm: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "landlord-studio-vs-simplifyem-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Managing contractors from a distance",
+		"category": "maintenance",
+		"slug": "managing-contractors-from-a-distance",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Photography tips for rental listings",
+		"category": "software-vault",
+		"slug": "photography-tips-for-rental-listings",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Property management for out-of-state landlords",
+		"category": "software-vault",
+		"slug": "property-management-for-out-of-state-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Propertyware vs ResMan: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "propertyware-vs-resman-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Propertyware vs SimplifyEm: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "propertyware-vs-simplifyem-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Propertyware vs Zillow Rental Manager: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "propertyware-vs-zillow-rental-manager-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Rent Manager alternatives under $100/month",
+		"category": "software-vault",
+		"slug": "rent-manager-alternatives-under-100-month",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Rent Manager pricing breakdown and hidden fees: what to know before you subscribe",
+		"category": "software-vault",
+		"slug": "rent-manager-pricing-breakdown-and-hidden-fees-what-you-need-to-know-before-you-subscribe",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Rent Manager vs ResMan: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "rent-manager-vs-resman-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Rentec Direct alternatives under $75/month for tech-savvy landlords",
+		"category": "software-vault",
+		"slug": "rentec-direct-alternatives-under-75-month-for-tech-savvy-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Rentec Direct vs Apartments.com: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "rentec-direct-vs-apartments-com-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Rentec Direct vs Avail: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "rentec-direct-vs-avail-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "RentRedi alternatives under $30/month for budget-conscious landlords",
+		"category": "software-vault",
+		"slug": "rentredi-alternatives-under-30-month-for-budget-conscious-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "RentRedi pricing breakdown and hidden fees: what every small landlord needs to know",
+		"category": "software-vault",
+		"slug": "rentredi-pricing-breakdown-and-hidden-fees-what-every-small-landlord-needs-to-know",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "ResMan vs Rent Manager: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "resman-vs-rent-manager-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Scaling from 10 to 100 rental properties: a landlord's growth blueprint",
+		"category": "software-vault",
+		"slug": "scaling-from-10-to-100-rental-properties-a-landlord-s-growth-blueprint",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Scaling from 10 to 20 rental properties: a self-managing landlord's guide",
+		"category": "software-vault",
+		"slug": "scaling-from-10-to-20-rental-properties-a-self-managing-landlord-s-guide",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Scaling from 5 to 15 rental properties: landlord tips for growth without burning out",
+		"category": "software-vault",
+		"slug": "scaling-from-5-to-15-rental-properties-landlord-tips-for-growth-without-burning-out",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Security systems for remote monitoring: essential tips for self-managing landlords",
+		"category": "maintenance",
+		"slug": "security-systems-for-remote-monitoring-essential-tips-for-self-managing-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "SimplifyEm pricing breakdown and hidden fees: what every property investor needs to know",
+		"category": "software-vault",
+		"slug": "simplifyem-pricing-breakdown-and-hidden-fees-what-every-property-investor-needs-to-know",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "SimplifyEm vs Avail: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "simplifyem-vs-avail-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Stessa vs AppFolio: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "stessa-vs-appfolio-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Stessa vs RentRedi: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "stessa-vs-rentredi-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Stessa vs SimplifyEm: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "stessa-vs-simplifyem-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Stessa vs TurboTenant: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "stessa-vs-turbotenant-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Tenant screening checklist for multi-family investors",
+		"category": "tenant-screening",
+		"slug": "tenant-screening-checklist-for-multi-family-investors",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "TenantCloud alternatives under $40/month",
+		"category": "software-vault",
+		"slug": "tenantcloud-alternatives-under-40-month",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "TenantCloud vs Stessa: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "tenantcloud-vs-stessa-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Coverage gaps landlords often miss and how to fix them with organized property management",
+		"category": "software-vault",
+		"slug": "tenantflow-coverage-gaps-landlords-often-miss-and-how-to-fix-them-with-smart-property-management",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "TenantFlow pricing vs competitors: a beginner landlord's guide",
+		"category": "software-vault",
+		"slug": "tenantflow-pricing-vs-competitors-a-landlord-s-guide-for-beginners",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "TenantFlow vs DoorLoop: a complete comparison for first-time landlords",
+		"category": "software-vault",
+		"slug": "tenantflow-vs-doorloop-complete-comparison-for-first-time-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "TenantFlow vs Hemlane: a complete comparison for commercial landlords",
+		"category": "software-vault",
+		"slug": "tenantflow-vs-hemlane-complete-comparison-for-commercial-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "TenantFlow vs Hemlane for commercial landlords: 2025 comparison",
+		"category": "software-vault",
+		"slug": "tenantflow-vs-hemlane-complete-comparison-for-commercial-landlords-in-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Picking the one property management app you need as a first-time landlord",
+		"category": "software-vault",
+		"slug": "top-1-property-management-app-for-first-time-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Picking the one property management app you need as a single-property owner",
+		"category": "software-vault",
+		"slug": "top-1-property-management-app-for-single-property-owners",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 10 budget-friendly property management apps for multi-family investors",
+		"category": "software-vault",
+		"slug": "top-10-property-management-apps-for-multi-family-investors-budget-friendly-options",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 10 property management apps for single-property owners",
+		"category": "software-vault",
+		"slug": "top-10-property-management-apps-for-single-property-owners",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "100 property management apps for first-time landlords: the complete list",
+		"category": "software-vault",
+		"slug": "top-100-property-management-apps-for-first-time-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "100 property management apps for real estate beginners: the complete list",
+		"category": "software-vault",
+		"slug": "top-100-property-management-apps-for-real-estate-beginners",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "100 property management apps for self-managing landlords: the complete list",
+		"category": "software-vault",
+		"slug": "top-100-property-management-apps-for-self-managing-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 20 property management apps for DIY landlords",
+		"category": "software-vault",
+		"slug": "top-20-property-management-apps-for-diy-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 3 property management apps for commercial landlords",
+		"category": "software-vault",
+		"slug": "top-3-property-management-apps-for-commercial-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 3 property management apps for professional landlords",
+		"category": "software-vault",
+		"slug": "top-3-property-management-apps-for-professional-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 5 property management apps for DIY landlords",
+		"category": "software-vault",
+		"slug": "top-5-property-management-apps-for-diy-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 5 property management apps for first-time landlords",
+		"category": "software-vault",
+		"slug": "top-5-property-management-apps-for-first-time-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 5 remote-friendly property management apps for first-time landlords",
+		"category": "software-vault",
+		"slug": "top-5-property-management-apps-for-first-time-landlords-remote-friendly",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Top 5 property management apps for small landlords",
+		"category": "software-vault",
+		"slug": "top-5-property-management-apps-for-small-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "50 property management apps for small landlords: the complete list",
+		"category": "software-vault",
+		"slug": "top-50-property-management-apps-for-small-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "50 budget-friendly, easy-to-use property management apps for small landlords",
+		"category": "software-vault",
+		"slug": "top-50-property-management-apps-for-small-landlords-budget-friendly-easy-to-use",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "TurboTenant vs Apartments.com: a complete comparison for 2025",
+		"category": "software-vault",
+		"slug": "turbotenant-vs-apartments-com-complete-comparison-for-2025",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Using Zapier for property management",
+		"category": "software-vault",
+		"slug": "using-zapier-for-property-management",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Vendor management for property owners: a beginner's guide",
+		"category": "maintenance",
+		"slug": "vendor-management-for-property-owners-a-beginner-s-guide",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Why DIY landlords pick TenantFlow: an honest look at fit, price, and tradeoffs",
+		"category": "software-vault",
+		"slug": "why-tenantflow-is-the-best-choice-for-diy-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Why small landlords pick TenantFlow: an honest look at fit, price, and tradeoffs",
+		"category": "software-vault",
+		"slug": "why-tenantflow-is-the-best-choice-for-small-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Why tech-savvy landlords pick TenantFlow: an honest look at fit, price, and tradeoffs",
+		"category": "software-vault",
+		"slug": "why-tenantflow-is-the-best-choice-for-tech-savvy-landlords",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Yardi Breeze alternatives under $100/month for multi-family investors",
+		"category": "software-vault",
+		"slug": "yardi-breeze-alternatives-under-100-month-for-multi-family-investors",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Yardi Breeze vs AppFolio: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "yardi-breeze-vs-appfolio-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Yardi Breeze vs Zillow Rental Manager: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "yardi-breeze-vs-zillow-rental-manager-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Zillow Rental Manager alternatives under $50/month",
+		"category": "software-vault",
+		"slug": "zillow-rental-manager-alternatives-under-50-month",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Zillow Rental Manager vs TenantCloud: a complete comparison for 2026",
+		"category": "software-vault",
+		"slug": "zillow-rental-manager-vs-tenantcloud-complete-comparison-for-2026",
+		"tier": "reclaim"
+	},
+	{
+		"topic": "Alabama security deposit law: the one-month cap and 60-day return deadline explained for landlords",
+		"category": "lease-law",
+		"slug": "alabama-security-deposit-law-one-month-cap-60-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to deduct mortgage interest on a rental property: Schedule E line 12 explained",
+		"category": "tax-prep",
+		"slug": "mortgage-interest-deduction-rental-property-schedule-e",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to read credit utilization on a tenant credit report (and what high balances really signal)",
+		"category": "tenant-screening",
+		"slug": "reading-credit-utilization-on-tenant-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Spring maintenance checklist for rental properties: 20 tasks that prevent summer emergencies",
+		"category": "maintenance",
+		"slug": "spring-rental-maintenance-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buildium vs AppFolio in 2026: which is overkill for landlords under 50 units?",
+		"category": "software-vault",
+		"slug": "buildium-vs-appfolio-2026-small-landlord-comparison",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Alaska security deposit rules: the two-month limit, return deadlines, and itemization requirements",
+		"category": "lease-law",
+		"slug": "alaska-security-deposit-rules-two-month-limit-return-deadlines",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting property taxes on a rental: why Schedule E escapes the SALT cap",
+		"category": "tax-prep",
+		"slug": "rental-property-tax-deduction-schedule-e-salt-cap",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Collections accounts on a rental application: which ones matter and which to overlook",
+		"category": "tenant-screening",
+		"slug": "collections-accounts-on-rental-applications-which-matter",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Summer maintenance checklist for rentals: cooling systems, pests, and exterior upkeep",
+		"category": "maintenance",
+		"slug": "summer-rental-maintenance-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "RentRedi vs TurboTenant for 2026: pricing, leases, and document handling compared",
+		"category": "software-vault",
+		"slug": "rentredi-vs-turbotenant-2026-comparison",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Arizona security deposit law: the 1.5-month cap and the 14-business-day return rule for landlords",
+		"category": "lease-law",
+		"slug": "arizona-security-deposit-law-cap-and-14-business-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Which landlord insurance premiums are deductible (and where they go on Schedule E)",
+		"category": "tax-prep",
+		"slug": "landlord-insurance-premium-deduction-schedule-e",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Medical debt on a tenant credit report: why it should not sink an otherwise strong applicant",
+		"category": "tenant-screening",
+		"slug": "medical-debt-on-tenant-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fall maintenance checklist for landlords: prepping your rental before the first freeze",
+		"category": "maintenance",
+		"slug": "fall-rental-maintenance-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hemlane vs DoorLoop for 2026: remote management support vs all-in-one depth",
+		"category": "software-vault",
+		"slug": "hemlane-vs-doorloop-2026-comparison",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Arkansas security deposit law: the two-month cap, 60-day returns, and the small-landlord exemption",
+		"category": "lease-law",
+		"slug": "arkansas-security-deposit-law-two-month-cap-60-day-returns",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Is PMI deductible on a rental property? How mortgage insurance works on Schedule E",
+		"category": "tax-prep",
+		"slug": "pmi-deduction-rental-property-mortgage-insurance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening applicants with a thin credit file: young renters, new immigrants, and cash-economy workers",
+		"category": "tenant-screening",
+		"slug": "screening-applicants-with-thin-credit-files",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Winter maintenance checklist for rental properties: pipes, heat, and ice management",
+		"category": "maintenance",
+		"slug": "winter-rental-maintenance-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Innago vs TenantCloud for 2026: what free really gets a small landlord",
+		"category": "software-vault",
+		"slug": "innago-vs-tenantcloud-2026-comparison",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "California security deposit law: the new one-month cap under AB 12 and the 21-day return rule",
+		"category": "lease-law",
+		"slug": "california-security-deposit-law-ab-12-one-month-cap-21-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting HOA fees and special assessments on a rental: expense vs capital",
+		"category": "tax-prep",
+		"slug": "hoa-fees-special-assessments-rental-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Chapter 7 vs Chapter 13 bankruptcy on a tenant credit report: timelines, signals, and screening responses",
+		"category": "tenant-screening",
+		"slug": "chapter-7-vs-chapter-13-bankruptcy-tenant-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Winterizing rentals in freeze-prone climates: a landlord's checklist for sub-zero stretches",
+		"category": "maintenance",
+		"slug": "freeze-prone-climate-rental-winterization-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Stessa vs Landlord Studio for 2026: finance-first tools compared for small landlords",
+		"category": "software-vault",
+		"slug": "stessa-vs-landlord-studio-2026-comparison",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Colorado security deposit rules: deposit caps and the one-month return window (60 days if the lease says so)",
+		"category": "lease-law",
+		"slug": "colorado-security-deposit-rules-cap-and-return-window",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting landlord-supplied utilities: gas, water, trash, and shared meters on Schedule E",
+		"category": "tax-prep",
+		"slug": "landlord-utilities-deduction-schedule-e",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Charge-offs on a tenant credit report: what they mean and how recency changes your risk math",
+		"category": "tenant-screening",
+		"slug": "charge-offs-on-tenant-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hurricane season prep for rental properties: a landlord's pre-storm maintenance checklist",
+		"category": "maintenance",
+		"slug": "hurricane-season-rental-property-prep-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Avail vs Zillow Rental Manager for 2026: listing reach vs lease management depth",
+		"category": "software-vault",
+		"slug": "avail-vs-zillow-rental-manager-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Connecticut security deposit law: the two-month cap, senior tenant exception, and interest requirements",
+		"category": "lease-law",
+		"slug": "connecticut-security-deposit-law-two-month-cap-interest",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting legal and accounting fees as a landlord: which professional services qualify",
+		"category": "tax-prep",
+		"slug": "legal-accounting-fees-landlord-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Reading late-payment patterns on a credit report: isolated slip vs chronic delinquency",
+		"category": "tenant-screening",
+		"slug": "late-payment-patterns-on-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Wildfire zone maintenance for landlords: defensible space and ember-resistant upgrades",
+		"category": "maintenance",
+		"slug": "wildfire-zone-rental-defensible-space-maintenance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rentec Direct vs Yardi Breeze for 2026: legacy depth against modern simplicity",
+		"category": "software-vault",
+		"slug": "rentec-direct-vs-yardi-breeze-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Delaware security deposit law: the one-month cap on year leases and the 20-day return deadline",
+		"category": "lease-law",
+		"slug": "delaware-security-deposit-law-one-month-cap-20-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Are eviction legal fees and court costs tax deductible for landlords?",
+		"category": "tax-prep",
+		"slug": "eviction-legal-fees-tax-deductible-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hard inquiries on an applicant credit report: when a cluster is a red flag and when it is not",
+		"category": "tenant-screening",
+		"slug": "hard-inquiries-on-applicant-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Humid-South rental maintenance: controlling mold, moisture, and termites year-round",
+		"category": "maintenance",
+		"slug": "humid-south-rental-mold-moisture-maintenance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rent Manager vs Propertyware for 2026: are these enterprise tools too much for you?",
+		"category": "software-vault",
+		"slug": "rent-manager-vs-propertyware-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Florida security deposit law: no cap, the 15/30-day return rules, and the claim notice landlords must send",
+		"category": "lease-law",
+		"slug": "florida-security-deposit-law-return-rules-claim-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The landlord travel deduction: local trips, out-of-town visits, and what the IRS allows",
+		"category": "tax-prep",
+		"slug": "landlord-travel-deduction-local-out-of-town",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why the credit score alone misleads landlords: reading the full report behind the number",
+		"category": "tenant-screening",
+		"slug": "why-credit-score-alone-misleads-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rental water heater maintenance: annual flushes, anode rods, and TPR valve testing",
+		"category": "maintenance",
+		"slug": "rental-water-heater-maintenance-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "SimplifyEm vs Rentec Direct for 2026: which suits hands-on small landlords?",
+		"category": "software-vault",
+		"slug": "simplifyem-vs-rentec-direct-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Georgia security deposit law: escrow rules, move-in inspection lists, and the 30-day return deadline",
+		"category": "lease-law",
+		"slug": "georgia-security-deposit-law-escrow-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Standard mileage vs actual expenses for landlord vehicle deductions, with log requirements",
+		"category": "tax-prep",
+		"slug": "standard-mileage-vs-actual-expenses-landlord-vehicle",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Student loan debt on rental applications: deferment, income-driven plans, and what counts against DTI",
+		"category": "tenant-screening",
+		"slug": "student-loan-debt-on-rental-applications",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Furnace maintenance for rentals: the pre-season tune-up that prevents winter no-heat calls",
+		"category": "maintenance",
+		"slug": "rental-furnace-pre-season-tune-up",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buildium vs DoorLoop for 2026: pricing tiers, contracts, and ease of setup",
+		"category": "software-vault",
+		"slug": "buildium-vs-doorloop-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hawaii security deposit law: the one-month cap, pet deposit rules, and the 14-day return deadline",
+		"category": "lease-law",
+		"slug": "hawaii-security-deposit-law-one-month-cap-14-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The home office deduction for landlords: exclusive-use test, simplified method, and pitfalls",
+		"category": "tax-prep",
+		"slug": "home-office-deduction-landlords-exclusive-use",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Authorized user accounts: how they inflate an applicant credit profile and how to spot them",
+		"category": "tenant-screening",
+		"slug": "authorized-user-accounts-inflated-credit-profiles",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Central AC maintenance for rental properties: coils, capacitors, and refrigerant basics",
+		"category": "maintenance",
+		"slug": "rental-central-ac-maintenance-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "AppFolio vs Yardi Breeze for 2026: minimums, onboarding, and who they really serve",
+		"category": "software-vault",
+		"slug": "appfolio-vs-yardi-breeze-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Idaho security deposit law: the 21-day default return deadline and how leases can extend it to 30",
+		"category": "lease-law",
+		"slug": "idaho-security-deposit-law-21-day-return-deadline",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting advertising and listing costs when filling a rental vacancy",
+		"category": "tax-prep",
+		"slug": "advertising-listing-costs-rental-vacancy-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why most evictions never appear on credit reports (and where eviction records actually live)",
+		"category": "tenant-screening",
+		"slug": "why-evictions-dont-appear-on-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rental roof inspections: what to check twice a year and when to call a roofer",
+		"category": "maintenance",
+		"slug": "rental-roof-inspection-what-to-check",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TurboTenant vs Zillow Rental Manager for 2026: two free tools, two very different limits",
+		"category": "software-vault",
+		"slug": "turbotenant-vs-zillow-rental-manager-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Illinois security deposit law: the Return Act's 30/45-day deadlines and when Chicago's RLTO applies",
+		"category": "lease-law",
+		"slug": "illinois-security-deposit-law-return-act-chicago-rlto",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting property management fees and leasing commissions on Schedule E",
+		"category": "tax-prep",
+		"slug": "property-management-fees-leasing-commissions-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Auto repossessions on a tenant credit report: severity, recency, and what to ask the applicant",
+		"category": "tenant-screening",
+		"slug": "auto-repossessions-on-tenant-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Gutter maintenance for rental properties: cleaning schedules, ice dams, and foundation damage",
+		"category": "maintenance",
+		"slug": "rental-gutter-maintenance-ice-dams-foundation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Innago vs Avail for 2026: free landlord platforms compared feature by feature",
+		"category": "software-vault",
+		"slug": "innago-vs-avail-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Indiana security deposit law: the 45-day return deadline and itemized damage list requirements",
+		"category": "lease-law",
+		"slug": "indiana-security-deposit-law-45-day-return-itemization",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Can landlords deduct property management software and other subscriptions? Here's how",
+		"category": "tax-prep",
+		"slug": "property-management-software-subscription-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "A past foreclosure on a rental applicant credit report: lasting risk signal or fresh-start renter?",
+		"category": "tenant-screening",
+		"slug": "foreclosure-on-rental-applicant-credit-report",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sump pump maintenance for rentals: testing routines, battery backups, and flood prevention",
+		"category": "maintenance",
+		"slug": "rental-sump-pump-maintenance-testing-backup",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hemlane vs RentRedi for 2026: which fits a self-managing landlord better?",
+		"category": "software-vault",
+		"slug": "hemlane-vs-rentredi-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Iowa security deposit law: the two-month cap, 30-day return deadline, and allowable deductions",
+		"category": "lease-law",
+		"slug": "iowa-security-deposit-law-two-month-cap-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting supplies and small tools as a landlord: where the de minimis rule helps",
+		"category": "tax-prep",
+		"slug": "supplies-small-tools-landlord-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Disputed accounts and consumer statements on credit reports: how landlords should weigh them",
+		"category": "tenant-screening",
+		"slug": "disputed-accounts-and-consumer-statements-credit-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Dryer vent cleaning in rentals: the overlooked fire risk landlords are responsible for",
+		"category": "maintenance",
+		"slug": "rental-dryer-vent-cleaning-fire-risk",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Landlord Studio vs TenantCloud for 2026: mobile-first vs browser-first management",
+		"category": "software-vault",
+		"slug": "landlord-studio-vs-tenantcloud-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Kansas security deposit law: the one-month cap for unfurnished rentals and the 30-day return rule",
+		"category": "lease-law",
+		"slug": "kansas-security-deposit-law-one-month-cap-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting part of your cell phone and internet as a landlord: the business-use split",
+		"category": "tax-prep",
+		"slug": "cell-phone-internet-partial-deduction-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Credit freezes and fraud alerts on applicant files: what they mean and how to proceed",
+		"category": "tenant-screening",
+		"slug": "credit-freezes-and-fraud-alerts-on-applicant-files",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Smoke and CO detector maintenance in rentals: testing schedules, placement, and expiration dates",
+		"category": "maintenance",
+		"slug": "rental-smoke-co-detector-maintenance-schedule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Stessa vs TurboTenant for 2026: finance tracker or leasing toolkit first?",
+		"category": "software-vault",
+		"slug": "stessa-vs-turbotenant-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Kentucky security deposit law: URLTA jurisdictions, separate account rules, and return deadlines",
+		"category": "lease-law",
+		"slug": "kentucky-security-deposit-law-urlta-return-deadlines",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting landlord education: books, courses, and seminars that pass the IRS test",
+		"category": "tax-prep",
+		"slug": "landlord-education-books-courses-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "VantageScore vs FICO vs ResidentScore: which number your tenant screening report actually shows",
+		"category": "tenant-screening",
+		"slug": "vantagescore-vs-fico-vs-residentscore-screening-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Garbage disposal maintenance and tenant education: ending the most common service call",
+		"category": "maintenance",
+		"slug": "rental-garbage-disposal-maintenance-tenant-education",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "DoorLoop vs TenantCloud for 2026: comparing real value at the 10-unit mark",
+		"category": "software-vault",
+		"slug": "doorloop-vs-tenantcloud-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Louisiana security deposit law: the 30-day return deadline and willful-noncompliance damages",
+		"category": "lease-law",
+		"slug": "louisiana-security-deposit-law-30-day-return-deadline",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Amortizing loan points on a rental mortgage: deducting costs over the loan term",
+		"category": "tax-prep",
+		"slug": "amortizing-loan-points-rental-mortgage",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Soft pull vs hard pull tenant screening: how each works and which protects your applicants",
+		"category": "tenant-screening",
+		"slug": "soft-pull-vs-hard-pull-tenant-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Window maintenance for rental properties: seals, screens, weep holes, and condensation",
+		"category": "maintenance",
+		"slug": "rental-window-maintenance-seals-screens",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buildium vs Rentec Direct for 2026: which one earns its monthly minimum?",
+		"category": "software-vault",
+		"slug": "buildium-vs-rentec-direct-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maine security deposit law: the two-month cap and the 30-day return deadline (21 for tenancies at will)",
+		"category": "lease-law",
+		"slug": "maine-security-deposit-law-two-month-cap-return-deadlines",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rental property closing costs: which are deductible, amortized, or added to basis",
+		"category": "tax-prep",
+		"slug": "rental-closing-costs-deductible-amortized-basis",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "A landlord walkthrough of credit report tradelines: account types, status codes, and account age",
+		"category": "tenant-screening",
+		"slug": "landlord-walkthrough-credit-report-tradelines",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deck safety inspections for rentals: ledger boards, railings, and rot checks landlords can't skip",
+		"category": "maintenance",
+		"slug": "rental-deck-safety-inspection-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "AppFolio vs Rent Manager for 2026: an honest look for landlords who feel out-priced",
+		"category": "software-vault",
+		"slug": "appfolio-vs-rent-manager-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maryland security deposit law: the lowered deposit cap, 45-day return rule, and interest requirements",
+		"category": "lease-law",
+		"slug": "maryland-security-deposit-law-45-day-return-interest",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting repairs on Schedule E line 14: what qualifies as an ordinary repair",
+		"category": "tax-prep",
+		"slug": "repairs-deduction-schedule-e-line-14",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Calculating debt-to-income from a credit report: a step-by-step method for landlords",
+		"category": "tenant-screening",
+		"slug": "calculating-debt-to-income-from-credit-report",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Driveway and walkway maintenance for rentals: sealing, crack repair, and trip-hazard liability",
+		"category": "maintenance",
+		"slug": "rental-driveway-walkway-maintenance-liability",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "RentRedi vs Innago for 2026: subscription vs free, and what each trade-off means",
+		"category": "software-vault",
+		"slug": "rentredi-vs-innago-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Massachusetts security deposit law: the one-month cap, interest, receipts, and the strict 30-day return rule",
+		"category": "lease-law",
+		"slug": "massachusetts-security-deposit-law-one-month-cap-strict-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting routine upkeep: landscaping, pest control, and snow removal for rentals",
+		"category": "tax-prep",
+		"slug": "routine-upkeep-landscaping-pest-control-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What income documents to request with every application: building a standardized verification packet",
+		"category": "tenant-screening",
+		"slug": "standardized-income-verification-document-packet",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Irrigation system maintenance for rentals: spring start-up, leak checks, and fall blowouts",
+		"category": "maintenance",
+		"slug": "rental-irrigation-system-maintenance-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Avail vs TenantCloud for 2026: which handles leases and documents better?",
+		"category": "software-vault",
+		"slug": "avail-vs-tenantcloud-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Michigan security deposit law: the 1.5-month cap, inventory checklists, and the 30-day itemization rule",
+		"category": "lease-law",
+		"slug": "michigan-security-deposit-law-cap-checklist-itemization",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Schedule E line 19 'other expenses': legitimate write-offs landlords overlook",
+		"category": "tax-prep",
+		"slug": "schedule-e-line-19-other-expenses-examples",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Spotting fake paystubs: the tells landlords miss, from rounded tax math to font mismatches",
+		"category": "tenant-screening",
+		"slug": "spotting-fake-paystubs-rental-applications",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sewer line maintenance for rental properties: camera inspections, root intrusion, and backups",
+		"category": "maintenance",
+		"slug": "rental-sewer-line-maintenance-camera-inspection",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hemlane vs Landlord Studio for 2026: management support vs financial reporting",
+		"category": "software-vault",
+		"slug": "hemlane-vs-landlord-studio-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Minnesota security deposit law: the 21-day return deadline, required interest, and itemization rules",
+		"category": "lease-law",
+		"slug": "minnesota-security-deposit-law-21-day-return-interest",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rental property depreciation 101: the 27.5-year straight-line method explained",
+		"category": "tax-prep",
+		"slug": "rental-depreciation-27-5-year-straight-line",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Using bank statements to verify applicant income: deposit patterns, averaging, and privacy boundaries",
+		"category": "tenant-screening",
+		"slug": "bank-statements-to-verify-applicant-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Electrical panel checks for rental properties: warning signs, recalled brands, and upgrade timing",
+		"category": "maintenance",
+		"slug": "rental-electrical-panel-warning-signs-upgrade",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Yardi Breeze vs Rent Manager for 2026: two heavyweights small landlords should question",
+		"category": "software-vault",
+		"slug": "yardi-breeze-vs-rent-manager-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mississippi security deposit law: the 45-day return deadline and wrongful-withholding penalties",
+		"category": "lease-law",
+		"slug": "mississippi-security-deposit-law-45-day-return-deadline",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to split land vs building value for depreciation (and defend it in an audit)",
+		"category": "tax-prep",
+		"slug": "land-vs-building-value-depreciation-allocation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to spot doctored bank statements: balance math, transaction gaps, and formatting tells",
+		"category": "tenant-screening",
+		"slug": "how-to-spot-doctored-bank-statements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The real cost of skipping HVAC filter changes in your rental, plus a schedule that sticks",
+		"category": "maintenance",
+		"slug": "cost-of-skipping-hvac-filter-changes-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Propertyware vs Buildium for 2026: single-family focus against broad portfolio tools",
+		"category": "software-vault",
+		"slug": "propertyware-vs-buildium-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Missouri security deposit law: the two-month cap, 30-day return rule, and the final inspection right",
+		"category": "lease-law",
+		"slug": "missouri-security-deposit-law-two-month-cap-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Bonus depreciation for landlords: what actually qualifies in a residential rental",
+		"category": "tax-prep",
+		"slug": "bonus-depreciation-residential-rental-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Verifying self-employed applicant income: tax returns, 1099s, and profit-and-loss statements",
+		"category": "tenant-screening",
+		"slug": "verifying-self-employed-applicant-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Caulk and grout maintenance in rentals: the cheap sealant schedule that prevents subfloor rot",
+		"category": "maintenance",
+		"slug": "rental-caulk-grout-maintenance-schedule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "SimplifyEm vs Landlord Studio for 2026: lightweight tools for landlords under 10 units",
+		"category": "software-vault",
+		"slug": "simplifyem-vs-landlord-studio-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Montana security deposit law: the 10- and 30-day return deadlines and cleaning deduction rules",
+		"category": "lease-law",
+		"slug": "montana-security-deposit-law-return-deadlines-deductions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Section 179 vs bonus depreciation for rental owners: the eligibility traps",
+		"category": "tax-prep",
+		"slug": "section-179-vs-bonus-depreciation-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Offer letters as income proof: verifying a new job before the first paycheck exists",
+		"category": "tenant-screening",
+		"slug": "offer-letters-as-income-proof",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Roof lifespan by material: how maintenance stretches asphalt, metal, and tile on rentals",
+		"category": "maintenance",
+		"slug": "roof-lifespan-by-material-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Zillow Rental Manager vs Innago for 2026: listing power vs management depth",
+		"category": "software-vault",
+		"slug": "zillow-rental-manager-vs-innago-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Nebraska security deposit law: the one-month cap, pet deposit allowance, and 14-day return deadline",
+		"category": "lease-law",
+		"slug": "nebraska-security-deposit-law-one-month-cap-14-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Cost segregation for small landlords: when a study pays for itself",
+		"category": "tax-prep",
+		"slug": "cost-segregation-small-landlords-when-worth-it",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening gig workers: verifying rideshare and delivery income that changes every week",
+		"category": "tenant-screening",
+		"slug": "screening-gig-workers-variable-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Washing machine hose replacement: the five-year schedule that prevents catastrophic floods",
+		"category": "maintenance",
+		"slug": "washing-machine-hose-replacement-schedule-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Stessa vs Avail for 2026: which gap does each one leave in your landlord stack?",
+		"category": "software-vault",
+		"slug": "stessa-vs-avail-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Nevada security deposit law: the three-month cap, the 30-day return deadline, and surety bond options",
+		"category": "lease-law",
+		"slug": "nevada-security-deposit-law-three-month-cap-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Depreciation recapture explained: the Section 1250 tax bill waiting when you sell",
+		"category": "tax-prep",
+		"slug": "depreciation-recapture-section-1250-rental-sale",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The employment verification call: what HR will actually confirm and how to phrase your questions",
+		"category": "tenant-screening",
+		"slug": "employment-verification-call-what-hr-confirms",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Braided supply lines and angle stops: the quiet leak sources to replace on a schedule",
+		"category": "maintenance",
+		"slug": "braided-supply-lines-angle-stops-replacement-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TurboTenant vs Avail for first-time landlords in 2026: a look beyond the usual comparison",
+		"category": "software-vault",
+		"slug": "turbotenant-vs-avail-first-time-landlords-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New Hampshire security deposit law: the one-month-or-100-dollar cap and the 30-day return deadline",
+		"category": "lease-law",
+		"slug": "new-hampshire-security-deposit-law-cap-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Depreciating appliances, carpet, and furniture: 5-year and 7-year property in rentals",
+		"category": "tax-prep",
+		"slug": "depreciating-appliances-carpet-furniture-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Qualifying applicants with seasonal or variable income: averaging methods that hold up",
+		"category": "tenant-screening",
+		"slug": "qualifying-applicants-with-seasonal-variable-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "AC condensate line clogs: the cheap monthly habit that prevents ceiling damage below air handlers",
+		"category": "maintenance",
+		"slug": "ac-condensate-line-clog-prevention-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "DoorLoop vs Innago for 2026: revisiting the matchup now that both have matured",
+		"category": "software-vault",
+		"slug": "doorloop-vs-innago-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New Jersey security deposit law: the 1.5-month cap, annual interest notices, and 30-day returns",
+		"category": "lease-law",
+		"slug": "new-jersey-security-deposit-law-cap-interest-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The mid-month convention: how first-year and final-year rental depreciation is prorated",
+		"category": "tax-prep",
+		"slug": "mid-month-convention-rental-depreciation-proration",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Verifying retirement income on rental applications: Social Security letters, pensions, and annuities",
+		"category": "tenant-screening",
+		"slug": "verifying-retirement-income-rental-applicants",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Refrigerator coil cleaning and door gaskets: extending appliance life in rental units",
+		"category": "maintenance",
+		"slug": "refrigerator-coil-cleaning-rental-appliance-life",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buildium vs TurboTenant for 2026: professional suite or starter toolkit?",
+		"category": "software-vault",
+		"slug": "buildium-vs-turbotenant-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New Mexico security deposit law: deposit limits on short leases, interest rules, and 30-day returns",
+		"category": "lease-law",
+		"slug": "new-mexico-security-deposit-law-limits-interest-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Missed depreciation? Fixing it with Form 3115 instead of amending old returns",
+		"category": "tax-prep",
+		"slug": "missed-depreciation-form-3115-fix",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening housing voucher applicants legally: source-of-income laws and the payment standard",
+		"category": "tenant-screening",
+		"slug": "screening-housing-voucher-applicants-legally",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Exterior paint and siding maintenance cycles: how deferral compounds into wood rot",
+		"category": "maintenance",
+		"slug": "exterior-paint-siding-maintenance-cycle-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "RentRedi vs DoorLoop for 2026: monthly cost, contracts, and feature overlap",
+		"category": "software-vault",
+		"slug": "rentredi-vs-doorloop-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New York security deposit law after the HSTPA: the one-month cap and the 14-day return deadline",
+		"category": "lease-law",
+		"slug": "new-york-security-deposit-law-hstpa-one-month-cap-14-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Depreciating capital improvements separately from the building: a worked example",
+		"category": "tax-prep",
+		"slug": "depreciating-capital-improvements-separately",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Counting child support and alimony as qualifying income: documentation that actually verifies",
+		"category": "tenant-screening",
+		"slug": "child-support-alimony-as-qualifying-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Chimney and fireplace maintenance for rentals: sweep schedules, liners, and liability",
+		"category": "maintenance",
+		"slug": "rental-chimney-fireplace-maintenance-schedule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hemlane vs TenantCloud for 2026: hybrid management against pure DIY software",
+		"category": "software-vault",
+		"slug": "hemlane-vs-tenantcloud-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "North Carolina security deposit law: tiered caps by tenancy length and the 30/60-day return rules",
+		"category": "lease-law",
+		"slug": "north-carolina-security-deposit-law-tiered-caps-return-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Land improvements on rentals: fences, driveways, and the 15-year depreciation class",
+		"category": "tax-prep",
+		"slug": "land-improvements-15-year-depreciation-fences-driveways",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The 3x rent-to-income rule: where it came from, when it fails, and defensible alternatives",
+		"category": "tenant-screening",
+		"slug": "the-3x-rent-to-income-rule-and-alternatives",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tree trimming schedule for rental properties: roof clearance, sewer roots, and storm risk",
+		"category": "maintenance",
+		"slug": "rental-tree-trimming-schedule-roof-sewer-storm",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TurboTenant vs RentRedi vs TenantFlow: which fits a 5-unit landlord in 2026?",
+		"category": "software-vault",
+		"slug": "turbotenant-vs-rentredi-vs-tenantflow-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "North Dakota security deposit law: the one-month cap, pet deposit add-ons, and the 30-day return rule",
+		"category": "lease-law",
+		"slug": "north-dakota-security-deposit-law-one-month-cap-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Form 4562 for landlords: when you must file it and how it ties to Schedule E",
+		"category": "tax-prep",
+		"slug": "form-4562-landlords-schedule-e",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Verifying commission-based income: W-2s, year-to-date paystubs, and a two-year earnings view",
+		"category": "tenant-screening",
+		"slug": "verifying-commission-based-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "A 12-month preventive maintenance calendar for single-family rental properties",
+		"category": "maintenance",
+		"slug": "twelve-month-preventive-maintenance-calendar-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buildium vs DoorLoop vs TenantFlow for 2026: total cost of ownership at 15 units",
+		"category": "software-vault",
+		"slug": "buildium-vs-doorloop-vs-tenantflow-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ohio security deposit law: 30-day returns, interest on large deposits, and double-damages risk",
+		"category": "lease-law",
+		"slug": "ohio-security-deposit-law-30-day-return-interest-damages",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Depreciation on an inherited rental: stepped-up basis and a fresh 27.5-year clock",
+		"category": "tax-prep",
+		"slug": "inherited-rental-stepped-up-basis-depreciation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Income verification for applicants who earn in cash: bank deposits, tax returns, and employer letters",
+		"category": "tenant-screening",
+		"slug": "income-verification-cash-earning-applicants",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deferred maintenance math: why small rental repairs compound into capital expenses",
+		"category": "maintenance",
+		"slug": "deferred-maintenance-cost-compounding-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Stessa vs Landlord Studio vs TenantFlow: documents, leases, and reporting compared",
+		"category": "software-vault",
+		"slug": "stessa-vs-landlord-studio-vs-tenantflow",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Oklahoma security deposit law: the escrow account requirement and the 45-day return deadline",
+		"category": "lease-law",
+		"slug": "oklahoma-security-deposit-law-escrow-45-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What happens to depreciation when a rental sits idle or you stop renting it",
+		"category": "tax-prep",
+		"slug": "depreciation-idle-rental-property",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Asset-based qualification: when savings can stand in for income on a rental application",
+		"category": "tenant-screening",
+		"slug": "asset-based-qualification-savings-instead-of-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Bathroom exhaust fan maintenance: the mold-prevention fix landlords keep ignoring",
+		"category": "maintenance",
+		"slug": "bathroom-exhaust-fan-maintenance-mold-prevention",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Avail vs Innago vs TenantFlow for 2026: three budget paths for small landlords",
+		"category": "software-vault",
+		"slug": "avail-vs-innago-vs-tenantflow-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Oregon security deposit law: the 31-day return deadline and what counts as a lawful deduction",
+		"category": "lease-law",
+		"slug": "oregon-security-deposit-law-31-day-return-deductions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Repairs vs improvements: the BAR test (betterment, adaptation, restoration) with examples",
+		"category": "tax-prep",
+		"slug": "repairs-vs-improvements-bar-test-examples",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Verifying military income: LES statements, BAH allowances, and what changes with PCS orders",
+		"category": "tenant-screening",
+		"slug": "verifying-military-income-les-bah",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to winterize a vacant rental property: a step-by-step shutdown checklist",
+		"category": "maintenance",
+		"slug": "winterize-vacant-rental-property-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Best Buildium alternatives for landlords with fewer than 20 units in 2026",
+		"category": "software-vault",
+		"slug": "buildium-alternatives-small-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pennsylvania security deposit law: the two-month first-year cap, escrow rules, and 30-day returns",
+		"category": "lease-law",
+		"slug": "pennsylvania-security-deposit-law-caps-escrow-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Roof repairs vs roof replacement: where the IRS draws the capitalization line",
+		"category": "tax-prep",
+		"slug": "roof-repair-vs-replacement-capitalization",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why the previous landlord beats the current one: reference-call strategy for honest answers",
+		"category": "tenant-screening",
+		"slug": "previous-landlord-vs-current-landlord-references",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Checking on a vacant rental in winter: a weekly walkthrough checklist and what to photograph",
+		"category": "maintenance",
+		"slug": "vacant-rental-winter-walkthrough-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "AppFolio alternatives when you can't meet the unit minimum or monthly spend",
+		"category": "software-vault",
+		"slug": "appfolio-alternatives-unit-minimum",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rhode Island security deposit law: the one-month cap and the 20-day return deadline for landlords",
+		"category": "lease-law",
+		"slug": "rhode-island-security-deposit-law-one-month-cap-20-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "HVAC fixes vs full system replacement: tax treatment scenario by scenario",
+		"category": "tax-prep",
+		"slug": "hvac-repair-vs-replacement-tax-treatment",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fifteen questions to ask a landlord reference (and the follow-ups that surface the truth)",
+		"category": "tenant-screening",
+		"slug": "questions-to-ask-landlord-references",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "De-winterizing a rental in spring: restoring water, testing systems, and finding winter damage",
+		"category": "maintenance",
+		"slug": "de-winterize-rental-spring-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "RentRedi alternatives for landlords who mainly need leases, documents, and maintenance logs",
+		"category": "software-vault",
+		"slug": "rentredi-alternatives-lease-document-focus",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "South Carolina security deposit law: the 30-day return deadline and itemization requirements",
+		"category": "lease-law",
+		"slug": "south-carolina-security-deposit-law-30-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Replacing carpet vs installing hardwood: flooring decisions and their tax treatment",
+		"category": "tax-prep",
+		"slug": "carpet-vs-hardwood-flooring-tax-treatment",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Red-flag answers on landlord reference calls: hesitation, vagueness, and suspicious over-enthusiasm",
+		"category": "tenant-screening",
+		"slug": "red-flag-answers-landlord-reference-calls",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hose bib and sprinkler winterization: the small fall jobs that prevent burst-pipe claims",
+		"category": "maintenance",
+		"slug": "hose-bib-sprinkler-winterization-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TurboTenant alternatives for landlords who have outgrown the free plan",
+		"category": "software-vault",
+		"slug": "turbotenant-alternatives-beyond-free-plan",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "South Dakota security deposit law: the one-month cap, two-week return rule, and itemized statements",
+		"category": "lease-law",
+		"slug": "south-dakota-security-deposit-law-one-month-cap-two-week-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fixing a leak vs repiping the house: plumbing costs on the repair-improvement line",
+		"category": "tax-prep",
+		"slug": "plumbing-leak-fix-vs-repipe-tax-treatment",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Detecting fake landlord references: scripted answers, callback tests, and reverse phone lookups",
+		"category": "tenant-screening",
+		"slug": "detecting-fake-landlord-references",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Appliance lifespan chart for rental properties: when each major unit typically wears out",
+		"category": "maintenance",
+		"slug": "rental-appliance-lifespan-chart",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Zillow Rental Manager alternatives that go beyond listing your vacancy",
+		"category": "software-vault",
+		"slug": "zillow-rental-manager-alternatives",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tennessee security deposit law: URLTA counties, separate account rules, and return deadlines",
+		"category": "lease-law",
+		"slug": "tennessee-security-deposit-law-urlta-counties-return-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Is painting between tenants a repair? The tax treatment of turnover work",
+		"category": "tax-prep",
+		"slug": "painting-between-tenants-repair-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to confirm a reference actually owns the rental: county records and parcel lookups",
+		"category": "tenant-screening",
+		"slug": "confirm-reference-owns-the-rental-county-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The 50 percent rule for appliance repairs in rentals: repair-versus-replace math that holds up",
+		"category": "maintenance",
+		"slug": "fifty-percent-rule-appliance-repair-vs-replace",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hemlane alternatives for self-managing landlords who don't need leasing agents",
+		"category": "software-vault",
+		"slug": "hemlane-alternatives-self-managing-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Texas security deposit law: limits, the 30-day return deadline, and itemization rules for landlords",
+		"category": "lease-law",
+		"slug": "texas-security-deposit-law-30-day-return-itemization",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Window replacement on a rental: one window vs all of them, repair vs improvement",
+		"category": "tax-prep",
+		"slug": "window-replacement-rental-repair-vs-improvement",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Documenting reference calls: note templates that protect you in a discrimination dispute",
+		"category": "tenant-screening",
+		"slug": "documenting-reference-calls-note-templates",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Refrigerator repair or replace? A landlord's decision framework by age and failure type",
+		"category": "maintenance",
+		"slug": "refrigerator-repair-or-replace-landlord-framework",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Stessa alternatives for landlords who care more about documents than bookkeeping",
+		"category": "software-vault",
+		"slug": "stessa-alternatives-document-first-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Utah security deposit law: the 30-day return deadline and the non-refundable deposit disclosure rule",
+		"category": "lease-law",
+		"slug": "utah-security-deposit-law-30-day-return-nonrefundable-disclosure",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Water heater replacement on a rental: expense it, capitalize it, or use a safe harbor?",
+		"category": "tax-prep",
+		"slug": "water-heater-replacement-expense-or-capitalize",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When landlord references will not call back: alternative verification paths and time limits",
+		"category": "tenant-screening",
+		"slug": "when-landlord-references-wont-call-back",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Dishwasher repair vs. replace in a rental: common failures and the break-even point",
+		"category": "maintenance",
+		"slug": "dishwasher-repair-vs-replace-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Innago alternatives: what to consider before committing to free software",
+		"category": "software-vault",
+		"slug": "innago-alternatives-before-free-software",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Vermont security deposit law: the 14-day return deadline and normal wear-and-tear standards",
+		"category": "lease-law",
+		"slug": "vermont-security-deposit-law-14-day-return-wear-and-tear",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Kitchen and bath remodels: why upgrades get capitalized even when old parts wore out",
+		"category": "tax-prep",
+		"slug": "kitchen-bath-remodel-capitalization-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Employer reference calls beyond income: tenure, reliability, and the questions you can legally ask",
+		"category": "tenant-screening",
+		"slug": "employer-reference-calls-beyond-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Washers and dryers in rentals: lifespan, repair economics, and whether to supply them at all",
+		"category": "maintenance",
+		"slug": "washer-dryer-rental-lifespan-repair-economics",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "DoorLoop alternatives for landlords priced out by per-unit minimums",
+		"category": "software-vault",
+		"slug": "doorloop-alternatives-budget-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Virginia security deposit law: the two-month cap, the 45-day return deadline, and itemization rules",
+		"category": "lease-law",
+		"slug": "virginia-security-deposit-law-two-month-cap-45-day-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The unit of property rules: why 'building systems' decide repair vs improvement",
+		"category": "tax-prep",
+		"slug": "unit-of-property-rules-building-systems",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Are personal references worthless? What friends-and-family contacts can still tell you",
+		"category": "tenant-screening",
+		"slug": "are-personal-references-worthless",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Water heater repair or replace: age, tank condition, and the leak that decides it",
+		"category": "maintenance",
+		"slug": "water-heater-repair-or-replace-decision",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Yardi Breeze alternatives for rental portfolios under 50 doors",
+		"category": "software-vault",
+		"slug": "yardi-breeze-alternatives-under-50-doors",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Washington security deposit law: the 30-day return deadline, checklist requirement, and documentation rules",
+		"category": "lease-law",
+		"slug": "washington-security-deposit-law-30-day-return-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Storm damage work on a rental: repairs, restorations, and the casualty-loss overlap",
+		"category": "tax-prep",
+		"slug": "storm-damage-restoration-repairs-casualty",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Residence history gaps on rental applications: innocent explanations vs patterns worth probing",
+		"category": "tenant-screening",
+		"slug": "residence-history-gaps-on-applications",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "HVAC repair vs. replace in rentals: the age-times-repair-cost rule and refrigerant phaseouts",
+		"category": "maintenance",
+		"slug": "hvac-repair-vs-replace-rental-decision",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TenantCloud alternatives for landlords who want simpler lease and document management",
+		"category": "software-vault",
+		"slug": "tenantcloud-alternatives-simpler-management",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "West Virginia security deposit law: the 60-day return window and the next-tenancy 45-day rule",
+		"category": "lease-law",
+		"slug": "west-virginia-security-deposit-law-60-day-return-window",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Turning a basement into a rentable bedroom: adaptation costs and capitalization",
+		"category": "tax-prep",
+		"slug": "basement-bedroom-conversion-adaptation-capitalization",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "First-come, first-qualified: building an application order policy that prevents bias claims",
+		"category": "tenant-screening",
+		"slug": "first-come-first-qualified-application-order-policy",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Stove and range maintenance in rentals: igniters, burner coils, and when replacement wins",
+		"category": "maintenance",
+		"slug": "stove-range-repair-vs-replace-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Avail alternatives for landlords who need more than listings and applications",
+		"category": "software-vault",
+		"slug": "avail-alternatives-beyond-listings",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Wisconsin security deposit law: the 21-day return deadline and ATCP 134 deduction rules",
+		"category": "lease-law",
+		"slug": "wisconsin-security-deposit-law-21-day-return-atcp-134",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The de minimis safe harbor: expensing items under $2,500 with the right election",
+		"category": "tax-prep",
+		"slug": "de-minimis-safe-harbor-2500-election",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Handling incomplete rental applications: cure windows, rejection rules, and consistency",
+		"category": "tenant-screening",
+		"slug": "handling-incomplete-rental-applications",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Builder-grade vs. mid-tier appliances for rentals: total cost of ownership compared honestly",
+		"category": "maintenance",
+		"slug": "builder-grade-vs-midtier-appliances-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rentec Direct alternatives with a gentler learning curve for part-time landlords",
+		"category": "software-vault",
+		"slug": "rentec-direct-alternatives-easier-tools",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Wyoming security deposit law: the 30-day return rule and the extra 15 days for damage deductions",
+		"category": "lease-law",
+		"slug": "wyoming-security-deposit-law-30-day-return-damage-extension",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The small taxpayer safe harbor: deducting building work under the 2%/$10,000 limit",
+		"category": "tax-prep",
+		"slug": "small-taxpayer-safe-harbor-building-work",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pre-screening questions before the showing: what saves time without crossing fair housing lines",
+		"category": "tenant-screening",
+		"slug": "pre-screening-questions-before-the-showing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Range hood and over-the-range microwave maintenance: filters, venting, and grease fire risk",
+		"category": "maintenance",
+		"slug": "range-hood-microwave-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Landlord Studio alternatives for landlords who want organization before accounting",
+		"category": "software-vault",
+		"slug": "landlord-studio-alternatives",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "California landlord entry rules: the 24-hour written notice requirement and lawful entry reasons",
+		"category": "lease-law",
+		"slug": "california-landlord-entry-rules-24-hour-written-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The routine maintenance safe harbor: deducting recurring work on rental buildings",
+		"category": "tax-prep",
+		"slug": "routine-maintenance-safe-harbor-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TransUnion SmartMove vs RentPrep vs E-Renter: choosing a screening report provider in 2026",
+		"category": "tenant-screening",
+		"slug": "smartmove-vs-rentprep-vs-e-renter-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Heat pump maintenance for rental properties: defrost cycles, filters, and cold-climate care",
+		"category": "maintenance",
+		"slug": "heat-pump-maintenance-rental-properties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Propertyware alternatives for single-family landlords with small portfolios",
+		"category": "software-vault",
+		"slug": "propertyware-alternatives-single-family",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "California rent increase rules under AB 1482: caps, exemptions, and 30- vs 90-day notice periods",
+		"category": "lease-law",
+		"slug": "california-rent-increase-rules-ab-1482-caps-notice-periods",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to attach safe harbor election statements to your return (and when each applies)",
+		"category": "tax-prep",
+		"slug": "safe-harbor-election-statements-how-to",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How long should you keep rejected rental applications? Retention timelines that survive disputes",
+		"category": "tenant-screening",
+		"slug": "how-long-to-keep-rejected-rental-applications",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mini-split maintenance in rentals: coil cleaning, blower wheels, and tenant filter care",
+		"category": "maintenance",
+		"slug": "mini-split-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "ResMan alternatives for owners who manage a handful of doors themselves",
+		"category": "software-vault",
+		"slug": "resman-alternatives-small-portfolios",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ending a California tenancy: just-cause termination, no-fault reasons, and relocation assistance",
+		"category": "lease-law",
+		"slug": "california-just-cause-termination-no-fault-relocation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Writing a capitalization policy for your rental activity before the year starts",
+		"category": "tax-prep",
+		"slug": "capitalization-policy-rental-business",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Comparing multiple qualified applicants: objective tiebreakers that keep you fair-housing safe",
+		"category": "tenant-screening",
+		"slug": "comparing-multiple-qualified-applicants-fairly",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Boiler and radiator maintenance for older rentals: bleeding, pressure checks, and annual service",
+		"category": "maintenance",
+		"slug": "boiler-radiator-maintenance-older-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buildium pricing in 2026: tiers, monthly minimums, and the fees that surprise small landlords",
+		"category": "software-vault",
+		"slug": "buildium-pricing-breakdown-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Texas late fee law: the reasonableness standard, safe-harbor percentages, and required lease language",
+		"category": "lease-law",
+		"slug": "texas-late-fee-law-reasonableness-safe-harbor",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Your first Schedule E: a line-by-line walkthrough for new landlords",
+		"category": "tax-prep",
+		"slug": "first-schedule-e-line-by-line-new-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening roommate groups: why every adult applies, joint income math, and shared liability",
+		"category": "tenant-screening",
+		"slug": "screening-roommate-groups-every-adult-applies",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tankless water heater maintenance: descaling schedules for hard-water rental markets",
+		"category": "maintenance",
+		"slug": "tankless-water-heater-descaling-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "AppFolio pricing explained: why the per-unit model punishes small portfolios",
+		"category": "software-vault",
+		"slug": "appfolio-pricing-per-unit-explained",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Texas landlord entry rules: why your lease controls and what a fair entry clause should cover",
+		"category": "lease-law",
+		"slug": "texas-landlord-entry-rules-lease-clause-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Reporting multiple rentals on Schedule E: columns, page two, and totals done right",
+		"category": "tax-prep",
+		"slug": "multiple-rentals-schedule-e-reporting",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Background check consent under the FCRA: the authorization language your application needs",
+		"category": "tenant-screening",
+		"slug": "background-check-consent-under-fcra",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ductwork inspection and sealing in rentals: leaks, dampers, and uneven-heat complaints",
+		"category": "maintenance",
+		"slug": "rental-ductwork-inspection-sealing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "DoorLoop pricing breakdown: plan tiers, add-ons, and the annual contract math",
+		"category": "software-vault",
+		"slug": "doorloop-pricing-breakdown",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Texas notice to vacate rules: the three-day default, lease modifications, and delivery methods",
+		"category": "lease-law",
+		"slug": "texas-notice-to-vacate-rules-three-day-default",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Schedule E for a partial-year rental: prorating expenses after a mid-year conversion",
+		"category": "tax-prep",
+		"slug": "partial-year-rental-schedule-e-proration",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Portable tenant screening reports: which states make you accept them and how to verify one",
+		"category": "tenant-screening",
+		"slug": "portable-tenant-screening-reports-state-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "GFCI and AFCI protection in rentals: where code requires it and how often to test",
+		"category": "maintenance",
+		"slug": "gfci-afci-testing-rental-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "RentRedi pricing: what the subscription covers and where extra costs hide",
+		"category": "software-vault",
+		"slug": "rentredi-pricing-hidden-costs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Florida month-to-month termination: the new 30-day notice rule and how it changed in 2023",
+		"category": "lease-law",
+		"slug": "florida-month-to-month-termination-30-day-notice-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Owner-occupied duplex taxes: splitting one building between Schedule E and your home",
+		"category": "tax-prep",
+		"slug": "owner-occupied-duplex-tax-split-schedule-e",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Holding deposits after approval: paperwork, refund conditions, and state-law landmines",
+		"category": "tenant-screening",
+		"slug": "holding-deposits-after-approval",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Aluminum wiring, knob-and-tube, and Federal Pacific panels: maintenance triage for older rentals",
+		"category": "maintenance",
+		"slug": "older-rental-wiring-hazards-maintenance-triage",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hemlane pricing tiers compared: when the per-unit fee stops making sense",
+		"category": "software-vault",
+		"slug": "hemlane-pricing-tiers-compared",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Florida landlord entry law: the 12-hour notice rule for repairs and reasonable-time standards",
+		"category": "lease-law",
+		"slug": "florida-landlord-entry-law-12-hour-notice-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Converting your home to a rental: the depreciation-basis trap most owners miss",
+		"category": "tax-prep",
+		"slug": "converting-home-to-rental-depreciation-basis",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Verifying a government ID at the showing: security features, expiration, and name matching",
+		"category": "tenant-screening",
+		"slug": "verifying-government-id-at-the-showing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Galvanized and polybutylene pipes in rentals: failure signs and planning a repipe",
+		"category": "maintenance",
+		"slug": "galvanized-polybutylene-pipes-rental-repipe",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TurboTenant's free plan: who actually pays, and what premium really adds",
+		"category": "software-vault",
+		"slug": "turbotenant-free-plan-real-costs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Florida late fee rules for landlords: lease requirements, grace periods, and enforceability limits",
+		"category": "lease-law",
+		"slug": "florida-late-fee-rules-lease-language-grace-periods",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Schedule E vs Schedule C: when rental activity becomes a business with SE tax",
+		"category": "tax-prep",
+		"slug": "schedule-e-vs-schedule-c-rental-activity",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening applicants with an ITIN instead of an SSN: credit checks, alternatives, and fair housing",
+		"category": "tenant-screening",
+		"slug": "screening-applicants-with-itin-instead-of-ssn",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Cast iron drain lines in pre-1980 rentals: scaling, channeling, and lining vs. replacement",
+		"category": "maintenance",
+		"slug": "cast-iron-drain-line-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Avail pricing: free vs Unlimited Plus, and the upgrade triggers to watch",
+		"category": "software-vault",
+		"slug": "avail-pricing-free-vs-unlimited-plus",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New York's HSTPA notice rules: 30, 60, and 90 days for rent increases and non-renewals",
+		"category": "lease-law",
+		"slug": "new-york-hstpa-notice-rules-rent-increases-non-renewals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fair rental days vs personal use days: getting Schedule E line 2 right",
+		"category": "tax-prep",
+		"slug": "fair-rental-days-vs-personal-use-days",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Synthetic identity fraud in rental applications: how fabricated credit profiles fool landlords",
+		"category": "tenant-screening",
+		"slug": "synthetic-identity-fraud-rental-applications",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Main water shutoff mapping: why every rental needs labeled valves and a tenant handout",
+		"category": "maintenance",
+		"slug": "main-water-shutoff-mapping-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "TenantCloud pricing tiers: the feature gates that matter under 20 units",
+		"category": "software-vault",
+		"slug": "tenantcloud-pricing-feature-gates",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New York late fee cap: the 50-dollar-or-5-percent limit and the mandatory five-day grace period",
+		"category": "lease-law",
+		"slug": "new-york-late-fee-cap-and-five-day-grace-period",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What counts as rental income: advance rent, kept deposits, and tenant-provided services",
+		"category": "tax-prep",
+		"slug": "what-counts-as-rental-income-deposits-services",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Catching doctored application documents: PDF metadata, layer artifacts, and edit timestamps",
+		"category": "tenant-screening",
+		"slug": "catching-doctored-application-documents-pdf-metadata",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Water leak detection for rentals: meter tests, moisture sensors, and where leaks hide",
+		"category": "maintenance",
+		"slug": "water-leak-detection-rental-properties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Yardi Breeze pricing for small landlords: minimum spend, setup, and contract terms",
+		"category": "software-vault",
+		"slug": "yardi-breeze-pricing-small-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New York landlord entry rules: notice expectations, emergencies, and lease entry clauses",
+		"category": "lease-law",
+		"slug": "new-york-landlord-entry-rules-notice-emergencies",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Security deposits and taxes: when a deposit becomes income (and when it never does)",
+		"category": "tax-prep",
+		"slug": "security-deposit-taxation-when-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Identity verification for sight-unseen applicants: video calls, liveness checks, and ID services",
+		"category": "tenant-screening",
+		"slug": "identity-verification-sight-unseen-applicants",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mold prevention in rental properties: moisture sources, ventilation, and early response",
+		"category": "maintenance",
+		"slug": "mold-prevention-rental-properties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rentec Direct pricing breakdown: PM vs Pro plans for the independent landlord",
+		"category": "software-vault",
+		"slug": "rentec-direct-pricing-breakdown",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pennsylvania lease termination notices: 15- and 30-day rules under the Landlord and Tenant Act",
+		"category": "lease-law",
+		"slug": "pennsylvania-lease-termination-notices-15-and-30-day-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting expenses during vacancy: what's allowed while you search for a tenant",
+		"category": "tax-prep",
+		"slug": "vacancy-expenses-deductible-between-tenants",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Googling your applicants: what online research is fair game and where fair housing draws the line",
+		"category": "tenant-screening",
+		"slug": "googling-applicants-online-research-fair-housing-limits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mold remediation in a rental: when DIY cleanup is fine and when to hire a pro",
+		"category": "maintenance",
+		"slug": "mold-remediation-diy-vs-pro-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Landlord Studio pricing: Go vs Pro, and where the unit caps start to bite",
+		"category": "software-vault",
+		"slug": "landlord-studio-pricing-go-vs-pro",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pennsylvania landlord entry and late fees: what state law leaves to the lease, plus Philadelphia's rules",
+		"category": "lease-law",
+		"slug": "pennsylvania-landlord-entry-late-fees-lease-philadelphia",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The $25,000 passive loss allowance: who qualifies and how the phase-out works",
+		"category": "tax-prep",
+		"slug": "passive-loss-allowance-25000-phase-out",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Professional tenant fraud rings: the playbook, the warning signs, and the screening defenses",
+		"category": "tenant-screening",
+		"slug": "professional-tenant-fraud-rings-warning-signs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Crawl space maintenance for rentals: moisture barriers, ventilation, and encapsulation",
+		"category": "maintenance",
+		"slug": "crawl-space-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Is Zillow Rental Manager really free? The costs landlords find after listing",
+		"category": "software-vault",
+		"slug": "zillow-rental-manager-real-costs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Illinois lease termination notices: 5-day, 10-day, and 30-day notices and when each applies",
+		"category": "lease-law",
+		"slug": "illinois-lease-termination-notices-5-10-30-day",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Form 8582 and suspended losses: how passive loss carryforwards actually work",
+		"category": "tax-prep",
+		"slug": "form-8582-suspended-passive-loss-carryforwards",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Application form red flags: rushed move-in timelines, inconsistent answers, and pressure tactics",
+		"category": "tenant-screening",
+		"slug": "application-form-red-flags",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Basement moisture control in rentals: grading, downspouts, and interior drainage options",
+		"category": "maintenance",
+		"slug": "basement-moisture-control-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to export your data from Buildium before you switch: leases, contacts, and files",
+		"category": "software-vault",
+		"slug": "export-data-from-buildium-switching-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Chicago RLTO vs Illinois state law: which landlord rules apply to your rental property",
+		"category": "lease-law",
+		"slug": "chicago-rlto-vs-illinois-state-law-landlord-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Real estate professional status: the 750-hour test and what it unlocks for landlords",
+		"category": "tax-prep",
+		"slug": "real-estate-professional-status-750-hour-test",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Verifying applicant phone numbers and emails: VOIP checks, disposable addresses, and callbacks",
+		"category": "tenant-screening",
+		"slug": "verifying-applicant-phone-numbers-and-emails",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Foundation crack monitoring for landlords: which cracks are cosmetic and which need an engineer",
+		"category": "maintenance",
+		"slug": "foundation-crack-monitoring-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Leaving AppFolio as a small landlord: a step-by-step migration checklist",
+		"category": "software-vault",
+		"slug": "leaving-appfolio-migration-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Illinois landlord entry rules: Chicago's two-day notice standard and downstate lease practice",
+		"category": "lease-law",
+		"slug": "illinois-landlord-entry-rules-chicago-two-day-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The QBI deduction for landlords: Section 199A and the 250-hour rental safe harbor",
+		"category": "tax-prep",
+		"slug": "qbi-deduction-landlords-section-199a-safe-harbor",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why every landlord needs written screening criteria before the first application arrives",
+		"category": "tenant-screening",
+		"slug": "written-screening-criteria-before-first-application",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Attic insulation and ventilation in rentals: ice dams, comfort complaints, and moisture",
+		"category": "maintenance",
+		"slug": "attic-insulation-ventilation-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Where Cozy landlords ended up: rebuilding your records after a platform shutdown",
+		"category": "software-vault",
+		"slug": "cozy-shutdown-rebuilding-landlord-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ohio landlord entry law: the 24-hour reasonable notice rule and tenant remedies for misuse",
+		"category": "lease-law",
+		"slug": "ohio-landlord-entry-law-24-hour-notice-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Selling a rental property: Form 4797, gain calculation, and recapture step by step",
+		"category": "tax-prep",
+		"slug": "selling-rental-form-4797-gain-recapture",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Choosing your income ratio: 2.5x vs 3x, local market math, and gross-vs-net decisions",
+		"category": "tenant-screening",
+		"slug": "choosing-your-income-ratio-2-5x-vs-3x",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pest prevention maintenance for rentals: exclusion, sealing, and the landlord-tenant divide",
+		"category": "maintenance",
+		"slug": "pest-prevention-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Switching from TurboTenant: how to take your leases and documents with you",
+		"category": "software-vault",
+		"slug": "switching-from-turbotenant-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ohio three-day notice rules: late rent, lease violations, and proper service for landlords",
+		"category": "lease-law",
+		"slug": "ohio-three-day-notice-rules-late-rent-lease-violations",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Section 1031 exchange basics for small landlords: deferring tax when trading up",
+		"category": "tax-prep",
+		"slug": "section-1031-exchange-basics-small-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Setting a credit score floor: picking a defensible number and applying it without exceptions",
+		"category": "tenant-screening",
+		"slug": "setting-a-defensible-credit-score-floor",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Garage door maintenance in rentals: springs, sensors, and the safety-reverse test",
+		"category": "maintenance",
+		"slug": "garage-door-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Switching from RentRedi: a clean-break checklist for your property records",
+		"category": "software-vault",
+		"slug": "switching-from-rentredi-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Georgia landlord entry rules: no state statute, lease clauses, and reasonable-notice best practices",
+		"category": "lease-law",
+		"slug": "georgia-landlord-entry-rules-lease-clauses-best-practices",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Casualty losses on rental property: deducting damage insurance didn't cover",
+		"category": "tax-prep",
+		"slug": "casualty-loss-rental-property-uninsured-damage",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Eviction history criteria: lookback windows, dismissed filings, and sealed-record states",
+		"category": "tenant-screening",
+		"slug": "eviction-history-criteria-lookback-windows",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lock maintenance and rekeying between tenants: cores, smart locks, and key control",
+		"category": "maintenance",
+		"slug": "lock-rekeying-between-tenants-maintenance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to get your data out of Stessa: exports, reports, and document downloads",
+		"category": "software-vault",
+		"slug": "export-data-from-stessa-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Georgia late fee rules: enforceability, lease requirements, and how courts treat penalty clauses",
+		"category": "lease-law",
+		"slug": "georgia-late-fee-rules-enforceability-lease-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why cash-basis landlords can't deduct rental income they never received",
+		"category": "tax-prep",
+		"slug": "cash-basis-landlords-uncollected-rental-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Auditing your screening criteria for fair housing risk: the seven protected classes and beyond",
+		"category": "tenant-screening",
+		"slug": "auditing-screening-criteria-fair-housing-risk",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fence and gate maintenance for rental properties: posts, rot, hardware, and longevity",
+		"category": "maintenance",
+		"slug": "fence-gate-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Moving on from Zillow Rental Manager: preserving applications and lease history",
+		"category": "software-vault",
+		"slug": "moving-on-from-zillow-rental-manager",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ending a month-to-month tenancy in Georgia: the 60-day landlord notice rule explained",
+		"category": "lease-law",
+		"slug": "georgia-month-to-month-termination-60-day-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Expenses before your first tenant: start-up costs and the placed-in-service date",
+		"category": "tax-prep",
+		"slug": "startup-costs-before-first-tenant-placed-in-service",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Disparate impact for landlords: how neutral screening rules can still discriminate",
+		"category": "tenant-screening",
+		"slug": "disparate-impact-for-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Septic system maintenance for rural rentals: pumping schedules and tenant do's and don'ts",
+		"category": "maintenance",
+		"slug": "septic-system-maintenance-rural-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Leaving Hemlane: what transfers cleanly and what you will have to rebuild",
+		"category": "software-vault",
+		"slug": "leaving-hemlane-what-transfers",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "North Carolina late fee caps: the 15-dollar-or-5-percent limit for weekly and monthly tenancies",
+		"category": "lease-law",
+		"slug": "north-carolina-late-fee-caps-weekly-monthly-tenancies",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When is a rental 'placed in service'? The date that starts depreciation and deductions",
+		"category": "tax-prep",
+		"slug": "placed-in-service-date-rental-depreciation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "City-level screening laws landlords miss: Seattle's first-in-time rule, Portland's FAIR ordinance, and more",
+		"category": "tenant-screening",
+		"slug": "city-level-screening-laws-first-in-time-fair",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Well water maintenance for rentals: annual testing, pressure tanks, and treatment systems",
+		"category": "maintenance",
+		"slug": "well-water-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "DoorLoop data export guide: getting leases, tenant records, and files out intact",
+		"category": "software-vault",
+		"slug": "doorloop-data-export-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "North Carolina lease termination notices: 2-day, 7-day, and one-month rules by tenancy type",
+		"category": "lease-law",
+		"slug": "north-carolina-lease-termination-notices-by-tenancy-type",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What receipts the IRS expects behind every repair deduction, and how to keep them",
+		"category": "tax-prep",
+		"slug": "repair-deduction-receipts-irs-documentation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Updating screening criteria between vacancies: what you can change and what to document",
+		"category": "tenant-screening",
+		"slug": "updating-screening-criteria-between-vacancies",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Water softener and filtration maintenance in rentals: salt, media life, and who handles it",
+		"category": "maintenance",
+		"slug": "water-softener-filtration-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Migrating from TenantCloud: an exit checklist for organized landlords",
+		"category": "software-vault",
+		"slug": "migrating-from-tenantcloud-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Michigan month-to-month termination: the one-rental-period notice rule explained for landlords",
+		"category": "lease-law",
+		"slug": "michigan-month-to-month-termination-notice-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maintaining a depreciation schedule across the years: the one record you cannot lose",
+		"category": "tax-prep",
+		"slug": "maintaining-depreciation-schedule-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Publishing your screening criteria in the listing: pros, cons, and the legal upside",
+		"category": "tenant-screening",
+		"slug": "publishing-screening-criteria-in-listings",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Flat and low-slope roof maintenance for small multifamily buildings: ponding, membranes, drains",
+		"category": "maintenance",
+		"slug": "flat-roof-maintenance-small-multifamily",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Exporting from Avail before you switch: applications, leases, and shared documents",
+		"category": "software-vault",
+		"slug": "exporting-from-avail-before-switching",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Michigan landlord entry rules: no statutory notice period and how to write a fair entry clause",
+		"category": "lease-law",
+		"slug": "michigan-landlord-entry-rules-fair-entry-clause",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How long to keep landlord tax records: the retention timelines that actually apply",
+		"category": "tax-prep",
+		"slug": "how-long-keep-landlord-tax-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "No credit history vs bad credit history: why your criteria should treat them differently",
+		"category": "tenant-screening",
+		"slug": "no-credit-vs-bad-credit-screening-criteria",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Balcony and exterior stair inspections: structural checks every small landlord should schedule",
+		"category": "maintenance",
+		"slug": "balcony-exterior-stair-inspection-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Platform shutdown survival guide: lessons from Cozy for choosing durable landlord software",
+		"category": "software-vault",
+		"slug": "platform-shutdown-lessons-from-cozy",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New Jersey's Anti-Eviction Act: the just-cause grounds every small landlord should know",
+		"category": "lease-law",
+		"slug": "new-jersey-anti-eviction-act-just-cause-grounds",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Schedule E audit triggers: the red flags small landlords should know about",
+		"category": "tax-prep",
+		"slug": "schedule-e-audit-triggers-small-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sex offender registry checks in tenant screening: legality, limits, and state restrictions",
+		"category": "tenant-screening",
+		"slug": "sex-offender-registry-checks-tenant-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Weatherstripping and door maintenance: drafts, sweeps, and tenant comfort complaints",
+		"category": "maintenance",
+		"slug": "weatherstripping-door-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What landlords with 1-5 units actually need from property management software",
+		"category": "software-vault",
+		"slug": "software-needs-1-to-5-unit-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New Jersey late fee rules: the five-business-day grace period for protected tenants and beyond",
+		"category": "lease-law",
+		"slug": "new-jersey-late-fee-rules-grace-period",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Estimated taxes for landlords: when rental profit requires quarterly filings",
+		"category": "tax-prep",
+		"slug": "estimated-quarterly-taxes-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening student applicants: guarantors, financial aid as income, and co-signing parents",
+		"category": "tenant-screening",
+		"slug": "screening-student-applicants-guarantors",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Toilet maintenance in rentals: flappers, fill valves, and silent leaks that inflate water bills",
+		"category": "maintenance",
+		"slug": "toilet-flapper-fill-valve-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What landlords with 10-20 units actually need, and the features they can skip",
+		"category": "software-vault",
+		"slug": "software-needs-10-to-20-unit-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New Jersey notice to quit rules: one-month notices, cause requirements, and proper service",
+		"category": "lease-law",
+		"slug": "new-jersey-notice-to-quit-rules-one-month-notices",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Does rental income owe self-employment tax? Where the IRS draws the line",
+		"category": "tax-prep",
+		"slug": "rental-income-self-employment-tax-line",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening first-time renters with no rental history: substitutes that actually predict performance",
+		"category": "tenant-screening",
+		"slug": "screening-first-time-renters-no-rental-history",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Faucet aerators, showerheads, and water-pressure complaints: quick fixes landlords can DIY",
+		"category": "maintenance",
+		"slug": "faucet-aerator-water-pressure-fixes-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Scaling from 20 to 50 doors: when software complexity starts paying for itself",
+		"category": "software-vault",
+		"slug": "scaling-20-to-50-doors-software",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Virginia late fee cap: the 10 percent limit under the VRLTA and how to apply it correctly",
+		"category": "lease-law",
+		"slug": "virginia-late-fee-cap-vrlta-10-percent-limit",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Out-of-state rentals: nonresident state returns and the credit that prevents double tax",
+		"category": "tax-prep",
+		"slug": "out-of-state-rental-nonresident-state-returns",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening travel nurses and contract workers: agency letters, contract terms, and income gaps",
+		"category": "tenant-screening",
+		"slug": "screening-travel-nurses-contract-workers",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Frozen pipe response plan for landlords: the first hour, safe thawing, and damage control",
+		"category": "maintenance",
+		"slug": "frozen-pipe-response-plan-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "A first-time landlord's software buying guide: start simple, stay organized",
+		"category": "software-vault",
+		"slug": "first-time-landlord-software-buying-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Virginia lease termination under the VRLTA: 30-day notices, renewals, and material breach rules",
+		"category": "lease-law",
+		"slug": "virginia-lease-termination-vrlta-30-day-notices",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Refinancing a rental: deducting old points, new points, and closing costs",
+		"category": "tax-prep",
+		"slug": "refinancing-rental-points-closing-costs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Co-signer approvals done right: when to offer one, what to screen, and how to paper it",
+		"category": "tenant-screening",
+		"slug": "co-signer-approvals-done-right",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Gas appliance and line safety in rentals: leak signs, CO risks, and annual checks",
+		"category": "maintenance",
+		"slug": "gas-appliance-line-safety-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Software for out-of-state landlords: managing leases and maintenance from afar",
+		"category": "software-vault",
+		"slug": "out-of-state-landlord-software-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Washington rent increase notice rules: the 60-day requirement and the new statewide cap explained",
+		"category": "lease-law",
+		"slug": "washington-rent-increase-notice-60-day-rule-state-cap",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "HELOC and cash-out funds used for a rental: the interest tracing rules explained",
+		"category": "tax-prep",
+		"slug": "heloc-interest-tracing-rules-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening the guarantor: income multiples, out-of-state enforcement, and credit thresholds",
+		"category": "tenant-screening",
+		"slug": "screening-the-guarantor",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Radon testing and mitigation in rentals: when to test and what mitigation actually involves",
+		"category": "maintenance",
+		"slug": "radon-testing-mitigation-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The accidental landlord's toolkit: managing one rental without enterprise software",
+		"category": "software-vault",
+		"slug": "accidental-landlord-software-toolkit",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Washington landlord entry law: two-day notice for inspections and one-day notice for showings",
+		"category": "lease-law",
+		"slug": "washington-landlord-entry-law-two-day-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "One mortgage, mixed use: splitting Form 1098 interest between home and rental",
+		"category": "tax-prep",
+		"slug": "mixed-use-form-1098-interest-split",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Higher security deposits as a conditional approval: the state caps that limit the option",
+		"category": "tenant-screening",
+		"slug": "higher-security-deposits-conditional-approval",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lead-safe maintenance in pre-1978 rentals: RRP rules for everyday repair work",
+		"category": "maintenance",
+		"slug": "lead-safe-rrp-maintenance-pre-1978-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The self-managing landlord's minimalist stack: five jobs your software must do",
+		"category": "software-vault",
+		"slug": "self-managing-landlord-minimalist-stack",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Washington's 14-day notice and just-cause eviction rules: what small landlords must know",
+		"category": "lease-law",
+		"slug": "washington-14-day-notice-just-cause-eviction-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Insurance payouts after property damage: taxable income or basis adjustment?",
+		"category": "tax-prep",
+		"slug": "insurance-payouts-property-damage-taxable",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Writing a conditional approval letter: terms, deadlines, and adverse-action overlap",
+		"category": "tenant-screening",
+		"slug": "writing-a-conditional-approval-letter",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Asbestos awareness for older rental maintenance: where it hides and when to stop work",
+		"category": "maintenance",
+		"slug": "asbestos-awareness-older-rental-maintenance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "House hackers and owner-occupants: choosing software for a duplex or triplex",
+		"category": "software-vault",
+		"slug": "house-hacker-duplex-software-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Arizona landlord entry law: the two-day notice rule and lawful reasons to enter a rental",
+		"category": "lease-law",
+		"slug": "arizona-landlord-entry-law-two-day-notice-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Do residential energy credits apply to rentals? What landlords can and can't claim",
+		"category": "tax-prep",
+		"slug": "residential-energy-credits-rentals-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Decline or conditionally approve? A decision framework for borderline applications",
+		"category": "tenant-screening",
+		"slug": "decline-or-conditionally-approve-framework",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fire extinguishers in rental units: placement, types, and inspection schedules",
+		"category": "maintenance",
+		"slug": "fire-extinguisher-rental-placement-inspection",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Landlording with a full-time job: software that respects your weekends",
+		"category": "software-vault",
+		"slug": "part-time-landlord-software-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Arizona's five-day and ten-day notice rules: curable breaches and lease termination steps",
+		"category": "lease-law",
+		"slug": "arizona-five-day-ten-day-notice-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Renting below market to family: the deduction limits nobody warns you about",
+		"category": "tax-prep",
+		"slug": "renting-below-market-to-family-deduction-limits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Requiring renters insurance as an approval condition: enforceability and verification",
+		"category": "tenant-screening",
+		"slug": "renters-insurance-as-approval-condition",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Smart thermostats in rentals: maintenance benefits, setting limits, and tenant friction",
+		"category": "maintenance",
+		"slug": "smart-thermostats-rentals-maintenance-benefits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Just inherited a rental property? How to organize the records before choosing software",
+		"category": "software-vault",
+		"slug": "inherited-rental-property-organize-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Massachusetts late fee law: why landlords cannot charge a fee until rent is 30 days late",
+		"category": "lease-law",
+		"slug": "massachusetts-late-fee-law-30-day-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The year-end tax prep checklist for landlords: what to gather before filing season",
+		"category": "tax-prep",
+		"slug": "year-end-tax-prep-checklist-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The FCRA disposal rule: how to securely destroy screening reports when retention ends",
+		"category": "tenant-screening",
+		"slug": "fcra-disposal-rule-destroying-screening-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Dehumidifiers and whole-house humidifiers in rentals: when they help and how to maintain them",
+		"category": "maintenance",
+		"slug": "humidifier-dehumidifier-maintenance-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Section 8 landlords: keeping inspection and paperwork records audit-ready with software",
+		"category": "software-vault",
+		"slug": "section-8-landlord-record-keeping-software",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Massachusetts notice to quit rules: 14-day and 30-day notices and how to serve them properly",
+		"category": "lease-law",
+		"slug": "massachusetts-notice-to-quit-rules-14-and-30-day",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Organizing receipts, leases, and Form 1098s: a tax document system that survives an audit",
+		"category": "tax-prep",
+		"slug": "organizing-tax-documents-audit-ready-system",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Standardizing denial reasons: a documented taxonomy that keeps every rejection consistent",
+		"category": "tenant-screening",
+		"slug": "standardizing-denial-reasons-documentation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pressure washing rental exteriors: what to wash, what to skip, and siding damage risks",
+		"category": "maintenance",
+		"slug": "pressure-washing-rental-exteriors-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Small multifamily owners: software needs for the 4-12 unit building",
+		"category": "software-vault",
+		"slug": "small-multifamily-software-needs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tennessee late fee cap: the 10 percent limit, the five-day grace period, and the Sunday rule",
+		"category": "lease-law",
+		"slug": "tennessee-late-fee-cap-10-percent-grace-period",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Missed a deduction last year? Amending with Form 1040-X as a landlord",
+		"category": "tax-prep",
+		"slug": "amending-return-missed-deduction-1040x-landlord",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fair housing rules for rental ads: words and phrases that invite discrimination complaints",
+		"category": "tenant-screening",
+		"slug": "fair-housing-rules-for-rental-ads-risky-words-and-phrases",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Downspout extensions and yard drainage: the cheapest fixes for chronic water intrusion",
+		"category": "maintenance",
+		"slug": "downspout-extensions-yard-drainage-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Do you really need built-in accounting in your landlord software?",
+		"category": "software-vault",
+		"slug": "do-you-need-built-in-accounting-landlord-software",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tennessee lease termination notices: URLTA counties vs the rest of the state for landlords",
+		"category": "lease-law",
+		"slug": "tennessee-lease-termination-notices-urlta-counties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Cash vs accrual method for rental owners: why most small landlords stay cash-basis",
+		"category": "tax-prep",
+		"slug": "cash-vs-accrual-accounting-rental-owners",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Writing a fair-housing-compliant rental listing: a checklist for independent landlords",
+		"category": "tenant-screening",
+		"slug": "fair-housing-compliant-rental-listing-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Are gutter guards worth it for rental properties? Types, costs, and maintenance trade-offs",
+		"category": "maintenance",
+		"slug": "gutter-guards-worth-it-rental-properties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Do small landlords need listing syndication, or is it a feature tax?",
+		"category": "software-vault",
+		"slug": "do-small-landlords-need-listing-syndication",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Indiana month-to-month termination: the one-month notice rule and lease carve-outs for landlords",
+		"category": "lease-law",
+		"slug": "indiana-month-to-month-termination-one-month-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Meals on rental property trips: the 50% rule and documentation that holds up",
+		"category": "tax-prep",
+		"slug": "travel-meals-50-percent-rule-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "No-kids and adults-only ads: how familial status discrimination catches landlords",
+		"category": "tenant-screening",
+		"slug": "no-kids-ads-familial-status-discrimination",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Building a maintenance reserve: how much to set aside per door by property age",
+		"category": "maintenance",
+		"slug": "maintenance-reserve-per-door-budgeting",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maintenance request software for small landlords: the features that actually matter",
+		"category": "software-vault",
+		"slug": "maintenance-software-features-that-matter",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Indiana landlord entry rules: the reasonable-notice standard and emergency entry exceptions",
+		"category": "lease-law",
+		"slug": "indiana-landlord-entry-rules-reasonable-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Carrying costs during a renovation: which expenses deduct while the unit is offline",
+		"category": "tax-prep",
+		"slug": "carrying-costs-during-renovation-deductions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Steering during showings: how well-meaning landlords accidentally violate fair housing",
+		"category": "tenant-screening",
+		"slug": "steering-during-showings-fair-housing-risk",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Documenting maintenance with photos and records: building a defensible repair history",
+		"category": "maintenance",
+		"slug": "documenting-maintenance-photos-repair-history",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to evaluate document storage in landlord software: search, categories, and bulk export",
+		"category": "software-vault",
+		"slug": "evaluate-document-storage-landlord-software",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Missouri lease termination notices: the one-month rule for month-to-month tenancies explained",
+		"category": "lease-law",
+		"slug": "missouri-lease-termination-one-month-notice-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "LLC vs sole proprietorship for rental property: what actually changes on your tax return",
+		"category": "tax-prep",
+		"slug": "llc-vs-sole-proprietorship-rental-property-tax-return",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Questions you can never ask rental applicants, and the compliant alternatives",
+		"category": "tenant-screening",
+		"slug": "questions-you-cannot-ask-rental-applicants",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Are HVAC service contracts worth it for small landlords? Costs vs. one-off service calls",
+		"category": "maintenance",
+		"slug": "hvac-service-contracts-worth-it-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lease renewal reminders and date management: a small but decisive software feature",
+		"category": "software-vault",
+		"slug": "lease-renewal-reminders-software-feature",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Missouri landlord entry and late fees: what state law covers and what your lease must spell out",
+		"category": "lease-law",
+		"slug": "missouri-landlord-entry-late-fees-lease-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When an S-corp makes sense for landlords and why it usually doesn't for rentals",
+		"category": "tax-prep",
+		"slug": "s-corp-for-landlords-when-it-makes-sense",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Federal protected classes vs state and local additions: building one screening standard",
+		"category": "tenant-screening",
+		"slug": "protected-classes-federal-state-local-screening-standard",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Home warranties for rental properties: coverage gaps, claim delays, and the honest math",
+		"category": "maintenance",
+		"slug": "home-warranty-rental-properties-honest-math",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Property inspection features compared: checklists, photos, and stored reports",
+		"category": "software-vault",
+		"slug": "property-inspection-features-compared",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maryland late fee cap: the 5 percent limit and the special rules for weekly tenancies",
+		"category": "lease-law",
+		"slug": "maryland-late-fee-cap-5-percent-limit",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Single-member LLC rental taxes: how disregarded entity status works on Schedule E",
+		"category": "tax-prep",
+		"slug": "single-member-llc-rental-taxes-disregarded-entity",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Assistance animals vs pets: handling reasonable accommodation requests during screening",
+		"category": "tenant-screening",
+		"slug": "assistance-animals-vs-pets-reasonable-accommodation-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "DIY vs. hiring a pro: a decision framework for landlord maintenance and repairs",
+		"category": "maintenance",
+		"slug": "diy-vs-pro-landlord-maintenance-framework",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why all-in-one property management suites overwhelm landlords under 20 units",
+		"category": "software-vault",
+		"slug": "all-in-one-suites-overwhelm-small-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maryland lease termination notices: the 60-day rule and how Baltimore City differs",
+		"category": "lease-law",
+		"slug": "maryland-lease-termination-notices-60-day-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Multi-member LLC rentals and Form 1065: partnership filing for co-owned properties",
+		"category": "tax-prep",
+		"slug": "multi-member-llc-form-1065-partnership-filing-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Emotional support animal letters: what documentation landlords can and cannot request",
+		"category": "tenant-screening",
+		"slug": "esa-letters-what-landlords-can-request",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maintenance request intake done right: what to ask tenants before dispatching anyone",
+		"category": "maintenance",
+		"slug": "maintenance-request-intake-questions-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "E-signature in landlord software: when you need it and when a PDF will do",
+		"category": "software-vault",
+		"slug": "esignature-landlord-software-when-needed",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maryland's prohibited lease clauses: provisions that make a rental agreement unenforceable",
+		"category": "lease-law",
+		"slug": "maryland-prohibited-lease-clauses",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Transferring a rental into an LLC: due-on-sale clauses, transfer taxes, and basis",
+		"category": "tax-prep",
+		"slug": "transferring-rental-into-llc-tax-consequences",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Service animals vs assistance animals: ADA, FHA, and state law differences for landlords",
+		"category": "tenant-screening",
+		"slug": "service-animals-ada-fha-state-law-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to build a contractor bench before your first emergency call",
+		"category": "maintenance",
+		"slug": "build-contractor-bench-before-first-emergency",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening report storage: why where you keep applicant records matters as much as the report",
+		"category": "software-vault",
+		"slug": "screening-report-storage-software",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Wisconsin landlord entry rules: the 12-hour advance notice requirement under ATCP 134",
+		"category": "lease-law",
+		"slug": "wisconsin-landlord-entry-rules-12-hour-notice-atcp-134",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Series LLCs for multi-property landlords: how the IRS actually treats them",
+		"category": "tax-prep",
+		"slug": "series-llc-landlord-tax-treatment",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why pet fees and pet deposits never apply to assistance animals",
+		"category": "tenant-screening",
+		"slug": "no-pet-fees-for-assistance-animals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Vetting a handyman vs hiring licensed trades: a decision framework for small landlords",
+		"category": "maintenance",
+		"slug": "handyman-vs-licensed-trades-decision-framework",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Landlord dashboards that earn their place: metrics worth watching at under 50 units",
+		"category": "software-vault",
+		"slug": "landlord-dashboards-metrics-worth-watching",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Wisconsin lease termination notices: 5-day, 14-day, and 28-day rules explained for landlords",
+		"category": "lease-law",
+		"slug": "wisconsin-lease-termination-notices-5-14-28-day",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Married couples owning rentals together: qualified joint venture vs partnership returns",
+		"category": "tax-prep",
+		"slug": "married-couple-rental-qualified-joint-venture-vs-partnership",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Source-of-income discrimination laws: a state-by-state guide for landlords",
+		"category": "tenant-screening",
+		"slug": "source-of-income-discrimination-laws-state-by-state",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Flat rate vs time-and-materials: choosing contractor pricing models for rental repairs",
+		"category": "maintenance",
+		"slug": "flat-rate-vs-time-and-materials-contractor-pricing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What unlimited units pricing really means in landlord software fine print",
+		"category": "software-vault",
+		"slug": "unlimited-units-pricing-fine-print",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Colorado late fee law: the 50-dollar-or-5-percent cap, seven-day grace period, and disclosure rules",
+		"category": "lease-law",
+		"slug": "colorado-late-fee-law-cap-grace-period-disclosure",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Holding company structures for ten-plus-door portfolios: when the complexity pays off",
+		"category": "tax-prep",
+		"slug": "holding-company-structures-larger-rental-portfolios",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening families with children: questions, criteria, and familial status traps",
+		"category": "tenant-screening",
+		"slug": "screening-families-with-children-familial-status",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Verifying contractor insurance and licensing before they enter your rental",
+		"category": "maintenance",
+		"slug": "verifying-contractor-insurance-and-licensing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Feature audit worksheet: how to score landlord software against what you actually do",
+		"category": "software-vault",
+		"slug": "landlord-software-feature-audit-worksheet",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Colorado's 10-day cure notices: lease violations, demands for compliance, and proper service",
+		"category": "lease-law",
+		"slug": "colorado-10-day-cure-notices-lease-violations",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "1099-NEC rules for landlords: which contractors and vendors actually need one",
+		"category": "tax-prep",
+		"slug": "landlord-1099-nec-rules-which-contractors-need-one",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The Keating memo and the two-per-bedroom rule: setting occupancy limits that hold up",
+		"category": "tenant-screening",
+		"slug": "keating-memo-two-per-bedroom-occupancy-limits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Finding reliable contractors in a new market when you manage rentals remotely",
+		"category": "maintenance",
+		"slug": "finding-contractors-remote-landlord-new-market",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The spreadsheet tipping point: when Excel stops working for your rentals",
+		"category": "software-vault",
+		"slug": "spreadsheet-tipping-point-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Colorado rent increase rules: the once-per-year limit and the 60-day notice requirement",
+		"category": "lease-law",
+		"slug": "colorado-rent-increase-rules-once-per-year-60-day-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "1099-NEC deadlines and dollar thresholds: a landlord's January filing calendar",
+		"category": "tax-prep",
+		"slug": "landlord-1099-nec-deadlines-thresholds-filing-calendar",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Limited English proficiency applicants: HUD guidance for screening and showings",
+		"category": "tenant-screening",
+		"slug": "limited-english-proficiency-hud-screening-guidance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When to put a contractor on retainer: service agreements for small rental portfolios",
+		"category": "maintenance",
+		"slug": "contractor-retainer-service-agreements-small-portfolios",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Google Drive folders vs a document vault: where lease files go to get lost",
+		"category": "software-vault",
+		"slug": "google-drive-vs-document-vault-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Minnesota landlord entry law: the new 24-hour notice requirement and allowed entry windows",
+		"category": "lease-law",
+		"slug": "minnesota-landlord-entry-law-24-hour-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Collect W-9s before the first check: the contractor intake habit that saves January",
+		"category": "tax-prep",
+		"slug": "collect-w9-before-first-check-contractor-intake",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Immigration status and national origin in screening: what landlords can legally ask",
+		"category": "tenant-screening",
+		"slug": "immigration-status-national-origin-screening-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Red flags when hiring rental property contractors: bids, deposits, and timelines",
+		"category": "maintenance",
+		"slug": "red-flags-hiring-rental-property-contractors",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The hidden cost of leases living in your email inbox as attachments",
+		"category": "software-vault",
+		"slug": "hidden-cost-leases-in-email-inbox",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Minnesota lease termination and notice rules: month-to-month timing and the newest tenant protections",
+		"category": "lease-law",
+		"slug": "minnesota-lease-termination-notice-rules-tenant-protections",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "1099-NEC vs 1099-MISC for landlords: matching the form to the expense type",
+		"category": "tax-prep",
+		"slug": "landlord-1099-nec-vs-1099-misc-which-form",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sexual orientation and gender identity in screening: HUD's Fair Housing Act interpretation",
+		"category": "tenant-screening",
+		"slug": "sexual-orientation-gender-identity-fair-housing-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Negotiating preferred-customer rates with HVAC and plumbing vendors as a small landlord",
+		"category": "maintenance",
+		"slug": "negotiating-preferred-rates-hvac-plumbing-vendors",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Free landlord spreadsheet templates: what they handle and where they quietly fail",
+		"category": "software-vault",
+		"slug": "free-landlord-spreadsheet-templates-limits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "South Carolina landlord entry rules: the 24-hour notice standard and emergency access rights",
+		"category": "lease-law",
+		"slug": "south-carolina-landlord-entry-rules-24-hour-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Do landlords have to issue 1099s? The trade-or-business question, answered",
+		"category": "tax-prep",
+		"slug": "do-landlords-have-to-issue-1099s-trade-or-business",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The 55-plus exemption explained: when senior housing can lawfully exclude families",
+		"category": "tenant-screening",
+		"slug": "hopa-55-plus-senior-housing-exemption",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to scope a repair job in writing so contractor bids are actually comparable",
+		"category": "maintenance",
+		"slug": "scope-repair-job-writing-comparable-bids",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "From filing cabinet to searchable archive: digitizing years of landlord paperwork",
+		"category": "software-vault",
+		"slug": "digitizing-landlord-paperwork-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "South Carolina lease termination notices: the 7-day and 30-day rules by tenancy type",
+		"category": "lease-law",
+		"slug": "south-carolina-lease-termination-notices-by-tenancy-type",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Backup withholding for landlords: what to do when a contractor refuses a W-9",
+		"category": "tax-prep",
+		"slug": "backup-withholding-contractor-refuses-w9",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "HUD's 2016 criminal history guidance: what it actually requires from landlords",
+		"category": "tenant-screening",
+		"slug": "hud-2016-criminal-history-guidance-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Keeping contractor W-9s, insurance certificates, and lien waivers organized in one document vault",
+		"category": "maintenance",
+		"slug": "organizing-contractor-w9s-cois-lien-waivers-document-vault",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Five signs your rental records have outgrown spreadsheets and shoeboxes",
+		"category": "software-vault",
+		"slug": "signs-outgrown-spreadsheets-rental-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Oregon rent increase limits: the statewide cap formula and the 90-day notice rule for landlords",
+		"category": "lease-law",
+		"slug": "oregon-rent-increase-limits-cap-formula-90-day-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Late or missing 1099 penalties: how landlords fix filing mistakes after the deadline",
+		"category": "tax-prep",
+		"slug": "late-missing-1099-penalties-how-landlords-fix",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Blanket criminal record bans: the fair housing liability hiding in your criteria",
+		"category": "tenant-screening",
+		"slug": "blanket-criminal-record-bans-fair-housing-liability",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Emergency vs urgent vs routine: a maintenance triage system for self-managing landlords",
+		"category": "maintenance",
+		"slug": "emergency-urgent-routine-maintenance-triage-system",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Free landlord software in 2026: the honest trade-offs behind every zero-dollar plan",
+		"category": "software-vault",
+		"slug": "free-landlord-software-trade-offs-2026",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Oregon lease termination rules: first-year flexibility, just cause afterward, and notice timelines",
+		"category": "lease-law",
+		"slug": "oregon-lease-termination-rules-first-year-just-cause",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Quarterly estimated taxes for landlords: safe harbor rules that avoid penalties",
+		"category": "tax-prep",
+		"slug": "quarterly-estimated-taxes-landlords-safe-harbor-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Individualized assessment for applicants with criminal records: a step-by-step process",
+		"category": "tenant-screening",
+		"slug": "individualized-assessment-criminal-records-process",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Setting your own response-time SLAs: 24-hour, 72-hour, and two-week repair tiers",
+		"category": "maintenance",
+		"slug": "landlord-response-time-slas-repair-tiers",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How free landlord software makes money, and what that means for your data",
+		"category": "software-vault",
+		"slug": "how-free-landlord-software-makes-money",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Nevada late fee cap: the 5 percent limit and how it applies to grace periods and partial months",
+		"category": "lease-law",
+		"slug": "nevada-late-fee-cap-5-percent-limit-grace-periods",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Calculating quarterly estimates when rental income swings month to month",
+		"category": "tax-prep",
+		"slug": "calculating-quarterly-estimates-fluctuating-rental-income",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Arrests vs convictions: why arrest records are off-limits in tenant screening",
+		"category": "tenant-screening",
+		"slug": "arrests-vs-convictions-tenant-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What counts as a true rental maintenance emergency (and what can wait until Monday)",
+		"category": "maintenance",
+		"slug": "what-counts-as-true-rental-maintenance-emergency",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Free-tier traps: the upgrade triggers in TurboTenant, Avail, Innago, and TenantCloud",
+		"category": "software-vault",
+		"slug": "free-tier-traps-landlord-software",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Nevada landlord entry law: the 24-hour notice requirement and tenant consent rules",
+		"category": "lease-law",
+		"slug": "nevada-landlord-entry-law-24-hour-notice-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "First-year landlord estimated taxes: when a new rental triggers quarterly filing",
+		"category": "tax-prep",
+		"slug": "first-year-landlord-estimated-taxes-quarterly-filing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "City and state fair chance housing laws: where criminal screening is restricted",
+		"category": "tenant-screening",
+		"slug": "fair-chance-housing-laws-criminal-screening-restrictions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Building an after-hours emergency plan when you are the only point of contact",
+		"category": "maintenance",
+		"slug": "after-hours-emergency-plan-solo-landlord",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The true cost of switching software twice: why outgrowing a free tool gets expensive",
+		"category": "software-vault",
+		"slug": "true-cost-of-switching-software-twice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to write an enforceable late fee clause: state caps, grace periods, and reasonableness tests",
+		"category": "lease-law",
+		"slug": "enforceable-late-fee-clause-state-caps-grace-periods",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Underpayment penalties explained: Form 2210 and the annualized income method",
+		"category": "tax-prep",
+		"slug": "underpayment-penalties-form-2210-annualized-income-method",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Setting criminal history lookback periods that survive a discrimination complaint",
+		"category": "tenant-screening",
+		"slug": "criminal-history-lookback-periods-defensible-policy",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "No heat in winter: the emergency response checklist for landlords",
+		"category": "maintenance",
+		"slug": "no-heat-winter-emergency-response-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The complete landlord document retention guide: how long to keep every record type",
+		"category": "software-vault",
+		"slug": "landlord-document-retention-guide-every-record-type",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pet clauses that hold up: deposits, fees, breed restrictions, and insurance pitfalls",
+		"category": "lease-law",
+		"slug": "pet-clauses-deposits-fees-breed-restrictions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Passive activity loss rules for rentals: why losses get suspended and where they go",
+		"category": "tax-prep",
+		"slug": "passive-activity-loss-rules-rentals-suspended-losses",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New Jersey's Fair Chance in Housing Act: the two-stage screening process explained",
+		"category": "tenant-screening",
+		"slug": "new-jersey-fair-chance-in-housing-act-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Water leak triage: the first 60 minutes after a tenant reports a leak",
+		"category": "maintenance",
+		"slug": "water-leak-triage-first-60-minutes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How long to keep old lease agreements after a tenant moves out (and why it matters)",
+		"category": "software-vault",
+		"slug": "how-long-to-keep-old-lease-agreements-after-move-out",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sublet and assignment clauses: keeping control without an unenforceable blanket ban",
+		"category": "lease-law",
+		"slug": "sublet-assignment-clauses-without-blanket-ban",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The $25,000 rental loss allowance: income phaseouts and who actually qualifies",
+		"category": "tax-prep",
+		"slug": "rental-loss-25k-special-allowance-phaseout",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Seattle's Fair Chance Housing ordinance: screening without criminal history",
+		"category": "tenant-screening",
+		"slug": "seattle-fair-chance-housing-ordinance-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Gas smell, sparking outlets, sewage backup: hazards that demand same-day response",
+		"category": "maintenance",
+		"slug": "same-day-response-hazards-gas-electrical-sewage",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rental application retention rules: FCRA, adverse action notices, and safe disposal",
+		"category": "software-vault",
+		"slug": "rental-application-retention-fcra-adverse-action-disposal",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Early termination clauses: structuring buyout fees and lease-break terms that hold up",
+		"category": "lease-law",
+		"slug": "early-termination-clause-buyout-fees",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Suspended passive losses: how they finally release when you sell the rental",
+		"category": "tax-prep",
+		"slug": "suspended-passive-losses-release-when-you-sell",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "FCRA basics for landlords: your legal duties when ordering tenant background reports",
+		"category": "tenant-screening",
+		"slug": "fcra-basics-for-landlords-background-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to handle maintenance requests while traveling: coverage planning for solo landlords",
+		"category": "maintenance",
+		"slug": "maintenance-coverage-planning-while-traveling",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How long to keep property inspection reports and why they win deposit disputes",
+		"category": "software-vault",
+		"slug": "how-long-to-keep-property-inspection-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The military clause explained: SCRA lease termination rights every landlord must honor",
+		"category": "lease-law",
+		"slug": "military-clause-scra-lease-termination-rights",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The seven material participation tests: counting your hours the IRS way",
+		"category": "tax-prep",
+		"slug": "seven-material-participation-tests-counting-hours",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Adverse action letters done right: exactly what to send when you deny an applicant",
+		"category": "tenant-screening",
+		"slug": "adverse-action-letters-for-landlords-step-by-step",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Triaging multiple repair requests across units: a priority matrix landlords can actually use",
+		"category": "maintenance",
+		"slug": "repair-request-priority-matrix-multiple-units",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Insurance policy recordkeeping for landlords: declarations pages, riders, and renewals",
+		"category": "software-vault",
+		"slug": "insurance-policy-recordkeeping-for-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Smoking and vaping clauses: drafting bans that cover marijuana in legalized states",
+		"category": "lease-law",
+		"slug": "smoking-vaping-marijuana-lease-clauses",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Active participation vs material participation: the distinction behind the $25k allowance",
+		"category": "tax-prep",
+		"slug": "active-vs-material-participation-rental-losses",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Beyond denials: when higher deposits and co-signer demands trigger adverse action notices",
+		"category": "tenant-screening",
+		"slug": "when-adverse-action-notices-are-required",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Normal wear and tear vs tenant damage: a room-by-room reference for landlords",
+		"category": "maintenance",
+		"slug": "normal-wear-vs-tenant-damage-room-by-room",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Contractor invoice retention: proving repair costs years after the work is done",
+		"category": "software-vault",
+		"slug": "contractor-invoice-retention-proving-repair-costs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Utility responsibility clauses: who pays what, RUBS billing, and shared meter rules",
+		"category": "lease-law",
+		"slug": "utility-responsibility-clauses-rubs-shared-meters",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Grouping multiple rentals as one activity: the aggregation election explained",
+		"category": "tax-prep",
+		"slug": "grouping-rentals-aggregation-election-explained",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Permissible purpose under the FCRA: certifying correctly before you pull a report",
+		"category": "tenant-screening",
+		"slug": "fcra-permissible-purpose-tenant-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Who pays for the clogged drain? Assigning repair costs fairly and legally",
+		"category": "maintenance",
+		"slug": "who-pays-clogged-drain-assigning-repair-costs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How long to keep tenant notices: entry, lease violation, and termination records",
+		"category": "software-vault",
+		"slug": "how-long-to-keep-tenant-notices",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Requiring renters insurance in the lease: what you can mandate and how to verify it",
+		"category": "lease-law",
+		"slug": "requiring-renters-insurance-lease-clause",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Time logs that survive an IRS audit: documenting real estate professional hours",
+		"category": "tax-prep",
+		"slug": "time-logs-real-estate-professional-hours-audit",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Investigative consumer reports vs standard background checks: the extra FCRA rules",
+		"category": "tenant-screening",
+		"slug": "investigative-consumer-reports-vs-background-checks",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Carpet life expectancy and depreciation: charging tenants fairly for flooring damage",
+		"category": "maintenance",
+		"slug": "carpet-life-expectancy-depreciation-flooring-damage",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "IRS recordkeeping rules for rental property: the 3-year, 7-year, and forever buckets",
+		"category": "software-vault",
+		"slug": "irs-recordkeeping-rules-rental-property-retention-buckets",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Joint and several liability: the one clause every roommate lease needs and why",
+		"category": "lease-law",
+		"slug": "joint-and-several-liability-roommate-lease-clause",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Real estate professional status for married couples: whose hours count and when",
+		"category": "tax-prep",
+		"slug": "real-estate-professional-status-spouse-hours",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When an applicant disputes their background check: the landlord's role and obligations",
+		"category": "tenant-screening",
+		"slug": "applicant-disputes-background-check-landlord-obligations",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Nail holes, scuffs, and faded paint: what landlords cannot deduct from deposits",
+		"category": "maintenance",
+		"slug": "nail-holes-scuffs-faded-paint-not-deductible",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Per-property vs per-tenant filing: choosing a document structure that scales",
+		"category": "software-vault",
+		"slug": "per-property-vs-per-tenant-document-filing-structure",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Guest and occupancy clauses: limiting long-term guests without fair housing trouble",
+		"category": "lease-law",
+		"slug": "guest-occupancy-clauses-long-term-guests",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Top IRS audit triggers for landlords and the records that defuse each one",
+		"category": "tax-prep",
+		"slug": "irs-audit-triggers-landlords-records-that-defuse",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Googling applicants and calling references: when DIY screening triggers FCRA duties",
+		"category": "tenant-screening",
+		"slug": "diy-screening-fcra-duties-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Documenting tenant-caused damage with photos and timestamps that hold up in disputes",
+		"category": "maintenance",
+		"slug": "documenting-tenant-damage-photos-timestamps-disputes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "File naming conventions for landlords: a system you can still search in five years",
+		"category": "software-vault",
+		"slug": "file-naming-conventions-for-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Attorney fee clauses in leases: one-way vs mutual provisions and state reciprocity rules",
+		"category": "lease-law",
+		"slug": "attorney-fee-clauses-residential-leases",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Inside a Schedule E audit: the documents the IRS asks for first",
+		"category": "tax-prep",
+		"slug": "schedule-e-audit-documents-irs-asks-for",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Choosing a tenant screening service: how to vet a consumer reporting agency",
+		"category": "tenant-screening",
+		"slug": "choosing-tenant-screening-service-vetting-cra",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pet damage vs pet wear: assessing repair charges after a pet-friendly tenancy",
+		"category": "maintenance",
+		"slug": "pet-damage-vs-pet-wear-repair-charges",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Custom document categories beyond the defaults: a taxonomy for growing portfolios",
+		"category": "software-vault",
+		"slug": "custom-document-categories-taxonomy-for-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Automatic renewal clauses: state notice requirements that can void your rollover",
+		"category": "lease-law",
+		"slug": "automatic-renewal-clauses-state-notice-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Repair vs improvement disputes: the receipts and photos that win an audit",
+		"category": "tax-prep",
+		"slug": "repair-vs-improvement-audit-receipts-photos",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "California's application screening fee law: the cap, the receipt, and the refund",
+		"category": "tenant-screening",
+		"slug": "california-application-screening-fee-cap-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Useful-life tables for rental fixtures: prorating damage charges the defensible way",
+		"category": "maintenance",
+		"slug": "useful-life-tables-prorating-damage-charges",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Going paperless as a landlord: a practical plan for digitizing decades of files",
+		"category": "software-vault",
+		"slug": "going-paperless-landlord-digitizing-plan",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lease clauses that are void on arrival: habitability waivers, deposit waivers, and more",
+		"category": "lease-law",
+		"slug": "void-lease-clauses-habitability-deposit-waivers",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mileage logs for landlords: substantiation rules the Tax Court actually enforces",
+		"category": "tax-prep",
+		"slug": "landlord-mileage-log-substantiation-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Washington State tenant screening laws: fee disclosures and comprehensive reports",
+		"category": "tenant-screening",
+		"slug": "washington-state-tenant-screening-fee-disclosure-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When a tenant's DIY repair makes things worse: liability and cost recovery options",
+		"category": "maintenance",
+		"slug": "tenant-diy-repair-gone-wrong-liability",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Scanning standards for legal documents: resolution, OCR, and PDF/A explained",
+		"category": "software-vault",
+		"slug": "scanning-standards-legal-documents-ocr-pdfa",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lease amendments vs addenda: when to use each and how to execute them properly",
+		"category": "lease-law",
+		"slug": "lease-amendment-vs-addendum",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The landlord home office deduction: when it's legitimate and how to document it",
+		"category": "tax-prep",
+		"slug": "landlord-home-office-deduction-documentation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New York's $20 application fee cap and what landlords can still charge",
+		"category": "tenant-screening",
+		"slug": "new-york-20-dollar-application-fee-cap",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The complete move-in inspection checklist for landlords, room by room",
+		"category": "maintenance",
+		"slug": "complete-move-in-inspection-checklist-room-by-room",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The documentation that wins security deposit disputes (and what judges ignore)",
+		"category": "software-vault",
+		"slug": "documentation-that-wins-security-deposit-disputes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Alterations and decorating clauses: nail holes, paint colors, and mounted TVs",
+		"category": "lease-law",
+		"slug": "alterations-decorating-clause-rental-lease",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How long to keep landlord tax records: statutes of limitations by document type",
+		"category": "tax-prep",
+		"slug": "how-long-keep-landlord-tax-records-retention",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Colorado's Rental Application Fairness Act: fee limits and portable report rules",
+		"category": "tenant-screening",
+		"slug": "colorado-rental-application-fairness-act-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Move-out inspection walkthrough: comparing condition against your move-in records",
+		"category": "maintenance",
+		"slug": "move-out-inspection-comparing-against-move-in-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Eviction-ready files: the documents a judge expects before you ever file",
+		"category": "software-vault",
+		"slug": "eviction-ready-files-documents-judges-expect",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Quiet enjoyment and nuisance clauses: setting noise rules you can actually enforce",
+		"category": "lease-law",
+		"slug": "quiet-enjoyment-nuisance-noise-clauses",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Selling a rental property: how adjusted basis and capital gains really get calculated",
+		"category": "tax-prep",
+		"slug": "selling-rental-adjusted-basis-capital-gains-calculation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Application fee laws by state: caps, disclosures, and refund triggers",
+		"category": "tenant-screening",
+		"slug": "application-fee-laws-by-state-caps-refunds",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Photo documentation standards for rental inspections: angles, lighting, and file naming",
+		"category": "maintenance",
+		"slug": "photo-documentation-standards-rental-inspections",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "New tenant document workflow: every file to collect and store before move-in day",
+		"category": "software-vault",
+		"slug": "new-tenant-document-workflow-before-move-in",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Domestic violence lease termination laws: landlord duties and required confidentiality",
+		"category": "lease-law",
+		"slug": "domestic-violence-lease-termination-laws",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Depreciation recapture when you sell: how unrecaptured Section 1250 gain is taxed",
+		"category": "tax-prep",
+		"slug": "depreciation-recapture-unrecaptured-1250-gain",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pre-application disclosures: what screening laws require you to tell applicants up front",
+		"category": "tenant-screening",
+		"slug": "pre-application-screening-disclosures",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Storing inspection reports and condition photos where you can find them years later",
+		"category": "maintenance",
+		"slug": "storing-inspection-reports-condition-photos-long-term",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lease renewal paperwork checklist: amendments, addenda, and version control",
+		"category": "software-vault",
+		"slug": "lease-renewal-paperwork-checklist-version-control",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lawn care and snow removal clauses: assigning exterior duties in single-family rentals",
+		"category": "lease-law",
+		"slug": "lawn-care-snow-removal-lease-clauses",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "1031 exchange basics for small landlords: timelines, rules, and common pitfalls",
+		"category": "tax-prep",
+		"slug": "small-landlord-1031-exchange-basics-timelines",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Security deposit alternatives: where cities require landlords to offer them",
+		"category": "tenant-screening",
+		"slug": "security-deposit-alternatives-city-mandates",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mid-lease inspections: how often, what notice, and what to look for",
+		"category": "maintenance",
+		"slug": "mid-lease-inspections-frequency-notice-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Move-out documentation workflow: condition reports, photos, and deduction evidence",
+		"category": "software-vault",
+		"slug": "move-out-documentation-workflow",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Banning short-term sublets: lease language that keeps long-term rentals long-term",
+		"category": "lease-law",
+		"slug": "banning-short-term-sublets-lease-language",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The 45-day identification window: three-property and 200 percent rules in a 1031",
+		"category": "tax-prep",
+		"slug": "exchange-identification-45-day-three-property-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening strategy in deposit-cap states: managing risk when you cannot raise the deposit",
+		"category": "tenant-screening",
+		"slug": "screening-in-deposit-cap-states-risk-management",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Getting tenant signatures on condition reports: why it matters and how to do it",
+		"category": "maintenance",
+		"slug": "tenant-signatures-on-condition-reports",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Selling a tenant-occupied rental: the document package buyers and escrow expect",
+		"category": "software-vault",
+		"slug": "selling-tenant-occupied-rental-document-package",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The duty to mitigate damages: your re-letting obligations after a broken lease",
+		"category": "lease-law",
+		"slug": "duty-to-mitigate-broken-lease",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Qualified intermediaries in a 1031 exchange: what they do and how to vet one",
+		"category": "tax-prep",
+		"slug": "qualified-intermediary-1031-exchange-how-to-vet",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Surety bonds and deposit insurance: how to evaluate deposit alternatives applicants propose",
+		"category": "tenant-screening",
+		"slug": "surety-bonds-deposit-insurance-evaluation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Video vs photo walkthroughs for move-in documentation: pros, cons, and storage",
+		"category": "maintenance",
+		"slug": "video-vs-photo-walkthroughs-move-in-documentation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Property insurance claims: the documentation insurers demand and how to have it ready",
+		"category": "software-vault",
+		"slug": "property-insurance-claim-documentation-for-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lock, key, and rekeying clauses: lost key charges and tenant lock-change rules",
+		"category": "lease-law",
+		"slug": "lock-key-rekeying-lease-clauses",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When a 1031 exchange fails: tax consequences and partial-exchange boot rules",
+		"category": "tax-prep",
+		"slug": "failed-1031-exchange-tax-consequences-boot",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Writing rental criteria: a defensible written-standards template for independent landlords",
+		"category": "tenant-screening",
+		"slug": "writing-defensible-rental-criteria-template",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The 7-day unit turn: a realistic timeline from move-out to rent-ready",
+		"category": "maintenance",
+		"slug": "seven-day-unit-turn-realistic-timeline",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Section 1031 exchange recordkeeping: documents to preserve from both sides of the swap",
+		"category": "software-vault",
+		"slug": "section-1031-exchange-recordkeeping-for-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pest control responsibility clauses: who pays for treatment and when liability shifts",
+		"category": "lease-law",
+		"slug": "pest-control-responsibility-lease-clause",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Installment sales for rental property: spreading gain across years with Form 6252",
+		"category": "tax-prep",
+		"slug": "installment-sale-rental-property-form-6252",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The screening paper trail that survives a fair housing complaint",
+		"category": "tenant-screening",
+		"slug": "screening-paper-trail-fair-housing-complaint",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Unit turn budget breakdown: what a typical turnover really costs per door",
+		"category": "maintenance",
+		"slug": "unit-turn-budget-breakdown-cost-per-door",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Are e-signed leases legally binding? ESIGN, UETA, and what landlords must keep",
+		"category": "software-vault",
+		"slug": "esigned-leases-legally-binding-esign-ueta",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ten lease mistakes that get small landlords in trouble in court, and how to fix each",
+		"category": "lease-law",
+		"slug": "lease-mistakes-small-landlords-court",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Section 121 after renting out your former home: the partial exclusion math",
+		"category": "tax-prep",
+		"slug": "section-121-exclusion-former-home-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Identical criteria, every applicant: building consistency into your screening process",
+		"category": "tenant-screening",
+		"slug": "consistent-screening-criteria-every-applicant",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Order of operations for a unit turn: why paint comes before carpet",
+		"category": "maintenance",
+		"slug": "unit-turn-order-of-operations-paint-before-carpet",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Disaster-proofing your rental records: the 3-2-1 backup rule for landlords",
+		"category": "software-vault",
+		"slug": "disaster-proofing-rental-records-321-backup",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Crime-free lease addenda: enforceability questions and fair housing risks",
+		"category": "lease-law",
+		"slug": "crime-free-lease-addenda-fair-housing-risks",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Moving back into your rental: nonqualified use and the shrinking home-sale exclusion",
+		"category": "tax-prep",
+		"slug": "moving-back-into-rental-nonqualified-use-exclusion",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Organizing screening documents: a vault system for applications, reports, and notices",
+		"category": "tenant-screening",
+		"slug": "organizing-screening-documents-vault-system",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deciding full repaint vs touch-up at turnover: a cost framework for landlords",
+		"category": "maintenance",
+		"slug": "repaint-vs-touch-up-turnover-cost-framework",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tax season handoff: packaging rental documents so your CPA stops emailing you",
+		"category": "software-vault",
+		"slug": "tax-season-document-handoff-to-cpa",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hold harmless and exculpatory clauses: why most fail in court and what works instead",
+		"category": "lease-law",
+		"slug": "hold-harmless-exculpatory-clauses-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Selling a rental at a loss: Section 1231 treatment and what the loss offsets",
+		"category": "tax-prep",
+		"slug": "selling-rental-at-loss-section-1231",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Adding a roommate mid-lease: screening the new occupant without redoing the lease",
+		"category": "tenant-screening",
+		"slug": "screening-new-roommate-mid-lease",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deep clean vs standard clean at turnover: scoping cleaning vendors correctly",
+		"category": "maintenance",
+		"slug": "deep-clean-vs-standard-clean-turnover-scoping",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Working with a landlord-tenant attorney: how to deliver a case file they can use",
+		"category": "software-vault",
+		"slug": "delivering-case-file-to-landlord-tenant-attorney",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lead-based paint disclosure: the pre-1978 federal rule, EPA pamphlet, and penalties",
+		"category": "lease-law",
+		"slug": "lead-based-paint-disclosure-pre-1978-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The 3.8 percent net investment income tax: when rental sales trigger the surtax",
+		"category": "tax-prep",
+		"slug": "net-investment-income-tax-rental-sale-surtax",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When an assistance animal letter looks fake: verification steps HUD actually permits",
+		"category": "tenant-screening",
+		"slug": "verifying-assistance-animal-letters-hud-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Turnover upgrades that reduce future maintenance: fixtures worth swapping every turn",
+		"category": "maintenance",
+		"slug": "turnover-upgrades-that-reduce-future-maintenance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What your insurance agent needs on file: appraisals, updates, and renewal documents",
+		"category": "software-vault",
+		"slug": "documents-your-insurance-agent-needs-on-file",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mold disclosure requirements: state rules plus a practical mold addendum walkthrough",
+		"category": "lease-law",
+		"slug": "mold-disclosure-requirements-addendum",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Inherited rental property and the step-up in basis: what heirs need to know first",
+		"category": "tax-prep",
+		"slug": "inherited-rental-step-up-basis-what-heirs-know",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Domestic violence survivor protections: screening rules under VAWA and state law",
+		"category": "tenant-screening",
+		"slug": "domestic-violence-survivor-screening-protections",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Scheduling contractors for a unit turn: sequencing trades to avoid idle days",
+		"category": "maintenance",
+		"slug": "scheduling-contractors-unit-turn-sequencing-trades",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Move-in and move-out photo standards that hold up in court",
+		"category": "software-vault",
+		"slug": "move-in-move-out-photo-standards-court",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Bed bug disclosure laws: what New York, Arizona, and Maine require before lease signing",
+		"category": "lease-law",
+		"slug": "bed-bug-disclosure-laws-by-state",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Depreciating an inherited rental: restarting the 27.5-year clock at stepped-up basis",
+		"category": "tax-prep",
+		"slug": "depreciating-inherited-rental-stepped-up-basis",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Open house vs individual showings: managing prospects fairly and documenting it",
+		"category": "tenant-screening",
+		"slug": "open-house-vs-individual-showings-fair-process",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The make-ready punch list: the final walkthrough before listing a vacant unit",
+		"category": "maintenance",
+		"slug": "make-ready-punch-list-final-walkthrough",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Photographing maintenance issues: before, during, and after repair documentation",
+		"category": "software-vault",
+		"slug": "photographing-maintenance-issues-before-after",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Flood disclosure requirements: which states make landlords reveal flood history",
+		"category": "lease-law",
+		"slug": "flood-disclosure-requirements-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Inheriting a rental with siblings: co-ownership filing options and buyout taxes",
+		"category": "tax-prep",
+		"slug": "inheriting-rental-with-siblings-co-ownership-taxes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Algorithmic screening tools and the SafeRent settlement: landlord liability for AI denials",
+		"category": "tenant-screening",
+		"slug": "algorithmic-screening-tools-landlord-liability",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Landlord heating obligations: minimum temperature laws and repair deadlines",
+		"category": "maintenance",
+		"slug": "landlord-heating-obligations-minimum-temperature-laws",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Photo metadata and timestamps: making your rental property photos credible evidence",
+		"category": "software-vault",
+		"slug": "photo-metadata-timestamps-credible-evidence",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Radon disclosure rules for rentals: state requirements and testing basics",
+		"category": "lease-law",
+		"slug": "radon-disclosure-rules-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Gifting a rental to your kids vs leaving it in your estate: the basis consequences",
+		"category": "tax-prep",
+		"slug": "gifting-rental-vs-inheritance-basis-consequences",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to tell an applicant no: compliant denial language for landlords",
+		"category": "tenant-screening",
+		"slug": "compliant-applicant-denial-language",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Hot water outages: habitability rules and how fast landlords must respond",
+		"category": "maintenance",
+		"slug": "hot-water-outage-habitability-response-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Audit-proofing Schedule E: the source documents behind every line you report",
+		"category": "software-vault",
+		"slug": "audit-proofing-schedule-e-source-documents",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "E-signing residential leases: ESIGN, UETA, and keeping executed copies audit-ready",
+		"category": "lease-law",
+		"slug": "esign-ueta-residential-leases",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "House hacking a duplex: splitting your return between Schedule E and your home",
+		"category": "tax-prep",
+		"slug": "house-hacking-duplex-schedule-e-split",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Managing an applicant waitlist fairly: order, documentation, and offer records",
+		"category": "tenant-screening",
+		"slug": "managing-applicant-waitlist-fairly",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mold in a rental: landlord responsibilities from first report to remediation",
+		"category": "maintenance",
+		"slug": "mold-in-rental-landlord-responsibilities-remediation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "After move-out: deciding what to archive and what to securely destroy",
+		"category": "software-vault",
+		"slug": "closed-tenancy-archive-what-to-keep-what-to-destroy",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Methamphetamine contamination disclosure: state laws and remediation standards",
+		"category": "lease-law",
+		"slug": "methamphetamine-contamination-disclosure-laws",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Renting a room in your home: allocating expenses by square footage and days",
+		"category": "tax-prep",
+		"slug": "renting-a-room-expense-allocation-square-footage",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Holding deposits vs application fees: the legal difference and how to document both",
+		"category": "tenant-screening",
+		"slug": "holding-deposits-vs-application-fees",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pest infestations in rentals: when the landlord pays and when the tenant does",
+		"category": "maintenance",
+		"slug": "pest-infestations-who-pays-landlord-or-tenant",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Storing screening reports safely: SSNs, credit data, and your legal exposure",
+		"category": "software-vault",
+		"slug": "storing-screening-reports-safely-ssn-credit-data",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Selling an occupied rental: transferring leases, deposits, and estoppel certificates",
+		"category": "lease-law",
+		"slug": "selling-occupied-rental-lease-transfer-estoppel",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Depreciating only the rental portion of a house hack: how the math actually works",
+		"category": "tax-prep",
+		"slug": "depreciating-rental-portion-house-hack",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Photo ID requirements in screening: acceptable documents and discrimination pitfalls",
+		"category": "tenant-screening",
+		"slug": "photo-id-requirements-screening-pitfalls",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The implied warranty of habitability explained for first-time landlords",
+		"category": "maintenance",
+		"slug": "implied-warranty-of-habitability-first-time-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The FTC Disposal Rule for landlords: legally destroying applicant records",
+		"category": "software-vault",
+		"slug": "ftc-disposal-rule-destroying-applicant-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sex offender database notices: which states require Megan's Law lease language",
+		"category": "lease-law",
+		"slug": "megans-law-sex-offender-lease-notices",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Selling a house hack: stacking the Section 121 exclusion with rental-side gain",
+		"category": "tax-prep",
+		"slug": "selling-house-hack-section-121-rental-gain",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Texas tenant selection criteria notice: the disclosure Section 92.3515 requires",
+		"category": "tenant-screening",
+		"slug": "texas-tenant-selection-criteria-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Repair-and-deduct laws: what happens when tenants fix problems themselves",
+		"category": "maintenance",
+		"slug": "repair-and-deduct-laws-explained-for-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Original signatures vs scans: which documents courts still want on paper",
+		"category": "software-vault",
+		"slug": "original-signatures-vs-scans-court-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Smoke and carbon monoxide detector laws: installation, testing, and lease documentation",
+		"category": "lease-law",
+		"slug": "smoke-carbon-monoxide-detector-lease-laws",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Short-term vs long-term holding for rentals: how the one-year line changes your tax",
+		"category": "tax-prep",
+		"slug": "short-vs-long-term-holding-rental-capital-gains",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Portland's FAIR ordinance: low-barrier screening criteria and the 72-hour rule",
+		"category": "tenant-screening",
+		"slug": "portland-fair-ordinance-screening-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lead paint, asbestos, and radon: disclosure and remediation duties for older rentals",
+		"category": "maintenance",
+		"slug": "lead-asbestos-radon-duties-older-rentals",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Digital evidence chain of custody: keeping your rental records admissible",
+		"category": "software-vault",
+		"slug": "digital-evidence-chain-of-custody-rental-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Move-in condition checklists: states that require them and how to document properly",
+		"category": "lease-law",
+		"slug": "move-in-condition-checklist-state-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Dealer vs investor status: when the IRS taxes your property sale as ordinary income",
+		"category": "tax-prep",
+		"slug": "dealer-vs-investor-status-property-sales",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Cook County's Just Housing Amendment: the mandatory two-step screening process",
+		"category": "tenant-screening",
+		"slug": "cook-county-just-housing-amendment-two-step-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sewer backups and standing water: habitability stakes and the documentation you need",
+		"category": "maintenance",
+		"slug": "sewer-backups-standing-water-habitability-documentation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tracking lease amendments without losing the thread: a version history system",
+		"category": "software-vault",
+		"slug": "tracking-lease-amendments-version-history",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Security deposit receipts and bank disclosures: states that require written notice",
+		"category": "lease-law",
+		"slug": "security-deposit-receipt-bank-disclosure-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Out-of-state rental income: nonresident state returns for remote landlords",
+		"category": "tax-prep",
+		"slug": "out-of-state-rental-income-nonresident-returns",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "NYC's Fair Chance for Housing Act: what landlords can no longer check",
+		"category": "tenant-screening",
+		"slug": "nyc-fair-chance-for-housing-act-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When a unit becomes uninhabitable: landlord duties, relocation, and repair timelines",
+		"category": "maintenance",
+		"slug": "uninhabitable-unit-landlord-duties-repair-timelines",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "First rental property document checklist: every file to gather before you list",
+		"category": "software-vault",
+		"slug": "first-rental-property-document-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Death in the unit and stigmatized property disclosures: California's rule and beyond",
+		"category": "lease-law",
+		"slug": "death-in-unit-stigmatized-property-disclosure",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buying a rental in a new state: the tax registration checklist before you close",
+		"category": "tax-prep",
+		"slug": "new-state-rental-tax-registration-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Massachusetts CORI checks: how landlords legally access criminal records",
+		"category": "tenant-screening",
+		"slug": "massachusetts-cori-checks-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How much to set aside for maintenance: the 1% rule, square-footage rule, and reality",
+		"category": "maintenance",
+		"slug": "maintenance-reserves-one-percent-rule-vs-reality",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Estoppel certificates explained: when landlords need them and where they belong on file",
+		"category": "software-vault",
+		"slug": "estoppel-certificates-when-landlords-need-them",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Security deposit itemization done right: deadlines, receipts, and penalty traps",
+		"category": "lease-law",
+		"slug": "security-deposit-itemization-deadlines-penalties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Resident-state credits for taxes paid where your rental sits: avoiding double tax",
+		"category": "tax-prep",
+		"slug": "resident-state-credit-rental-double-taxation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Marijuana legalization and tenant screening: drug-related criteria in legal states",
+		"category": "tenant-screening",
+		"slug": "marijuana-legalization-tenant-screening-criteria",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Building a capital expenditure schedule for roofs, HVAC, and water heaters",
+		"category": "maintenance",
+		"slug": "capital-expenditure-schedule-roofs-hvac-water-heaters",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Buying a rental with tenants in place: the records to demand at closing",
+		"category": "software-vault",
+		"slug": "buying-rental-with-tenants-records-to-demand-at-closing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Normal wear and tear vs tenant damage: a deduction framework with real examples",
+		"category": "lease-law",
+		"slug": "normal-wear-and-tear-vs-damage-deductions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Composite returns and pass-through withholding for out-of-state rental LLCs",
+		"category": "tax-prep",
+		"slug": "composite-returns-pass-through-withholding-rental-llc",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Your first vacancy: a realistic timeline from listing to signed lease",
+		"category": "tenant-screening",
+		"slug": "first-vacancy-realistic-timeline-listing-to-signed-lease",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maintenance reserves for a one-property landlord: how big and where to keep them",
+		"category": "maintenance",
+		"slug": "maintenance-reserves-one-property-landlord",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Estate planning for landlords: the records your successor will need on day one",
+		"category": "software-vault",
+		"slug": "estate-planning-landlord-records-for-successor",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Security deposit interest requirements: which states make landlords pay and how much",
+		"category": "lease-law",
+		"slug": "security-deposit-interest-requirements-by-state",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "City-level landlord taxes: rental licensing fees and gross receipts obligations",
+		"category": "tax-prep",
+		"slug": "city-rental-licensing-gross-receipts-taxes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to read a tenant credit report: what first-time landlords should weigh and what to ignore",
+		"category": "tenant-screening",
+		"slug": "how-to-read-tenant-credit-report-first-time-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Component lifespan cheat sheet: when major rental systems actually fail",
+		"category": "maintenance",
+		"slug": "component-lifespan-cheat-sheet-rental-systems",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Firing your property manager: the complete records retrieval checklist",
+		"category": "software-vault",
+		"slug": "firing-property-manager-records-retrieval-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Holding deposits vs security deposits: what each covers and when refunds are due",
+		"category": "lease-law",
+		"slug": "holding-deposit-vs-security-deposit",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The year-end tax checklist for landlords: moves to make before December 31",
+		"category": "tax-prep",
+		"slug": "year-end-tax-checklist-landlords-december-moves",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pricing your first rental: comps, concessions, and the vacancy math behind the asking number",
+		"category": "tenant-screening",
+		"slug": "pricing-your-first-rental-comps-vacancy-math",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Repair vs replace decisions for aging HVAC: a cost-per-remaining-year method",
+		"category": "maintenance",
+		"slug": "repair-vs-replace-aging-hvac-cost-method",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Documenting security deposit deductions: receipts, photos, and itemization letters",
+		"category": "software-vault",
+		"slug": "documenting-security-deposit-deductions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pet deposits and pet fees by state: where extra charges are capped or banned",
+		"category": "lease-law",
+		"slug": "pet-deposits-fees-state-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Prepaying rental expenses in December: which deductions you can pull forward",
+		"category": "tax-prep",
+		"slug": "prepaying-rental-expenses-december-deductions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fair housing before your first listing: ad wording and screening questions that cross the line",
+		"category": "tenant-screening",
+		"slug": "fair-housing-first-listing-ad-wording-screening-questions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Planning a roof replacement on an occupied rental: budgeting, timing, and tenant notice",
+		"category": "maintenance",
+		"slug": "roof-replacement-occupied-rental-planning",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Proof of notice service: certified mail receipts, posting photos, and delivery logs",
+		"category": "software-vault",
+		"slug": "proof-of-notice-service-certified-mail-posting",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What every residential lease must include: a required-terms checklist for landlords",
+		"category": "lease-law",
+		"slug": "required-lease-terms-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pre-tax-season document cleanup: organizing a year of receipts into audit-ready files",
+		"category": "tax-prep",
+		"slug": "tax-season-document-cleanup-audit-ready-files",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Building your first rental application: required documents, fees, and state fee caps",
+		"category": "tenant-screening",
+		"slug": "building-first-rental-application-documents-fees-caps",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Forecasting five years of capital expenses across a small rental portfolio",
+		"category": "maintenance",
+		"slug": "forecasting-five-years-capex-small-portfolio",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Archiving tenant emails and texts: turning conversations into court-ready records",
+		"category": "software-vault",
+		"slug": "archiving-tenant-emails-texts-court-ready",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Security deposit alternatives: surety bonds and deposit insurance, state by state",
+		"category": "lease-law",
+		"slug": "security-deposit-alternatives-surety-bonds",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Bonus depreciation for landlords: appliances, carpet, and other five-year property",
+		"category": "tax-prep",
+		"slug": "bonus-depreciation-landlords-five-year-property",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening tenants for the home you used to live in: taking emotion out of applicant decisions",
+		"category": "tenant-screening",
+		"slug": "screening-tenants-for-home-you-lived-in",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Preventive maintenance calendar: monthly, quarterly, and annual tasks that protect big-ticket systems",
+		"category": "maintenance",
+		"slug": "preventive-maintenance-calendar-monthly-quarterly-annual",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Documenting habitability complaints: the paper trail that protects landlords",
+		"category": "software-vault",
+		"slug": "documenting-habitability-complaints-paper-trail",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pay-or-quit notices: required contents, service methods, and counting days correctly",
+		"category": "lease-law",
+		"slug": "pay-or-quit-notice-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The de minimis safe harbor election: expensing small purchases without capitalizing",
+		"category": "tax-prep",
+		"slug": "de-minimis-safe-harbor-election-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Written screening criteria that scale: setting standards before door number three",
+		"category": "tenant-screening",
+		"slug": "written-screening-criteria-that-scale",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What landlords can legally DIY: repairs that require a licensed professional by law",
+		"category": "maintenance",
+		"slug": "what-landlords-can-legally-diy-licensed-pro-limits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mold complaints and remediation records: the documentation timeline that matters",
+		"category": "software-vault",
+		"slug": "mold-complaint-remediation-documentation-timeline",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Cure-or-quit notices: giving tenants a real chance to fix lease violations",
+		"category": "lease-law",
+		"slug": "cure-or-quit-notice-lease-violations",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The safe harbor for small taxpayers: deducting building repairs without a fight",
+		"category": "tax-prep",
+		"slug": "safe-harbor-small-taxpayers-building-repairs",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Forty applications, one unit: a fair and consistent process for high-volume tenant screening",
+		"category": "tenant-screening",
+		"slug": "forty-applications-one-unit-high-volume-screening",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Electrical work landlords should never DIY: permits, code, and insurance consequences",
+		"category": "maintenance",
+		"slug": "electrical-work-landlords-should-never-diy",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Lead paint disclosure records: the federal three-year rule and what to store",
+		"category": "software-vault",
+		"slug": "lead-paint-disclosure-records-federal-rule",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Unconditional quit notices: when states allow termination without a second chance",
+		"category": "lease-law",
+		"slug": "unconditional-quit-notice-state-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Remote tenant screening: verifying identity, income, and rental history without meeting in person",
+		"category": "tenant-screening",
+		"slug": "remote-tenant-screening-verifying-identity-income-history",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Gas appliance repairs: why licensed technicians are non-negotiable for rentals",
+		"category": "maintenance",
+		"slug": "gas-appliance-repairs-licensed-technicians-only",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fair housing defense files: documenting consistent screening criteria over time",
+		"category": "software-vault",
+		"slug": "fair-housing-defense-documenting-consistent-criteria",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Non-renewal notices: timing rules, just-cause limits, and proper delivery methods",
+		"category": "lease-law",
+		"slug": "non-renewal-notice-timing-delivery",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "CPA vs DIY tax software for landlords: a decision framework by portfolio size",
+		"category": "tax-prep",
+		"slug": "cpa-vs-diy-tax-software-landlords-decision-framework",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Leasing a unit you can't visit: virtual showings without falling for application fraud",
+		"category": "tenant-screening",
+		"slug": "leasing-unit-you-cant-visit-virtual-showings-application-fraud",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Permits for rental property repairs: when you need one and what happens if you skip it",
+		"category": "maintenance",
+		"slug": "permits-for-rental-repairs-when-needed",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Reasonable accommodation requests: what landlords must keep on file and never ask for",
+		"category": "software-vault",
+		"slug": "reasonable-accommodation-request-documentation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Notice of entry rules: 24-hour requirements, emergencies, and showing an occupied unit",
+		"category": "lease-law",
+		"slug": "notice-of-entry-rules-24-hour-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What to hand your CPA in January: the landlord document package that cuts your bill",
+		"category": "tax-prep",
+		"slug": "landlord-cpa-document-package-january",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pets, ESAs, and service animals: what landlords can ask, charge, and refuse",
+		"category": "tenant-screening",
+		"slug": "pets-esas-service-animals-what-landlords-can-ask",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Handyman license thresholds by job size: staying under legal dollar limits",
+		"category": "maintenance",
+		"slug": "handyman-license-thresholds-job-size-limits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Emotional support animal paperwork: what to keep on file and what crosses the line",
+		"category": "software-vault",
+		"slug": "esa-paperwork-what-landlords-keep-on-file",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rent increase notices: how much warning each state requires and how to serve them",
+		"category": "lease-law",
+		"slug": "rent-increase-notice-state-requirements",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Questions to ask before hiring a rental property tax accountant",
+		"category": "tax-prep",
+		"slug": "questions-hiring-rental-property-tax-accountant",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How to write a rental listing that attracts qualified applicants (with a section-by-section template)",
+		"category": "tenant-screening",
+		"slug": "write-rental-listing-qualified-applicants-template",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "DIY plumbing in rentals: where the line sits between simple fix and licensed work",
+		"category": "maintenance",
+		"slug": "diy-plumbing-rentals-licensed-work-line",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Exporting your rental records: why bulk download matters before audits and lawsuits",
+		"category": "software-vault",
+		"slug": "exporting-rental-records-bulk-download-before-audits",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Serving legal notices properly: personal delivery, posting, and certified mail rules",
+		"category": "lease-law",
+		"slug": "serving-legal-notices-delivery-methods",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "EA vs CPA vs tax attorney: matching the professional to the landlord problem",
+		"category": "tax-prep",
+		"slug": "ea-vs-cpa-vs-tax-attorney-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What to disclose in a rental listing: utilities, policies, and quirks that prevent wasted showings",
+		"category": "tenant-screening",
+		"slug": "rental-listing-disclosures-prevent-wasted-showings",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Unpermitted work discovered at your rental: how to remediate and document it",
+		"category": "maintenance",
+		"slug": "unpermitted-work-discovered-rental-remediation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Built to be found: organizing rental files so any document surfaces in seconds",
+		"category": "software-vault",
+		"slug": "organizing-rental-files-for-instant-search",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Ending a month-to-month tenancy: 30, 60, and 90-day notice rules by state",
+		"category": "lease-law",
+		"slug": "ending-month-to-month-tenancy-notice-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Common Schedule E mistakes that quietly cost landlords deductions every year",
+		"category": "tax-prep",
+		"slug": "common-schedule-e-mistakes-cost-deductions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rental listing red flags that drive away qualified renters (and how to fix them)",
+		"category": "tenant-screening",
+		"slug": "rental-listing-red-flags-qualified-renters",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Insurance implications of DIY repairs gone wrong at a rental property",
+		"category": "maintenance",
+		"slug": "insurance-implications-diy-repairs-gone-wrong",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Tagging and metadata strategies for rental documents that go beyond folders",
+		"category": "software-vault",
+		"slug": "tagging-metadata-strategies-rental-documents",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Holdover tenants: your notice options when the lease expires and the tenant stays",
+		"category": "lease-law",
+		"slug": "holdover-tenant-notice-options",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Forgot to depreciate your rental? Fixing missed depreciation with Form 3115",
+		"category": "tax-prep",
+		"slug": "missed-depreciation-fix-form-3115",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Photographing small or dated units honestly: accuracy that pre-qualifies applicants",
+		"category": "tenant-screening",
+		"slug": "photographing-small-dated-units-honestly",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why a per-property maintenance log is your best defense in a habitability dispute",
+		"category": "maintenance",
+		"slug": "per-property-maintenance-log-habitability-defense",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Folder structures by portfolio size: filing templates for 1, 5, and 25 doors",
+		"category": "software-vault",
+		"slug": "folder-structures-by-portfolio-size",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Retaliation claims: timing mistakes that make a lawful eviction look unlawful",
+		"category": "lease-law",
+		"slug": "landlord-retaliation-claims-timing-mistakes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Misclassifying improvements as repairs: the capitalization rules in plain English",
+		"category": "tax-prep",
+		"slug": "improvements-vs-repairs-capitalization-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Recording a smartphone video walkthrough that pre-screens applicants before in-person showings",
+		"category": "tenant-screening",
+		"slug": "video-walkthrough-prescreen-before-showings",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What to record for every repair: dates, costs, vendors, photos, and outcomes",
+		"category": "maintenance",
+		"slug": "what-to-record-every-repair-dates-costs-vendors",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "From filing cabinet to cloud: migrating twenty years of paper rental records",
+		"category": "software-vault",
+		"slug": "filing-cabinet-to-cloud-migrating-paper-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The eviction process step by step: a stage-by-stage overview for first-time landlords",
+		"category": "lease-law",
+		"slug": "eviction-process-step-by-step-overview",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Security deposits and taxable income: when a deposit stops being a liability",
+		"category": "tax-prep",
+		"slug": "security-deposits-taxable-income-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Sight-unseen applications: managing risk when tenants apply from a virtual tour",
+		"category": "tenant-screening",
+		"slug": "sight-unseen-applications-virtual-tour-risk",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Organizing maintenance records by property and unit: a filing system that scales",
+		"category": "maintenance",
+		"slug": "organizing-maintenance-records-by-property-unit",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Outgrowing Google Drive: when shared folders stop working for rental documents",
+		"category": "software-vault",
+		"slug": "outgrowing-google-drive-for-rental-documents",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Eviction stage one: choosing and serving the right termination notice",
+		"category": "lease-law",
+		"slug": "eviction-stage-one-termination-notice",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Travel deductions landlords get wrong: local trips, overnight stays, and mixed purpose",
+		"category": "tax-prep",
+		"slug": "landlord-travel-deductions-local-vs-overnight",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Open house vs individual showings: which fills a rental vacancy faster",
+		"category": "tenant-screening",
+		"slug": "open-house-vs-individual-showings-vacancy",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Maintenance history as a selling point: documentation that boosts property value at sale",
+		"category": "maintenance",
+		"slug": "maintenance-history-documentation-boosts-sale-value",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Signs your spreadsheet-and-folders system is failing your rental business",
+		"category": "software-vault",
+		"slug": "signs-spreadsheet-folder-system-failing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Filing an eviction complaint: court forms, filing fees, and naming defendants correctly",
+		"category": "lease-law",
+		"slug": "filing-eviction-complaint-court-forms",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Start-up expenses before your first tenant: the $5,000 first-year deduction rule",
+		"category": "tax-prep",
+		"slug": "rental-startup-expenses-first-year-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fair-housing-safe pre-screening questions to ask before scheduling a showing",
+		"category": "tenant-screening",
+		"slug": "fair-housing-safe-prescreening-questions",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "From text-message chaos to a single repair record: centralizing tenant maintenance requests",
+		"category": "maintenance",
+		"slug": "centralizing-maintenance-requests-single-repair-record",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Encrypting tenant data: a landlord's guide to protecting PII in stored documents",
+		"category": "software-vault",
+		"slug": "encrypting-tenant-data-protecting-pii",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Summons and service of process: why bad service restarts your eviction timeline",
+		"category": "lease-law",
+		"slug": "eviction-summons-service-of-process",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Deducting expenses on a vacant unit: the placed-in-service rules that decide it",
+		"category": "tax-prep",
+		"slug": "vacant-unit-deductions-placed-in-service-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "A landlord's showing checklist: what to bring, what to say, and what to document",
+		"category": "tenant-screening",
+		"slug": "landlord-showing-checklist-what-to-document",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "How long to keep maintenance records: retention guidelines for rental property owners",
+		"category": "maintenance",
+		"slug": "how-long-to-keep-maintenance-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "State data privacy laws and landlord files: what applies when you store tenant PII",
+		"category": "software-vault",
+		"slug": "state-data-privacy-laws-landlord-files",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Preparing for the eviction hearing: evidence, witnesses, and the lease file judges expect",
+		"category": "lease-law",
+		"slug": "eviction-hearing-preparation-evidence",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Renting to family below market rate: the personal-use trap that kills deductions",
+		"category": "tax-prep",
+		"slug": "renting-to-family-below-market-tax-trap",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Documenting showing traffic and applicant contacts to keep tenant selection consistent and defensible",
+		"category": "tenant-screening",
+		"slug": "documenting-showing-traffic-consistent-selection",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Using maintenance logs to spot recurring problems before they become capital repairs",
+		"category": "maintenance",
+		"slug": "maintenance-logs-spot-recurring-problems-early",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Certificates of insurance from contractors: collecting, verifying, and storing COIs",
+		"category": "software-vault",
+		"slug": "contractor-certificates-of-insurance-collecting-storing",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Default judgments in eviction cases: what happens when the tenant never answers",
+		"category": "lease-law",
+		"slug": "eviction-default-judgment-explained",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Closing costs on a rental purchase: deduct now, amortize, or add to basis",
+		"category": "tax-prep",
+		"slug": "rental-closing-costs-deduct-amortize-basis",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Personal safety at rental showings: protocols for landlords meeting strangers alone",
+		"category": "tenant-screening",
+		"slug": "personal-safety-rental-showings-solo-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Audit-ready repair documentation: matching invoices, photos, and warranty papers",
+		"category": "maintenance",
+		"slug": "audit-ready-repair-documentation-invoices-warranties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "W-9s and 1099-NEC prep: the contractor paperwork to collect before the first job",
+		"category": "software-vault",
+		"slug": "w9-and-1099-nec-contractor-paperwork",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The writ of possession: what happens between judgment and the sheriff's lockout",
+		"category": "lease-law",
+		"slug": "writ-of-possession-after-eviction-judgment",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Points and refinancing on a rental: the amortization rules landlords miss",
+		"category": "tax-prep",
+		"slug": "rental-refinance-points-amortization-rules",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Reducing no-shows at rental showings: confirmation tactics and smarter scheduling windows",
+		"category": "tenant-screening",
+		"slug": "reducing-no-shows-rental-showings",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Filing a landlord insurance claim: the documentation packet adjusters actually want",
+		"category": "maintenance",
+		"slug": "landlord-insurance-claim-documentation-packet",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Repairs vs improvements: organizing receipts so the IRS distinction is obvious",
+		"category": "software-vault",
+		"slug": "repairs-vs-improvements-organizing-receipts",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Self-help eviction is illegal: lockouts, utility shutoffs, and the penalties landlords face",
+		"category": "lease-law",
+		"slug": "self-help-eviction-illegal-lockouts-penalties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Interest tracing rules: deducting HELOC funds you put into a rental property",
+		"category": "tax-prep",
+		"slug": "interest-tracing-heloc-rental-deduction",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Why your rental isn't getting applications: a 10-point diagnostic for slow listings",
+		"category": "tenant-screening",
+		"slug": "rental-not-getting-applications-diagnostic",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Before-and-after photos for insurance claims: building evidence from day one of ownership",
+		"category": "maintenance",
+		"slug": "before-after-photos-insurance-claims-evidence",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Cost basis and depreciation records: the documents you keep until you sell, plus three years",
+		"category": "software-vault",
+		"slug": "cost-basis-depreciation-records-keep-until-sale",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Cash for keys: structuring a legal move-out agreement instead of an eviction",
+		"category": "lease-law",
+		"slug": "cash-for-keys-move-out-agreement",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Casualty losses and insurance proceeds: rental tax treatment after a disaster",
+		"category": "tax-prep",
+		"slug": "casualty-losses-insurance-proceeds-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Allowing pets to widen your applicant pool: demand, damage risk, and the middle ground",
+		"category": "tenant-screening",
+		"slug": "allowing-pets-applicant-pool-damage-risk",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Storm damage at your rental: claim timeline, mitigation duties, and proof of loss",
+		"category": "maintenance",
+		"slug": "storm-damage-rental-claim-timeline-mitigation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Closing documents and settlement statements: lifetime retention for every property",
+		"category": "software-vault",
+		"slug": "closing-documents-settlement-statements-retention",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Eviction stipulations: settling at the courthouse with enforceable agreed judgments",
+		"category": "lease-law",
+		"slug": "eviction-stipulation-agreed-judgment",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Your first tax season as a landlord: a Schedule E walkthrough for a single rental",
+		"category": "tax-prep",
+		"slug": "first-tax-season-landlord-schedule-e-walkthrough",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Pet screening for landlords: vet references, pet interviews, and pet resumes",
+		"category": "tenant-screening",
+		"slug": "pet-screening-vet-references-pet-resumes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Water damage claims: proving sudden loss vs long-term neglect to your insurer",
+		"category": "maintenance",
+		"slug": "water-damage-claims-sudden-loss-vs-neglect",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mortgage and loan file retention for rental properties: notes, payoffs, and refis",
+		"category": "software-vault",
+		"slug": "mortgage-loan-file-retention-rental-properties",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Abandoned tenant belongings: storage, notice, and disposal laws by state",
+		"category": "lease-law",
+		"slug": "abandoned-tenant-belongings-laws",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "First-year landlord tax mistakes: missed depreciation, commingled expenses, and thin records",
+		"category": "tax-prep",
+		"slug": "first-year-landlord-tax-mistakes",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Screening mid-term tenants: verifying travel contracts, employers, and prior landlords",
+		"category": "tenant-screening",
+		"slug": "screening-midterm-tenants-travel-contracts",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Working with an insurance adjuster on rental damage: prep, walkthrough, and follow-up",
+		"category": "maintenance",
+		"slug": "working-with-insurance-adjuster-rental-damage",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "HOA documents landlords must keep: CC&Rs, violation notices, and assessment letters",
+		"category": "software-vault",
+		"slug": "hoa-documents-landlords-must-keep",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Inherited tenants: lease and removal rules when you buy an occupied rental",
+		"category": "lease-law",
+		"slug": "inherited-tenants-buying-occupied-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Do you owe quarterly estimated taxes on rental income? A first-year landlord's guide",
+		"category": "tax-prep",
+		"slug": "quarterly-estimated-taxes-rental-income-first-year-guide",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Leasing in a downturn: concessions, flexible terms, and the screening standards you should never lower",
+		"category": "tenant-screening",
+		"slug": "downturn-leasing-keep-screening-standards",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fire damage documentation: inventories, receipts, and contractor estimates insurers accept",
+		"category": "maintenance",
+		"slug": "fire-damage-documentation-insurers-accept",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Permits and code compliance records: proving your rental was legal all along",
+		"category": "software-vault",
+		"slug": "permits-code-compliance-records-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Squatters vs holdover tenants: why the legal removal process is different",
+		"category": "lease-law",
+		"slug": "squatters-vs-holdover-tenants-removal",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Inherited rental property taxes: stepped-up basis and restarting depreciation",
+		"category": "tax-prep",
+		"slug": "inherited-rental-property-taxes-stepped-up-basis-depreciation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Soft-market screening: adjusting income ratios responsibly without inviting risk",
+		"category": "tenant-screening",
+		"slug": "soft-market-income-ratio-adjustments",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "When to file vs absorb the cost: deductibles, premium impact, and claim thresholds for landlords",
+		"category": "maintenance",
+		"slug": "when-to-file-vs-absorb-cost-claim-thresholds",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Smoke and CO detector compliance: the installation and testing records that protect you",
+		"category": "software-vault",
+		"slug": "smoke-co-detector-compliance-records",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Winter eviction limits: states and cities with seasonal moratoria and how they work",
+		"category": "lease-law",
+		"slug": "winter-eviction-limits-seasonal-moratoria",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "House hack taxes: splitting the mortgage, utilities, and repairs between your unit and the rental",
+		"category": "tax-prep",
+		"slug": "house-hack-taxes-splitting-expenses-owner-unit-rental",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Your first tenant turn: a room-by-room checklist between move-out and move-in",
+		"category": "maintenance",
+		"slug": "first-tenant-turn-room-by-room-checklist",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "A repeatable room-by-room photo protocol for routine rental inspections",
+		"category": "software-vault",
+		"slug": "room-by-room-photo-protocol-routine-inspections",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Evicting one roommate from a joint lease: why it rarely works mid-term",
+		"category": "lease-law",
+		"slug": "evicting-one-roommate-joint-lease",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The Section 121 clock: how long accidental landlords can rent before losing the home-sale exclusion",
+		"category": "tax-prep",
+		"slug": "section-121-clock-accidental-landlords-home-sale-exclusion",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Your first maintenance request: triage, response times, and the paper trail to keep",
+		"category": "maintenance",
+		"slug": "first-maintenance-request-triage-response-paper-trail",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Mid-lease inspections: documenting property condition without violating quiet enjoyment",
+		"category": "software-vault",
+		"slug": "mid-lease-inspection-documentation",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "What an eviction really costs: court fees, lost time, and turnover math for small landlords",
+		"category": "lease-law",
+		"slug": "true-cost-of-eviction-small-landlords",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "LLCs for rental property: liability, lending, and tax realities at each portfolio size",
+		"category": "tax-prep",
+		"slug": "llcs-for-rental-property-liability-lending-tax-realities",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Move-in inspections that hold up: documenting condition before your first tenant arrives",
+		"category": "maintenance",
+		"slug": "move-in-inspections-documenting-condition-first-tenant",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Exterior and drive-by inspection records for landlords who live far away",
+		"category": "software-vault",
+		"slug": "exterior-drive-by-inspection-records-remote",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Fair-housing-safe rental ads: phrases that trigger complaints and what to write instead",
+		"category": "lease-law",
+		"slug": "fair-housing-safe-rental-ads",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Multi-property tax prep: organizing receipts, mileage, and 1099s by property before filing season",
+		"category": "tax-prep",
+		"slug": "multi-property-tax-prep-organizing-receipts-by-property",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Couldn't sell, so you're renting it out: making the house rent-ready without over-improving",
+		"category": "maintenance",
+		"slug": "couldnt-sell-renting-it-out-rent-ready-without-over-improving",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "The remote landlord's document system: managing records from another state",
+		"category": "software-vault",
+		"slug": "remote-landlord-document-system",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Familial status rules: occupancy limits, adults-only mistakes, and HUD's two-per-bedroom guidance",
+		"category": "lease-law",
+		"slug": "familial-status-occupancy-limits-hud-guidance",
+		"tier": "evergreen"
+	},
+	{
+		"topic": "Rent control and rent stabilization basics: which states and cities have it, and what small landlords need to know",
+		"category": "lease-law",
+		"slug": "rent-control-rent-stabilization-basics-for-landlords",
+		"tier": "evergreen"
+	}
+]

--- a/scripts/blog-topics.test.ts
+++ b/scripts/blog-topics.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { DELETED_BLOG_REDIRECTS } from "../src/lib/seo/blog-redirects";
+import type { BlogTopicEntry } from "./run-scheduled-blog";
+import { mapTopicEntry } from "./run-scheduled-blog";
+
+// The canonical 1,000-topic bank the scheduled blog factory works through.
+// Every invariant here protects the pipeline: bad categories/slugs would fail
+// the generator's gates AFTER burning a local-LLM run; banned phrases would
+// steer the model into content the ingest EF rejects; duplicate slugs would
+// make the runner spin on the same topic.
+
+const SLUG_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+const VALID_CATEGORIES = new Set([
+	"lease-law",
+	"tax-prep",
+	"tenant-screening",
+	"maintenance",
+	"software-vault",
+]);
+// Mirrors the generator BANLIST (scripts/generate-blog-draft.ts) — phrases the
+// product must never claim; a topic containing one would push the model into
+// content the gates reject.
+const BANLIST = [
+	"rent collection",
+	"online rent",
+	"autopay",
+	"auto-pay",
+	"tenant portal",
+	"automated rent",
+	"collect rent",
+	"rent processing",
+	"pay rent online",
+	"online payments",
+	"online rent payment",
+	"rent collection software",
+	"tenants can pay",
+	"pay rent through",
+	"automated workflow",
+	"rent tracking",
+	"mobile app access",
+	"record rent",
+	"paid rent",
+	"pay rent",
+];
+// The 9 posts live at the time the bank was researched (mirrors the hardcoded
+// LIVE_PUBLISHED_SLUGS guard in src/lib/seo/__tests__/blog-redirects.test.ts).
+// Slugs added to that guard later come FROM this bank (reclaim publishes), so
+// only this original set must never appear here.
+const ORIGINAL_LIVE_SLUGS = new Set([
+	"innago-vs-doorloop-complete-comparison-for-2025",
+	"hemlane-vs-zillow-rental-manager-complete-comparison-for-2025",
+	"propertyware-vs-innago-vs-tenantflow-the-definitive-guide-for-small-landlords-in-2025",
+	"cozy-vs-resman-complete-comparison-for-2026",
+	"hemlane-vs-simplifyem-vs-tenantflow-the-definitive-2025-comparison-for-independent-landlords",
+	"the-essential-tenant-screening-checklist-for-first-time-landlords",
+	"virtual-tours-that-attract-quality-tenants",
+	"avail-vs-turbotenant-complete-comparison-for-2026",
+	"stessa-vs-innago-complete-comparison-for-2026",
+]);
+
+// cwd-relative: vitest runs from the repo root (same convention as the
+// migration-lockstep test in documents.test.ts).
+const bank: BlogTopicEntry[] = (
+	JSON.parse(readFileSync("scripts/blog-topics.json", "utf8")) as Record<
+		string,
+		unknown
+	>[]
+).map(mapTopicEntry);
+
+describe("blog-topics.json bank", () => {
+	it("holds exactly 1,000 topics", () => {
+		expect(bank.length).toBe(1000);
+	});
+
+	it("every entry uses a valid generator category", () => {
+		for (const t of bank) {
+			expect(VALID_CATEGORIES.has(t.category), `bad category: ${t.slug}`).toBe(
+				true,
+			);
+		}
+	});
+
+	it("every slug passes the generator slug gate (regex + 3-120)", () => {
+		for (const t of bank) {
+			expect(SLUG_RE.test(t.slug), `bad slug: ${t.slug}`).toBe(true);
+			expect(t.slug.length).toBeGreaterThanOrEqual(3);
+			expect(t.slug.length).toBeLessThanOrEqual(120);
+		}
+	});
+
+	it("every topic is a trimmed, sane-length working title", () => {
+		for (const t of bank) {
+			expect(t.topic, `untrimmed: ${t.slug}`).toBe(t.topic.trim());
+			expect(t.topic.length, `too short: ${t.slug}`).toBeGreaterThanOrEqual(20);
+			expect(t.topic.length, `too long: ${t.slug}`).toBeLessThanOrEqual(160);
+		}
+	});
+
+	it("slugs are unique", () => {
+		expect(new Set(bank.map((t) => t.slug)).size).toBe(bank.length);
+	});
+
+	it("normalized topics are unique (no reworded duplicates)", () => {
+		const norm = bank.map((t) =>
+			t.topic
+				.toLowerCase()
+				.replace(/[^a-z0-9]+/g, " ")
+				.trim(),
+		);
+		expect(new Set(norm).size).toBe(bank.length);
+	});
+
+	it("no topic or slug contains a banned phrase", () => {
+		for (const t of bank) {
+			const haystacks = [t.topic.toLowerCase(), t.slug.replace(/-/g, " ")];
+			for (const phrase of BANLIST) {
+				for (const hay of haystacks) {
+					expect(
+						hay.includes(phrase),
+						`"${t.slug}" contains banned phrase "${phrase}"`,
+					).toBe(false);
+				}
+			}
+		}
+	});
+
+	it("no entry collides with the original live published slugs", () => {
+		for (const t of bank) {
+			expect(ORIGINAL_LIVE_SLUGS.has(t.slug), `live collision: ${t.slug}`).toBe(
+				false,
+			);
+		}
+	});
+
+	it("evergreen entries never squat a ghost-redirect slug (reclaim tier owns those)", () => {
+		const ghostSlugs = new Set(
+			DELETED_BLOG_REDIRECTS.map((r) => r.source.replace("/blog/", "")),
+		);
+		for (const t of bank) {
+			if (t.tier === "evergreen") {
+				expect(
+					ghostSlugs.has(t.slug),
+					`evergreen entry squats ghost slug: ${t.slug}`,
+				).toBe(false);
+			}
+		}
+	});
+
+	it("reclaim entries lead the bank (highest SEO value first)", () => {
+		const firstEvergreen = bank.findIndex((t) => t.tier === "evergreen");
+		const lastReclaim = bank.map((t) => t.tier).lastIndexOf("reclaim");
+		expect(firstEvergreen).toBeGreaterThan(0);
+		expect(lastReclaim).toBeLessThan(firstEvergreen);
+	});
+});

--- a/scripts/run-scheduled-blog.test.ts
+++ b/scripts/run-scheduled-blog.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { BlogTopicEntry } from "./run-scheduled-blog";
+import {
+	fetchAllSlugs,
+	mapTopicEntry,
+	pickNextTopic,
+} from "./run-scheduled-blog";
+
+const entry = (
+	slug: string,
+	tier: "reclaim" | "evergreen",
+): BlogTopicEntry => ({
+	topic: `Topic for ${slug} with enough length`,
+	category: "software-vault",
+	slug,
+	tier,
+});
+
+describe("pickNextTopic", () => {
+	const bank = [
+		entry("a-one", "reclaim"),
+		entry("b-two", "reclaim"),
+		entry("c-three", "evergreen"),
+	];
+
+	it("picks the first topic whose slug is not yet written", () => {
+		expect(pickNextTopic(bank, new Set(["a-one"]))?.slug).toBe("b-two");
+	});
+
+	it("picks the very first entry when nothing is written", () => {
+		expect(pickNextTopic(bank, new Set())?.slug).toBe("a-one");
+	});
+
+	it("returns undefined when the bank is exhausted", () => {
+		expect(
+			pickNextTopic(bank, new Set(["a-one", "b-two", "c-three"])),
+		).toBeUndefined();
+	});
+});
+
+describe("mapTopicEntry", () => {
+	it("maps a valid entry", () => {
+		expect(
+			mapTopicEntry({
+				topic: "A valid topic title",
+				category: "lease-law",
+				slug: "a-valid-slug",
+				tier: "evergreen",
+			}),
+		).toEqual({
+			topic: "A valid topic title",
+			category: "lease-law",
+			slug: "a-valid-slug",
+			tier: "evergreen",
+		});
+	});
+
+	it("throws on a bad slug", () => {
+		expect(() =>
+			mapTopicEntry({
+				topic: "t",
+				category: "lease-law",
+				slug: "Bad Slug!",
+				tier: "evergreen",
+			}),
+		).toThrow(/bad slug/);
+	});
+
+	it("throws on a bad tier", () => {
+		expect(() =>
+			mapTopicEntry({
+				topic: "t",
+				category: "lease-law",
+				slug: "ok-slug",
+				tier: "weekly",
+			}),
+		).toThrow(/bad tier/);
+	});
+});
+
+describe("fetchAllSlugs", () => {
+	it("paginates until a short page and collects every slug", async () => {
+		const pages = [
+			{ data: [{ slug: "p1-a" }, { slug: "p1-b" }], error: null },
+			{ data: [{ slug: "p2-a" }], error: null },
+		];
+		let call = 0;
+		const result = await fetchAllSlugs(async () => {
+			const page = pages[call] ?? { data: [], error: null };
+			call++;
+			return page;
+		}, 2);
+		expect(call).toBe(2);
+		expect([...result].sort()).toEqual(["p1-a", "p1-b", "p2-a"]);
+	});
+
+	it("rejects on a page error — never a silent partial set", async () => {
+		await expect(
+			fetchAllSlugs(async () => ({
+				data: null,
+				error: { message: "permission denied" },
+			})),
+		).rejects.toMatchObject({
+			message: expect.stringContaining("permission denied"),
+		});
+	});
+});

--- a/scripts/run-scheduled-blog.ts
+++ b/scripts/run-scheduled-blog.ts
@@ -1,0 +1,128 @@
+/**
+ * Scheduled blog-factory runner (n8n Execute Command entrypoint).
+ *
+ * Picks the FIRST topic in scripts/blog-topics.json whose slug does not yet
+ * exist in public.blogs (any status), then spawns the generator pinned to that
+ * slug. The existence check runs BEFORE generation, so a scheduled run never
+ * burns local-LLM minutes on a topic that's already written — the bank is
+ * worked through front-to-back (reclaim ghost slugs first, then evergreen,
+ * already ordered in the JSON). When every slug exists, the run logs and exits
+ * 0 (clean idle, not a failure).
+ *
+ * Env (Bun auto-loads .env/.env.local from cwd, same as the generator):
+ * NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SECRET_KEY (or SUPABASE_SERVICE_ROLE_KEY).
+ *
+ * Usage: bun scripts/run-scheduled-blog.ts
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createClient } from "@supabase/supabase-js";
+import { formatGenFailure } from "./generate-blog-draft";
+
+export interface BlogTopicEntry {
+	readonly topic: string;
+	readonly category: string;
+	readonly slug: string;
+	readonly tier: "reclaim" | "evergreen";
+}
+
+const TOPICS_PATH = new URL("./blog-topics.json", import.meta.url).pathname;
+const SLUG_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+// Typed mapper at the JSON boundary (CLAUDE.md: no `as unknown as`). Throws on a
+// malformed entry so a corrupted bank fails loudly instead of generating junk.
+export function mapTopicEntry(raw: Record<string, unknown>): BlogTopicEntry {
+	const { topic, category, slug, tier } = raw;
+	if (typeof topic !== "string" || topic.length === 0)
+		throw new Error("blog-topics.json: entry missing topic");
+	if (typeof category !== "string" || category.length === 0)
+		throw new Error(`blog-topics.json: entry "${topic}" missing category`);
+	if (typeof slug !== "string" || !SLUG_RE.test(slug))
+		throw new Error(`blog-topics.json: entry "${topic}" has a bad slug`);
+	if (tier !== "reclaim" && tier !== "evergreen")
+		throw new Error(`blog-topics.json: entry "${topic}" has a bad tier`);
+	return { topic, category, slug, tier };
+}
+
+export function loadTopics(path: string = TOPICS_PATH): BlogTopicEntry[] {
+	const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+	if (!Array.isArray(parsed)) throw new Error("blog-topics.json: not an array");
+	return (parsed as Record<string, unknown>[]).map(mapTopicEntry);
+}
+
+// First topic whose slug isn't already written. Pure — unit-tested.
+export function pickNextTopic(
+	topics: readonly BlogTopicEntry[],
+	existingSlugs: ReadonlySet<string>,
+): BlogTopicEntry | undefined {
+	return topics.find((t) => !existingSlugs.has(t.slug));
+}
+
+// Result shape of one slug page; the probe closure keeps this decoupled from
+// the deeply-generic SupabaseClient type (same pattern as blogSlugExists).
+type SlugPageResult = { data: unknown; error: { message: string } | null };
+
+export async function fetchAllSlugs(
+	fetchPage: (from: number, to: number) => PromiseLike<SlugPageResult>,
+	pageSize = 1000,
+): Promise<Set<string>> {
+	const slugs = new Set<string>();
+	for (let from = 0; ; from += pageSize) {
+		const { data, error } = await fetchPage(from, from + pageSize - 1);
+		if (error) throw new Error(`fetchAllSlugs: ${error.message}`);
+		const rows = (data ?? []) as { slug: string }[];
+		for (const row of rows) slugs.add(row.slug);
+		if (rows.length < pageSize) return slugs;
+	}
+}
+
+async function main(): Promise<void> {
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const key =
+		process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+	if (!url || !key) {
+		console.error(
+			formatGenFailure(
+				"run-scheduled-blog: missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY",
+			),
+		);
+		process.exit(1);
+	}
+
+	const topics = loadTopics();
+	const supabase = createClient(url, key, { auth: { persistSession: false } });
+	const existing = await fetchAllSlugs((from, to) =>
+		supabase.from("blogs").select("slug").range(from, to),
+	);
+	const next = pickNextTopic(topics, existing);
+	if (!next) {
+		console.log(
+			`topic bank exhausted — all ${topics.length} slugs already exist in public.blogs. Nothing to generate.`,
+		);
+		return;
+	}
+
+	console.log(
+		`[${existing.size} written / ${topics.length} banked] generating ${next.tier} topic: "${next.topic}" (${next.category}) --slug ${next.slug}`,
+	);
+	const child = spawnSync(
+		process.execPath,
+		[
+			new URL("./generate-blog-draft.ts", import.meta.url).pathname,
+			next.topic,
+			next.category,
+			"--slug",
+			next.slug,
+		],
+		{ stdio: "inherit" },
+	);
+	process.exit(child.status ?? 1);
+}
+
+// CLI guard — import-safe for unit tests (same pattern as generate-blog-draft).
+if (process.argv[1]?.endsWith("/run-scheduled-blog.ts")) {
+	main().catch((e: unknown) => {
+		console.error(formatGenFailure(e instanceof Error ? e.message : String(e)));
+		process.exit(1);
+	});
+}


### PR DESCRIPTION
## 1,000-topic canonical blog bank + zero-waste scheduled runner

Eliminates blog redundancy by construction and locks brand positioning at the topic level — the scheduled factory now works front-to-back through a researched, validated, committed topic bank instead of a 20-item in-workflow rotation.

### `scripts/blog-topics.json` — the bank
- **1,000 topics**, researched via a 16-agent fan-out (12 domain researchers + ghost-slug curation + 3 brand verifiers) and then deterministically validated.
- **93 reclaim entries first** (SEO gold): curated from all 126 deleted ghost slugs — dropped junk `error-*` slugs, banned rent-collection framing, fabricated `success-stories`, tenant/vacation-audience slugs. Each pins its exact deleted URL.
- **907 evergreen** across the 5 categories (software-vault 268 incl. competitor comparisons, maintenance 187, lease-law 184 incl. a 50-state security-deposit-law series, tax-prep 182, tenant-screening 179), interleaved for day-to-day variety.
- Brand rules enforced: landlord-only audience, no payments/portal/accounting framing (full generator BANLIST absent from every topic+slug), no hype/fabricated stats, honest competitor angles.

### `scripts/run-scheduled-blog.ts` — the runner (n8n entrypoint)
- Loads the bank (typed mapper boundary), pages **all existing `blogs` slugs** via a probe closure, picks the **first unwritten topic**, spawns the generator pinned to its slug.
- Dedup now runs **before** generation (the Phase-14 in-generator check stays as backstop) → a scheduled run never burns local-LLM minutes on an already-written topic. Bank exhausted → clean exit 0. Failures emit the greppable `BLOG-GEN-FAIL` prefix.

### Tests (18 new; 47 pass incl. generator suite)
- 10 bank invariants: exactly 1,000, valid categories, slug gate (regex + 3-120), trimmed sane-length titles, unique slugs, unique normalized topics, banlist absence, no live-slug collision, no evergreen ghost-squatting, reclaim-first ordering.
- 8 runner tests: pick-next logic, typed mapper rejects bad slug/tier, pagination collects all pages + fail-closed on PostgREST error.

n8n side (local config, not in diff): the workflow is now `Every 30 min → bun scripts/run-scheduled-blog.ts`.

[hudsor01]
