### PR TITLE
fix(blog-factory): wire the FB-post trigger call site in main()

### DIFF
--- a/scripts/run-scheduled-blog.ts
+++ b/scripts/run-scheduled-blog.ts
@@ -218,6 +218,8 @@ async function main(): Promise<number> {
 			],
 			{ stdio: "inherit" },
 		);
+		// Publish succeeded -> draft its Facebook post (detached, fail-open).
+		if (child.status === 0) triggerFbPostSession(next.slug);
 		return child.status ?? 1;
 	} finally {
 		releaseLock();


### PR DESCRIPTION
#827 shipped buildFbTriggerArgv + triggerFbPostSession fully tested but never called them from main() — confirmed by three trigger-less publishes since merge (wildfire-zone, buildium-alternatives-under-40, rentec-direct-vs-yardi-breeze; no /tmp/fb-post-*.log files). One-line fix: invoke on generator exit 0. The three missed slugs are being backfilled manually with the same headless procedure.

[hudsor01]