### PR TITLE
fix(blog): bust the optimizer cache poisoned by 0-byte covers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -59,6 +59,14 @@ const nextConfig: NextConfig = {
 	images: {
 		// Cache optimized images for 7 days before re-fetching from origin
 		minimumCacheTTL: 60 * 60 * 24 * 7,
+		// next/image local sources with a query string must be allowlisted.
+		// First entry keeps ALL query-less local images working (defining
+		// localPatterns is restrictive); second allows the generated blog
+		// covers' ?v=2 cache-buster (poisoned-optimizer-cache recovery).
+		localPatterns: [
+			{ pathname: "/**", search: "" },
+			{ pathname: "/api/og/blog/**", search: "?v=2" },
+		],
 		remotePatterns: [
 			{ protocol: "https", hostname: "*.supabase.co" },
 			{ protocol: "https", hostname: "images.unsplash.com" },

--- a/src/app/blog/[slug]/blog-post-page.tsx
+++ b/src/app/blog/[slug]/blog-post-page.tsx
@@ -127,7 +127,7 @@ export default function BlogPostPage({ post, slug }: BlogPostProps) {
 			    composition) so every post has unique on-brand hero art. */}
 			<div className="relative aspect-video max-w-4xl mx-auto overflow-hidden rounded-lg mb-8">
 				<Image
-					src={post.featured_image ?? `/api/og/blog/${slug}`}
+					src={post.featured_image ?? `/api/og/blog/${slug}?v=2`}
 					alt={post.title}
 					fill
 					sizes="(max-width: 768px) 100vw, 896px"

--- a/src/app/blog/[slug]/page.test.tsx
+++ b/src/app/blog/[slug]/page.test.tsx
@@ -198,7 +198,7 @@ describe("BlogArticlePage", () => {
 		// Unique on-brand cover from /api/og/blog/[slug] — every post gets hero
 		// art, never a bare header.
 		const image = screen.getByTestId("featured-image");
-		expect(image).toHaveAttribute("src", "/api/og/blog/test-post");
+		expect(image).toHaveAttribute("src", "/api/og/blog/test-post?v=2");
 	});
 
 	it("renders category name in meta bar linked to /blog/category/[slug]", () => {

--- a/src/components/blog/blog-card.test.tsx
+++ b/src/components/blog/blog-card.test.tsx
@@ -93,7 +93,10 @@ describe("BlogCard", () => {
 		// Unique on-brand cover art from /api/og/blog/[slug] (category palette +
 		// slug-hashed composition) — never a shared placeholder.
 		const img = screen.getByTestId("next-image");
-		expect(img).toHaveAttribute("src", "/api/og/blog/manage-rental-properties");
+		expect(img).toHaveAttribute(
+			"src",
+			"/api/og/blog/manage-rental-properties?v=2",
+		);
 	});
 
 	it("renders excerpt text", () => {

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -23,7 +23,7 @@ export function BlogCard({ post, className }: BlogCardProps) {
 				    slug-hashed composition — unique, on-brand art for every post
 				    with zero manual curation. */}
 				<Image
-					src={post.featured_image ?? `/api/og/blog/${post.slug}`}
+					src={post.featured_image ?? `/api/og/blog/${post.slug}?v=2`}
 					alt={post.title}
 					fill
 					sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"


### PR DESCRIPTION
The 0-byte #807 covers are cached by `/_next/image` for 3600s — `?v=2` on the fallback URL mints fresh cache keys so the fixed renders show immediately instead of after TTL expiry.

[hudsor01]