### PR TITLE
feat(blog-factory): continuous runner to burn down the topic bank

### DIFF
--- a/scripts/run-continuous-blog.test.ts
+++ b/scripts/run-continuous-blog.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { nextUnwrittenTopic } from "./run-continuous-blog";
+import type { BlogTopicEntry } from "./run-scheduled-blog";
+
+const entry = (
+	slug: string,
+	tier: "reclaim" | "evergreen" = "evergreen",
+): BlogTopicEntry => ({
+	topic: `Topic for ${slug} with enough length`,
+	category: "software-vault",
+	slug,
+	tier,
+});
+
+const bank = [entry("a-one"), entry("b-two"), entry("c-three")];
+
+describe("nextUnwrittenTopic", () => {
+	it("picks the first topic that is neither written nor skipped", () => {
+		expect(nextUnwrittenTopic(bank, new Set(["a-one"]), new Set())?.slug).toBe(
+			"b-two",
+		);
+	});
+
+	it("treats a skipped slug as blocked (never re-picks a poison topic)", () => {
+		// a-one written, b-two skipped -> next must be c-three, not b-two
+		expect(
+			nextUnwrittenTopic(bank, new Set(["a-one"]), new Set(["b-two"]))?.slug,
+		).toBe("c-three");
+	});
+
+	it("picks the very first entry when nothing is written or skipped", () => {
+		expect(nextUnwrittenTopic(bank, new Set(), new Set())?.slug).toBe("a-one");
+	});
+
+	it("returns undefined when every topic is written or skipped (loop terminates)", () => {
+		expect(
+			nextUnwrittenTopic(
+				bank,
+				new Set(["a-one", "b-two"]),
+				new Set(["c-three"]),
+			),
+		).toBeUndefined();
+	});
+});

--- a/scripts/run-continuous-blog.ts
+++ b/scripts/run-continuous-blog.ts
@@ -39,6 +39,15 @@ const MAX_ATTEMPTS = Math.max(
 	Number(process.env.CONTINUOUS_MAX_ATTEMPTS ?? "2"),
 );
 const TRANSIENT_RETRY_MS = 30_000;
+// Wait out an in-flight n8n tick (a tick holds the lock for one generation,
+// then releases — up to the 30-min generation timeout) so the runner can be
+// launched at any moment without timing the n8n cycle. Past this window,
+// assume another continuous runner is active and bail.
+const ACQUIRE_WAIT_MS = Math.max(
+	0,
+	Number(process.env.CONTINUOUS_ACQUIRE_WAIT_MS ?? String(40 * 60_000)),
+);
+const ACQUIRE_POLL_MS = 15_000;
 
 const sleep = (ms: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(resolve, ms));
@@ -89,12 +98,22 @@ async function main(): Promise<number> {
 	}
 
 	// Hold the shared factory lock for the whole run so concurrent n8n ticks
-	// (and a second continuous runner) cleanly no-op.
-	if (!acquireLock(process.pid)) {
+	// (and a second continuous runner) cleanly no-op. Wait out an in-flight n8n
+	// generation rather than exiting immediately, so launch timing never matters.
+	const deadline = Date.now() + ACQUIRE_WAIT_MS;
+	let acquired = acquireLock(process.pid);
+	while (!acquired && Date.now() < deadline) {
 		console.log(
-			"another blog-factory run holds the lock — exiting (continuous runner already active?).",
+			"factory lock held by another run (n8n tick mid-generation?) — waiting 15s to take over...",
 		);
-		return 0;
+		await sleep(ACQUIRE_POLL_MS);
+		acquired = acquireLock(process.pid);
+	}
+	if (!acquired) {
+		console.error(
+			"could not acquire the factory lock within the wait window — is another continuous runner already active? Exiting.",
+		);
+		return 1;
 	}
 
 	try {

--- a/scripts/run-continuous-blog.ts
+++ b/scripts/run-continuous-blog.ts
@@ -1,0 +1,174 @@
+/**
+ * Continuous blog-factory runner — back-to-back generation with NO 30-minute
+ * idle gaps. Burns down the whole topic bank in one sustained run (the n8n
+ * Schedule trigger caps at ~48/day and skips ticks during slow generations;
+ * this is limited only by generation time, ~5-7 days for the full bank).
+ *
+ * Owner-run (needs .env.local creds + a loaded LM Studio model). Launch detached
+ * so it survives the terminal closing (the Mac must stay awake — see the
+ * com.hudson.blog-factory-caffeinate LaunchAgent):
+ *   nohup bun scripts/run-continuous-blog.ts > /tmp/continuous-blog.log 2>&1 &
+ *   tail -f /tmp/continuous-blog.log      # watch progress
+ *   pkill -f run-continuous-blog          # stop early
+ *
+ * Holds the SHARED factory lock (run-scheduled-blog's DEFAULT_LOCK_PATH) for its
+ * entire lifetime, so the n8n 30-min ticks see the lock held and cleanly no-op —
+ * no need to disable the n8n schedule.
+ *
+ * FB post drafting is intentionally SKIPPED here (this runner never calls the
+ * publish-time trigger) so a multi-day burn doesn't spawn ~939 headless Claude
+ * sessions. Backfill FB posts in one batch afterward.
+ *
+ * Env knobs: CONTINUOUS_MAX_ATTEMPTS (default 2) — outer retries before a topic
+ * is skipped as poison (generate-blog-draft already does 6 inner repair attempts).
+ */
+import { spawnSync } from "node:child_process";
+import { createClient } from "@supabase/supabase-js";
+import { formatGenFailure } from "./generate-blog-draft";
+import {
+	acquireLock,
+	type BlogTopicEntry,
+	fetchAllSlugs,
+	loadTopics,
+	pickNextTopic,
+	releaseLock,
+} from "./run-scheduled-blog";
+
+const MAX_ATTEMPTS = Math.max(
+	1,
+	Number(process.env.CONTINUOUS_MAX_ATTEMPTS ?? "2"),
+);
+const TRANSIENT_RETRY_MS = 30_000;
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Next bank topic that is neither already written nor skipped. Reuses
+ * pickNextTopic by treating skipped slugs as "blocked" alongside written ones,
+ * so a poison topic can't be re-picked and stall the loop. Pure — unit-tested.
+ */
+export function nextUnwrittenTopic(
+	topics: readonly BlogTopicEntry[],
+	written: ReadonlySet<string>,
+	skipped: ReadonlySet<string>,
+): BlogTopicEntry | undefined {
+	const blocked = new Set<string>(written);
+	for (const slug of skipped) blocked.add(slug);
+	return pickNextTopic(topics, blocked);
+}
+
+// One synchronous generation, same invocation run-scheduled-blog uses. Returns
+// the child exit code (0 = published; non-zero = failed after inner repairs).
+function generateOne(topic: BlogTopicEntry): number {
+	const child = spawnSync(
+		process.execPath,
+		[
+			new URL("./generate-blog-draft.ts", import.meta.url).pathname,
+			topic.topic,
+			topic.category,
+			"--slug",
+			topic.slug,
+		],
+		{ stdio: "inherit" },
+	);
+	return child.status ?? 1;
+}
+
+async function main(): Promise<number> {
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const key =
+		process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+	if (!url || !key) {
+		console.error(
+			formatGenFailure(
+				"run-continuous-blog: missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY",
+			),
+		);
+		return 1;
+	}
+
+	// Hold the shared factory lock for the whole run so concurrent n8n ticks
+	// (and a second continuous runner) cleanly no-op.
+	if (!acquireLock(process.pid)) {
+		console.log(
+			"another blog-factory run holds the lock — exiting (continuous runner already active?).",
+		);
+		return 0;
+	}
+
+	try {
+		const topics = loadTopics();
+		const supabase = createClient(url, key, {
+			auth: { persistSession: false },
+		});
+		const skipped = new Set<string>();
+		const failCount = new Map<string, number>();
+		let generated = 0;
+
+		for (;;) {
+			let next: BlogTopicEntry | undefined;
+			let writtenCount = 0;
+			try {
+				const existing = await fetchAllSlugs((from, to) =>
+					supabase.from("blogs").select("slug").range(from, to),
+				);
+				writtenCount = existing.size;
+				next = nextUnwrittenTopic(topics, existing, skipped);
+			} catch (e) {
+				// Transient DB/network blip must not kill a multi-day run.
+				console.error(
+					`  slug fetch failed (transient?) — retrying in ${TRANSIENT_RETRY_MS / 1000}s: ${e instanceof Error ? e.message : String(e)}`,
+				);
+				await sleep(TRANSIENT_RETRY_MS);
+				continue;
+			}
+
+			if (!next) {
+				console.log(
+					`\nCONTINUOUS RUN COMPLETE — ${generated} generated this run, ${skipped.size} skipped after ${MAX_ATTEMPTS} attempts. ${writtenCount}/${topics.length} bank slugs now written.`,
+				);
+				if (skipped.size > 0) {
+					console.log(`skipped (investigate): ${[...skipped].join(", ")}`);
+				}
+				return 0;
+			}
+
+			console.log(
+				`\n[${writtenCount}/${topics.length} written | ${generated} this run | ${skipped.size} skipped] generating ${next.tier} "${next.topic}" --slug ${next.slug}`,
+			);
+			const status = generateOne(next);
+			if (status === 0) {
+				generated++;
+				continue;
+			}
+
+			const n = (failCount.get(next.slug) ?? 0) + 1;
+			failCount.set(next.slug, n);
+			if (n >= MAX_ATTEMPTS) {
+				skipped.add(next.slug);
+				console.error(
+					`  SKIPPING poison topic after ${n} failed attempt(s): ${next.slug}`,
+				);
+			} else {
+				console.error(
+					`  generation failed (attempt ${n}/${MAX_ATTEMPTS}) — will retry: ${next.slug}`,
+				);
+			}
+		}
+	} finally {
+		releaseLock();
+	}
+}
+
+// CLI guard — import-safe for unit tests (same pattern as the sibling runners).
+if (process.argv[1]?.endsWith("/run-continuous-blog.ts")) {
+	main()
+		.then((code) => process.exit(code))
+		.catch((e: unknown) => {
+			console.error(
+				formatGenFailure(e instanceof Error ? e.message : String(e)),
+			);
+			process.exit(1);
+		});
+}


### PR DESCRIPTION
## What

A continuous, back-to-back blog generation runner so the remaining topic bank finishes in ~5-7 days instead of the ~6-7 weeks the 30-min n8n interval implies.

## Why
The n8n Schedule trigger caps at ~48/day and skips ticks during slow generations. With ~939 bank topics left, that's weeks. Generating back-to-back (no idle gaps) is limited only by generation time.

## Design
- **Shares the factory lock** (`run-scheduled-blog`'s `DEFAULT_LOCK_PATH`) for the runner's whole lifetime, so concurrent n8n ticks see it held and cleanly no-op. No need to disable the n8n schedule.
- **Poison-topic skip**: a topic failing `CONTINUOUS_MAX_ATTEMPTS` (default 2) is treated as blocked so the tight loop never stalls retrying it forever — the failure mode the 30-min interval masked. Reuses the existing `pickNextTopic` by treating skipped slugs as "blocked".
- **Transient-error resilient**: a DB/network blip retries after 30s instead of killing a multi-day run.
- **FB drafting intentionally off**: a 900+ blog burn shouldn't spawn 900+ headless FB sessions; FB posts get backfilled in one batch afterward.
- Reuses `loadTopics` / `fetchAllSlugs` / `pickNextTopic` / `acquireLock` / `releaseLock` from `run-scheduled-blog` (no duplication).

## Run
Owner-run (needs `.env.local` + a loaded LM Studio model), detached under the caffeinate LaunchAgent:
```
nohup bun scripts/run-continuous-blog.ts > /tmp/continuous-blog.log 2>&1 &
```

## Verification
20 unit tests pass (skip/terminate logic); `bun run typecheck` + `bun run lint` clean.

[hudsor01]