### PR TITLE
feat(blog): unique category-themed generated cover art for every post

### DIFF
--- a/src/app/api/og/blog/[slug]/route.tsx
+++ b/src/app/api/og/blog/[slug]/route.tsx
@@ -10,6 +10,12 @@ import { ImageResponse } from "@vercel/og";
 // the edge bundle under Vercel's 1 MB plan limit. @supabase/ssr +
 // @t3-oss/env-nextjs + zod were pushing this route to 1.05 MB and failing
 // to deploy.
+//
+// This route doubles as the blog COVER ART system: BlogCard and the post
+// hero fall back to it whenever `featured_image` is null (every factory
+// post), so each post gets a unique, on-brand, high-res cover with zero
+// manual curation — category picks the palette, the slug hash drives the
+// composition, the title is the artwork.
 export const runtime = "edge";
 export const revalidate = 3600;
 
@@ -20,6 +26,49 @@ interface RouteParams {
 interface BlogRow {
 	title: string;
 	category: string | null;
+}
+
+// Brand-derived category palettes (oklch). `@vercel/og` requires inline CSS
+// values so canonical token literals are duplicated here — this is the ONE
+// permitted exception to the no-hex/no-inline-color rule (Phase 6
+// CONTEXT.md § Design Token). software-vault keeps the original brand
+// gradient; the other four are hue-shifted siblings at matched lightness/
+// chroma so the catalogue reads as one family, never one repeated card.
+const CATEGORY_PALETTES: Record<string, { from: string; to: string }> = {
+	"software-vault": {
+		from: "oklch(0.62 0.18 250)",
+		to: "oklch(0.45 0.20 270)",
+	},
+	"lease-law": {
+		from: "oklch(0.55 0.16 285)",
+		to: "oklch(0.38 0.16 300)",
+	},
+	"tax-prep": {
+		from: "oklch(0.58 0.14 175)",
+		to: "oklch(0.40 0.13 195)",
+	},
+	"tenant-screening": {
+		from: "oklch(0.56 0.17 320)",
+		to: "oklch(0.40 0.16 335)",
+	},
+	maintenance: {
+		from: "oklch(0.64 0.14 70)",
+		to: "oklch(0.46 0.13 45)",
+	},
+};
+const DEFAULT_PALETTE = CATEGORY_PALETTES["software-vault"] as {
+	from: string;
+	to: string;
+};
+
+// Deterministic djb2 hash — per-slug composition variety (gradient angle +
+// accent geometry) so two posts in the same category still get distinct art.
+function hashSlug(slug: string): number {
+	let h = 5381;
+	for (let i = 0; i < slug.length; i++) {
+		h = (h * 33) ^ slug.charCodeAt(i);
+	}
+	return Math.abs(h);
 }
 
 export async function GET(_req: Request, { params }: RouteParams) {
@@ -56,12 +105,14 @@ export async function GET(_req: Request, { params }: RouteParams) {
 		return new Response("Not found", { status: 404 });
 	}
 
-	// Brand colors derived from globals.css `--color-primary` (oklch).
-	// `@vercel/og` requires inline CSS values so the canonical token
-	// literals are duplicated here. This is the ONE permitted exception
-	// to the no-hex/no-inline-color rule (Phase 6 CONTEXT.md § Design Token).
-	const bgGradient =
-		"linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)";
+	const palette = CATEGORY_PALETTES[post.category ?? ""] ?? DEFAULT_PALETTE;
+	const h = hashSlug(slug);
+	const angle = 115 + (h % 60); // 115-174deg
+	const glowX = 55 + (h % 35); // accent glow: right half, varies per slug
+	const glowY = (h >> 3) % 70; // 0-69% from top
+	const ringX = (h >> 5) % 30; // outline ring: left third
+	const ringY = 40 + ((h >> 7) % 50);
+	const ringSize = 220 + ((h >> 9) % 160);
 
 	return new ImageResponse(
 		<div
@@ -71,41 +122,104 @@ export async function GET(_req: Request, { params }: RouteParams) {
 				display: "flex",
 				flexDirection: "column",
 				justifyContent: "space-between",
-				padding: "60px",
-				background: bgGradient,
+				padding: "72px 80px",
+				background: `linear-gradient(${angle}deg, ${palette.from} 0%, ${palette.to} 100%)`,
 				color: "oklch(1 0 0)",
 				fontFamily: "sans-serif",
+				position: "relative",
+				overflow: "hidden",
 			}}
 		>
+			{/* per-slug accent geometry — soft glow + outline ring */}
 			<div
 				style={{
+					position: "absolute",
+					top: `${glowY - 25}%`,
+					left: `${glowX}%`,
+					width: 560,
+					height: 560,
+					borderRadius: 9999,
+					background:
+						"radial-gradient(circle, oklch(1 0 0 / 0.22) 0%, oklch(1 0 0 / 0) 65%)",
+				}}
+			/>
+			<div
+				style={{
+					position: "absolute",
+					top: `${ringY}%`,
+					left: `${ringX - 8}%`,
+					width: ringSize,
+					height: ringSize,
+					borderRadius: 9999,
+					border: "3px solid oklch(1 0 0 / 0.18)",
+				}}
+			/>
+			<div
+				style={{
+					position: "absolute",
+					bottom: "-18%",
+					right: "-6%",
+					width: 420,
+					height: 420,
+					borderRadius: 9999,
+					border: "2px solid oklch(1 0 0 / 0.10)",
+				}}
+			/>
+
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: 14,
 					fontSize: 24,
 					textTransform: "uppercase",
-					letterSpacing: "0.1em",
-					opacity: 0.85,
+					letterSpacing: "0.12em",
+					opacity: 0.9,
 				}}
 			>
+				<div
+					style={{
+						width: 14,
+						height: 14,
+						borderRadius: 4,
+						background: "oklch(1 0 0 / 0.9)",
+					}}
+				/>
 				{post.category ?? "TenantFlow Blog"}
 			</div>
 			<div
 				style={{
-					fontSize: 64,
-					fontWeight: 900,
+					fontSize: 58,
+					fontWeight: 800,
 					lineHeight: 1.15,
-					maxWidth: "90%",
+					maxWidth: "84%",
 					display: "flex",
+					textWrap: "balance",
 				}}
 			>
 				{post.title}
 			</div>
 			<div
 				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
 					fontSize: 28,
 					fontWeight: 700,
-					opacity: 0.9,
+					opacity: 0.92,
 				}}
 			>
-				TenantFlow
+				<div style={{ display: "flex" }}>TenantFlow</div>
+				<div
+					style={{
+						display: "flex",
+						fontSize: 22,
+						fontWeight: 500,
+						opacity: 0.75,
+					}}
+				>
+					tenantflow.app/blog
+				</div>
 			</div>
 		</div>,
 		{

--- a/src/app/blog/[slug]/blog-post-page.tsx
+++ b/src/app/blog/[slug]/blog-post-page.tsx
@@ -122,25 +122,25 @@ export default function BlogPostPage({ post, slug }: BlogPostProps) {
 				</Link>
 			</div>
 
-			{/* Featured Image */}
-			{post.featured_image && (
-				<div className="relative aspect-video max-w-4xl mx-auto overflow-hidden rounded-lg mb-8">
-					<Image
-						src={post.featured_image}
-						alt={post.title}
-						fill
-						sizes="(max-width: 768px) 100vw, 896px"
-						priority
-						className={cn(
-							"object-cover transition-all duration-700 ease-out",
-							imageLoaded
-								? "blur-0 opacity-100 scale-100"
-								: "blur-sm opacity-0 scale-105",
-						)}
-						onLoad={() => setImageLoaded(true)}
-					/>
-				</div>
-			)}
+			{/* Featured image — curated when present, otherwise the generated
+			    per-post cover (/api/og/blog/[slug]; category palette + slug-hashed
+			    composition) so every post has unique on-brand hero art. */}
+			<div className="relative aspect-video max-w-4xl mx-auto overflow-hidden rounded-lg mb-8">
+				<Image
+					src={post.featured_image ?? `/api/og/blog/${slug}`}
+					alt={post.title}
+					fill
+					sizes="(max-width: 768px) 100vw, 896px"
+					priority
+					className={cn(
+						"object-cover transition-all duration-700 ease-out",
+						imageLoaded
+							? "blur-0 opacity-100 scale-100"
+							: "blur-sm opacity-0 scale-105",
+					)}
+					onLoad={() => setImageLoaded(true)}
+				/>
+			</div>
 
 			{/* Article */}
 			<article className="container mx-auto px-6 pb-16 max-w-4xl">

--- a/src/app/blog/[slug]/page.test.tsx
+++ b/src/app/blog/[slug]/page.test.tsx
@@ -193,9 +193,12 @@ describe("BlogArticlePage", () => {
 		);
 	});
 
-	it("does NOT render featured image when post.featured_image is null", () => {
+	it("falls back to the generated per-post cover when featured_image is null", () => {
 		render(<BlogArticlePage post={mockPostNoImage} slug="test-post" />);
-		expect(screen.queryByTestId("featured-image")).not.toBeInTheDocument();
+		// Unique on-brand cover from /api/og/blog/[slug] — every post gets hero
+		// art, never a bare header.
+		const image = screen.getByTestId("featured-image");
+		expect(image).toHaveAttribute("src", "/api/og/blog/test-post");
 	});
 
 	it("renders category name in meta bar linked to /blog/category/[slug]", () => {

--- a/src/components/blog/blog-card.test.tsx
+++ b/src/components/blog/blog-card.test.tsx
@@ -84,19 +84,16 @@ describe("BlogCard", () => {
 		);
 	});
 
-	it("renders placeholder when featured_image is null", () => {
+	it("falls back to the generated per-post cover when featured_image is null", () => {
 		const postWithoutImage: BlogListItem = {
 			...mockPost,
 			featured_image: null,
 		};
-		const { container } = render(<BlogCard post={postWithoutImage} />);
-		expect(screen.queryByTestId("next-image")).not.toBeInTheDocument();
-		// Branded placeholder (gradient + Newspaper glyph), not a flat gray box.
-		const placeholder = container.querySelector(
-			"[data-slot='blog-card-placeholder']",
-		);
-		expect(placeholder).toBeInTheDocument();
-		expect(placeholder?.querySelector("svg")).toBeInTheDocument();
+		render(<BlogCard post={postWithoutImage} />);
+		// Unique on-brand cover art from /api/og/blog/[slug] (category palette +
+		// slug-hashed composition) — never a shared placeholder.
+		const img = screen.getByTestId("next-image");
+		expect(img).toHaveAttribute("src", "/api/og/blog/manage-rental-properties");
 	});
 
 	it("renders excerpt text", () => {

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -1,4 +1,3 @@
-import { Newspaper } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import type { BlogListItem } from "#hooks/api/query-keys/blog-keys";
@@ -19,25 +18,17 @@ export function BlogCard({ post, className }: BlogCardProps) {
 			)}
 		>
 			<div className="relative aspect-[16/10] overflow-hidden">
-				{post.featured_image ? (
-					<Image
-						src={post.featured_image}
-						alt={post.title}
-						fill
-						sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-						className="object-cover transition-transform duration-300 group-hover:scale-105"
-					/>
-				) : (
-					<div
-						data-slot="blog-card-placeholder"
-						className="flex h-full w-full items-center justify-center bg-linear-to-br from-primary/10 via-muted to-accent/10"
-					>
-						<Newspaper
-							className="size-10 text-muted-foreground/40"
-							aria-hidden="true"
-						/>
-					</div>
-				)}
+				{/* Posts without a curated featured_image fall back to the generated
+				    per-post cover (/api/og/blog/[slug]): category-themed palette +
+				    slug-hashed composition — unique, on-brand art for every post
+				    with zero manual curation. */}
+				<Image
+					src={post.featured_image ?? `/api/og/blog/${post.slug}`}
+					alt={post.title}
+					fill
+					sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+					className="object-cover transition-transform duration-300 group-hover:scale-105"
+				/>
 			</div>
 
 			<div className="flex flex-1 flex-col gap-2 p-4">


### PR DESCRIPTION
Fixes missing/duplicate blog imagery: factory posts had `featured_image=null` (placeholder icon) and 5 legacy posts shared one Unsplash photo.

- `/api/og/blog/[slug]` upgraded into the cover-art system: 5 brand-derived category palettes + per-slug hashed composition (angle/glow/ring, oklch alpha) → unique, high-res (1200×630), on-brand art for every post, fully automatic forever.
- `BlogCard` + post hero fall back to it when `featured_image` is null; curated images still win.
- The 5 shared-photo legacy rows nulled in prod → unique covers on deploy.
- 80 blog tests pass; design-token drift guard clean.

[hudsor01]