### PR TITLE
fix(blog): sanitize banned-phrase substrings (unpaid/prepaid rent blocked the queue)

### DIFF
--- a/scripts/generate-blog-draft.test.ts
+++ b/scripts/generate-blog-draft.test.ts
@@ -11,6 +11,7 @@ import {
 	parseCritique,
 	parsePositionals,
 	parseSlugOverride,
+	sanitizeBanlist,
 } from "./generate-blog-draft";
 
 type Scores = {
@@ -377,5 +378,69 @@ describe("capDocusealMentions (docuseal_mention gate, max 1)", () => {
 		expect(capDocusealMentions("No e-sign tools here.")).toBe(
 			"No e-sign tools here.",
 		);
+	});
+});
+
+describe("sanitizeBanlist substring safety (EF gate matches substrings)", () => {
+	// Mirror of the EF/generator BANLIST — the gate uses lc.includes(phrase),
+	// so NO output may contain any of these as a substring.
+	const BANLIST_MIRROR = [
+		"rent collection",
+		"online rent",
+		"autopay",
+		"auto-pay",
+		"tenant portal",
+		"automated rent",
+		"collect rent",
+		"rent processing",
+		"pay rent online",
+		"online payments",
+		"online rent payment",
+		"rent collection software",
+		"tenants can pay",
+		"pay rent through",
+		"automated workflow",
+		"rent tracking",
+		"mobile app access",
+		"record rent",
+		"paid rent",
+		"pay rent",
+	];
+
+	const expectGateClean = (output: string) => {
+		const lc = output.toLowerCase();
+		for (const phrase of BANLIST_MIRROR) {
+			expect(lc.includes(phrase), `survived: "${phrase}" in "${output}"`).toBe(
+				false,
+			);
+		}
+	};
+
+	it('neutralizes "unpaid rent" (contains the "paid rent" substring — exec 282/283 failure)', () => {
+		const out = sanitizeBanlist(
+			"Send collections notices for unpaid rent promptly.",
+		);
+		expect(out).toContain("overdue rent");
+		expectGateClean(out);
+	});
+
+	it('neutralizes "prepaid rent"', () => {
+		const out = sanitizeBanlist("Prepaid rent counts as income when received.");
+		expect(out.toLowerCase()).toContain("rent paid in advance");
+		expectGateClean(out);
+	});
+
+	it("keeps the plain-phrase rewrites working", () => {
+		const out = sanitizeBanlist(
+			"Tenants who paid rent late should pay rent on time next month.",
+		);
+		expectGateClean(out);
+	});
+
+	it("clears every banned phrase from a worst-case paragraph", () => {
+		const out = sanitizeBanlist(
+			"Use rent collection software with autopay and a tenant portal so tenants can pay rent online; unpaid rent and prepaid rent need rent tracking.",
+		);
+		expectGateClean(out);
 	});
 });

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -208,10 +208,21 @@ function runGates(p: Draft): { gate: string; message: string; fix: string }[] {
 // Neutralize banlist phrases the model slips in (the EF gate bans the literal
 // strings; these substitutions keep the meaning while clearing the gate). Ordered
 // longest-first so multi-word phrases resolve before their substrings.
+//
+// CRITICAL: the EF gate matches SUBSTRINGS (`lc.includes(phrase)`), so compound
+// words that CONTAIN a banned phrase trip it even though a \b-anchored rule
+// can't see them — "unpaid rent" and "prepaid rent" both contain "paid rent"
+// (n8n execs 282/283 burned 6 attempts each on exactly this in collections
+// content). Specific compound rewrites run FIRST, then a literal no-boundary
+// catch-all guarantees the substring cannot survive.
 const BANLIST_REPLACEMENTS: [RegExp, string][] = [
+	[/\bunpaid rent\b/gi, "overdue rent"],
+	[/\bprepaid rent\b/gi, "rent paid in advance"],
 	[/\bpaid rent on time\b/gi, "paid on time"],
 	[/\bpay rent on time\b/gi, "stay current on the lease"],
 	[/\bpaid rent\b/gi, "paid on time"],
+	// literal catch-all (no word boundaries) — mirrors the EF's substring match
+	[/paid rent/gi, "paid on time"],
 	[/\bpay rent online\b/gi, "make payments"],
 	[/\bpay rent through\b/gi, "manage payments through"],
 	[/\bpay rent\b/gi, "make payments"],
@@ -231,7 +242,7 @@ const BANLIST_REPLACEMENTS: [RegExp, string][] = [
 	[/\bonline payments\b/gi, "payments"],
 	[/\bmobile app access\b/gi, "easy access"],
 ];
-function sanitizeBanlist(s: string): string {
+export function sanitizeBanlist(s: string): string {
 	let out = s;
 	// Loop to a fixed point: a replacement can leave adjacent fragments that
 	// re-form a banned phrase (e.g. "online online rent" -> "online rent").


### PR DESCRIPTION
EF gate matches substrings; sanitizer used \b regexes — 'unpaid rent' contains 'paid rent' and survived, burning 6 attempts × 2 runs and blocking the queue head (the runner retries the first unwritten topic forever). Compound rewrites + a literal catch-all now mirror the gate's substring semantics. +4 tests.

[hudsor01]