### PR TITLE
fix(blog-factory): auto-cure internal_links + citations to restore throughput

### DIFF
--- a/scripts/generate-blog-draft.test.ts
+++ b/scripts/generate-blog-draft.test.ts
@@ -7,6 +7,7 @@ import {
 	capH2Count,
 	critique,
 	deriveTags,
+	ensureInternalLinks,
 	extractComparisonBrands,
 	extractExternalUrls,
 	findDuplicateComparison,
@@ -22,6 +23,7 @@ import {
 	pickLoadedModel,
 	runGates,
 	sanitizeBanlist,
+	stripNonAllowlistedExternalLinks,
 	validateInternalLinks,
 } from "./generate-blog-draft";
 
@@ -537,6 +539,88 @@ describe("capH2Count (h2_count gate, max 10 — keep 9, demote the rest)", () =>
 		expect(out).toContain("\n## FAQ");
 		expect(h2s(out)).toBe(10); // first 9 kept + the protected FAQ
 		expect(out).toContain("### Section 11");
+	});
+});
+
+describe("stripNonAllowlistedExternalLinks (citations offlist auto-cure)", () => {
+	it("drops a non-allowlisted markdown link to its anchor text", () => {
+		const out = stripNonAllowlistedExternalLinks(
+			"See [the manual](https://manufacturer.com/guide) for details.",
+		);
+		expect(out).toBe("See the manual for details.");
+	});
+
+	it("preserves a .gov citation verbatim", () => {
+		const src = "Per [IRS Schedule E](https://www.irs.gov/forms-pubs).";
+		expect(stripNonAllowlistedExternalLinks(src)).toBe(src);
+	});
+
+	it("preserves a law.cornell.edu citation verbatim", () => {
+		const src =
+			"See [the FCRA](https://www.law.cornell.edu/uscode/text/15/1681).";
+		expect(stripNonAllowlistedExternalLinks(src)).toBe(src);
+	});
+
+	it("removes a bare non-allowlisted URL", () => {
+		const out = stripNonAllowlistedExternalLinks(
+			"ref https://doorloop.com here",
+		);
+		expect(out).not.toContain("doorloop.com");
+	});
+
+	it("leaves internal /blog links untouched", () => {
+		const src =
+			"Read [the winter guide](/blog/winter-rental-maintenance-checklist).";
+		expect(stripNonAllowlistedExternalLinks(src)).toBe(src);
+	});
+});
+
+describe("ensureInternalLinks (internal_links auto-cure)", () => {
+	const cands = [
+		"winter-rental-maintenance-checklist",
+		"fall-rental-maintenance-checklist",
+		"spring-rental-maintenance-checklist",
+	];
+
+	it("appends a Related reading line when no internal links are present", () => {
+		const out = ensureInternalLinks("Body text only.", cands);
+		const links = [...out.matchAll(/\]\(\/blog\/([^)]+)\)/g)].map((m) => m[1]);
+		expect(links.length).toBe(2);
+		expect(out).toContain("Related reading:");
+		// both appended links are real candidates
+		for (const l of links) expect(cands).toContain(l);
+	});
+
+	it("strips a link to an unknown slug down to its text", () => {
+		const out = ensureInternalLinks(
+			"See [the made-up post](/blog/not-a-real-slug) and [winter](/blog/winter-rental-maintenance-checklist) and [fall](/blog/fall-rental-maintenance-checklist).",
+			cands,
+		);
+		expect(out).not.toContain("/blog/not-a-real-slug");
+		expect(out).toContain("the made-up post"); // text kept
+	});
+
+	it("strips a dead # link and tops up to two valid links", () => {
+		const out = ensureInternalLinks("Body with [dead](#) link.", cands);
+		expect(out).not.toContain("](#)");
+		const links = [...out.matchAll(/\]\(\/blog\/([^)]+)\)/g)].map((m) => m[1]);
+		expect(links.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("leaves content with two valid links unchanged (no append)", () => {
+		const src =
+			"A [winter](/blog/winter-rental-maintenance-checklist) and [fall](/blog/fall-rental-maintenance-checklist) post.";
+		expect(ensureInternalLinks(src, cands)).toBe(src);
+	});
+
+	it("inserts the line before the FAQ section", () => {
+		const out = ensureInternalLinks("Intro.\n\n## FAQ\n\n### Q?\n\nA.", cands);
+		expect(out.indexOf("Related reading:")).toBeLessThan(out.indexOf("## FAQ"));
+	});
+
+	it("is a no-op when fewer than two candidates exist", () => {
+		const src = "Body text only.";
+		expect(ensureInternalLinks(src, ["only-one"])).toBe(src);
 	});
 });
 

--- a/scripts/generate-blog-draft.ts
+++ b/scripts/generate-blog-draft.ts
@@ -742,6 +742,78 @@ export function capDocusealMentions(s: string): string {
 	});
 }
 
+// Deterministic cure for the `citations` offlist failure (the model habitually
+// links to manufacturer/how-to sites). Same philosophy as sanitizeBanlist: keep
+// the anchor TEXT, drop the disallowed href, so the post loses a junk link, not
+// content. Allowlisted (.gov / law.cornell.edu) links are preserved verbatim.
+// Pure — unit-tested.
+export function stripNonAllowlistedExternalLinks(content: string): string {
+	// markdown links to a non-allowlisted external URL -> plain anchor text
+	let out = content.replace(
+		/\[([^\]]*)\]\((https?:\/\/[^)\s]+)(?:\s+"[^"]*")?\)/g,
+		(match, text: string, url: string) =>
+			isAllowlistedCitation(url) ? match : text,
+	);
+	// bare non-allowlisted external URLs -> removed (rare; the model occasionally
+	// drops a raw link). Allowlisted bare URLs are left intact.
+	out = out.replace(/https?:\/\/[^\s)\]>"']+/g, (url) =>
+		isAllowlistedCitation(url.replace(/[.,;:!?]+$/, "")) ? url : "",
+	);
+	return out;
+}
+
+function humanizeSlug(slug: string): string {
+	return slug
+		.split("-")
+		.map((w) => (w.length > 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+		.join(" ");
+}
+
+// Deterministic cure for the `internal_links` failure: (1) strip internal links
+// to unknown slugs or dead "#" hrefs down to plain text, then (2) if fewer than
+// two valid candidate links remain, append a "Related reading" line wiring in
+// fresh candidates. A related-reading footer of same-category siblings is a
+// legitimate internal-linking pattern, not gate-gaming. No-op when fewer than
+// two candidates exist (the gate passes vacuously there). Pure — unit-tested.
+export function ensureInternalLinks(
+	content: string,
+	candidateSlugs: readonly string[],
+): string {
+	const candidates = new Set(candidateSlugs);
+	// 1. strip unknown-slug internal links + dead "#" links to plain text
+	const out = content.replace(
+		/\[([^\]]*)\]\((\/blog\/[^)\s]+|#)(?:\s+"[^"]*")?\)/g,
+		(match, text: string, href: string) => {
+			if (href === "#") return text;
+			return candidates.has(href.slice("/blog/".length)) ? match : text;
+		},
+	);
+	if (candidateSlugs.length < 2) return out;
+
+	// 2. count valid candidate links already present
+	const linked = new Set<string>();
+	for (const m of out.matchAll(/\]\(\/blog\/([^)\s]+)\)/g)) {
+		const slug = m[1];
+		if (slug !== undefined && candidates.has(slug)) linked.add(slug);
+	}
+	if (linked.size >= 2) return out;
+
+	const need = 2 - linked.size;
+	const pick = candidateSlugs.filter((s) => !linked.has(s)).slice(0, need);
+	if (pick.length < need) return out; // not enough distinct candidates
+	const line = `Related reading: ${pick
+		.map((s) => `[${humanizeSlug(s)}](/blog/${s})`)
+		.join(" and ")}.`;
+
+	// insert just before the FAQ section if present (keeps FAQ near the end for
+	// the faq_required position check), otherwise append at the end.
+	const faq = out.match(/^##\s+(?:faq|frequently asked questions)\s*$/im);
+	if (faq?.index !== undefined) {
+		return `${out.slice(0, faq.index)}${line}\n\n${out.slice(faq.index)}`;
+	}
+	return `${out.trimEnd()}\n\n${line}\n`;
+}
+
 async function embed(input: string): Promise<number[]> {
 	const r = await fetch(`${LM_BASE}/embeddings`, {
 		method: "POST",
@@ -1008,6 +1080,14 @@ async function generateValidDraft(
 		d.content = capDocusealMentions(d.content);
 		// demote surplus H2s (h2_count gate max 10; keep 9 for margin)
 		d.content = capH2Count(d.content);
+		// deterministically clear the two gates the local model rarely lands on
+		// its own: strip non-allowlisted external links (citations offlist) and
+		// guarantee >=2 valid same-category internal links (internal_links).
+		d.content = stripNonAllowlistedExternalLinks(d.content);
+		d.content = ensureInternalLinks(
+			d.content,
+			ctx.internalLinkCandidates ?? [],
+		);
 		let failures = runGates(d, ctx);
 		if (failures.length === 0) {
 			// structural gates pass — verify the external citations actually


### PR DESCRIPTION
## Problem (caught live during the continuous burn)

The 18-gate SEO factory (#830) starved the local 24B-6bit model. At the 30-min mark of the continuous run: **0 published, 1 skipped**. Topics reached **16/18** gates — the only two they couldn't land within 6 repair attempts were **`internal_links`** and the **`citations`** offlist check, on every topic. The old 9-gate factory did 18-25/day; the SEO gates dropped it to ~0.

## Fix — deterministic cures, not loosened gates

Both blockers are mechanical, so they get the same treatment as the existing `capH2Count` / `sanitizeBanlist` sanitizers. Posts stay fully SEO-complete (takeaways, FAQ, tables, valid internal links, clean external links):

- **`stripNonAllowlistedExternalLinks`** — the model habitually links to manufacturer/how-to sites; drop the href, keep the anchor text. `.gov` / `law.cornell.edu` citations preserved verbatim.
- **`ensureInternalLinks`** — strip hallucinated-slug and dead `#` links to plain text, then append a "Related reading" line wiring in same-category candidate siblings when fewer than two valid links remain (no-op below two candidates). Inserted before the FAQ so `faq_required`'s position check still holds.

Applied after `capH2Count`, before `runGates`.

## Verification
+12 unit tests; **119 pass**; `bun run typecheck` + `bun run lint` clean. The running continuous runner spawns a fresh generator per topic, so it picks this up on the next generation — no restart.

[hudsor01]