### PR TITLE
fix(blog): success message reflects auto-publish

### DIFF
--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -864,7 +864,7 @@ STRICT requirements:
 	console.log(`  -> HTTP ${res.status}: ${text}`);
 	if (res.status === 201) {
 		console.log(
-			`\nSUCCESS: draft "${draft.slug}" is now status='in-review'. Review + publish in the dashboard.`,
+			`\nSUCCESS: "${draft.slug}" is PUBLISHED — live on /blog now; its own page builds on the next deploy. Unpublish anytime at /admin/blog.`,
 		);
 	} else if (res.status === 401) {
 		fail(


### PR DESCRIPTION
The 201 success line still said "status='in-review'. Review + publish in the dashboard" — stale since EF v18 auto-publishes. Now states published + next-deploy page note + /admin/blog unpublish pointer.

[hudsor01]