### PR TITLE
fix(blog): pid-lockfile overlap guard for the scheduled runner

### DIFF
--- a/scripts/run-scheduled-blog.test.ts
+++ b/scripts/run-scheduled-blog.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import type { BlogTopicEntry } from "./run-scheduled-blog";
 import {
+	acquireLock,
 	fetchAllSlugs,
 	mapTopicEntry,
 	pickNextTopic,
+	releaseLock,
 } from "./run-scheduled-blog";
 
 const entry = (
@@ -103,5 +108,43 @@ describe("fetchAllSlugs", () => {
 		).rejects.toMatchObject({
 			message: expect.stringContaining("permission denied"),
 		});
+	});
+});
+
+describe("overlap lock", () => {
+	const lockPath = join(tmpdir(), `tf-blog-lock-test-${process.pid}.lock`);
+
+	afterEach(() => {
+		releaseLock(lockPath);
+	});
+
+	it("acquires when no lock exists and records the pid", () => {
+		expect(acquireLock(process.pid, lockPath)).toBe(true);
+		expect(readFileSync(lockPath, "utf8")).toBe(String(process.pid));
+	});
+
+	it("refuses while the holder process is alive", () => {
+		expect(acquireLock(process.pid, lockPath)).toBe(true);
+		// process.pid is this very test process — definitely alive
+		expect(acquireLock(process.pid, lockPath)).toBe(false);
+	});
+
+	it("reclaims a stale lock left by a dead process", () => {
+		// PID 4194304 exceeds the macOS/Linux default pid_max — never alive.
+		writeFileSync(lockPath, "4194304");
+		expect(acquireLock(process.pid, lockPath)).toBe(true);
+		expect(readFileSync(lockPath, "utf8")).toBe(String(process.pid));
+	});
+
+	it("reclaims a corrupted lockfile", () => {
+		writeFileSync(lockPath, "not-a-pid");
+		expect(acquireLock(process.pid, lockPath)).toBe(true);
+	});
+
+	it("releaseLock removes the file and is idempotent", () => {
+		expect(acquireLock(process.pid, lockPath)).toBe(true);
+		releaseLock(lockPath);
+		expect(existsSync(lockPath)).toBe(false);
+		releaseLock(lockPath); // no throw on second call
 	});
 });

--- a/scripts/run-scheduled-blog.ts
+++ b/scripts/run-scheduled-blog.ts
@@ -15,7 +15,9 @@
  * Usage: bun scripts/run-scheduled-blog.ts
  */
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createClient } from "@supabase/supabase-js";
 import { formatGenFailure } from "./generate-blog-draft";
 
@@ -76,7 +78,46 @@ export async function fetchAllSlugs(
 	}
 }
 
-async function main(): Promise<void> {
+// Overlap guard: a slow generation (judge regenerations can exceed the 30-min
+// schedule spacing) must not run concurrently with the next tick — n8n execs
+// 151+152 proved two simultaneous 24B generations halve decode speed and both
+// time out. PID lockfile with stale-takeover: a live holder skips the tick
+// cleanly (exit 0); a dead holder's lock is reclaimed.
+const DEFAULT_LOCK_PATH = join(tmpdir(), "tenantflow-blog-factory.lock");
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function acquireLock(
+	pid: number,
+	lockPath: string = DEFAULT_LOCK_PATH,
+): boolean {
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			writeFileSync(lockPath, String(pid), { flag: "wx" });
+			return true;
+		} catch {
+			const holder = Number.parseInt(readFileSync(lockPath, "utf8"), 10);
+			if (Number.isInteger(holder) && holder > 0 && isProcessAlive(holder)) {
+				return false;
+			}
+			rmSync(lockPath, { force: true }); // stale lock — reclaim and retry
+		}
+	}
+	return false;
+}
+
+export function releaseLock(lockPath: string = DEFAULT_LOCK_PATH): void {
+	rmSync(lockPath, { force: true });
+}
+
+async function main(): Promise<number> {
 	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
 	const key =
 		process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -86,43 +127,59 @@ async function main(): Promise<void> {
 				"run-scheduled-blog: missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY",
 			),
 		);
-		process.exit(1);
+		return 1;
 	}
 
-	const topics = loadTopics();
-	const supabase = createClient(url, key, { auth: { persistSession: false } });
-	const existing = await fetchAllSlugs((from, to) =>
-		supabase.from("blogs").select("slug").range(from, to),
-	);
-	const next = pickNextTopic(topics, existing);
-	if (!next) {
+	if (!acquireLock(process.pid)) {
 		console.log(
-			`topic bank exhausted — all ${topics.length} slugs already exist in public.blogs. Nothing to generate.`,
+			"previous blog-factory run still in progress — skipping this tick.",
 		);
-		return;
+		return 0;
 	}
+	try {
+		const topics = loadTopics();
+		const supabase = createClient(url, key, {
+			auth: { persistSession: false },
+		});
+		const existing = await fetchAllSlugs((from, to) =>
+			supabase.from("blogs").select("slug").range(from, to),
+		);
+		const next = pickNextTopic(topics, existing);
+		if (!next) {
+			console.log(
+				`topic bank exhausted — all ${topics.length} slugs already exist in public.blogs. Nothing to generate.`,
+			);
+			return 0;
+		}
 
-	console.log(
-		`[${existing.size} written / ${topics.length} banked] generating ${next.tier} topic: "${next.topic}" (${next.category}) --slug ${next.slug}`,
-	);
-	const child = spawnSync(
-		process.execPath,
-		[
-			new URL("./generate-blog-draft.ts", import.meta.url).pathname,
-			next.topic,
-			next.category,
-			"--slug",
-			next.slug,
-		],
-		{ stdio: "inherit" },
-	);
-	process.exit(child.status ?? 1);
+		console.log(
+			`[${existing.size} written / ${topics.length} banked] generating ${next.tier} topic: "${next.topic}" (${next.category}) --slug ${next.slug}`,
+		);
+		const child = spawnSync(
+			process.execPath,
+			[
+				new URL("./generate-blog-draft.ts", import.meta.url).pathname,
+				next.topic,
+				next.category,
+				"--slug",
+				next.slug,
+			],
+			{ stdio: "inherit" },
+		);
+		return child.status ?? 1;
+	} finally {
+		releaseLock();
+	}
 }
 
 // CLI guard — import-safe for unit tests (same pattern as generate-blog-draft).
 if (process.argv[1]?.endsWith("/run-scheduled-blog.ts")) {
-	main().catch((e: unknown) => {
-		console.error(formatGenFailure(e instanceof Error ? e.message : String(e)));
-		process.exit(1);
-	});
+	main()
+		.then((code) => process.exit(code))
+		.catch((e: unknown) => {
+			console.error(
+				formatGenFailure(e instanceof Error ? e.message : String(e)),
+			);
+			process.exit(1);
+		});
 }


### PR DESCRIPTION
Execs 151+152 ran concurrently (tick fired mid-generation) — two simultaneous 24B generations halved decode speed and both timed out. The runner now acquires a pid lockfile (stale/corrupt holders reclaimed, live holders make the tick skip cleanly with exit 0), released in `finally`. +5 lock tests; 25 pass.

[hudsor01]