### PR TITLE
ops: pause blog factory via run-scheduled-blog kill-switch

### DIFF
--- a/scripts/run-scheduled-blog.test.ts
+++ b/scripts/run-scheduled-blog.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -7,9 +7,11 @@ import {
 	acquireLock,
 	buildFbTriggerArgv,
 	fetchAllSlugs,
+	isFactoryStopped,
 	mapTopicEntry,
 	pickNextTopic,
 	releaseLock,
+	STOP_SENTINEL_PATH,
 	triggerFbPostSession,
 } from "./run-scheduled-blog";
 
@@ -148,6 +150,38 @@ describe("overlap lock", () => {
 		releaseLock(lockPath);
 		expect(existsSync(lockPath)).toBe(false);
 		releaseLock(lockPath); // no throw on second call
+	});
+});
+
+describe("isFactoryStopped (kill-switch)", () => {
+	const sentinel = join(tmpdir(), `tf-blog-off-test-${process.pid}`);
+
+	afterEach(() => {
+		if (existsSync(sentinel)) rmSync(sentinel);
+	});
+
+	it("is false when neither the env flag nor the sentinel is present", () => {
+		expect(isFactoryStopped({}, sentinel)).toBe(false);
+	});
+
+	it("is true when BLOG_FACTORY_OFF=1 (sentinel absent)", () => {
+		expect(isFactoryStopped({ BLOG_FACTORY_OFF: "1" }, sentinel)).toBe(true);
+	});
+
+	it("ignores BLOG_FACTORY_OFF values other than '1'", () => {
+		expect(isFactoryStopped({ BLOG_FACTORY_OFF: "0" }, sentinel)).toBe(false);
+		expect(isFactoryStopped({ BLOG_FACTORY_OFF: "true" }, sentinel)).toBe(
+			false,
+		);
+	});
+
+	it("is true when the sentinel file exists (env flag absent)", () => {
+		writeFileSync(sentinel, "paused");
+		expect(isFactoryStopped({}, sentinel)).toBe(true);
+	});
+
+	it("defaults the sentinel path to a persistent home dotfile", () => {
+		expect(STOP_SENTINEL_PATH).toMatch(/\.tenantflow-blog-factory\.off$/);
 	});
 });
 

--- a/scripts/run-scheduled-blog.ts
+++ b/scripts/run-scheduled-blog.ts
@@ -15,7 +15,13 @@
  * Usage: bun scripts/run-scheduled-blog.ts
  */
 import { spawn, spawnSync } from "node:child_process";
-import { openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	openSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClient } from "@supabase/supabase-js";
@@ -84,6 +90,26 @@ export async function fetchAllSlugs(
 // time out. PID lockfile with stale-takeover: a live holder skips the tick
 // cleanly (exit 0); a dead holder's lock is reclaimed.
 const DEFAULT_LOCK_PATH = join(tmpdir(), "tenantflow-blog-factory.lock");
+
+// Operational kill-switch. The n8n "tfBlogGenerate" schedule keeps firing every
+// 30 min, but when the factory is intentionally paused (e.g. the topic bank has
+// outrun any downstream use) this makes each tick a clean no-op (exit 0) instead
+// of generating — WITHOUT deactivating the n8n workflow (which needs an n8n
+// restart that would briefly drop the sibling error-alert / lease-reminder /
+// maintenance-notify workflows). Re-arm by deleting the sentinel file or
+// unsetting BLOG_FACTORY_OFF. Persistent path (survives reboot), outside the
+// repo so it is never committed or scanned.
+export const STOP_SENTINEL_PATH = join(
+	homedir(),
+	".tenantflow-blog-factory.off",
+);
+
+export function isFactoryStopped(
+	env: Record<string, string | undefined> = process.env,
+	sentinelPath: string = STOP_SENTINEL_PATH,
+): boolean {
+	return env.BLOG_FACTORY_OFF === "1" || existsSync(sentinelPath);
+}
 
 function isProcessAlive(pid: number): boolean {
 	try {
@@ -170,6 +196,13 @@ export function triggerFbPostSession(slug: string): void {
 }
 
 async function main(): Promise<number> {
+	if (isFactoryStopped()) {
+		console.log(
+			`blog factory paused — skipping this tick (re-arm: rm ${STOP_SENTINEL_PATH} or unset BLOG_FACTORY_OFF).`,
+		);
+		return 0;
+	}
+
 	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
 	const key =
 		process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;


### PR DESCRIPTION
## Why

We're at **218 published blog posts**. Facebook's content scheduler caps posts at **29 days out**, so the remaining ~780 topics in the bank have no near-term scheduling use — continuing the burn just ties up the local GPU/model (needed next for the HDS site) for zero marginal value. Pausing.

DB-space was the stated worry but isn't the real one: all 218 posts are **2.1 MB in a 95 MB database** (~2%). The valid reason to stop is the FB cap.

## What this does

The n8n **`tfBlogGenerate`** workflow ("Blog draft generate (every 30 min)") fires `run-scheduled-blog.ts`. I can't deactivate that workflow without restarting the bare n8n process, which would briefly drop the **3 sibling workflows we keep** (`tfCritic` error alerts, `tfLeaseR` lease reminders, `tfMaintN` maintenance notifications).

So instead: `main()` now early-exits (exit 0, no generation) when either:
- the persistent sentinel `~/.tenantflow-blog-factory.off` exists, or
- `BLOG_FACTORY_OFF=1`

The schedule keeps firing harmlessly — each tick is a millisecond no-op. **Re-arm** by deleting the sentinel.

- Guard is inside `main()` (CLI-run path only) → module stays import-safe for `fb-append-post.ts`.
- `isFactoryStopped()` exported + unit-tested (env flag, sentinel presence, ignores non-`1` values, default home-dotfile path).

## Host-side teardown already done (outside this PR)

- Killed `run-continuous-blog.ts` runner + in-flight `generate-blog-draft.ts`
- Unloaded the `com.hudson.blog-factory-caffeinate` LaunchAgent + killed its `caffeinate`
- Cleared the stale factory lock
- **Created the sentinel** — verified `bun scripts/run-scheduled-blog.ts` (the exact n8n command) now prints "paused" and exits 0

## Follow-up (optional, your one click)

For full tidiness, toggle **`tfBlogGenerate`** to Inactive in the n8n UI so it stops firing entirely. Non-urgent — generation is already paused by the kill-switch.

[hudsor01]