### PR TITLE
fix(seo): allow /api/og/ in robots so OG images aren't blocked

### DIFF
--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -9,7 +9,11 @@ vi.mock("#lib/generate-metadata", () => ({
 // below. A previous version of this file duplicated the lists, which
 // only caught one drift direction (test missing an entry the source
 // added) — this version catches both.
-import robots, { AI_USER_AGENTS, PRIVATE_PATHS } from "./robots";
+import robots, {
+	AI_USER_AGENTS,
+	CRAWLABLE_API_PATHS,
+	PRIVATE_PATHS,
+} from "./robots";
 
 const ROUTE = robots();
 
@@ -35,6 +39,26 @@ describe("robots()", () => {
 		const disallow = asArray(wildcard!.disallow);
 		for (const path of PRIVATE_PATHS) {
 			expect(disallow).toContain(path);
+		}
+	});
+
+	it("allows /api/og/ (OG images) while keeping /api disallowed wholesale", () => {
+		const rules = Array.isArray(ROUTE.rules) ? ROUTE.rules : [ROUTE.rules];
+		// Both the wildcard and every AI bot must carry the override so Google
+		// and answer engines can fetch og:image / twitter:image thumbnails.
+		const carriers = rules.filter(
+			(r) =>
+				r.userAgent === "*" || AI_USER_AGENTS.includes(r.userAgent as never),
+		);
+		expect(carriers.length).toBe(AI_USER_AGENTS.length + 1);
+		for (const rule of carriers) {
+			const allow = asArray(rule.allow);
+			const disallow = asArray(rule.disallow);
+			for (const p of CRAWLABLE_API_PATHS) {
+				expect(allow, `${rule.userAgent} should allow ${p}`).toContain(p);
+			}
+			// the broad /api block must remain — only /api/og/ is the exception
+			expect(disallow).toContain("/api");
 		}
 	});
 
@@ -66,6 +90,7 @@ describe("robots()", () => {
 			"/feed.xml",
 			"/sitemap.xml",
 			"/.well-known/security.txt",
+			...CRAWLABLE_API_PATHS,
 		];
 
 		for (const ua of AI_USER_AGENTS) {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -32,6 +32,19 @@ export const PRIVATE_PATHS = [
 	"/pricing/complete",
 ] as const satisfies readonly string[];
 
+// Paths UNDER a disallowed prefix that must stay crawlable. `/api` is blocked
+// wholesale (auth, webhooks, internal endpoints), but `/api/og/*` renders the
+// social/OG card images referenced as `og:image`/`twitter:image` on every
+// marketing and blog page. Blocking them made Google report the images as
+// "Blocked by robots.txt" (GSC indexing alert) AND suppressed rich-result +
+// social-preview thumbnails. A more-specific `Allow:` overrides the broad
+// `Disallow:` under longest-match precedence (Google, Bing, the major bots).
+//
+// Exported so `robots.test.ts` pins it in the drift guard.
+export const CRAWLABLE_API_PATHS = [
+	"/api/og/",
+] as const satisfies readonly string[];
+
 // AI-content user agents listed in the canonical vendor docs. Per the
 // best-practices brief (May 2026): the marketing surface is intentionally
 // crawlable by training and answer engines so the brand can be cited in
@@ -82,6 +95,9 @@ export default function robots(): MetadataRoute.Robots {
 		"/feed.xml",
 		"/sitemap.xml",
 		"/.well-known/security.txt",
+		// Override the `/api` disallow for the OG-image routes so crawlers can
+		// fetch social/rich-result thumbnails (longest-match precedence).
+		...CRAWLABLE_API_PATHS,
 	];
 
 	const aiBotRules = AI_USER_AGENTS.map((userAgent) => ({


### PR DESCRIPTION
## GSC alert
"Blocked by robots.txt" — a new, growing reason preventing pages from being indexed on tenantflow.app.

## Cause
Every marketing and blog page sets `og:image`/`twitter:image` to `/api/og/<...>`, but `robots.txt` disallowed `/api` wholesale. Google tried to fetch each social-card image, got blocked, and reported it — and the ~160-post (and climbing) blog catalogue made it escalate. It also suppressed rich-result + social-preview thumbnails.

## Fix
Add `CRAWLABLE_API_PATHS` (`/api/og/`) to the allow list for the wildcard + every AI-bot rule. A more-specific `Allow:` overrides the broad `/api` `Disallow:` under longest-match precedence; the rest of `/api` (auth, webhooks, internal) stays blocked. Verified the generated robots: allow contains `/api/og/`, disallow still contains `/api`. Drift-guard test extended — 6 pass.

[hudsor01]