### PR TITLE
perf(blog): render covers once at publish — static CDN files, not edge renders

### DIFF
--- a/scripts/backfill-blog-covers.ts
+++ b/scripts/backfill-blog-covers.ts
@@ -1,0 +1,99 @@
+/**
+ * One-shot backfill: render + store a static cover for every published post
+ * whose featured_image is NULL, then point featured_image at the CDN file.
+ * Future posts get this automatically at publish time (generator step 3d);
+ * this covers the catalogue published before static covers shipped.
+ *
+ * OWNER-RUN (needs .env.local service credentials):
+ *   bun scripts/backfill-blog-covers.ts
+ *
+ * Idempotent: storage upload is upsert, and rows with featured_image set are
+ * skipped — safe to re-run.
+ */
+import { createClient } from "@supabase/supabase-js";
+import { loadDotenv } from "./_shared/load-dotenv";
+import { renderBlogCoverPng } from "./render-blog-cover";
+
+loadDotenv(process.cwd());
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY =
+	process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+interface CoverRow {
+	slug: string;
+	title: string;
+	category: string | null;
+}
+
+function mapCoverRow(raw: Record<string, unknown>): CoverRow {
+	if (typeof raw.slug !== "string" || typeof raw.title !== "string") {
+		throw new Error("blogs row missing slug/title");
+	}
+	return {
+		slug: raw.slug,
+		title: raw.title,
+		category: typeof raw.category === "string" ? raw.category : null,
+	};
+}
+
+async function main(): Promise<void> {
+	if (!SUPABASE_URL || !SERVICE_KEY) {
+		console.error(
+			"Missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY (.env.local)",
+		);
+		process.exit(1);
+	}
+	const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+		auth: { persistSession: false },
+	});
+
+	const { data, error } = await supabase
+		.from("blogs")
+		.select("slug, title, category")
+		.eq("status", "published")
+		.is("featured_image", null)
+		.limit(1000);
+	if (error) {
+		console.error(`query failed: ${error.message}`);
+		process.exit(1);
+	}
+
+	const rows = ((data ?? []) as Record<string, unknown>[]).map(mapCoverRow);
+	console.log(`${rows.length} published posts without a stored cover`);
+
+	let ok = 0;
+	for (const row of rows) {
+		try {
+			const png = await renderBlogCoverPng(row);
+			const { error: upErr } = await supabase.storage
+				.from("blog-covers")
+				.upload(`${row.slug}.png`, png, {
+					contentType: "image/png",
+					upsert: true,
+					cacheControl: "31536000",
+				});
+			if (upErr) throw new Error(upErr.message);
+			const url = `${SUPABASE_URL}/storage/v1/object/public/blog-covers/${row.slug}.png`;
+			const { error: dbErr } = await supabase
+				.from("blogs")
+				.update({ featured_image: url })
+				.eq("slug", row.slug);
+			if (dbErr) throw new Error(dbErr.message);
+			ok++;
+			console.log(`  ✓ ${row.slug} (${(png.length / 1024).toFixed(0)}KB)`);
+		} catch (e) {
+			console.error(
+				`  ✗ ${row.slug}: ${e instanceof Error ? e.message : String(e)}`,
+			);
+		}
+	}
+	console.log(`done: ${ok}/${rows.length} covers stored`);
+}
+
+if (process.argv[1]?.endsWith("/backfill-blog-covers.ts")) {
+	main().catch((e: unknown) => {
+		console.error(e instanceof Error ? e.message : String(e));
+		process.exit(1);
+	});
+}

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -835,6 +835,34 @@ STRICT requirements:
 		return;
 	}
 
+	// 3d. render the branded cover ONCE and ship it as a static CDN file —
+	// thumbnails then never pay the on-demand edge render (the /api/og/blog
+	// route stays as fallback for rows without a stored cover). FAIL-OPEN:
+	// any render/upload error leaves og_image_url unset.
+	let ogImageUrl: string | undefined;
+	try {
+		const { renderBlogCoverPng } = await import("./render-blog-cover");
+		const png = await renderBlogCoverPng({
+			title: draft.title,
+			category: draft.category,
+			slug: draft.slug,
+		});
+		const { error: coverErr } = await supabase.storage
+			.from("blog-covers")
+			.upload(`${draft.slug}.png`, png, {
+				contentType: "image/png",
+				upsert: true,
+				cacheControl: "31536000",
+			});
+		if (coverErr) throw new Error(coverErr.message);
+		ogImageUrl = `${SUPABASE_URL}/storage/v1/object/public/blog-covers/${draft.slug}.png`;
+		console.log(`  cover uploaded: ${ogImageUrl}`);
+	} catch (e) {
+		console.error(
+			`  cover upload failed (edge-render fallback stays): ${e instanceof Error ? e.message : e}`,
+		);
+	}
+
 	// 4. HMAC-sign the exact body bytes + POST to the ingest EF
 	const payload = {
 		title: draft.title,
@@ -843,6 +871,7 @@ STRICT requirements:
 		content: draft.content,
 		category: draft.category,
 		meta_description: draft.meta_description,
+		og_image_url: ogImageUrl,
 	};
 	const body = JSON.stringify(payload);
 	const signature = createHmac("sha256", HMAC_SECRET as string)

--- a/scripts/render-blog-cover.tsx
+++ b/scripts/render-blog-cover.tsx
@@ -1,0 +1,176 @@
+/**
+ * Render one blog cover PNG (1200x630) — the SAME pixel-verified design as
+ * /api/og/blog/[slug]/route.tsx, but executed ONCE at publish time so the
+ * cover ships to Supabase Storage as a static CDN file. Thumbnails then never
+ * pay the on-demand satori render again (the edge route stays as the fallback
+ * for rows without a stored cover, and for social-card URLs already indexed).
+ *
+ * Palettes are exact oklch->hsl conversions of the official globals.css chart
+ * tokens (satori does NOT support oklch — renders it black). The logo is read
+ * from public/tenant-flow-logo.png on disk.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ImageResponse } from "next/og";
+
+const CATEGORY_PALETTES: Record<
+	string,
+	{ from: string; to: string; glow: string }
+> = {
+	"software-vault": {
+		from: "hsl(214 100% 57%)",
+		to: "hsl(229 69% 47%)",
+		glow: "hsl(206 100% 66%)",
+	},
+	"tax-prep": {
+		from: "hsl(171 100% 38%)",
+		to: "hsl(176 100% 27%)",
+		glow: "hsl(169 83% 53%)",
+	},
+	maintenance: {
+		from: "hsl(44 100% 41%)",
+		to: "hsl(45 100% 28%)",
+		glow: "hsl(39 100% 69%)",
+	},
+	"tenant-screening": {
+		from: "hsl(356 76% 62%)",
+		to: "hsl(2 70% 39%)",
+		glow: "hsl(353 100% 78%)",
+	},
+	"lease-law": {
+		from: "hsl(209 56% 45%)",
+		to: "hsl(215 71% 29%)",
+		glow: "hsl(207 59% 61%)",
+	},
+};
+const DEFAULT_PALETTE = CATEGORY_PALETTES["software-vault"] as {
+	from: string;
+	to: string;
+	glow: string;
+};
+
+function hashSlug(slug: string): number {
+	let h = 5381;
+	for (let i = 0; i < slug.length; i++) {
+		h = (h * 33) ^ slug.charCodeAt(i);
+	}
+	return Math.abs(h);
+}
+
+let logoCache: string | null = null;
+function logoDataUri(): string {
+	if (!logoCache) {
+		const buf = readFileSync(
+			join(process.cwd(), "public/tenant-flow-logo.png"),
+		);
+		logoCache = `data:image/png;base64,${buf.toString("base64")}`;
+	}
+	return logoCache;
+}
+
+export async function renderBlogCoverPng(opts: {
+	title: string;
+	category: string | null;
+	slug: string;
+}): Promise<Buffer> {
+	const { title, category, slug } = opts;
+	const palette = CATEGORY_PALETTES[category ?? ""] ?? DEFAULT_PALETTE;
+	const h = hashSlug(slug);
+	const angle = 120 + (h % 50);
+	const glowX = 18 + (h % 64);
+	const ringRight = -12 + ((h >> 4) % 18);
+	const logo = logoDataUri();
+
+	const res = new ImageResponse(
+		<div
+			style={{
+				height: "100%",
+				width: "100%",
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				background: `linear-gradient(${angle}deg, ${palette.from} 0%, ${palette.to} 100%)`,
+				color: "white",
+				fontFamily: "sans-serif",
+				position: "relative",
+				overflow: "hidden",
+				textAlign: "center",
+			}}
+		>
+			<div
+				style={{
+					position: "absolute",
+					top: "-30%",
+					left: `${glowX}%`,
+					width: 700,
+					height: 700,
+					borderRadius: 9999,
+					background: `radial-gradient(circle, ${palette.glow} 0%, transparent 60%)`,
+					opacity: 0.4,
+				}}
+			/>
+			<div
+				style={{
+					position: "absolute",
+					bottom: "-32%",
+					right: `${ringRight}%`,
+					width: 520,
+					height: 520,
+					borderRadius: 9999,
+					border: "3px solid white",
+					opacity: 0.14,
+				}}
+			/>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: 12,
+					fontSize: 22,
+					fontWeight: 700,
+					textTransform: "uppercase",
+					letterSpacing: "0.18em",
+					opacity: 0.92,
+					marginBottom: 30,
+				}}
+			>
+				<div
+					style={{
+						width: 10,
+						height: 10,
+						borderRadius: 9999,
+						background: "white",
+					}}
+				/>
+				{category ?? "TenantFlow Blog"}
+			</div>
+			<div
+				style={{
+					display: "flex",
+					fontSize: 58,
+					fontWeight: 800,
+					lineHeight: 1.16,
+					maxWidth: 760,
+					justifyContent: "center",
+				}}
+			>
+				{title}
+			</div>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					marginTop: 34,
+					backgroundColor: "white",
+					borderRadius: 18,
+					padding: "2px 12px",
+				}}
+			>
+				<img src={logo} width={154} height={144} alt="" />
+			</div>
+		</div>,
+		{ width: 1200, height: 630 },
+	);
+	return Buffer.from(await res.arrayBuffer());
+}


### PR DESCRIPTION
Thumbnails were satori-rendered per request at the edge (~0.5-1.5s cold, re-colded by every cache-key bump). Now: rendered once at publish → `blog-covers` Storage bucket (public, immutable) → `og_image_url` → `featured_image` → cards/hero serve a static CDN file. Edge route stays as fallback + social cards. Owner-run `backfill-blog-covers.ts` for the existing catalogue. 44 tests pass.

[hudsor01]