### PR TITLE
feat(blog-factory): FB post drafting triggered on every blog publish

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,8 @@
 			"!**/node_modules/**",
 			"!**/.vercel/**",
 			"!playwright-report/**",
-			"!test-results/**"
+			"!test-results/**",
+			"!.planning/**"
 		]
 	},
 	"formatter": { "enabled": true, "indentStyle": "tab" },

--- a/scripts/fb-append-post.test.ts
+++ b/scripts/fb-append-post.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEntry } from "./fb-append-post";
+import {
+	DAILY_SLOTS,
+	dayAfter,
+	lintFbCopy,
+	mapCalendarEntry,
+	nextFreeSlot,
+	renderCalendarDoc,
+	slotSortKey,
+} from "./fb-append-post";
+
+const entry = (
+	date: string,
+	time: string,
+	slug = `post-${date}-${time.replace(/[^0-9]/g, "")}`,
+): CalendarEntry => ({
+	date,
+	time,
+	title: `Title for ${slug}`,
+	slug,
+	category: "lease-law",
+	copy: "copy",
+	first_comment: `https://tenantflow.app/blog/${slug}`,
+});
+
+const CLEAN_COPY = `One for the Colorado landlords here.
+
+Your default deposit return window is one month, not 60 days.
+
+We wrote up the rules, nothing locked behind an email. The breakdown is linked in the comments.
+
+Anyone here with Colorado rentals? Tell me what your lease says and I'll tell you which deadline you're on.
+
+#SecurityDeposit #LandlordTips #LandlordLife`;
+
+describe("dayAfter", () => {
+	it("advances one day", () => {
+		expect(dayAfter("2026-06-12")).toBe("2026-06-13");
+	});
+
+	it("crosses month boundaries", () => {
+		expect(dayAfter("2026-06-30")).toBe("2026-07-01");
+	});
+});
+
+describe("nextFreeSlot", () => {
+	it("starts at the first slot of the day after fromYmd", () => {
+		expect(nextFreeSlot([], "2026-06-12")).toEqual({
+			date: "2026-06-13",
+			time: "9:00 AM",
+		});
+	});
+
+	it("fills the next slot on a partially used day", () => {
+		const taken = [entry("2026-06-13", "9:00 AM")];
+		expect(nextFreeSlot(taken, "2026-06-12")).toEqual({
+			date: "2026-06-13",
+			time: "1:00 PM",
+		});
+	});
+
+	it("rolls to the next day when all slots are taken", () => {
+		const taken = DAILY_SLOTS.map((t) => entry("2026-06-13", t));
+		expect(nextFreeSlot(taken, "2026-06-12")).toEqual({
+			date: "2026-06-14",
+			time: "9:00 AM",
+		});
+	});
+
+	it("ignores legacy 10:00 AM anchors when counting slots", () => {
+		const taken = [entry("2026-06-15", "10:00 AM")];
+		expect(nextFreeSlot(taken, "2026-06-14")).toEqual({
+			date: "2026-06-15",
+			time: "9:00 AM",
+		});
+	});
+
+	it("fills gap days before extending the tail", () => {
+		const taken = [
+			...DAILY_SLOTS.map((t) => entry("2026-06-13", t)),
+			entry("2026-06-14", "9:00 AM"),
+			...DAILY_SLOTS.map((t) => entry("2026-06-15", t)),
+		];
+		expect(nextFreeSlot(taken, "2026-06-12")).toEqual({
+			date: "2026-06-14",
+			time: "1:00 PM",
+		});
+	});
+});
+
+describe("lintFbCopy", () => {
+	it("passes clean copy", () => {
+		expect(lintFbCopy(CLEAN_COPY)).toEqual([]);
+	});
+
+	it("flags em-dashes", () => {
+		expect(
+			lintFbCopy(CLEAN_COPY.replace("not 60 days", "not 60 days — ever")),
+		).toContain("em/en dash");
+	});
+
+	it("flags exclamation marks", () => {
+		expect(lintFbCopy(CLEAN_COPY.replace("here.", "here!"))).toContain(
+			"exclamation mark",
+		);
+	});
+
+	it("flags persona leaks", () => {
+		expect(
+			lintFbCopy(CLEAN_COPY.replace("landlords", "property owners")),
+		).toContain("'property owner' persona leak");
+	});
+
+	it("flags wrong hashtag count", () => {
+		expect(lintFbCopy(CLEAN_COPY.replace(" #LandlordLife", ""))).toContain(
+			"hashtags=2 (need exactly 3)",
+		);
+	});
+
+	it("flags engagement-bait verbs", () => {
+		expect(
+			lintFbCopy(
+				CLEAN_COPY.replace("Tell me what", "Drop your state and what"),
+			),
+		).toContain("engagement-bait verb");
+	});
+
+	it("flags crutch phrases", () => {
+		expect(
+			lintFbCopy(CLEAN_COPY.replace("One for the", "Quick gut check for the")),
+		).toContain("overused crutch phrase");
+	});
+
+	it("flags a missing closing question", () => {
+		const noQuestion = CLEAN_COPY.replace(
+			"Anyone here with Colorado rentals? Tell me what your lease says and I'll tell you which deadline you're on.",
+			"Worth checking your lease today.",
+		);
+		expect(lintFbCopy(noQuestion)).toContain("no closing question");
+	});
+
+	it("flags a missing comments pointer", () => {
+		const noPointer = CLEAN_COPY.replace(
+			"The breakdown is linked in the comments.",
+			"The breakdown is on the blog.",
+		);
+		expect(lintFbCopy(noPointer)).toContain("no linked-in-comments pointer");
+	});
+});
+
+describe("mapCalendarEntry", () => {
+	it("maps a full entry", () => {
+		const e = mapCalendarEntry({
+			date: "2026-06-13",
+			time: "1:00 PM",
+			title: "T",
+			slug: "s",
+			category: "tax-prep",
+			copy: "c",
+			first_comment: "f",
+		});
+		expect(e.time).toBe("1:00 PM");
+	});
+
+	it("defaults missing time to the legacy 10:00 AM anchor", () => {
+		const e = mapCalendarEntry({
+			date: "2026-06-15",
+			title: "T",
+			slug: "s",
+			category: "tax-prep",
+			copy: "c",
+			first_comment: "f",
+		});
+		expect(e.time).toBe("10:00 AM");
+	});
+
+	it("throws on a malformed entry", () => {
+		expect(() => mapCalendarEntry({ date: "2026-06-13" })).toThrow(
+			"calendar.json: malformed entry",
+		);
+	});
+});
+
+describe("slotSortKey + renderCalendarDoc", () => {
+	it("orders anchors before slots within a day", () => {
+		expect(
+			slotSortKey({ date: "2026-06-15", time: "10:00 AM" }) <
+				slotSortKey({ date: "2026-06-15", time: "9:00 AM" }),
+		).toBe(true);
+	});
+
+	it("renders chronologically regardless of array order", () => {
+		const doc = renderCalendarDoc([
+			entry("2026-06-14", "9:00 AM", "later"),
+			entry("2026-06-13", "9:00 AM", "earlier"),
+		]);
+		expect(doc.indexOf("earlier")).toBeLessThan(doc.indexOf("later"));
+		expect(doc).toContain("| 2026-06-13 | Sat | 9:00 AM |");
+	});
+});

--- a/scripts/fb-append-post.ts
+++ b/scripts/fb-append-post.ts
@@ -1,0 +1,322 @@
+/**
+ * Append one voice-written Facebook post to the FB content-calendar staging
+ * (.planning/social/fb-staging/) — the mechanical half of the publish-time
+ * trigger. The headless Claude session writes the copy; this script owns
+ * everything deterministic: AI-tell lint, slot assignment (earliest free
+ * DAILY_SLOTS opening from tomorrow on), cover-exists check, manifest + post
+ * file + doc regeneration. Idempotent: a slug already in calendar.json exits
+ * 0 untouched.
+ *
+ * The actual Meta Business Suite scheduling happens separately in rolling
+ * runs (Meta caps scheduling at 29 days out — see
+ * .planning/social/fb-staging/SCHEDULED-THROUGH.txt).
+ *
+ * Usage:
+ *   bun scripts/fb-append-post.ts <slug> \
+ *     --copy-file /tmp/fb-copy-<slug>.txt \
+ *     --first-comment "one casual sentence + https://tenantflow.app/blog/<slug>" \
+ *     --title "Blog Title" --category lease-law
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { acquireLock, releaseLock } from "./run-scheduled-blog";
+
+const STAGING_DIR = new URL("../.planning/social/fb-staging/", import.meta.url)
+	.pathname;
+const DOC_PATH = new URL(
+	"../.planning/social/FB-CONTENT-CALENDAR-2026-Q3.md",
+	import.meta.url,
+).pathname;
+const COVER_BASE =
+	"https://bshjmbshupiibfiewpxb.supabase.co/storage/v1/object/public/blog-covers";
+const LOCK_PATH = join(tmpdir(), "tenantflow-fb-staging.lock");
+const DOW = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export interface CalendarEntry {
+	readonly date: string;
+	readonly time: string;
+	readonly title: string;
+	readonly slug: string;
+	readonly category: string;
+	readonly copy: string;
+	readonly first_comment: string;
+}
+
+/**
+ * Daily posting slots (CT). Meta caps scheduling at 29 days out, so density —
+ * not weekday spacing — is what keeps the queue inside the window. The legacy
+ * 10:00 AM anchors (posts 01-20, scheduled 2026-06-12) sit outside this slot
+ * set and never block it.
+ */
+export const DAILY_SLOTS = ["9:00 AM", "1:00 PM", "5:00 PM"] as const;
+
+// Typed mapper at the JSON boundary (CLAUDE.md: no `as unknown as`).
+export function mapCalendarEntry(raw: Record<string, unknown>): CalendarEntry {
+	const { date, time, title, slug, category, copy, first_comment } = raw;
+	if (
+		typeof date !== "string" ||
+		typeof title !== "string" ||
+		typeof slug !== "string" ||
+		typeof category !== "string" ||
+		typeof copy !== "string" ||
+		typeof first_comment !== "string"
+	) {
+		throw new Error("calendar.json: malformed entry");
+	}
+	return {
+		date,
+		time: typeof time === "string" ? time : "10:00 AM",
+		title,
+		slug,
+		category,
+		copy,
+		first_comment,
+	};
+}
+
+/** YYYY-MM-DD for the day after the given YYYY-MM-DD. Pure. */
+export function dayAfter(ymd: string): string {
+	const d = new Date(`${ymd}T12:00:00`);
+	d.setDate(d.getDate() + 1);
+	return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Earliest free slot strictly after `fromYmd`, scanning DAILY_SLOTS per day.
+ * Entries at non-slot times (the legacy 10:00 AM anchors) don't occupy slots.
+ * Pure.
+ */
+export function nextFreeSlot(
+	entries: readonly Pick<CalendarEntry, "date" | "time">[],
+	fromYmd: string,
+): { date: string; time: string } {
+	const taken = new Set(entries.map((e) => `${e.date} ${e.time}`));
+	for (let date = dayAfter(fromYmd); ; date = dayAfter(date)) {
+		for (const time of DAILY_SLOTS) {
+			if (!taken.has(`${date} ${time}`)) return { date, time };
+		}
+	}
+}
+
+/**
+ * Mechanical AI-tell + format lint — the same gate every one of the original
+ * 56 calendar posts passed. Returns a list of problems; empty = clean.
+ */
+export function lintFbCopy(copy: string): string[] {
+	const problems: string[] = [];
+	if (/—|–/.test(copy)) problems.push("em/en dash");
+	if (/!/.test(copy)) problems.push("exclamation mark");
+	if (/property owner/i.test(copy))
+		problems.push("'property owner' persona leak");
+	if (/real estate investor/i.test(copy))
+		problems.push("'real estate investor' persona leak");
+	const tags = copy.match(/#[A-Za-z]+/g) ?? [];
+	if (tags.length !== 3)
+		problems.push(`hashtags=${tags.length} (need exactly 3)`);
+	if (/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u.test(copy))
+		problems.push("emoji");
+	if (/\*\*|•|^- /m.test(copy)) problems.push("markdown/bullets");
+	if (
+		/here'?s the thing|game-changer|pro tip|dive in|seamless|robust|unlock|elevate|leverage|crucial|navigate the/i.test(
+			copy,
+		)
+	)
+		problems.push("banned phrase");
+	if (/sounds simple until|quick gut check|honest question:/i.test(copy))
+		problems.push("overused crutch phrase");
+	if (
+		/\b(drop (a|the|your|it)|comment (below|your)|tag a|share (this|if))\b/i.test(
+			copy,
+		)
+	)
+		problems.push("engagement-bait verb");
+	if (!/\?/.test(copy.split("#")[0] ?? ""))
+		problems.push("no closing question");
+	if (!/comment/i.test(copy)) problems.push("no linked-in-comments pointer");
+	return problems;
+}
+
+/** Chronological sort key: date, then slot order (anchors first). Pure. */
+export function slotSortKey(e: Pick<CalendarEntry, "date" | "time">): string {
+	const order = ["10:00 AM", ...DAILY_SLOTS];
+	const i = order.indexOf(e.time);
+	return `${e.date}#${i === -1 ? 9 : i}`;
+}
+
+/** Regenerate the full calendar markdown doc, chronologically sorted. Pure. */
+export function renderCalendarDoc(raw: readonly CalendarEntry[]): string {
+	const entries = [...raw].sort((a, b) =>
+		slotSortKey(a).localeCompare(slotSortKey(b)),
+	);
+	const lines: string[] = [];
+	lines.push(
+		`# Facebook Content Calendar — ${entries.length} posts, ${entries[0]?.date ?? "?"} to ${entries[entries.length - 1]?.date ?? "?"}`,
+	);
+	lines.push("");
+	lines.push(
+		"Up to 3 posts/day at 9:00 AM, 1:00 PM, 5:00 PM CT (posts 01-20 are legacy 10:00 AM anchors). Workflow per post: publish copy as the page -> immediately add the first comment with the blog link -> pin that comment.",
+	);
+	lines.push(
+		"Visual for every post: the branded cover from the blog-covers Storage bucket.",
+	);
+	lines.push(
+		"New posts append automatically at publish time (scripts/fb-append-post.ts via the run-scheduled-blog trigger). Meta Business Suite scheduling happens in rolling 29-day windows — see fb-staging/SCHEDULED-THROUGH.txt.",
+	);
+	lines.push("");
+	lines.push("## Index");
+	lines.push("");
+	lines.push("| Date | Day | Time | Category | Post |");
+	lines.push("|------|-----|------|----------|------|");
+	for (const c of entries) {
+		const d = new Date(`${c.date}T12:00:00`);
+		lines.push(
+			`| ${c.date} | ${DOW[d.getDay()]} | ${c.time} | ${c.category} | ${c.title} |`,
+		);
+	}
+	lines.push("");
+	lines.push("---");
+	for (const c of entries) {
+		const d = new Date(`${c.date}T12:00:00`);
+		lines.push("");
+		lines.push(`## ${c.date} (${DOW[d.getDay()]}) ${c.time} — ${c.title}`);
+		lines.push("");
+		lines.push(
+			`Category: ${c.category} · Article: https://tenantflow.app/blog/${c.slug}`,
+		);
+		lines.push("");
+		lines.push("### Post copy (paste as-is)");
+		lines.push("");
+		lines.push("```");
+		lines.push(c.copy);
+		lines.push("```");
+		lines.push("");
+		lines.push("### First comment (post immediately, then pin)");
+		lines.push("");
+		lines.push("```");
+		lines.push(c.first_comment);
+		lines.push("```");
+		lines.push("");
+		lines.push("---");
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function parseArgs(argv: string[]): {
+	slug: string;
+	copyFile: string;
+	firstComment: string;
+	title: string;
+	category: string;
+} {
+	const slug = argv[0];
+	if (!slug || slug.startsWith("--")) throw new Error("missing <slug>");
+	const get = (flag: string): string => {
+		const i = argv.indexOf(flag);
+		const v = i === -1 ? undefined : argv[i + 1];
+		if (!v) throw new Error(`missing ${flag}`);
+		return v;
+	};
+	return {
+		slug,
+		copyFile: get("--copy-file"),
+		firstComment: get("--first-comment"),
+		title: get("--title"),
+		category: get("--category"),
+	};
+}
+
+async function main(): Promise<number> {
+	const args = parseArgs(process.argv.slice(2));
+
+	if (!acquireLock(process.pid, LOCK_PATH)) {
+		console.error(
+			"fb-append-post: another append is in progress — retry shortly",
+		);
+		return 1;
+	}
+	try {
+		const calPath = join(STAGING_DIR, "calendar.json");
+		const parsed: unknown = JSON.parse(readFileSync(calPath, "utf8"));
+		if (!Array.isArray(parsed)) throw new Error("calendar.json: not an array");
+		const entries = (parsed as Record<string, unknown>[]).map(mapCalendarEntry);
+
+		if (entries.some((e) => e.slug === args.slug)) {
+			console.log(
+				`fb-append-post: "${args.slug}" already in calendar — nothing to do`,
+			);
+			return 0;
+		}
+
+		const copy = readFileSync(args.copyFile, "utf8").trim();
+		const problems = lintFbCopy(copy);
+		if (problems.length > 0) {
+			console.error(
+				`fb-append-post: copy failed lint — ${problems.join("; ")}`,
+			);
+			return 1;
+		}
+		if (
+			!args.firstComment.includes(`https://tenantflow.app/blog/${args.slug}`)
+		) {
+			console.error("fb-append-post: first comment must contain the blog URL");
+			return 1;
+		}
+
+		const cover = await fetch(`${COVER_BASE}/${args.slug}.png`, {
+			method: "HEAD",
+		});
+		if (!cover.ok) {
+			console.error(
+				`fb-append-post: cover missing on CDN (${cover.status}) — run the cover backfill for "${args.slug}" first`,
+			);
+			return 1;
+		}
+
+		if (entries.length === 0) throw new Error("calendar.json: empty calendar");
+		// Earliest free slot from tomorrow onward — fills gap days before
+		// extending the tail (Meta needs 20+ min lead, so never today).
+		const today = new Date().toISOString().slice(0, 10);
+		const slot = nextFreeSlot(entries, today);
+		const entry: CalendarEntry = {
+			date: slot.date,
+			time: slot.time,
+			title: args.title,
+			slug: args.slug,
+			category: args.category,
+			copy,
+			first_comment: args.firstComment,
+		};
+		const next = [...entries, entry];
+
+		const num = String(next.length).padStart(2, "0");
+		const [y, m, d] = slot.date.split("-");
+		writeFileSync(calPath, JSON.stringify(next, null, 1));
+		writeFileSync(join(STAGING_DIR, "posts", `${num}-${args.slug}.txt`), copy);
+		const manifestPath = join(STAGING_DIR, "_manifest.txt");
+		const manifest = readFileSync(manifestPath, "utf8");
+		writeFileSync(
+			manifestPath,
+			`${manifest}${num} | ${m}/${d}/${y} | ${slot.time} | ${args.slug}\n`,
+		);
+		writeFileSync(DOC_PATH, renderCalendarDoc(next));
+
+		console.log(
+			`fb-append-post: "${args.slug}" appended as post ${num} on ${slot.date} ${slot.time} (${next.length} total)`,
+		);
+		return 0;
+	} finally {
+		releaseLock(LOCK_PATH);
+	}
+}
+
+if (process.argv[1]?.endsWith("/fb-append-post.ts")) {
+	main()
+		.then((code) => process.exit(code))
+		.catch((e: unknown) => {
+			console.error(
+				`fb-append-post: ${e instanceof Error ? e.message : String(e)}`,
+			);
+			process.exit(1);
+		});
+}

--- a/scripts/fb-fetch-blog.ts
+++ b/scripts/fb-fetch-blog.ts
@@ -1,0 +1,78 @@
+/**
+ * Print one published blog row as JSON for the FB-post-on-publish session
+ * (title, category, excerpt, first 2,500 chars of content). The headless
+ * Claude session calls this to ground the Facebook copy in the article's
+ * actual facts instead of inventing details.
+ *
+ * Usage: bun scripts/fb-fetch-blog.ts <slug>
+ * Env: NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SECRET_KEY (or SUPABASE_SERVICE_ROLE_KEY),
+ * auto-loaded from .env/.env.local by Bun like the other factory scripts.
+ */
+import { createClient } from "@supabase/supabase-js";
+
+export interface FbBlogFacts {
+	readonly slug: string;
+	readonly title: string;
+	readonly category: string;
+	readonly excerpt: string;
+	readonly contentHead: string;
+}
+
+// Typed mapper at the PostgREST boundary (CLAUDE.md: no `as unknown as`).
+export function mapFbBlogRow(raw: Record<string, unknown>): FbBlogFacts {
+	const { slug, title, category, excerpt, content } = raw;
+	if (typeof slug !== "string" || typeof title !== "string") {
+		throw new Error("blogs row missing slug/title");
+	}
+	return {
+		slug,
+		title,
+		category: typeof category === "string" ? category : "software-vault",
+		excerpt: typeof excerpt === "string" ? excerpt : "",
+		contentHead: typeof content === "string" ? content.slice(0, 2500) : "",
+	};
+}
+
+async function main(): Promise<number> {
+	const slug = process.argv[2];
+	if (!slug) {
+		console.error("usage: bun scripts/fb-fetch-blog.ts <slug>");
+		return 1;
+	}
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const key =
+		process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+	if (!url || !key) {
+		console.error(
+			"fb-fetch-blog: missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY",
+		);
+		return 1;
+	}
+	const supabase = createClient(url, key, { auth: { persistSession: false } });
+	const { data, error } = await supabase
+		.from("blogs")
+		.select("slug, title, category, excerpt, content")
+		.eq("slug", slug)
+		.eq("status", "published")
+		.limit(1);
+	if (error) {
+		console.error(`fb-fetch-blog: ${error.message}`);
+		return 1;
+	}
+	const row = ((data ?? []) as Record<string, unknown>[])[0];
+	if (!row) {
+		console.error(`fb-fetch-blog: no published blog with slug "${slug}"`);
+		return 1;
+	}
+	console.log(JSON.stringify(mapFbBlogRow(row), null, 2));
+	return 0;
+}
+
+if (process.argv[1]?.endsWith("/fb-fetch-blog.ts")) {
+	main()
+		.then((code) => process.exit(code))
+		.catch((e: unknown) => {
+			console.error(e instanceof Error ? e.message : String(e));
+			process.exit(1);
+		});
+}

--- a/scripts/fb-post-voice-guide.md
+++ b/scripts/fb-post-voice-guide.md
@@ -1,0 +1,82 @@
+# FB Post on Publish — Voice Guide + Procedure
+
+You are a headless Claude Code session spawned by the blog factory because a new
+blog post just published. Your ONLY job: write one Facebook post for it in
+Richard's voice and append it to the FB content calendar staging. You do NOT
+touch a browser, do NOT schedule anything in Meta, do NOT commit to git, do NOT
+modify any file except via the append script and your own /tmp scratch file.
+
+## Procedure (exactly these steps)
+
+1. The slug is in your prompt. Run:
+   `bun scripts/fb-fetch-blog.ts <slug>`
+   This prints JSON facts (title, category, excerpt, contentHead). Every claim
+   in your post must come from these facts — never invent statistics, prices,
+   or legal specifics.
+2. Read `.planning/social/fb-staging/_manifest.txt` (last ~10 lines) and the
+   matching recent post files in `.planning/social/fb-staging/posts/` so your
+   hook does not duplicate a recent opener or question formula.
+3. Write the post copy (rules below). Save it to `/tmp/fb-copy-<slug>.txt`.
+4. Run:
+   `bun scripts/fb-append-post.ts <slug> --copy-file /tmp/fb-copy-<slug>.txt --first-comment "<one casual sentence> https://tenantflow.app/blog/<slug>" --title "<title from step 1>" --category <category from step 1>`
+   The script lints. If it reports problems, fix the copy and re-run (max 3
+   attempts, then print the failure and stop).
+5. Print the script's success line as your final output.
+
+## Richard's voice — match this verbatim sample's register
+
+---
+Quick one for the landlords here.
+
+Your state has a hard security deposit return deadline, and a lot of people blow right past it without realizing. In a bunch of states, if you're even a few days late your tenant can come after you for 2-3x the deposit... even if every deduction you made was completely fair.
+
+Some that catch people off guard:
+
+Alabama gives you 60 days but caps the deposit at one month's rent
+Alaska is either 14 or 30 days depending on the shape the unit's in
+Arizona is 14 business days
+
+We put together a free breakdown of the deposit rules for every state, written for folks managing their own rentals. Nothing locked behind an email, the full 50-state table is linked in the comments.
+
+Which state are your rentals in? I'll reply with your exact deadline and what it could cost you to miss it.
+
+#LandlordTips #SecurityDeposit #LandlordLife
+---
+
+Voice DNA: one landlord texting another, zero marketing energy. Plain
+colloquial verbs ("blow right past it", "catch people off guard", "squared
+away", "folks managing their own rentals"). "a lot of people" not "many
+landlords". Occasional "..." mid-sentence for a beat. Bare-line lists, no
+bullets or bold. One trust signal where natural ("nothing locked behind an
+email" / "no signup, it's just on the blog"). End with a genuine question PLUS
+an offer of Richard's personal reply time ("tell me your state and I'll reply
+with your deadline" energy). Contractions always, short paragraphs, fragments
+fine. Numbers casual: "2-3x", "60 days", "$20/month".
+
+## Structure
+
+Hook (vary it — check recent posts in step 2), the genuinely useful meat with
+real specifics from the article, one natural pointer that the full guide is
+linked in the comments (vary the wording), closing question + reply-time offer,
+final line exactly 3 CamelCase hashtags chosen from:
+#LandlordTips #LandlordLife #TenantScreening #SecurityDeposit #RentalProperty
+#PropertyMaintenance #LandlordTaxes #RentalPropertyOwner #SmallLandlord #ScheduleE
+
+Length: 80-170 words before hashtags.
+
+## Hard bans (the append script lints for these — write clean the first time)
+
+- em-dashes or en-dashes anywhere (use commas, periods, or "...")
+- exclamation marks
+- "property owners" / "real estate investors" as the audience (it is "landlords" / "folks")
+- emoji, bold, italics, bullet symbols
+- "Here's the thing", "dive in", "game-changer", "Pro tip", "the kicker",
+  "navigate", "landscape", "robust", "seamless", "unlock", "elevate",
+  "crucial", "essential", "leverage"
+- "sounds simple until", "Quick gut check", "Honest question:" (overused)
+- "it's not just X, it's Y" constructions; "Whether you're a ... or a ..."
+- "Bottom line:" / "The takeaway:" summarizing lines
+- engagement-bait verbs in the closer: drop / comment below / tag a / share if
+  (ask the question plainly; "tell me" / "give me" are fine)
+- links in the post body (the URL goes ONLY in the first comment)
+- implying TenantFlow handles rent payments or has a tenant portal (it never does)

--- a/scripts/run-scheduled-blog.test.ts
+++ b/scripts/run-scheduled-blog.test.ts
@@ -5,10 +5,12 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { BlogTopicEntry } from "./run-scheduled-blog";
 import {
 	acquireLock,
+	buildFbTriggerArgv,
 	fetchAllSlugs,
 	mapTopicEntry,
 	pickNextTopic,
 	releaseLock,
+	triggerFbPostSession,
 } from "./run-scheduled-blog";
 
 const entry = (
@@ -146,5 +148,45 @@ describe("overlap lock", () => {
 		releaseLock(lockPath);
 		expect(existsSync(lockPath)).toBe(false);
 		releaseLock(lockPath); // no throw on second call
+	});
+});
+
+describe("buildFbTriggerArgv", () => {
+	it("builds a headless prompt pinned to the slug with a strict tool allowlist", () => {
+		const argv = buildFbTriggerArgv("my-new-post");
+		expect(argv[0]).toBe("-p");
+		expect(argv[1]).toContain('"my-new-post"');
+		expect(argv[1]).toContain("scripts/fb-post-voice-guide.md");
+		const allowed = argv[argv.indexOf("--allowedTools") + 1];
+		expect(allowed).toBe("Read,Write,Bash(bun:*)");
+		expect(argv).toContain("--max-turns");
+	});
+});
+
+describe("triggerFbPostSession", () => {
+	it("is a no-op when FB_POST_TRIGGER=0", () => {
+		const prev = process.env.FB_POST_TRIGGER;
+		process.env.FB_POST_TRIGGER = "0";
+		try {
+			// Would throw on spawn of a nonexistent binary if the guard failed.
+			process.env.CLAUDE_BIN = "/nonexistent/claude-binary";
+			expect(() => triggerFbPostSession("any-slug")).not.toThrow();
+		} finally {
+			if (prev === undefined) delete process.env.FB_POST_TRIGGER;
+			else process.env.FB_POST_TRIGGER = prev;
+			delete process.env.CLAUDE_BIN;
+		}
+	});
+
+	it("never throws even when the binary is missing (fail-open)", () => {
+		const prev = process.env.FB_POST_TRIGGER;
+		delete process.env.FB_POST_TRIGGER;
+		process.env.CLAUDE_BIN = "/nonexistent/claude-binary";
+		try {
+			expect(() => triggerFbPostSession("any-slug")).not.toThrow();
+		} finally {
+			if (prev !== undefined) process.env.FB_POST_TRIGGER = prev;
+			delete process.env.CLAUDE_BIN;
+		}
 	});
 });

--- a/scripts/run-scheduled-blog.ts
+++ b/scripts/run-scheduled-blog.ts
@@ -14,9 +14,9 @@
  *
  * Usage: bun scripts/run-scheduled-blog.ts
  */
-import { spawnSync } from "node:child_process";
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { spawn, spawnSync } from "node:child_process";
+import { openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClient } from "@supabase/supabase-js";
 import { formatGenFailure } from "./generate-blog-draft";
@@ -115,6 +115,58 @@ export function acquireLock(
 
 export function releaseLock(lockPath: string = DEFAULT_LOCK_PATH): void {
 	rmSync(lockPath, { force: true });
+}
+
+/**
+ * Headless Claude Code argv for the FB-post-on-publish step. Pure — unit-tested.
+ * The spawned session reads scripts/fb-post-voice-guide.md and appends one
+ * voice-written Facebook post to .planning/social/fb-staging/ for the slug.
+ * Tool allowlist is the minimum the guide's procedure needs.
+ */
+export function buildFbTriggerArgv(slug: string): string[] {
+	return [
+		"-p",
+		`A TenantFlow blog post was just published with slug "${slug}". Read scripts/fb-post-voice-guide.md and follow its procedure exactly for this slug.`,
+		"--allowedTools",
+		"Read,Write,Bash(bun:*)",
+		"--output-format",
+		"text",
+		"--max-turns",
+		"40",
+	];
+}
+
+/**
+ * Fire-and-forget: spawn a detached headless Claude session that drafts the
+ * Facebook post for a freshly published blog. Strictly non-fatal — the blog
+ * factory must never fail because the social step did. Opt out with
+ * FB_POST_TRIGGER=0; override the binary with CLAUDE_BIN.
+ */
+export function triggerFbPostSession(slug: string): void {
+	if (process.env.FB_POST_TRIGGER === "0") return;
+	try {
+		const bin = process.env.CLAUDE_BIN ?? join(homedir(), ".local/bin/claude");
+		const logPath = join(tmpdir(), `fb-post-${slug}.log`);
+		const log = openSync(logPath, "a");
+		const child = spawn(bin, buildFbTriggerArgv(slug), {
+			cwd: new URL("..", import.meta.url).pathname,
+			detached: true,
+			stdio: ["ignore", log, log],
+		});
+		// spawn() reports a missing binary asynchronously — swallow it so the
+		// blog factory never crashes on the social step (fail-open).
+		child.on("error", (e) => {
+			console.warn(`fb-post trigger spawn error (non-fatal): ${e.message}`);
+		});
+		child.unref();
+		console.log(
+			`fb-post trigger spawned for "${slug}" (pid ${child.pid ?? "?"}) — log: ${logPath}`,
+		);
+	} catch (e) {
+		console.warn(
+			`fb-post trigger failed (non-fatal): ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
 }
 
 async function main(): Promise<number> {


### PR DESCRIPTION
## What

Every blog that passes the factory's gates and publishes now automatically gets a Facebook post drafted for it, in the owner's voice, appended to the FB content calendar staging.

- `run-scheduled-blog.ts`: after a successful generation, spawns a detached headless `claude -p` session (fail-open — the blog flow can never break on the social step; `FB_POST_TRIGGER=0` opt-out, `CLAUDE_BIN` override, async spawn errors swallowed)
- `scripts/fb-post-voice-guide.md`: the spawned session's complete procedure — voice sample, AI-tell banlist, structure rules, dedup-against-recent-hooks step
- `scripts/fb-fetch-blog.ts`: prints article facts as JSON so copy is grounded, never invented
- `scripts/fb-append-post.ts`: deterministic half — mechanical AI-tell lint (em-dashes, bait verbs, persona leaks, hashtag count, crutch phrases), slot assignment at 3/day (9:00 AM / 1:00 PM / 5:00 PM CT, fills gaps before extending the tail, legacy 10 AM anchors don't block), CDN cover-exists check, manifest + calendar-doc regen, idempotent per slug, PID lockfile against concurrent appends
- Biome: `.planning/**` excluded (factory-churned working artifacts)

## Why 3 slots/day

Meta Business Suite hard-caps scheduling at 29 days out. Weekday-only spacing pushed the queue months past the window; 3/day keeps the whole backlog inside it.

## Verification

- 37 unit tests pass (slot logic incl. gap-fill + anchor cases, lint rules, mapper defaults, argv builder, fail-open trigger)
- `bun run typecheck` + `bun run lint` clean
- Live end-to-end test: headless session drafted + appended `late-payment-patterns-on-credit-reports` as post 57 (Jun 25, 9:00 AM) — copy passed lint on the first attempt

[hudsor01]