### PR TITLE
fix(blog): return 404 for out-of-range ?page instead of a 416 Sentry error

### DIFF
--- a/src/app/blog/page.test.tsx
+++ b/src/app/blog/page.test.tsx
@@ -22,6 +22,14 @@ vi.mock("@sentry/nextjs", () => ({
 	captureException: vi.fn(),
 }));
 
+vi.mock("next/navigation", () => ({
+	notFound: () => {
+		const err = new Error("NEXT_NOT_FOUND") as Error & { digest: string };
+		err.digest = "NEXT_NOT_FOUND";
+		throw err;
+	},
+}));
+
 vi.mock("next/link", () => ({
 	default: ({
 		children,
@@ -174,7 +182,7 @@ interface MockBuilderOpts {
 	posts?: BlogListItem[];
 	postsCount?: number | null;
 	comparisons?: BlogListItem[];
-	postsError?: { message: string } | null;
+	postsError?: { message: string; code?: string } | null;
 	categoriesError?: { message: string } | null;
 	comparisonsError?: { message: string } | null;
 	rejectPosts?: boolean;
@@ -286,6 +294,22 @@ describe("BlogPage (server component)", () => {
 	it("does NOT render pagination when totalPages = 1", async () => {
 		render(await renderPage({ postsCount: 3 }));
 		expect(screen.queryByTestId("blog-pagination")).not.toBeInTheDocument();
+	});
+
+	it("returns a 404 (notFound) for an out-of-range ?page — PostgREST 416 — without logging a Sentry error", async () => {
+		mockCreateClient.mockResolvedValue(
+			makeFromBuilder({
+				postsError: {
+					code: "PGRST103",
+					message: "Requested range not satisfiable",
+				},
+			}),
+		);
+		await expect(
+			BlogPage({ searchParams: Promise.resolve({ page: "11" }) }),
+		).rejects.toMatchObject({ digest: "NEXT_NOT_FOUND" });
+		// the 416 is expected control flow, not a server error to report
+		expect(Sentry.captureException).not.toHaveBeenCalled();
 	});
 
 	it("renders empty-state branch when zero posts", async () => {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { BlogCard } from "#components/blog/blog-card";
 import { BlogPagination } from "#components/blog/blog-pagination";
 import { NewsletterSignup } from "#components/blog/newsletter-signup";
@@ -109,6 +110,20 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 					.limit(6),
 			]);
 
+		// An out-of-range ?page=N (offset past the last row) makes PostgREST
+		// return 416 "Requested range not satisfiable" (code PGRST103). That's
+		// not a server error — the pagination URL points beyond the last page
+		// (e.g. a crawler probing ?page=11 of a 10-page blog). Return a real 404
+		// so crawlers drop the URL, instead of logging noise + soft-rendering an
+		// empty page. notFound() throws NEXT_NOT_FOUND, which the catch re-raises.
+		const rangeCode = (postsResult.error as { code?: string } | null)?.code;
+		if (
+			rangeCode === "PGRST103" ||
+			/range not satisfiable/i.test(postsResult.error?.message ?? "")
+		) {
+			notFound();
+		}
+
 		if (
 			postsResult.error ||
 			categoriesResult.error ||
@@ -127,6 +142,18 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 		comparisons = (comparisonsResult.data ?? []) as BlogListItem[];
 		totalPages = Math.max(1, Math.ceil((postsResult.count ?? 0) / PAGE_LIMIT));
 	} catch (err) {
+		// notFound() (and redirect()) signal via a thrown error carrying a
+		// `digest` — re-raise it so Next can render the 404, instead of
+		// swallowing it into the empty-state + a bogus Sentry "error".
+		if (
+			err &&
+			typeof err === "object" &&
+			"digest" in err &&
+			(err.digest === "NEXT_NOT_FOUND" ||
+				String(err.digest).startsWith("NEXT_REDIRECT"))
+		) {
+			throw err;
+		}
 		Sentry.captureException(err, {
 			tags: { surface: "blog-index" },
 			extra: { page },


### PR DESCRIPTION
## Production error
Sentry (release 0340ddd8, surface blog-index): `HEAD /blog?page=11` -> **"Requested range not satisfiable"** (416).

## Cause
#831's crawlable pagination exposed real `?page=N` URLs. A request past the last page makes the PostgREST `.range(offset, offset+8)` exceed the row count -> 416 (`PGRST103`). It was caught, logged as a server error, and soft-rendered an empty page — wrong: an out-of-range pagination URL should be a 404.

## Fix
Detect `PGRST103` / "range not satisfiable" on the posts query and `notFound()`. The catch now re-raises Next's `NEXT_NOT_FOUND`/`NEXT_REDIRECT` control-flow throws instead of swallowing them into the empty-state + a bogus Sentry capture. +1 regression test (asserts 404 + no Sentry capture). 18 tests pass.

[hudsor01]