### PR TITLE
fix(blog): deterministically cap DocuSeal at one mention

### DIFF
--- a/scripts/generate-blog-draft.test.ts
+++ b/scripts/generate-blog-draft.test.ts
@@ -3,6 +3,7 @@ import type { Draft } from "./generate-blog-draft";
 import {
 	applySlugOverride,
 	blogSlugExists,
+	capDocusealMentions,
 	critique,
 	formatGenFailure,
 	gateOnCritique,
@@ -351,5 +352,30 @@ describe("structured failure output (BLOG-09b)", () => {
 		const line = formatGenFailure("match_blog_rag_chunks: boom");
 		expect(line.startsWith("BLOG-GEN-FAIL: ")).toBe(true);
 		expect(line).toContain("match_blog_rag_chunks: boom");
+	});
+});
+
+describe("capDocusealMentions (docuseal_mention gate, max 1)", () => {
+	it("keeps a single mention untouched", () => {
+		expect(capDocusealMentions("Sign it with DocuSeal today.")).toBe(
+			"Sign it with DocuSeal today.",
+		);
+	});
+
+	it("generifies the second and later mentions, preserving possessives", () => {
+		const input =
+			"DocuSeal handles e-signing. Later, DocuSeal's audit trail helps, and DocuSeal stores copies.";
+		expect(capDocusealMentions(input)).toBe(
+			"DocuSeal handles e-signing. Later, your e-signature tool's audit trail helps, and your e-signature tool stores copies.",
+		);
+	});
+
+	it("is case-insensitive and leaves zero-mention content unchanged", () => {
+		expect(capDocusealMentions("docuseal then DOCUSEAL")).toBe(
+			"docuseal then your e-signature tool",
+		);
+		expect(capDocusealMentions("No e-sign tools here.")).toBe(
+			"No e-sign tools here.",
+		);
 	});
 });

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -243,6 +243,19 @@ function sanitizeBanlist(s: string): string {
 	return out;
 }
 
+// The docuseal_mention gate allows AT MOST one "DocuSeal" (Phase 4 COPY-04); the
+// model reliably over-mentions it in e-sign-adjacent topics and burns all 4
+// repair attempts failing to fix itself (n8n exec 183). Deterministic cure, same
+// philosophy as sanitizeBanlist: keep the first mention, generify the rest.
+export function capDocusealMentions(s: string): string {
+	let seen = 0;
+	return s.replace(/DocuSeal(['’]s)?/gi, (match, poss: string | undefined) => {
+		seen++;
+		if (seen <= 1) return match; // first mention stays exactly as written
+		return poss ? "your e-signature tool's" : "your e-signature tool";
+	});
+}
+
 async function embed(input: string): Promise<number[]> {
 	const r = await fetch(`${LM_BASE}/embeddings`, {
 		method: "POST",
@@ -489,6 +502,8 @@ async function generateValidDraft(
 		d.content = d.content.replace(/^\s*#[^#].*(?:\r?\n)+/, "");
 		// deterministically neutralize any banlist phrases the model slips in
 		d.content = sanitizeBanlist(d.content);
+		// cap DocuSeal at one mention (docuseal_mention gate, max 1)
+		d.content = capDocusealMentions(d.content);
 		const failures = runGates(d);
 		console.log(
 			`  ${9 - failures.length}/9 gates  (${countWords(d.content)} words, "${d.title}")`,


### PR DESCRIPTION
Exec 183 wasted 14 min failing 'docuseal_mention (2x)' across all 4 attempts — the model can't self-edit it out. Deterministic post-generation cap (keep first mention, generify the rest), same philosophy as the banlist sanitizer. +3 tests.

[hudsor01]