### PR TITLE
fix(blog): demote surplus H2s to H3 (kills the word-count/h2-count ping-pong)

### DIFF
--- a/scripts/generate-blog-draft.test.ts
+++ b/scripts/generate-blog-draft.test.ts
@@ -4,6 +4,7 @@ import {
 	applySlugOverride,
 	blogSlugExists,
 	capDocusealMentions,
+	capH2Count,
 	critique,
 	formatGenFailure,
 	gateOnCritique,
@@ -489,5 +490,32 @@ describe("pickLoadedModel (LM Studio loaded-instance resolution)", () => {
 		expect(
 			pickLoadedModel([{ id: "qwen3-reranker-0.6b", state: "loaded" }], BASE),
 		).toBe(BASE);
+	});
+});
+
+describe("capH2Count (h2_count gate, max 10 — keep 9, demote the rest)", () => {
+	const h2s = (s: string) => (s.match(/^## /gm) ?? []).length;
+	const h3s = (s: string) => (s.match(/^### /gm) ?? []).length;
+
+	it("demotes H2s beyond the 9th to H3, preserving every line", () => {
+		const content = Array.from(
+			{ length: 12 },
+			(_, i) => `## Section ${i + 1}\n\nBody ${i + 1}.`,
+		).join("\n\n");
+		const out = capH2Count(content);
+		expect(h2s(out)).toBe(9);
+		expect(h3s(out)).toBe(3);
+		expect(out.split("\n").length).toBe(content.split("\n").length);
+		expect(out).toContain("### Section 12");
+	});
+
+	it("leaves compliant content (<=9 H2s) untouched", () => {
+		const content = "## One\n\nBody.\n\n## Two\n\nBody.";
+		expect(capH2Count(content)).toBe(content);
+	});
+
+	it("does not touch existing H3s while counting H2s", () => {
+		const content = "## A\n\n### A.1\n\n## B\n\nBody.";
+		expect(capH2Count(content)).toBe(content);
 	});
 });

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -191,7 +191,7 @@ function runGates(p: Draft): { gate: string; message: string; fix: string }[] {
 		out.push({
 			gate: "h2_count",
 			message: `${h2} H2s`,
-			fix: `Use EXACTLY 7 "## " section headings (currently ${h2}).`,
+			fix: `Use 8 or 9 "## " section headings (currently ${h2}); surplus sections become "### " subsections instead of new H2s.`,
 		});
 	if (!/landlord/i.test(p.content))
 		out.push({
@@ -294,6 +294,25 @@ export function sanitizeBanlist(s: string): string {
 		if (out === before) break;
 	}
 	return out;
+}
+
+// The h2_count gate allows 4-10 "## " sections, but the word_count repair
+// hint tells the model to ADD sections — the two hints ping-pong (add
+// sections -> 12 H2s -> trim sections -> short again; exec 313 burned 6
+// attempts). Deterministic cure: keep the first 9 H2s and demote the rest
+// to H3 subsections — every word survives, the gate passes, no ping-pong.
+export function capH2Count(content: string, max = 9): string {
+	let seen = 0;
+	return content
+		.split("\n")
+		.map((line) => {
+			if (line.startsWith("## ")) {
+				seen++;
+				if (seen > max) return `#${line}`; // "## " -> "### "
+			}
+			return line;
+		})
+		.join("\n");
 }
 
 // The docuseal_mention gate allows AT MOST one "DocuSeal" (Phase 4 COPY-04); the
@@ -566,6 +585,8 @@ async function generateValidDraft(
 		d.meta_description = sanitizeBanlist(d.meta_description);
 		// cap DocuSeal at one mention (docuseal_mention gate, max 1)
 		d.content = capDocusealMentions(d.content);
+		// demote surplus H2s (h2_count gate max 10; keep 9 for margin)
+		d.content = capH2Count(d.content);
 		const failures = runGates(d);
 		console.log(
 			`  ${9 - failures.length}/9 gates  (${countWords(d.content)} words, "${d.title}")`,


### PR DESCRIPTION
The word_count hint says add sections; the h2 gate caps them — exec 313 ping-ponged for 6 attempts (12 H2s). Sanitizer now keeps 9 H2s and demotes the rest to H3 subsections: words preserved, gate passes, expansion unconstrained. Hint aligned to 8-9. +3 tests.

[hudsor01]