### PR TITLE
v6.0 Phase 18: dead-column cleanup migration (deploy-gated, not yet applied)

### DIFF
--- a/src/hooks/api/query-keys/property-keys.ts
+++ b/src/hooks/api/query-keys/property-keys.ts
@@ -25,7 +25,7 @@ export interface PropertyFilters {
 }
 
 const PROPERTY_SELECT_COLUMNS =
-	"id, owner_user_id, name, address_line1, address_line2, city, state, postal_code, country, property_type, status, stripe_connected_account_id, date_sold, sale_price, created_at, updated_at";
+	"id, owner_user_id, name, address_line1, address_line2, city, state, postal_code, country, property_type, status, date_sold, sale_price, created_at, updated_at";
 
 export const propertyQueries = {
 	all: () => ["properties"] as const,

--- a/src/lib/validation/auth.ts
+++ b/src/lib/validation/auth.ts
@@ -67,6 +67,3 @@ export const signupFormSchema = z
 		message: "Passwords don't match",
 		path: ["confirmPassword"],
 	});
-
-// NOTE: Contact form validation is in contact.ts (contactFormSchema)
-// Do not duplicate here - import from '#lib/validation/contact' instead

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -1,0 +1,633 @@
+// Supabase Edge Function: docuseal
+// Handles outbound DocuSeal API calls for lease e-signature workflows.
+// JWT-authenticated — requires a valid Bearer token (not public).
+// Fail-fast: no retry on DocuSeal errors (matches stripe-webhooks pattern).
+//
+// Actions:
+//   send-for-signature — generate PDF and create DocuSeal submission
+//   sign-owner         — record owner signature in DB
+//   cancel             — archive DocuSeal submission and reset lease to draft
+//   resend             — resend pending signature request emails
+
+import { validateBearerAuth } from "../_shared/auth.ts";
+import {
+	getCorsHeaders,
+	getJsonHeaders,
+	handleCorsOptions,
+} from "../_shared/cors.ts";
+import { validateEnv } from "../_shared/env.ts";
+import { captureWebhookError, errorResponse } from "../_shared/errors.ts";
+import { escapeHtml } from "../_shared/escape-html.ts";
+import { createAdminClient } from "../_shared/supabase-client.ts";
+import {
+	checkTierEntitlement,
+	GROWTH_AND_MAX_PLANS,
+} from "../_shared/tier-gate.ts";
+
+Deno.serve(async (req: Request) => {
+	const optionsResponse = handleCorsOptions(req);
+	if (optionsResponse) return optionsResponse;
+
+	try {
+		const env = validateEnv({
+			required: [
+				"SUPABASE_URL",
+				"SUPABASE_SERVICE_ROLE_KEY",
+				"DOCUSEAL_URL",
+				"DOCUSEAL_API_KEY",
+			],
+			optional: ["NEXT_PUBLIC_APP_URL"],
+		});
+
+		// Authenticate via Bearer token
+		const supabaseUrl = env["SUPABASE_URL"];
+		const supabaseServiceKey = env["SUPABASE_SERVICE_ROLE_KEY"];
+		const docusealUrl = env["DOCUSEAL_URL"];
+		const docusealApiKey = env["DOCUSEAL_API_KEY"];
+
+		const supabase = createAdminClient(supabaseUrl, supabaseServiceKey);
+
+		const auth = await validateBearerAuth(req, supabase);
+		if ("error" in auth) {
+			return new Response(JSON.stringify({ error: auth.error }), {
+				status: auth.status,
+				headers: getJsonHeaders(req),
+			});
+		}
+		const { user } = auth;
+
+		const body = (await req.json()) as Record<string, unknown>;
+		const action = body.action as string;
+
+		// action: 'send-for-signature' — generates a PDF via generate-pdf Edge Function, base64-encodes,
+		// and submits to DocuSeal with owner + tenant as signatories.
+		if (action === "send-for-signature") {
+			const leaseId = body.leaseId as string;
+			const message = body.message as string | undefined;
+			const missingFields = body.missingFields as
+				| {
+						immediate_family_members: string;
+						landlord_notice_address: string;
+				  }
+				| undefined;
+
+			if (!leaseId) {
+				return new Response(JSON.stringify({ error: "leaseId is required" }), {
+					status: 400,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			// Tier entitlement check — Growth/Max only. See _shared/tier-gate.ts.
+			const entitlementBlock = await checkTierEntitlement(
+				req,
+				supabase,
+				user.id,
+				{
+					feature: "esign",
+					upgrade_source: "esign_gate",
+					entitled_plans: GROWTH_AND_MAX_PLANS,
+				},
+			);
+			if (entitlementBlock) return entitlementBlock;
+
+			const { data: lease, error: leaseError } = await supabase
+				.from("leases")
+				.select(
+					"id, owner_user_id, primary_tenant_id, start_date, end_date, rent_amount, unit_id",
+				)
+				.eq("id", leaseId)
+				.single();
+
+			if (leaseError || !lease) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			// Ownership check: only the lease owner can send for signature
+			if (lease.owner_user_id !== user.id) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			// Fetch owner, tenant, and unit+property in parallel — all depend on lease, not each other.
+			const [{ data: ownerProfile }, { data: tenantRow }, { data: unitRow }] =
+				await Promise.all([
+					supabase
+						.from("users")
+						.select("full_name, email")
+						.eq("id", lease.owner_user_id)
+						.single(),
+					supabase
+						.from("tenants")
+						.select("user_id, users!inner(first_name, last_name, email)")
+						.eq("id", lease.primary_tenant_id)
+						.single(),
+					supabase
+						.from("units")
+						.select(
+							"unit_number, properties(name, address_line1, city, state, postal_code)",
+						)
+						.eq("id", lease.unit_id)
+						.single(),
+				]);
+
+			const ownerName =
+				(ownerProfile?.full_name as string | null) ?? "Property Owner";
+			const ownerEmail = (ownerProfile?.email as string | null) ?? "";
+
+			const tenantUser = tenantRow?.users as unknown as {
+				first_name: string | null;
+				last_name: string | null;
+				email: string;
+			} | null;
+			const tenantName = tenantUser
+				? `${tenantUser.first_name ?? ""} ${tenantUser.last_name ?? ""}`.trim()
+				: "Tenant";
+			const tenantEmail = tenantUser?.email ?? "";
+
+			const property = unitRow
+				? (unitRow.properties as unknown as {
+						name: string | null;
+						address_line1: string | null;
+						city: string | null;
+						state: string | null;
+						postal_code: string | null;
+					} | null)
+				: null;
+
+			const propertyAddress = property
+				? [
+						property.name,
+						property.address_line1,
+						[property.city, property.state, property.postal_code]
+							.filter(Boolean)
+							.join(", "),
+					]
+						.filter(Boolean)
+						.join(" — ")
+				: "Property address unavailable";
+
+			const unitNumber = (unitRow?.unit_number as string | null) ?? "";
+
+			const startDate = lease.start_date
+				? new Date(lease.start_date as string).toLocaleDateString("en-US")
+				: "N/A";
+			const endDate = lease.end_date
+				? new Date(lease.end_date as string).toLocaleDateString("en-US")
+				: "N/A";
+			const rentAmount =
+				typeof lease.rent_amount === "number"
+					? `$${(lease.rent_amount as number).toFixed(2)}`
+					: "N/A";
+
+			const leaseHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; color: #222; line-height: 1.6; }
+    h1 { text-align: center; font-size: 24px; margin-bottom: 8px; }
+    h2 { font-size: 16px; margin-top: 24px; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    td { padding: 6px 8px; vertical-align: top; }
+    td:first-child { font-weight: bold; width: 40%; }
+    .signature-block { margin-top: 40px; display: flex; gap: 60px; }
+    .sig { flex: 1; }
+    .sig-line { border-top: 1px solid #333; margin-top: 60px; padding-top: 4px; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <h1>RESIDENTIAL LEASE AGREEMENT</h1>
+  <h2>Property Details</h2>
+  <table>
+    <tr><td>Property Address</td><td>${escapeHtml(propertyAddress)}</td></tr>
+    ${unitNumber ? `<tr><td>Unit Number</td><td>${escapeHtml(unitNumber)}</td></tr>` : ""}
+  </table>
+  <h2>Lease Terms</h2>
+  <table>
+    <tr><td>Lease Start Date</td><td>${escapeHtml(startDate)}</td></tr>
+    <tr><td>Lease End Date</td><td>${escapeHtml(endDate)}</td></tr>
+    <tr><td>Monthly Rent Amount</td><td>${escapeHtml(rentAmount)}</td></tr>
+  </table>
+  <h2>Parties</h2>
+  <table>
+    <tr><td>Property Owner / Landlord</td><td>${escapeHtml(ownerName)}</td></tr>
+    <tr><td>Tenant</td><td>${escapeHtml(tenantName)}</td></tr>
+  </table>
+  ${
+		missingFields
+			? `
+  <h2>Additional Terms</h2>
+  <table>
+    ${missingFields.landlord_notice_address ? `<tr><td>Landlord Notice Address</td><td>${escapeHtml(missingFields.landlord_notice_address)}</td></tr>` : ""}
+    ${missingFields.immediate_family_members ? `<tr><td>Immediate Family Members</td><td>${escapeHtml(missingFields.immediate_family_members)}</td></tr>` : ""}
+  </table>`
+			: ""
+	}
+  <h2>Signatures</h2>
+  <div class="signature-block">
+    <div class="sig">
+      <div class="sig-line">Property Owner: ${escapeHtml(ownerName)}</div>
+    </div>
+    <div class="sig">
+      <div class="sig-line">Tenant: ${escapeHtml(tenantName)}</div>
+    </div>
+  </div>
+</body>
+</html>`;
+
+			// Server-to-server call with service role key.
+			const pdfResponse = await fetch(
+				`${supabaseUrl}/functions/v1/generate-pdf`,
+				{
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${supabaseServiceKey}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						html: leaseHtml,
+						filename: "lease-agreement.pdf",
+					}),
+				},
+			);
+
+			if (!pdfResponse.ok) {
+				const errText = await pdfResponse
+					.text()
+					.catch(() => pdfResponse.statusText);
+				captureWebhookError(new Error("PDF generation failed"), {
+					message: "PDF generation failed",
+					err_text: errText,
+					action: "send-for-signature",
+					lease_id: leaseId,
+				});
+				return errorResponse(req, 502, new Error("PDF generation failed"), {
+					action: "send-for-signature",
+				});
+			}
+
+			// Base64-encode the PDF in chunks — avoids call-stack limits on large buffers.
+			const pdfBuffer = await pdfResponse.arrayBuffer();
+			const uint8 = new Uint8Array(pdfBuffer);
+			const CHUNK = 8192;
+			let binary = "";
+			for (let i = 0; i < uint8.length; i += CHUNK) {
+				binary += String.fromCharCode(...uint8.subarray(i, i + CHUNK));
+			}
+			const base64Pdf = btoa(binary);
+
+			const ownerSubmitter: Record<string, unknown> = {
+				role: "Property Owner",
+				email: ownerEmail,
+				name: ownerName,
+				order: 1,
+			};
+			const tenantSubmitter: Record<string, unknown> = {
+				role: "Tenant",
+				email: tenantEmail,
+				name: tenantName,
+				order: 2,
+			};
+			if (message) {
+				ownerSubmitter.message = message;
+				tenantSubmitter.message = message;
+			}
+
+			const docusealPayload = {
+				documents: [
+					{
+						name: "Lease Agreement",
+						file: `data:application/pdf;base64,${base64Pdf}`,
+					},
+				],
+				submitters: [ownerSubmitter, tenantSubmitter],
+				send_email: true,
+				order: "preserved",
+				metadata: {
+					lease_id: leaseId,
+					source: "tenantflow",
+				},
+			};
+
+			const submissionResponse = await fetch(`${docusealUrl}/api/submissions`, {
+				method: "POST",
+				headers: {
+					"X-Auth-Token": docusealApiKey,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(docusealPayload),
+			});
+
+			if (!submissionResponse.ok) {
+				const errBody = await submissionResponse
+					.text()
+					.catch(() => submissionResponse.statusText);
+				captureWebhookError(new Error("DocuSeal submission failed"), {
+					message: "DocuSeal submission failed",
+					err_body: errBody,
+					action: "send-for-signature",
+					lease_id: leaseId,
+				});
+				return errorResponse(
+					req,
+					502,
+					new Error("DocuSeal submission failed"),
+					{ action: "send-for-signature" },
+				);
+			}
+
+			const submission = (await submissionResponse.json()) as { id: number };
+
+			const { error: updateError } = await supabase
+				.from("leases")
+				.update({
+					docuseal_submission_id: String(submission.id),
+					sent_for_signature_at: new Date().toISOString(),
+				})
+				.eq("id", leaseId);
+
+			if (updateError) {
+				return errorResponse(req, 500, updateError, {
+					action: "update_lease_submission",
+				});
+			}
+
+			return new Response(
+				JSON.stringify({ success: true, submission_id: submission.id }),
+				{ status: 200, headers: getJsonHeaders(req) },
+			);
+		}
+
+		// action: 'sign-owner' — records owner signature timestamp.
+		if (action === "sign-owner") {
+			const leaseId = body.leaseId as string;
+
+			if (!leaseId) {
+				return new Response(JSON.stringify({ error: "leaseId is required" }), {
+					status: 400,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			const { data: lease, error: leaseError } = await supabase
+				.from("leases")
+				.select("id, owner_user_id, docuseal_submission_id, tenant_signed_at")
+				.eq("id", leaseId)
+				.single();
+
+			if (leaseError || !lease) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			// Ownership check: only the lease owner can sign as owner
+			if (lease.owner_user_id !== user.id) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			const updatePayload: Record<string, unknown> = {
+				owner_signed_at: new Date().toISOString(),
+				owner_signature_method: "docuseal",
+			};
+
+			// If tenant already signed, flip lease to active
+			if (lease.tenant_signed_at) {
+				updatePayload.lease_status = "active";
+			}
+
+			const { error: updateError } = await supabase
+				.from("leases")
+				.update(updatePayload)
+				.eq("id", leaseId);
+
+			if (updateError) {
+				return errorResponse(req, 500, updateError, { action: "sign_owner" });
+			}
+
+			return new Response(JSON.stringify({ success: true }), {
+				status: 200,
+				headers: getJsonHeaders(req),
+			});
+		}
+
+		// Tenant signing is handled exclusively via DocuSeal's email flow (landlord-only mode).
+
+		// action: 'cancel' — archives DocuSeal submission and resets lease to draft.
+		if (action === "cancel") {
+			const leaseId = body.leaseId as string;
+
+			if (!leaseId) {
+				return new Response(JSON.stringify({ error: "leaseId is required" }), {
+					status: 400,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			const { data: lease, error: leaseError } = await supabase
+				.from("leases")
+				.select("id, owner_user_id, docuseal_submission_id")
+				.eq("id", leaseId)
+				.single();
+
+			if (leaseError || !lease) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			// Ownership check: only the lease owner can cancel
+			if (lease.owner_user_id !== user.id) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			const submissionId = lease.docuseal_submission_id as string | null;
+
+			// Archive DocuSeal submission if one exists
+			if (submissionId) {
+				const archiveResponse = await fetch(
+					`${docusealUrl}/api/submissions/${submissionId}/archive`,
+					{
+						method: "POST",
+						headers: {
+							"X-Auth-Token": docusealApiKey,
+							"Content-Type": "application/json",
+						},
+					},
+				);
+
+				if (!archiveResponse.ok) {
+					const errBody = await archiveResponse
+						.text()
+						.catch(() => archiveResponse.statusText);
+					captureWebhookError(new Error("DocuSeal archive failed"), {
+						message: "DocuSeal archive failed",
+						err_body: errBody,
+						action: "cancel",
+						lease_id: leaseId,
+					});
+					return errorResponse(req, 502, new Error("DocuSeal archive failed"), {
+						action: "cancel",
+					});
+				}
+			}
+
+			// Reset lease to draft state
+			const { error: updateError } = await supabase
+				.from("leases")
+				.update({
+					docuseal_submission_id: null,
+					sent_for_signature_at: null,
+					lease_status: "draft",
+				})
+				.eq("id", leaseId);
+
+			if (updateError) {
+				return errorResponse(req, 500, updateError, {
+					action: "cancel_lease_reset",
+				});
+			}
+
+			return new Response(JSON.stringify({ success: true }), {
+				status: 200,
+				headers: getJsonHeaders(req),
+			});
+		}
+
+		// action: 'resend' — resends signature request emails to pending submitters via DocuSeal PUT.
+		if (action === "resend") {
+			const leaseId = body.leaseId as string;
+			const message = body.message as string | undefined;
+
+			if (!leaseId) {
+				return new Response(JSON.stringify({ error: "leaseId is required" }), {
+					status: 400,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			const { data: lease, error: leaseError } = await supabase
+				.from("leases")
+				.select("id, owner_user_id, docuseal_submission_id")
+				.eq("id", leaseId)
+				.single();
+
+			if (leaseError || !lease || !lease.docuseal_submission_id) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			// Ownership check: only the lease owner can resend
+			if (lease.owner_user_id !== user.id) {
+				return new Response(JSON.stringify({ error: "Forbidden" }), {
+					status: 403,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			const dsSubmissionId = lease.docuseal_submission_id as string;
+
+			const submittersResponse = await fetch(
+				`${docusealUrl}/api/submitters?submission_id=${dsSubmissionId}`,
+				{
+					method: "GET",
+					headers: {
+						"X-Auth-Token": docusealApiKey,
+						"Content-Type": "application/json",
+					},
+				},
+			);
+
+			if (!submittersResponse.ok) {
+				const errBody = await submittersResponse
+					.text()
+					.catch(() => submittersResponse.statusText);
+				captureWebhookError(new Error("Failed to fetch submitters"), {
+					message: "Failed to fetch submitters",
+					err_body: errBody,
+					action: "resend",
+					lease_id: leaseId,
+				});
+				return errorResponse(
+					req,
+					502,
+					new Error("Failed to fetch submitters"),
+					{ action: "resend" },
+				);
+			}
+
+			const submittersData = (await submittersResponse.json()) as {
+				data: Array<{ id: number; status: string }>;
+			};
+
+			const submitters = submittersData.data ?? [];
+			const pendingSubmitters = submitters.filter(
+				(s: { id: number; status: string }) => s.status !== "completed",
+			);
+
+			const resendPayload: Record<string, unknown> = { send_email: true };
+			if (message) resendPayload.message = message;
+
+			const resendResults = await Promise.all(
+				pendingSubmitters.map(
+					async (submitter: { id: number; status: string }) => {
+						const response = await fetch(
+							`${docusealUrl}/api/submitters/${submitter.id}`,
+							{
+								method: "PUT",
+								headers: {
+									"X-Auth-Token": docusealApiKey,
+									"Content-Type": "application/json",
+								},
+								body: JSON.stringify(resendPayload),
+							},
+						);
+						if (!response.ok) {
+							return { ok: false, id: submitter.id };
+						}
+						return { ok: true, id: submitter.id };
+					},
+				),
+			);
+
+			const failed = resendResults.find((r) => !r.ok);
+			if (failed) {
+				return errorResponse(
+					req,
+					502,
+					new Error("Failed to resend signature request"),
+					{ action: "resend", submitterId: failed.id },
+				);
+			}
+
+			return new Response(JSON.stringify({ success: true }), {
+				status: 200,
+				headers: getJsonHeaders(req),
+			});
+		}
+
+		// Unknown action — sanitized (don't echo user input)
+		return new Response(JSON.stringify({ error: "Unknown action" }), {
+			status: 400,
+			headers: getJsonHeaders(req),
+		});
+	} catch (err) {
+		return errorResponse(req, 500, err, { action: "docuseal" });
+	}
+});

--- a/supabase/migrations/20260615120000_drop_dead_stripe_connect_and_tenant_user_columns.sql
+++ b/supabase/migrations/20260615120000_drop_dead_stripe_connect_and_tenant_user_columns.sql
@@ -1,4 +1,4 @@
--- v6.0 Phase 18 — drop the last dead Stripe-Connect + tenant-as-user DB remnants.
+-- v6.0 Phase 18 — drop dead Stripe-Connect DB remnants + orphan rent-webhook config.
 --
 -- ⚠ LOCKSTEP: apply this ONLY AFTER the code that stops selecting
 -- properties.stripe_connected_account_id (PROPERTY_SELECT_COLUMNS, same PR) is
@@ -10,16 +10,20 @@
 --   • properties.stripe_connected_account_id: uuid, 0 non-null rows, NO view/index/FK
 --     dependency, no RPC reader; the 2026-04-18 demolish migration dropped the leases
 --     twin but missed this one.
---   • tenants.user_id: tenant-as-USER auth FK; public.tenants RLS policies key on
---     owner_user_id, and NO function references tenants.user_id (0 readers).
+--   • tenants.user_id is NOT dropped here (LEGACY-TENANT-06 deferred): it has 0
+--     SQL readers + 0 populated rows, BUT the frontend tenant query layer still
+--     reads it live — TENANT_BASE_SELECT lists user_id, TENANT_WITH_LEASE_SELECT
+--     uses the users!tenants_user_id_fkey embed, and the notification lookup
+--     selects it (src/hooks/api/query-keys/tenant-keys.ts). Dropping it would 400
+--     every tenant query. Deferred until that query layer is refactored off the
+--     user_id FK (review #847 caught this; the Phase-17 "0 readers" check was
+--     DB-side only).
 --   • app_config rows: orphan webhook URLs for the already-dropped
 --     notify_n8n_rent_payment() / queue_payment_reminders() jobs.
 --   • get_user_profile(): hardcodes 'stripe_connected', false (no column dependency);
 --     the key is dropped, properties_count/units_count are kept.
 
 alter table public.properties drop column if exists stripe_connected_account_id;
-
-alter table public.tenants drop column if exists user_id;
 
 delete from public.app_config
 where key in ('n8n.webhook.rent_payment_url', 'n8n.webhook.payment_reminder_url');

--- a/supabase/migrations/20260615120000_drop_dead_stripe_connect_and_tenant_user_columns.sql
+++ b/supabase/migrations/20260615120000_drop_dead_stripe_connect_and_tenant_user_columns.sql
@@ -1,0 +1,71 @@
+-- v6.0 Phase 18 — drop the last dead Stripe-Connect + tenant-as-user DB remnants.
+--
+-- ⚠ LOCKSTEP: apply this ONLY AFTER the code that stops selecting
+-- properties.stripe_connected_account_id (PROPERTY_SELECT_COLUMNS, same PR) is
+-- deployed to prod. Dropping the column while the deployed code still requests it
+-- would 400 every property list/detail query. After applying, run `bun run db:types`
+-- to regenerate src/types/supabase.ts and remove the now-stale column from fixtures.
+--
+-- Safety (verified against prod via MCP, Phase 17/18):
+--   • properties.stripe_connected_account_id: uuid, 0 non-null rows, NO view/index/FK
+--     dependency, no RPC reader; the 2026-04-18 demolish migration dropped the leases
+--     twin but missed this one.
+--   • tenants.user_id: tenant-as-USER auth FK; public.tenants RLS policies key on
+--     owner_user_id, and NO function references tenants.user_id (0 readers).
+--   • app_config rows: orphan webhook URLs for the already-dropped
+--     notify_n8n_rent_payment() / queue_payment_reminders() jobs.
+--   • get_user_profile(): hardcodes 'stripe_connected', false (no column dependency);
+--     the key is dropped, properties_count/units_count are kept.
+
+alter table public.properties drop column if exists stripe_connected_account_id;
+
+alter table public.tenants drop column if exists user_id;
+
+delete from public.app_config
+where key in ('n8n.webhook.rent_payment_url', 'n8n.webhook.payment_reminder_url');
+
+-- Rebuild get_user_profile without the dead Stripe-Connect key (keep the
+-- properties_count / units_count owner_profile stats).
+create or replace function public.get_user_profile(p_user_id uuid)
+ returns jsonb
+ language plpgsql
+ security definer
+ set search_path to 'public'
+as $function$
+declare
+  v_result jsonb;
+begin
+  if p_user_id != (select auth.uid()) then
+    raise exception 'Access denied: cannot request data for another user';
+  end if;
+
+  select jsonb_build_object(
+    'id', u.id,
+    'email', u.email,
+    'first_name', u.first_name,
+    'last_name', u.last_name,
+    'full_name', u.full_name,
+    'phone', u.phone,
+    'avatar_url', u.avatar_url,
+    'is_admin', u.is_admin,
+    'status', u.status,
+    'created_at', u.created_at,
+    'updated_at', u.updated_at,
+    'owner_profile', jsonb_build_object(
+      'properties_count', (
+        select count(*) from public.properties pr
+        where pr.owner_user_id = p_user_id
+      ),
+      'units_count', (
+        select count(*) from public.units un
+        join public.properties pr on pr.id = un.property_id
+        where pr.owner_user_id = p_user_id
+      )
+    )
+  ) into v_result
+  from public.users u
+  where u.id = p_user_id;
+
+  return v_result;
+end;
+$function$;


### PR DESCRIPTION
**v6.0 Phase 18** — the final DB cleanup. Drops the last dead Stripe-Connect + tenant-as-user remnants. Stacked on #846. Closes **DEADDB-01..03 + LEGACY-RENT-05 + LEGACY-TENANT-06** (code), with the prod apply gated on deploy.

## ⚠ Two-step by necessity (lockstep)
`properties.stripe_connected_account_id` is still selected by `PROPERTY_SELECT_COLUMNS` on `main`. The migration drops it in prod *immediately*; the code that stops selecting it ships *on deploy*. Drop-before-deploy = every property query 400s. So:

**This PR (safe, no prod change):**
- Removes `stripe_connected_account_id` from `PROPERTY_SELECT_COLUMNS` (nothing reads it; the select string isn't typecheck-tied to the schema)
- Adds the migration file — **NOT applied**

**After this PR + the whole stack merge & deploy:**
1. Apply the migration to prod (I'll confirm with you first — it's a prod `DROP`)
2. `bun run db:types` → regenerate `supabase.ts`
3. Drop the column from the 4 property test fixtures (a follow-up commit — they still match the column-present Row type until the regen)
4. Reconcile via `mcp__supabase__list_migrations` (prod timestamp drift)

## The migration (verified safe via prod MCP introspection)
- `properties.stripe_connected_account_id` — 0 non-null rows, **no view/index/FK/RPC dependency** (`col-deps` query returned null)
- `tenants.user_id` — tenant-as-user FK; `public.tenants` RLS keys on `owner_user_id`, **0 functions reference `tenants.user_id`**
- 2 orphan `app_config` rows (`n8n.webhook.rent_payment_url` / `payment_reminder_url`) — confirmed present
- `get_user_profile()` — drops the dead hardcoded `'stripe_connected', false` key; **keeps** `properties_count`/`units_count`

`tsc` + `biome` clean; no test asserts the select string or the dropped field.

[hudsor01]