### PR TITLE
v6.0 Phase 16: tenant-as-user remnants + screening provider cleanup

### DIFF
--- a/src/app/(owner)/documents/templates/components/rental-application-template.client.tsx
+++ b/src/app/(owner)/documents/templates/components/rental-application-template.client.tsx
@@ -109,7 +109,7 @@ export function RentalApplicationTemplate() {
 			section: "Screening",
 			fullWidth: true,
 			description:
-				"Include authorization for a third-party screening provider.",
+				"Include the applicant's authorization for the landlord to obtain a background/credit report from a third-party screening service.",
 		},
 		{
 			name: "notes",
@@ -173,7 +173,6 @@ export function RentalApplicationTemplate() {
 				references: values.references ?? [],
 				backgroundCheck: {
 					consent: values.backgroundCheck,
-					provider: "TransUnion SmartMove",
 				},
 				notes: values.notes,
 				dynamicFields,

--- a/src/app/(owner)/tenants/components/tenant-transforms.ts
+++ b/src/app/(owner)/tenants/components/tenant-transforms.ts
@@ -1,26 +1,6 @@
 import type { LeaseStatus, TenantWithLeaseInfo } from "#types/core";
 import type { TenantItem, TenantSectionDetail } from "#types/sections/tenants";
 
-type TenantPaymentStatus = NonNullable<
-	TenantSectionDetail["paymentHistory"]
->[number]["status"];
-
-export function normalizePaymentStatus(
-	status: string | null | undefined,
-): TenantPaymentStatus {
-	const normalized = status?.toLowerCase();
-	if (
-		normalized === "pending" ||
-		normalized === "processing" ||
-		normalized === "succeeded" ||
-		normalized === "failed" ||
-		normalized === "cancelled"
-	) {
-		return normalized;
-	}
-	return "processing";
-}
-
 /**
  * Transform API tenant data to design-os TenantItem format
  */
@@ -67,7 +47,6 @@ export function transformToTenantItem(
 export function transformToTenantSectionDetail(
 	tenant: TenantWithLeaseInfo,
 	totalPaidByTenant?: Map<string, number>,
-	paymentHistory?: TenantSectionDetail["paymentHistory"],
 ): TenantSectionDetail {
 	const base = transformToTenantItem(tenant, totalPaidByTenant);
 
@@ -85,7 +64,6 @@ export function transformToTenantSectionDetail(
 		identityVerified: tenant.identity_verified ?? false,
 		createdAt: tenant.created_at ?? new Date().toISOString(),
 		updatedAt: tenant.updated_at ?? new Date().toISOString(),
-		...(paymentHistory ? { paymentHistory } : {}),
 		...(tenant.currentLease
 			? {
 					currentLease: {

--- a/src/app/(owner)/tenants/layout.tsx
+++ b/src/app/(owner)/tenants/layout.tsx
@@ -3,7 +3,7 @@ import { ownerPageMetadata } from "#lib/seo/owner-page-metadata";
 
 export const metadata = ownerPageMetadata(
 	"Tenants",
-	"Manage tenants, invitations, and tenant details",
+	"Manage tenants and tenant details",
 );
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/src/components/admin/funnel-chart.tsx
+++ b/src/components/admin/funnel-chart.tsx
@@ -23,7 +23,7 @@ const FunnelRenderer = dynamic(
 const STEP_LABELS: Record<FunnelStepName, string> = {
 	signup: "Signed Up",
 	first_property: "Added Property",
-	first_tenant: "Invited Tenant",
+	first_tenant: "Added Tenant",
 };
 
 // Below this threshold a step is flagged destructive. 0.5 matches the

--- a/src/components/leases/wizard/__tests__/selection-step.spec.tsx
+++ b/src/components/leases/wizard/__tests__/selection-step.spec.tsx
@@ -221,7 +221,7 @@ describe("SelectionStep - Tenant Filtering", () => {
 		// Wait for empty state to appear
 		await waitFor(() => {
 			expect(
-				screen.getByText(/No tenants have been invited to this property yet/),
+				screen.getByText(/No tenants added to this property yet/),
 			).toBeInTheDocument();
 		});
 

--- a/src/components/leases/wizard/selection-step-filters.tsx
+++ b/src/components/leases/wizard/selection-step-filters.tsx
@@ -17,7 +17,7 @@ interface InlineFormData {
 	phone: string;
 }
 
-interface InlineTenantInviteProps {
+interface InlineTenantCreateProps {
 	propertyId: string | undefined;
 	onToggleMode: () => void;
 }
@@ -26,10 +26,10 @@ interface InlineTenantInviteProps {
  * Inline "add tenant" sub-form for the lease selection step.
  * Lets the landlord quickly create a tenant record without leaving the wizard.
  */
-export function InlineTenantInvite({
+export function InlineTenantCreate({
 	propertyId: _propertyId,
 	onToggleMode,
-}: InlineTenantInviteProps) {
+}: InlineTenantCreateProps) {
 	const [form, setForm] = useState<InlineFormData>({
 		first_name: "",
 		last_name: "",

--- a/src/components/leases/wizard/selection-step.tsx
+++ b/src/components/leases/wizard/selection-step.tsx
@@ -40,7 +40,7 @@ import type {
 	Property as SharedProperty,
 	Unit as SharedUnit,
 } from "#types/core";
-import { InlineTenantInvite, TenantModeToggle } from "./selection-step-filters";
+import { InlineTenantCreate, TenantModeToggle } from "./selection-step-filters";
 
 interface SelectionStepProps {
 	data: Partial<SelectionStepData>;
@@ -257,7 +257,7 @@ export function SelectionStep({
 					</div>
 
 					{inviteMode ? (
-						<InlineTenantInvite
+						<InlineTenantCreate
 							propertyId={data.property_id}
 							onToggleMode={() => setInviteMode(false)}
 						/>
@@ -277,8 +277,8 @@ export function SelectionStep({
 								<EmptyTitle>No Tenants Available</EmptyTitle>
 								<EmptyDescription>
 									{data.property_id
-										? 'No tenants have been invited to this property yet. Use "Invite New Tenant" above to get started.'
-										: 'No tenants found. Use "Invite New Tenant" above to get started.'}
+										? 'No tenants added to this property yet. Use "Add Tenant" above to get started.'
+										: 'No tenants found. Use "Add Tenant" above to get started.'}
 								</EmptyDescription>
 							</EmptyHeader>
 						</Empty>

--- a/src/components/tenants/tenant-detail-sheet-tabs.tsx
+++ b/src/components/tenants/tenant-detail-sheet-tabs.tsx
@@ -1,37 +1,7 @@
-import {
-	AlertTriangle,
-	Check,
-	ChevronRight,
-	Clock,
-	Mail,
-	MapPin,
-	Phone,
-} from "lucide-react";
+import { Check, ChevronRight, Mail, MapPin, Phone } from "lucide-react";
 import { formatDate } from "#lib/formatters/date";
 import { formatCurrency } from "#lib/utils/currency";
-import type {
-	TenantPaymentHistoryItem,
-	TenantSectionDetail,
-} from "#types/sections/tenants";
-
-function PaymentStatusIcon({
-	status,
-}: {
-	status: TenantPaymentHistoryItem["status"];
-}) {
-	switch (status) {
-		case "succeeded":
-			return <Check className="w-4 h-4 text-emerald-500" />;
-		case "pending":
-		case "processing":
-			return <Clock className="w-4 h-4 text-amber-500" />;
-		case "failed":
-		case "cancelled":
-			return <AlertTriangle className="w-4 h-4 text-red-500" />;
-		default:
-			return null;
-	}
-}
+import type { TenantSectionDetail } from "#types/sections/tenants";
 
 export function ContactSection({
 	tenant,
@@ -122,54 +92,6 @@ export function CurrentLeaseSection({
 					</span>
 				</div>
 			</button>
-		</section>
-	);
-}
-
-export function RecentPaymentsSection({
-	tenant,
-	onViewPaymentHistory,
-}: {
-	tenant: TenantSectionDetail;
-	onViewPaymentHistory: (tenantId: string) => void;
-}) {
-	if (!tenant.paymentHistory || tenant.paymentHistory.length === 0) return null;
-	return (
-		<section>
-			<div className="flex items-center justify-between mb-3">
-				<h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
-					Recent Payments
-				</h3>
-				<button
-					onClick={() => onViewPaymentHistory(tenant.id)}
-					className="text-xs text-primary-text hover:underline"
-				>
-					View all
-				</button>
-			</div>
-			<div className="space-y-2">
-				{tenant.paymentHistory.slice(0, 3).map((payment) => (
-					<div
-						key={payment.id}
-						className="flex items-center justify-between p-3 rounded-lg bg-muted/30"
-					>
-						<div className="flex items-center gap-3">
-							<PaymentStatusIcon status={payment.status} />
-							<div>
-								<p className="text-sm font-medium text-foreground">
-									{formatCurrency(payment.amount)}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									{formatDate(payment.dueDate)}
-								</p>
-							</div>
-						</div>
-						<span className="text-xs text-muted-foreground capitalize">
-							{payment.status}
-						</span>
-					</div>
-				))}
-			</div>
 		</section>
 	);
 }

--- a/src/components/tenants/tenant-detail-sheet.tsx
+++ b/src/components/tenants/tenant-detail-sheet.tsx
@@ -10,7 +10,6 @@ import {
 	ContactSection,
 	CurrentLeaseSection,
 	LeaseHistorySection,
-	RecentPaymentsSection,
 } from "./tenant-detail-sheet-tabs";
 
 interface TenantDetailSheetProps {
@@ -20,7 +19,6 @@ interface TenantDetailSheetProps {
 	onEdit: (tenantId: string) => void;
 	onContact: (tenantId: string, method: "email" | "phone") => void;
 	onViewLease: (leaseId: string) => void;
-	onViewPaymentHistory?: (tenantId: string) => void;
 }
 
 export function TenantDetailSheet({
@@ -30,7 +28,6 @@ export function TenantDetailSheet({
 	onEdit,
 	onContact,
 	onViewLease,
-	onViewPaymentHistory,
 }: TenantDetailSheetProps) {
 	useEffect(() => {
 		if (isOpen) {
@@ -107,12 +104,6 @@ export function TenantDetailSheet({
 								)}
 							</div>
 						</section>
-					)}
-					{onViewPaymentHistory && (
-						<RecentPaymentsSection
-							tenant={tenant}
-							onViewPaymentHistory={onViewPaymentHistory}
-						/>
 					)}
 					<LeaseHistorySection tenant={tenant} onViewLease={onViewLease} />
 					<AccountInfoSection tenant={tenant} />

--- a/src/components/tenants/tenants.tsx
+++ b/src/components/tenants/tenants.tsx
@@ -25,7 +25,6 @@ export function Tenants({
 	onEditTenant,
 	onContactTenant,
 	onViewLease,
-	onViewPaymentHistory,
 }: TenantsProps) {
 	const router = useRouter();
 
@@ -248,7 +247,6 @@ export function Tenants({
 				onEdit={onEditTenant}
 				onContact={onContactTenant}
 				onViewLease={onViewLease}
-				{...(onViewPaymentHistory ? { onViewPaymentHistory } : {})}
 			/>
 		</div>
 	);

--- a/src/hooks/api/use-auth.ts
+++ b/src/hooks/api/use-auth.ts
@@ -10,7 +10,7 @@
  * React 19 + TanStack Query v5 patterns
  */
 
-import type { Session, User as SupabaseUser } from "@supabase/supabase-js";
+import type { User as SupabaseUser } from "@supabase/supabase-js";
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QUERY_CACHE_TIMES } from "#lib/constants/query-config";
 import { logger } from "#lib/frontend-logger";
@@ -209,29 +209,6 @@ export function useAuthCacheUtils() {
 				queryClient.invalidateQueries({ queryKey: authKeys.user() }),
 			]);
 		},
-	};
-}
-
-/**
- * Get current user from React Query cache (from AuthProvider)
- * Lightweight hook that doesn't trigger additional requests
- */
-export function useCurrentUser() {
-	const queryClient = useQueryClient();
-	const sessionData = queryClient.getQueryData(authKeys.session()) as
-		| Session
-		| null
-		| undefined;
-	const userData = queryClient.getQueryData(authKeys.user()) as
-		| SupabaseUser
-		| null
-		| undefined;
-
-	return {
-		user: userData || sessionData?.user || null,
-		user_id: userData?.id || sessionData?.user?.id || null,
-		session: sessionData,
-		isAuthenticated: !!(userData || sessionData?.user),
 	};
 }
 

--- a/src/lib/validation/__tests__/tenants.test.ts
+++ b/src/lib/validation/__tests__/tenants.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-	activateTenantSchema,
 	addTenantRequestSchema,
 	addTenantSchema,
 	bulkDeleteTenantsSchema,
@@ -293,21 +292,6 @@ describe("bulkDeleteTenantsSchema", () => {
 			bulkDeleteTenantsSchema.safeParse({
 				ids: Array.from({ length: 101 }, () => VALID_UUID),
 			}).success,
-		).toBe(false);
-	});
-});
-describe("activateTenantSchema", () => {
-	it("accepts valid authuser_id", () => {
-		expect(
-			activateTenantSchema.safeParse({ authuser_id: VALID_UUID }).success,
-		).toBe(true);
-	});
-	it("rejects missing authuser_id", () => {
-		expect(activateTenantSchema.safeParse({}).success).toBe(false);
-	});
-	it("rejects invalid UUID", () => {
-		expect(
-			activateTenantSchema.safeParse({ authuser_id: "not-uuid" }).success,
 		).toBe(false);
 	});
 });

--- a/src/lib/validation/tenants.ts
+++ b/src/lib/validation/tenants.ts
@@ -221,7 +221,7 @@ export const addTenantSchema = z.object({
 	unit_id: uuidSchema.optional(),
 });
 
-// Nested structure - matches backend DTO (InviteWithLeaseDto)
+// Nested structure for creating a tenant record (with an optional lease)
 // Used for API requests
 export const addTenantRequestSchema = z.object({
 	tenantData: z.object({
@@ -273,11 +273,5 @@ export const bulkUpdateTenantsSchema = z.object({
 		.max(100, "Cannot update more than 100 tenants at once"),
 });
 
-// Tenant activation schema (used by public invitation acceptance endpoints)
-export const activateTenantSchema = z.object({
-	authuser_id: uuidSchema,
-});
-
 export type BulkDeleteTenants = z.infer<typeof bulkDeleteTenantsSchema>;
 export type BulkUpdateTenants = z.infer<typeof bulkUpdateTenantsSchema>;
-export type ActivateTenant = z.infer<typeof activateTenantSchema>;

--- a/src/types/api-contracts.ts
+++ b/src/types/api-contracts.ts
@@ -354,70 +354,6 @@ export interface SubscriptionStatusResponse {
 	trialEndsAt: string | null;
 }
 
-export interface TenantMaintenanceRequest {
-	id: string;
-	title: string;
-	description: string;
-	status: string;
-	priority: string;
-	created_at: string;
-	completed_at: string | null;
-	property_id: string;
-	property_name: string;
-	unit_id: string;
-	unit_number: string;
-	assigned_to: string | null;
-	assigned_to_name: string | null;
-}
-
-export interface TenantMaintenanceStats {
-	total: number;
-	open: number;
-	in_progress: number;
-	completed: number;
-	emergency: number;
-}
-
-export interface TenantLease {
-	id: string;
-	start_date: string;
-	end_date: string;
-	rent_amount: number;
-	security_deposit: number;
-	status: string;
-	property_name: string;
-	unit_number: string;
-	property_address: string;
-}
-
-export interface TenantDocument {
-	id: string;
-	name: string;
-	type: string;
-	created_at: string;
-	file_size: number;
-	storage_url: string;
-	entity_id: string;
-	entity_type: string;
-}
-
-export interface TenantProfile {
-	id: string;
-	first_name: string | null;
-	last_name: string | null;
-	email: string;
-	phone: string | null;
-	date_of_birth: string | null;
-	emergency_contact_name: string | null;
-	emergency_contact_phone: string | null;
-	emergency_contact_relationship: string | null;
-}
-
-export interface TenantSettings {
-	profile: TenantProfile;
-	notification_preferences: TenantNotificationSettingsResponse;
-}
-
 export interface CreateMaintenanceRequestInput {
 	title: string;
 	description: string;
@@ -442,18 +378,6 @@ export interface UpdateMaintenanceRequestInput {
 	scheduledDate?: string;
 	completedDate?: string | null;
 	estimated_cost?: number;
-}
-
-/**
- * Tenant Notification Settings Response
- * API response format for tenant notification settings in TenantSettings
- * Note: Different from TenantNotificationPreferences in core.ts which is more extensive
- */
-export interface TenantNotificationSettingsResponse {
-	emailNotifications: boolean;
-	smsNotifications: boolean;
-	maintenanceUpdates: boolean;
-	paymentReminders: boolean;
 }
 
 export interface EmergencyContact {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -481,18 +481,6 @@ export type SubscriptionStatus =
 	| "unpaid"
 	| "paused";
 
-export interface TenantNotificationPreferences {
-	pushNotifications?: boolean;
-	emailNotifications?: boolean;
-	smsNotifications?: boolean;
-	leaseNotifications?: boolean;
-	maintenanceNotifications?: boolean;
-	paymentReminders?: boolean;
-	rentalApplications?: boolean;
-	propertyNotices?: boolean;
-	[key: string]: boolean | undefined;
-}
-
 // WithVersion types for optimistic locking
 export type LeaseWithVersion = Lease & { version?: number };
 export type MaintenanceRequestWithVersion = MaintenanceRequest & {

--- a/src/types/sections/tenants.ts
+++ b/src/types/sections/tenants.ts
@@ -1,5 +1,5 @@
 // Tenants Section Types
-import type { LeaseStatus, PaymentStatus } from "../core";
+import type { LeaseStatus } from "../core";
 
 export interface TenantsProps {
 	tenants: TenantItem[];
@@ -10,7 +10,6 @@ export interface TenantsProps {
 	onEditTenant: (tenantId: string) => void;
 	onContactTenant: (tenantId: string, method: "email" | "phone") => void;
 	onViewLease: (leaseId: string) => void;
-	onViewPaymentHistory?: (tenantId: string) => void;
 }
 
 export interface TenantItem {
@@ -41,7 +40,6 @@ export interface TenantSectionDetail extends TenantItem {
 	stripeCustomerId?: string;
 	currentLease?: CurrentLeaseInfo;
 	leaseHistory?: LeaseHistoryItem[];
-	paymentHistory?: TenantPaymentHistoryItem[];
 	createdAt?: string;
 	updatedAt?: string;
 }
@@ -64,16 +62,6 @@ export interface LeaseHistoryItem {
 	endDate: string;
 	rentAmount: number;
 	status: LeaseStatus;
-}
-
-export interface TenantPaymentHistoryItem {
-	id: string;
-	amount: number;
-	status: PaymentStatus;
-	paidDate?: string;
-	dueDate: string;
-	periodStart?: string;
-	periodEnd?: string;
 }
 
 export type UserStatus = "active" | "inactive" | "suspended";


### PR DESCRIPTION
**v6.0 Phase 16.** Removes legacy tenant-as-user / portal remnants, relabels pre-pivot "invite" wording, strips a never-built screening provider, and removes the dead tenant payment-history surface discovered in Phase 15. Stacked on #843 (Phase 15).

Closes **LEGACY-TENANT-01..04** + **LEGACY-SCREENING-01..02**. 16 files, **−273 lines**; every removed symbol grep-verified zero-consumer; `tsc` + `biome` + `next build` clean.

## Tenant-as-user / portal
- Deleted `activateTenantSchema` (+ test), the 6 tenant-portal view types, the now-orphaned `TenantNotificationSettingsResponse` + `TenantNotificationPreferences`, and the **duplicate `useCurrentUser`** export in `use-auth.ts` (0 importers — the 7 real consumers use `#hooks/use-current-user`).

## Relabels (behavior unchanged — tenants are records)
"Invited Tenant" → "Added Tenant" (funnel) · `InlineTenantInvite` → `InlineTenantCreate` + "Invite New Tenant" → "Add Tenant" + "No tenants have been invited" → "No tenants added" (lease wizard) · `tenants/layout` drops "invitations" · the removed-backend-DTO comment reworded.

## Dead tenant payment-history surface (Phase 15 carryover)
Removed `RecentPaymentsSection` + `onViewPaymentHistory` threading + `sections/tenants.ts` `paymentHistory`/`TenantPaymentHistoryItem` + the transform mapping (never wired from any page). **Kept** the settings subscription billing-history + `reports.ts` paymentHistory (different things).

## Screening
Removed the hardcoded `provider: "TransUnion SmartMove"` (never built); reworded the rental-application authorization copy to clearly **landlord-run third-party** screening. Kept the printable form + `backgroundCheck` consent.

## Kept for later phases
`inviteToSignLeaseSchema` (Phase 17 — DocuSeal-vs-login INVESTIGATE), all DB objects (Phase 18).

[hudsor01]