### PR TITLE
feat(blog): full auto-publish — no human gate, no manual redirect edits

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,37 @@ import type { NextConfig } from "next";
  */
 import "./src/env";
 // 301 map for the deleted Phase-1 blog catalogue (SEO ranking-equity recovery).
-import { DELETED_BLOG_REDIRECTS } from "./src/lib/seo/blog-redirects";
+import {
+	DELETED_BLOG_REDIRECTS,
+	filterActiveRedirects,
+} from "./src/lib/seo/blog-redirects";
+
+// Build-time fetch of the published blog slug set (anon PostgREST read — RLS
+// exposes only status=published). Used to drop ghost 301s whose slug has been
+// republished by the blog factory, so a reclaimed URL serves its new post on
+// the very next deploy with zero manual edits. FAIL-OPEN: any error returns
+// null and redirects() keeps the FULL map — a Supabase blip can never break
+// the build, worst case a reclaimed slug keeps 301ing until the next deploy.
+async function fetchPublishedBlogSlugs(): Promise<Set<string> | null> {
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+	if (!url || !key || url.includes("placeholder")) return null;
+	try {
+		const res = await fetch(
+			`${url}/rest/v1/blogs?select=slug&status=eq.published&limit=2000`,
+			{ headers: { apikey: key, Authorization: `Bearer ${key}` } },
+		);
+		if (!res.ok) return null;
+		const rows = (await res.json()) as { slug?: unknown }[];
+		return new Set(
+			rows
+				.map((r) => r.slug)
+				.filter((slug): slug is string => typeof slug === "string"),
+		);
+	} catch {
+		return null;
+	}
+}
 
 const nextConfig: NextConfig = {
 	output: "standalone",
@@ -110,7 +140,12 @@ const nextConfig: NextConfig = {
 			// accumulated Google ranking signal transfers instead of decaying on
 			// a bare 404. permanent: true emits 308 (Google treats as 301).
 			// See src/lib/seo/blog-redirects.ts for the map + reclaim notes.
-			...DELETED_BLOG_REDIRECTS.map((r) => ({
+			// Filtered at build time against the published slug set: a ghost slug
+			// whose post has been republished serves the post, not the 301.
+			...filterActiveRedirects(
+				DELETED_BLOG_REDIRECTS,
+				(await fetchPublishedBlogSlugs()) ?? new Set<string>(),
+			).map((r) => ({
 				source: r.source,
 				destination: r.destination,
 				permanent: true,

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -360,7 +360,10 @@ async function generate(
 // prose is genuinely helpful, on-brand, or grounded. The judge is that gate. ---
 const CRITIQUE_THRESHOLD = 4;
 const MAX_CRITIQUE = 2;
-const MAX_REPAIR = 4;
+// 6 attempts: word_count undershoot is the one remaining stochastic gate flake
+// (exec 188 burned 4/4 with 990 words); two extra rolls at ~3-5 min each still
+// fit the 30-min schedule spacing + overlap lock.
+const MAX_REPAIR = 6;
 
 interface Critique {
 	scores: {

--- a/src/app/actions/blog-publish.ts
+++ b/src/app/actions/blog-publish.ts
@@ -16,8 +16,11 @@ import type { Database } from "#types/supabase";
  * UPDATE at the DB. The service role is NEVER imported here — every write
  * crosses RLS as the signed-in admin.
  *
- * Nothing publishes without an explicit admin Approve click: status='published'
- * is set in exactly one place (publishBlogPost).
+ * Role note: the blog factory AUTO-PUBLISHES via the n8n-blog-ingest Edge
+ * Function (the 9 gates + the generator's fail-closed LLM-as-judge are the
+ * review). This surface is the manual OVERRIDE: approve any row parked
+ * in-review and, more importantly, reject/archive a published post after the
+ * fact.
  */
 
 export type BlogActionResult = { ok: true } | { ok: false; error: string };

--- a/src/lib/seo/__tests__/blog-redirects.test.ts
+++ b/src/lib/seo/__tests__/blog-redirects.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { DELETED_BLOG_REDIRECTS } from "../blog-redirects";
+import {
+	DELETED_BLOG_REDIRECTS,
+	filterActiveRedirects,
+} from "../blog-redirects";
 
 // The 9 live published slugs (prod public.blogs WHERE status='published',
 // 2026-05-29). A redirect whose source matches one of these would SHADOW the
@@ -85,5 +88,20 @@ describe("DELETED_BLOG_REDIRECTS", () => {
 				expect(destination === "/compare" || okLiveBlog).toBe(true);
 			}
 		}
+	});
+});
+
+describe("filterActiveRedirects (build-time reclaim filter)", () => {
+	it("drops a redirect whose slug has a published post, keeps the rest", () => {
+		const sample = DELETED_BLOG_REDIRECTS.slice(0, 3);
+		const reclaimed = sample[0]?.source.replace("/blog/", "") ?? "";
+		const out = filterActiveRedirects(sample, new Set([reclaimed]));
+		expect(out.length).toBe(sample.length - 1);
+		expect(out.some((r) => r.source === sample[0]?.source)).toBe(false);
+	});
+
+	it("keeps the full map when nothing is published (fail-open input)", () => {
+		const out = filterActiveRedirects(DELETED_BLOG_REDIRECTS, new Set());
+		expect(out.length).toBe(DELETED_BLOG_REDIRECTS.length);
 	});
 });

--- a/src/lib/seo/blog-redirects.ts
+++ b/src/lib/seo/blog-redirects.ts
@@ -10,13 +10,28 @@
 // -> /compare; (4) generic guide -> /blog.
 // See .planning/seo-audit/ANALYSIS-2026-05-29.md.
 //
-// REPUBLISH-RECLAIM (Hybrid plan, top-10 first): when a quality replacement is
-// published at one of these slugs, DELETE that entry so the new post serves
-// instead of redirecting.
+// REPUBLISH-RECLAIM: next.config.ts filters this map AT BUILD TIME against the
+// published slug set (filterActiveRedirects below), so a reclaimed slug 301
+// drops automatically on the next deploy after its post publishes — no manual
+// entry deletion required. scripts/reclaim-finalize.ts remains as optional
+// hygiene to permanently delete stale entries.
 
 export interface BlogRedirect {
 	readonly source: string;
 	readonly destination: string;
+}
+
+// Build-time filter: keep a ghost 301 ONLY while no published post exists at its
+// slug. Pure + unit-tested; next.config.ts calls it with the slug set fetched
+// from Supabase at build (fail-open to the full map when the fetch fails, so a
+// Supabase blip can never break the build or strand a redirect).
+export function filterActiveRedirects(
+	redirects: readonly BlogRedirect[],
+	publishedSlugs: ReadonlySet<string>,
+): BlogRedirect[] {
+	return redirects.filter(
+		(r) => !publishedSlugs.has(r.source.replace("/blog/", "")),
+	);
 }
 
 export const DELETED_BLOG_REDIRECTS: readonly BlogRedirect[] = [

--- a/supabase/functions/n8n-blog-ingest/index.ts
+++ b/supabase/functions/n8n-blog-ingest/index.ts
@@ -8,14 +8,15 @@
 // preflight gates only exist to fail fast with structured error responses and to
 // keep load off the DB on obviously-broken payloads).
 //
-// On success: INSERT into `public.blogs` with `status='in-review'` (service-role
-// client; this endpoint bypasses RLS — HMAC is the auth boundary). Optional
+// On success: INSERT into `public.blogs` with `status='published'` + a
+// `published_at` stamp (service-role client; this endpoint bypasses RLS — HMAC is
+// the auth boundary; the gates + the generator's judge are the review). Optional
 // `canonical_url` from the payload threads into the new row's `canonical_url`
 // column (Blocker-#1 wiring; Plan 06-02's generateMetadata emits
 // <link rel="canonical"> when the column is non-null).
 //
 // Response shapes:
-//   201 — { id, slug, status: 'in-review', canonical_url, blog_url }
+//   201 — { id, slug, status: 'published', canonical_url, blog_url }
 //   400 — { error: 'malformed_json' | 'validation_failed', gate_failures?: [...] }
 //   401 — { error: 'unauthorized' }
 //   405 — { error: 'method_not_allowed' }
@@ -378,7 +379,7 @@ Deno.serve(async (req: Request) => {
 			category: payload.category,
 			meta_description: payload.meta_description,
 			featured_image: payload.og_image_url ?? null,
-			status: "in-review",
+			status: "published", published_at: new Date().toISOString(),
 		};
 		// Thread canonical_url into INSERT only when provided. Otherwise rely on
 		// the column DEFAULT (NULL) so generateMetadata() in Plan 06-02 omits the

--- a/supabase/functions/tests/n8n-blog-ingest.test.ts
+++ b/supabase/functions/tests/n8n-blog-ingest.test.ts
@@ -138,13 +138,13 @@ Deno.test("n8n-blog-ingest: _setup clears orphan phase-6-deno- rows", async () =
 
 // ---------------------------------------------------------------------------
 
-Deno.test("n8n-blog-ingest: valid HMAC + valid payload returns 201 in-review", async () => {
+Deno.test("n8n-blog-ingest: valid HMAC + valid payload returns 201 published (auto-publish)", async () => {
 	const body = validBody(`valid-${Date.now()}`);
 	insertedSlugs.add(body.slug);
 
 	const { status, data } = await postSigned(body);
 	assertEquals(status, 201);
-	assertEquals(data.status, "in-review");
+	assertEquals(data.status, "published");
 	assertEquals(data.slug, body.slug);
 	assertExists(data.id);
 	assertEquals(data.blog_url, `${APP_URL}/blog/${body.slug}`);


### PR DESCRIPTION
Closes the loop on 'nothing waits on the user':
- **EF v18 (live + repo synced):** inserts `status='published'` + `published_at` — the 9 gates + judge + EF/DB re-validation are the review. `/admin/blog` becomes the manual override (archive bad posts after the fact).
- **Build-time redirect filtering:** `redirects()` drops a ghost 301 automatically once its slug has a published post (anon PostgREST fetch at build, fail-open to the full map). Reclaims need zero code edits forever.
- **MAX_REPAIR 4→6** for the word_count flake.
- 4 parked drafts flipped to published in prod; this merge's deploy builds their pages + drops the first reclaim 301.
- 66 tests pass (incl. 2 new filter tests + EF assertion update).

[hudsor01]