### PR TITLE
fix(esign): make lease e-signature work end-to-end (DocuSeal API drift + 2 latent bugs)

### DIFF
--- a/.planning/esign-railway-migration-runbook.md
+++ b/.planning/esign-railway-migration-runbook.md
@@ -1,0 +1,100 @@
+# Lease E-Signature — Railway Migration Runbook
+
+**Goal:** restore lease e-signature end-to-end after the homelab outage, by re-hosting the two
+self-hosted dependencies (DocuSeal + Stirling PDF) on Railway and wiring them up.
+
+**Status of the code:** the app-side fixes are done in **PR #851** (`fix/esign-pending-signature-and-dead-tenant-path`). The integration was broken against *current* DocuSeal (the code targeted an old self-hosted build); #851 fixes the send endpoint, raw-base64 PDF, webhook HMAC scheme, the `data`-nested webhook payload, the cancel endpoint, an email guard, and `pending_signature` on send. **Once you complete the steps below and redeploy the functions, the flow works start-to-finish.**
+
+---
+
+## The flow (what must work)
+
+```
+Owner clicks "Send for Signature"
+  → generate-pdf  → POST ${STIRLING_PDF_URL}/api/v1/misc/html-to-pdf   ← homelab dep #1
+  → docuseal fn   → POST ${DOCUSEAL_URL}/api/submissions/pdf            ← homelab dep #2
+  → DocuSeal emails owner + tenant signing links
+  → each signs → DocuSeal POSTs docuseal-webhook (HMAC) → records signatures
+  → both signed → lease_status='active' + signed-PDF URL persisted + owner notified
+```
+
+Both `STIRLING_PDF_URL` and `DOCUSEAL_URL` point at the dead homelab today. **Both** must be re-hosted.
+
+---
+
+## Step 1 — Deploy DocuSeal on Railway
+
+1. Use the official one-click template: **https://railway.com/deploy/docuseal** (DocuSeal app + Postgres + Redis).
+2. Give it a stable public domain (Railway provides `*.up.railway.app`, or attach a custom one).
+3. **(Recommended)** Point DocuSeal file storage at your existing **Supabase Storage** (S3-compatible) so signed PDFs live on infra you already run and survive any future host outage. In DocuSeal env: set the S3 vars to your Supabase project's S3 endpoint/keys. (Otherwise it uses a Railway volume / local disk.)
+4. Open the DocuSeal admin UI, create the first admin account.
+
+## Step 2 — Deploy Stirling PDF on Railway
+
+`generate-pdf` converts the lease HTML to a PDF via Stirling PDF *before* DocuSeal is ever called.
+
+1. Deploy the `stirlingtools/stirling-pdf` (a.k.a. `frooodle/s-pdf`) Docker image as a Railway service.
+2. Give it a stable public HTTPS domain.
+3. No DB needed. Confirm `POST /api/v1/misc/html-to-pdf` responds (that's the exact endpoint the function calls).
+
+## Step 3 — Configure DocuSeal (admin UI)
+
+1. **API key:** Settings → API → copy the token (this becomes `DOCUSEAL_API_KEY`, sent as `X-Auth-Token`).
+2. **Webhook:** Settings → Webhooks → add:
+   - **URL:** `https://bshjmbshupiibfiewpxb.supabase.co/functions/v1/docuseal-webhook`
+   - **Events:** enable **`form.completed`** and **`submission.completed`** (the only two handled).
+   - **HMAC / Security:** enable signing; reveal + copy the **`whsec_…`** value (this becomes `DOCUSEAL_WEBHOOK_SECRET`).
+   - No Supabase auth header is needed — the function is `verify_jwt:false` and gates on the HMAC.
+
+> The webhook function accepts **both** the current `<timestamp>.<hex>` signature scheme **and** the legacy plain-hex scheme, so it works whether Railway gives you a current or pinned DocuSeal image.
+
+## Step 4 — Set the Supabase Edge Function secrets
+
+Project-level (shared by all functions). `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are auto-injected — do **not** set them.
+
+| Secret | Value |
+|---|---|
+| `DOCUSEAL_URL` | Bare DocuSeal origin — **no trailing slash, no `/api`** (e.g. `https://docuseal-production.up.railway.app`). The code appends `/api/...`. |
+| `DOCUSEAL_API_KEY` | DocuSeal API token (Step 3.1) |
+| `DOCUSEAL_WEBHOOK_SECRET` | The `whsec_…` value (Step 3.2) |
+| `STIRLING_PDF_URL` | Bare Stirling PDF origin — no trailing slash (the code appends `/api/v1/misc/html-to-pdf`) |
+
+```bash
+supabase secrets set \
+  DOCUSEAL_URL=https://<your-docuseal-host> \
+  DOCUSEAL_API_KEY=<token> \
+  DOCUSEAL_WEBHOOK_SECRET=whsec_<...> \
+  STIRLING_PDF_URL=https://<your-stirling-host> \
+  --project-ref bshjmbshupiibfiewpxb
+```
+
+## Step 5 — Redeploy the edge functions
+
+Required so they pick up the new env **and** the PR #851 code (after #851 merges):
+
+```bash
+supabase functions deploy docuseal docuseal-webhook generate-pdf --project-ref bshjmbshupiibfiewpxb
+# or, per the deploy-401 memory: bun scripts/deploy-edge-functions.ts
+```
+
+## Step 6 — Smoke test (the start-to-finish check)
+
+1. Create a **draft** lease for a unit, with a tenant that has a **real email**.
+2. Click **Send for Signature** (fill the landlord notice address).
+   - ✅ no 502; the lease moves to **Pending Signature**; owner + tenant receive DocuSeal emails.
+3. Open the **tenant** email → sign. Then the **owner** email (or in-app "Sign as Owner") → sign.
+   - ✅ after the second signature, the webhook flips the lease to **Active** and the owner gets a "Lease fully signed" notification.
+4. ✅ the signed PDF is downloadable from the active lease.
+5. If the webhook seems to not fire: check the `docuseal-webhook` logs for `401 Unauthorized` (→ `DOCUSEAL_WEBHOOK_SECRET` mismatch) or "Lease not found" (→ submission/metadata lookup).
+
+---
+
+## Known follow-ups (not blockers; tracked for later)
+
+- **M4 — signed-doc URL freshness:** DocuSeal blob URLs can expire. The webhook persists `docuseal_document_url` for immediate access, but the canonical reference is `docuseal_submission_id`. A later improvement: fetch a fresh URL via `GET /api/submissions/{id}` when the owner opens an old lease (a new `docuseal` action + a tweak to the download button).
+- **FE polish:** show the signature-status card on `active` leases (who-signed summary); add Realtime/poll on the lease detail while `pending_signature` so webhook-driven activation surfaces without a manual refresh.
+- **Long-term option (no vendor):** token-based in-app tenant signing (emailed magic link → public Edge Function → the existing `sign_lease_and_check_activation` RPC) removes the DocuSeal + Stirling + Railway dependencies entirely. See the migration research for the design.
+
+---
+
+_Generated as part of the DocuSeal migration investigation. The code half is PR #851; the deploy half is this runbook (owner-run — Railway + Supabase secrets + function deploy need your credentials)._

--- a/.planning/esign-railway-migration-runbook.md
+++ b/.planning/esign-railway-migration-runbook.md
@@ -81,9 +81,9 @@ supabase functions deploy docuseal docuseal-webhook generate-pdf --project-ref b
 
 1. Create a **draft** lease for a unit, with a tenant that has a **real email**.
 2. Click **Send for Signature** (fill the landlord notice address).
-   - ✅ no 502; the lease moves to **Pending Signature**; owner + tenant receive DocuSeal emails.
-3. Open the **tenant** email → sign. Then the **owner** email (or in-app "Sign as Owner") → sign.
-   - ✅ after the second signature, the webhook flips the lease to **Active** and the owner gets a "Lease fully signed" notification.
+   - ✅ no 502; the lease moves to **Pending Signature**; **both** owner + tenant receive DocuSeal emails immediately (the submission uses `order:"random"`, so they can sign in any order).
+3. Sign as **both** parties, in either order: the **tenant** via their DocuSeal email; the **owner** via the in-app **"Sign as Owner"** button (or their DocuSeal email).
+   - ✅ once **both** `owner_signed_at` and `tenant_signed_at` are set, the lease flips to **Active** and the owner gets a "Lease fully signed" notification — whether the last signature came from the in-app owner path or a DocuSeal webhook.
 4. ✅ the signed PDF is downloadable from the active lease.
 5. If the webhook seems to not fire: check the `docuseal-webhook` logs for `401 Unauthorized` (→ `DOCUSEAL_WEBHOOK_SECRET` mismatch) or "Lease not found" (→ submission/metadata lookup).
 

--- a/src/components/leases/detail/lease-header.tsx
+++ b/src/components/leases/detail/lease-header.tsx
@@ -121,7 +121,6 @@ export function LeaseHeader({
 					<>
 						<SignLeaseButton
 							leaseId={lease.id}
-							role="owner"
 							alreadySigned={!!lease.owner_signed_at}
 							size="sm"
 						/>

--- a/src/components/leases/sign-lease-button.tsx
+++ b/src/components/leases/sign-lease-button.tsx
@@ -17,17 +17,11 @@ import {
 import { Button } from "#components/ui/button";
 import { Checkbox } from "#components/ui/checkbox";
 import { Label } from "#components/ui/label";
-import {
-	useSignLeaseAsOwnerMutation,
-	useSignLeaseAsTenantMutation,
-} from "#hooks/api/use-lease-signature-mutations";
+import { useSignLeaseAsOwnerMutation } from "#hooks/api/use-lease-signature-mutations";
 import { cn } from "#lib/utils";
-
-type SignerRole = "owner" | "tenant";
 
 interface SignLeaseButtonProps {
 	leaseId: string;
-	role: SignerRole;
 	disabled?: boolean;
 	alreadySigned?: boolean;
 	className?: string;
@@ -36,12 +30,12 @@ interface SignLeaseButtonProps {
 }
 
 /**
- * Button component for signing a lease as owner or tenant
- * Shows a confirmation dialog with legal acknowledgment
+ * Button for the OWNER to sign a lease in-app (direct signature with IP capture).
+ * Shows a confirmation dialog with legal acknowledgment. Tenants sign via the
+ * separate DocuSeal email flow (tenants are records, not auth users).
  */
 export function SignLeaseButton({
 	leaseId,
-	role,
 	disabled = false,
 	alreadySigned = false,
 	className,
@@ -50,10 +44,7 @@ export function SignLeaseButton({
 }: SignLeaseButtonProps) {
 	const [agreed, setAgreed] = useState(false);
 	const [open, setOpen] = useState(false);
-	const signAsOwner = useSignLeaseAsOwnerMutation();
-	const signAsTenant = useSignLeaseAsTenantMutation();
-
-	const mutation = role === "owner" ? signAsOwner : signAsTenant;
+	const mutation = useSignLeaseAsOwnerMutation();
 
 	const handleSign = async () => {
 		if (!agreed) {
@@ -92,8 +83,6 @@ export function SignLeaseButton({
 		);
 	}
 
-	const roleLabel = role === "owner" ? "Owner" : "Tenant";
-
 	return (
 		<AlertDialog open={open} onOpenChange={setOpen}>
 			<AlertDialogTrigger asChild>
@@ -102,7 +91,7 @@ export function SignLeaseButton({
 					size={size}
 					disabled={disabled}
 					className={cn("gap-2", className)}
-					data-testid={`sign-lease-${role}-button`}
+					data-testid="sign-lease-owner-button"
 				>
 					<PenLine className="h-4 w-4" />
 					Sign Lease
@@ -114,7 +103,7 @@ export function SignLeaseButton({
 					<AlertDialogDescription className="space-y-3">
 						<p>
 							You are about to electronically sign this lease agreement as the{" "}
-							<strong>{roleLabel.toLowerCase()}</strong>.
+							<strong>owner</strong>.
 						</p>
 						<p>
 							By signing, you acknowledge that you have read and agree to all
@@ -158,7 +147,7 @@ export function SignLeaseButton({
 						) : (
 							<>
 								<PenLine className="h-4 w-4" />
-								Sign as {roleLabel}
+								Sign as Owner
 							</>
 						)}
 					</AlertDialogAction>

--- a/src/hooks/api/__tests__/use-lease.test.tsx
+++ b/src/hooks/api/__tests__/use-lease.test.tsx
@@ -42,7 +42,6 @@ import {
 	useCancelSignatureRequestMutation,
 	useSendLeaseForSignatureMutation,
 	useSignLeaseAsOwnerMutation,
-	useSignLeaseAsTenantMutation,
 } from "../use-lease-signature-mutations";
 
 // Mock logger
@@ -573,24 +572,6 @@ describe("Mutation Hooks", () => {
 				expect.objectContaining({
 					method: "POST",
 					body: expect.stringContaining('"action":"sign-owner"'),
-				}),
-			);
-		});
-	});
-
-	describe("useSignLeaseAsTenantMutation", () => {
-		it("should call docuseal Edge Function with sign-tenant action", async () => {
-			const { result } = renderHook(() => useSignLeaseAsTenantMutation(), {
-				wrapper: createWrapper(),
-			});
-
-			await result.current.mutateAsync("lease-123");
-
-			expect(fetchMock).toHaveBeenCalledWith(
-				expect.stringContaining("/functions/v1/docuseal"),
-				expect.objectContaining({
-					method: "POST",
-					body: expect.stringContaining('"action":"sign-tenant"'),
 				}),
 			);
 		});

--- a/src/hooks/api/query-keys/lease-mutation-options.ts
+++ b/src/hooks/api/query-keys/lease-mutation-options.ts
@@ -213,13 +213,6 @@ export const leaseMutations = {
 				callDocuSealEdgeFunction("sign-owner", { leaseId }),
 		}),
 
-	signAsTenant: () =>
-		mutationOptions({
-			mutationKey: mutationKeys.leases.sign,
-			mutationFn: (leaseId: string) =>
-				callDocuSealEdgeFunction("sign-tenant", { leaseId }),
-		}),
-
 	cancelSignature: () =>
 		mutationOptions({
 			mutationKey: mutationKeys.leases.cancelSignature,

--- a/src/hooks/api/use-lease-signature-mutations.ts
+++ b/src/hooks/api/use-lease-signature-mutations.ts
@@ -47,27 +47,6 @@ export function useSignLeaseAsOwnerMutation() {
 	});
 }
 
-export function useSignLeaseAsTenantMutation() {
-	const queryClient = useQueryClient();
-
-	return useMutation({
-		...leaseMutations.signAsTenant(),
-		onSuccess: (_result, leaseId) => {
-			queryClient.invalidateQueries({
-				queryKey: leaseQueries.detail(leaseId).queryKey,
-			});
-			queryClient.invalidateQueries({
-				queryKey: leaseQueries.signatureStatus(leaseId).queryKey,
-			});
-			queryClient.invalidateQueries({ queryKey: leaseQueries.lists() });
-			logger.info("Lease signed by tenant", { leaseId });
-		},
-		onError: (err) => {
-			handleMutationError(err, "Sign lease");
-		},
-	});
-}
-
 // Archives DocuSeal submission and reverts lease to draft.
 export function useCancelSignatureRequestMutation() {
 	const queryClient = useQueryClient();

--- a/supabase/functions/docuseal-webhook/index.ts
+++ b/supabase/functions/docuseal-webhook/index.ts
@@ -10,9 +10,10 @@
 //
 // Payload shape (current DocuSeal): { event_type, timestamp, data: {...} }.
 //   form.completed       -> data = the submitter: { role, external_id, completed_at,
-//                            submission: { id, metadata, combined_document_url } }
-//   submission.completed -> data = the submission: { id, status, metadata,
+//                            submission: { id, variables, combined_document_url } }
+//   submission.completed -> data = the submission: { id, status, variables,
 //                            combined_document_url, documents: [{ name, url }] }
+//   (lease_id is carried in submission.variables — see leaseIdFrom.)
 //
 // Signature (current DocuSeal): X-Docuseal-Signature: `<timestamp>.<hex_hmac>` where the
 //   HMAC-SHA256 is computed over `<timestamp>.<raw_body>` with the raw `whsec_...` secret.

--- a/supabase/functions/docuseal-webhook/index.ts
+++ b/supabase/functions/docuseal-webhook/index.ts
@@ -28,8 +28,9 @@ interface SubmissionRef {
 	status?: string;
 	combined_document_url?: string;
 	documents?: Array<{ name: string; url: string }>;
-	// Create-time submission metadata re-surfaces under `variables` in current
-	// DocuSeal webhook payloads; `metadata` is kept for older builds.
+	// lease_id is sent as a top-level submission `variable` on create, which
+	// round-trips here as data.submission.variables. `metadata` is a harmless
+	// secondary fallback (the primary join is docuseal_submission_id).
 	variables?: { lease_id?: string };
 	metadata?: { lease_id?: string };
 }
@@ -52,10 +53,14 @@ const leaseIdFrom = (
 ): string | undefined => s?.variables?.lease_id ?? s?.metadata?.lease_id;
 
 /**
- * Activate the lease + notify the owner, exactly once. The conditional UPDATE
- * (`.neq lease_status active`) makes activation idempotent, and the notification
- * is inserted only when this call is the one that flipped the row — so repeated
- * form.completed/submission.completed deliveries never double-notify.
+ * Activate the lease + notify the owner, exactly once — IFF both parties have
+ * signed. The decision is made atomically inside the UPDATE (re-checking
+ * owner_signed_at + tenant_signed_at at flip time, not from a stale pre-read),
+ * so it is race-safe: whichever signature path runs LAST sees both timestamps
+ * set and flips the row. The conditional `.neq lease_status active` + the
+ * flipped-row gate make it idempotent — repeated deliveries / the parallel
+ * in-app path never double-activate or double-notify. Safe to call after any
+ * signature write (it no-ops when only one party has signed).
  */
 async function activateLease(
 	supabase: SupabaseClient,
@@ -67,9 +72,11 @@ async function activateLease(
 		.update({ lease_status: "active" })
 		.eq("id", leaseId)
 		.neq("lease_status", "active")
+		.not("owner_signed_at", "is", null)
+		.not("tenant_signed_at", "is", null)
 		.select("id");
 	if (error) throw new Error(`Failed to activate lease: ${error.message}`);
-	if (!flipped || flipped.length === 0) return; // already active — no duplicate notify
+	if (!flipped || flipped.length === 0) return; // not both-signed yet, or already active
 
 	// notification_type must be 'lease' per notifications_notification_type_check.
 	const { error: notifError } = await supabase.from("notifications").insert({
@@ -129,7 +136,7 @@ async function handleFormCompleted(
 
 	const lease = (await lookupLease(
 		supabase,
-		"id, lease_status, owner_signed_at, tenant_signed_at, owner_user_id",
+		"id, owner_signed_at, tenant_signed_at, owner_user_id",
 		submissionId,
 		leaseId,
 	)) as {
@@ -169,12 +176,10 @@ async function handleFormCompleted(
 		if (updateError)
 			throw new Error(`Failed to update owner signature: ${updateError.message}`);
 		logEvent("Owner signature recorded", { lease_id: lease.id });
-		// If the tenant had already signed, both parties are done -> activate.
-		// (submission.completed won't fire when the owner signs in-app, so order-
-		// independent activation has to happen here too.)
-		if (lease.tenant_signed_at) {
-			await activateLease(supabase, lease.id, lease.owner_user_id);
-		}
+		// Activate iff both parties have now signed (activateLease re-checks
+		// atomically). submission.completed won't fire when the owner signs
+		// in-app, so order-independent activation must happen here too.
+		await activateLease(supabase, lease.id, lease.owner_user_id);
 	} else if (isTenant) {
 		if (lease.tenant_signed_at) {
 			logEvent("tenant_signed_at already set — duplicate delivery, skipping", {
@@ -194,9 +199,7 @@ async function handleFormCompleted(
 				`Failed to update tenant signature: ${updateError.message}`,
 			);
 		logEvent("Tenant signature recorded", { lease_id: lease.id });
-		if (lease.owner_signed_at) {
-			await activateLease(supabase, lease.id, lease.owner_user_id);
-		}
+		await activateLease(supabase, lease.id, lease.owner_user_id);
 	} else {
 		logEvent("Unrecognised role — no signature update performed", {
 			role,
@@ -214,12 +217,11 @@ async function handleSubmissionCompleted(
 
 	const lease = (await lookupLease(
 		supabase,
-		"id, lease_status, owner_user_id, docuseal_document_url",
+		"id, owner_user_id, docuseal_document_url",
 		submissionId,
 		leaseId,
 	)) as {
 		id: string;
-		lease_status: string;
 		owner_user_id: string;
 		docuseal_document_url: string | null;
 	} | null;

--- a/supabase/functions/docuseal-webhook/index.ts
+++ b/supabase/functions/docuseal-webhook/index.ts
@@ -7,83 +7,111 @@
 // Events handled:
 //   form.completed       — individual party has signed (updates owner_signed_at or tenant_signed_at)
 //   submission.completed — all parties signed (flips lease_status to active + inserts notification)
+//
+// Payload shape (current DocuSeal): { event_type, timestamp, data: {...} }.
+//   form.completed       -> data = the submitter: { role, external_id, completed_at,
+//                            submission: { id, metadata, combined_document_url } }
+//   submission.completed -> data = the submission: { id, status, metadata,
+//                            combined_document_url, documents: [{ name, url }] }
+//
+// Signature (current DocuSeal): X-Docuseal-Signature: `<timestamp>.<hex_hmac>` where the
+//   HMAC-SHA256 is computed over `<timestamp>.<raw_body>` with the raw `whsec_...` secret.
+//   Legacy self-hosted builds sign plain hex of the raw body — both are accepted below.
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { validateEnv } from "../_shared/env.ts";
 import { errorResponse, logEvent } from "../_shared/errors.ts";
 import { createAdminClient } from "../_shared/supabase-client.ts";
 
-interface FormCompletedPayload {
-	event_type: string;
-	id: number;
-	submission_id: number;
-	role: string;
-	email: string;
-	completed_at?: string;
+interface SubmissionRef {
+	id?: number;
+	status?: string;
+	combined_document_url?: string;
+	documents?: Array<{ name: string; url: string }>;
 	metadata?: { lease_id?: string };
 }
 
-interface SubmissionCompletedPayload {
-	event_type: string;
-	id: number;
-	status: string;
-	documents?: Array<{ name: string; url: string }>;
+interface FormCompletedData {
+	id?: number;
+	role?: string;
+	external_id?: string | null;
+	email?: string;
 	completed_at?: string;
 	metadata?: { lease_id?: string };
+	submission?: SubmissionRef;
+}
+
+type SubmissionCompletedData = SubmissionRef;
+
+async function lookupLease(
+	supabase: SupabaseClient,
+	columns: string,
+	submissionId: number | undefined,
+	leaseId: string | undefined,
+): Promise<unknown> {
+	if (submissionId != null) {
+		const { data, error } = await supabase
+			.from("leases")
+			.select(columns)
+			.eq("docuseal_submission_id", String(submissionId))
+			.maybeSingle();
+		if (error)
+			throw new Error(
+				`Database error querying lease by submission_id: ${error.message}`,
+			);
+		if (data) return data;
+	}
+	// Fall back to metadata.lease_id for submissions created without/before the id write.
+	if (leaseId) {
+		const { data, error } = await supabase
+			.from("leases")
+			.select(columns)
+			.eq("id", leaseId)
+			.maybeSingle();
+		if (error)
+			throw new Error(
+				`Database error querying lease by metadata.lease_id: ${error.message}`,
+			);
+		if (data) return data;
+	}
+	return null;
 }
 
 async function handleFormCompleted(
 	supabase: SupabaseClient,
-	body: FormCompletedPayload,
+	data: FormCompletedData,
 ): Promise<void> {
-	const { submission_id, role, completed_at, metadata } = body;
+	const submissionId = data.submission?.id;
+	const leaseId = data.submission?.metadata?.lease_id ?? data.metadata?.lease_id;
+	const role = data.role ?? "";
+	const externalId = data.external_id ?? "";
+	const completed_at = data.completed_at;
 
-	// Lookup by docuseal_submission_id; fall back to metadata.lease_id for older submissions.
-	const { data: leaseBySubmission, error: submissionError } = await supabase
-		.from("leases")
-		.select(
-			"id, lease_status, owner_signed_at, tenant_signed_at, owner_user_id",
-		)
-		.eq("docuseal_submission_id", String(submission_id))
-		.maybeSingle();
-
-	if (submissionError) {
-		throw new Error(
-			`Database error querying lease by submission_id: ${submissionError.message}`,
-		);
-	}
-
-	let lease = leaseBySubmission;
-
-	if (!lease && metadata?.lease_id) {
-		const { data: leaseById, error: leaseIdError } = await supabase
-			.from("leases")
-			.select(
-				"id, lease_status, owner_signed_at, tenant_signed_at, owner_user_id",
-			)
-			.eq("id", metadata.lease_id)
-			.maybeSingle();
-
-		if (leaseIdError) {
-			throw new Error(
-				`Database error querying lease by metadata.lease_id: ${leaseIdError.message}`,
-			);
-		}
-
-		lease = leaseById;
-	}
+	const lease = (await lookupLease(
+		supabase,
+		"id, lease_status, owner_signed_at, tenant_signed_at, owner_user_id",
+		submissionId,
+		leaseId,
+	)) as {
+		id: string;
+		owner_signed_at: string | null;
+		tenant_signed_at: string | null;
+	} | null;
 
 	// Not our document; ignore gracefully (no 500 so DocuSeal stops retrying).
 	if (!lease) {
 		logEvent("Lease not found for form.completed event — ignoring", {
-			submission_id,
-			metadata_lease_id: metadata?.lease_id ?? null,
+			submission_id: submissionId ?? null,
+			metadata_lease_id: leaseId ?? null,
 		});
 		return;
 	}
 
-	const isOwner = role.toLowerCase().includes("owner");
-	const isTenant = role.toLowerCase().includes("tenant");
+	// Prefer the stable external_id ('owner'/'tenant' set on submission create);
+	// fall back to the role label for submissions created before external_id.
+	const roleLower = role.toLowerCase();
+	const isOwner = externalId === "owner" || roleLower.includes("owner");
+	const isTenant = externalId === "tenant" || roleLower.includes("tenant");
 	const signedAt = completed_at ?? new Date().toISOString();
 
 	if (isOwner) {
@@ -93,21 +121,12 @@ async function handleFormCompleted(
 			});
 			return;
 		}
-
 		const { error: updateError } = await supabase
 			.from("leases")
-			.update({
-				owner_signed_at: signedAt,
-				owner_signature_method: "docuseal",
-			})
+			.update({ owner_signed_at: signedAt, owner_signature_method: "docuseal" })
 			.eq("id", lease.id);
-
-		if (updateError) {
-			throw new Error(
-				`Failed to update owner signature: ${updateError.message}`,
-			);
-		}
-
+		if (updateError)
+			throw new Error(`Failed to update owner signature: ${updateError.message}`);
 		logEvent("Owner signature recorded", { lease_id: lease.id });
 	} else if (isTenant) {
 		if (lease.tenant_signed_at) {
@@ -116,7 +135,6 @@ async function handleFormCompleted(
 			});
 			return;
 		}
-
 		const { error: updateError } = await supabase
 			.from("leases")
 			.update({
@@ -124,59 +142,42 @@ async function handleFormCompleted(
 				tenant_signature_method: "docuseal",
 			})
 			.eq("id", lease.id);
-
-		if (updateError) {
+		if (updateError)
 			throw new Error(
 				`Failed to update tenant signature: ${updateError.message}`,
 			);
-		}
-
 		logEvent("Tenant signature recorded", { lease_id: lease.id });
 	} else {
-		logEvent("Unrecognised role — no signature update performed", { role });
+		logEvent("Unrecognised role — no signature update performed", {
+			role,
+			external_id: externalId,
+		});
 	}
 }
 
 async function handleSubmissionCompleted(
 	supabase: SupabaseClient,
-	body: SubmissionCompletedPayload,
+	data: SubmissionCompletedData,
 ): Promise<void> {
-	const { id: submissionId, documents, metadata } = body;
+	const submissionId = data.id;
+	const leaseId = data.metadata?.lease_id;
 
-	const { data: leaseBySubmission, error: submissionError } = await supabase
-		.from("leases")
-		.select("id, lease_status, owner_user_id, docuseal_document_url")
-		.eq("docuseal_submission_id", String(submissionId))
-		.maybeSingle();
-
-	if (submissionError) {
-		throw new Error(
-			`Database error querying lease by submission_id: ${submissionError.message}`,
-		);
-	}
-
-	let lease = leaseBySubmission;
-
-	if (!lease && metadata?.lease_id) {
-		const { data: leaseById, error: leaseIdError } = await supabase
-			.from("leases")
-			.select("id, lease_status, owner_user_id, docuseal_document_url")
-			.eq("id", metadata.lease_id)
-			.maybeSingle();
-
-		if (leaseIdError) {
-			throw new Error(
-				`Database error querying lease by metadata.lease_id: ${leaseIdError.message}`,
-			);
-		}
-
-		lease = leaseById;
-	}
+	const lease = (await lookupLease(
+		supabase,
+		"id, lease_status, owner_user_id, docuseal_document_url",
+		submissionId,
+		leaseId,
+	)) as {
+		id: string;
+		lease_status: string;
+		owner_user_id: string;
+		docuseal_document_url: string | null;
+	} | null;
 
 	if (!lease) {
 		logEvent("Lease not found for submission.completed event — ignoring", {
-			submission_id: submissionId,
-			metadata_lease_id: metadata?.lease_id ?? null,
+			submission_id: submissionId ?? null,
+			metadata_lease_id: leaseId ?? null,
 		});
 		return;
 	}
@@ -184,8 +185,16 @@ async function handleSubmissionCompleted(
 	// Activation is idempotent: only flip lease_status if not already active.
 	// URL persistence heals on redelivery: if the signed URL is missing on the
 	// existing row, write it even when lease_status is already 'active'.
+	// NOTE: combined_document_url is a (possibly short-lived) DocuSeal blob URL —
+	// the canonical reference is docuseal_submission_id; consumers should refresh
+	// the URL via the API rather than trusting this one long-term.
 	const signedDocUrl =
-		typeof documents?.[0]?.url === "string" ? documents[0].url : null;
+		(typeof data.combined_document_url === "string"
+			? data.combined_document_url
+			: null) ??
+		(typeof data.documents?.[0]?.url === "string"
+			? data.documents[0].url
+			: null);
 	const updatePayload: {
 		lease_status?: "active";
 		docuseal_document_url?: string;
@@ -243,6 +252,59 @@ async function handleSubmissionCompleted(
 	}
 }
 
+const toHex = (buf: ArrayBuffer): string =>
+	Array.from(new Uint8Array(buf))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+
+/**
+ * Verify the DocuSeal webhook HMAC. Current DocuSeal sends
+ * `X-Docuseal-Signature: <timestamp>.<hex>` and signs `<timestamp>.<raw_body>`
+ * with the raw `whsec_...` secret. Older self-hosted builds sign plain hex of
+ * the raw body. Both schemes are accepted (the signed payload differs only by
+ * the `<timestamp>.` prefix). Returns true on a valid signature.
+ */
+async function verifySignature(
+	header: string,
+	rawBody: string,
+	secret: string,
+): Promise<boolean> {
+	const encoder = new TextEncoder();
+	const key = await crypto.subtle.importKey(
+		"raw",
+		encoder.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const dotIdx = header.indexOf(".");
+	// New scheme: `<timestamp>.<signature>` — sign `<timestamp>.<raw_body>`.
+	// Legacy scheme: header is plain hex of the raw body.
+	const candidates: Array<{ provided: string; signed: string }> =
+		dotIdx > 0
+			? [
+					{
+						provided: header.slice(dotIdx + 1),
+						signed: `${header.slice(0, dotIdx)}.${rawBody}`,
+					},
+				]
+			: [{ provided: header, signed: rawBody }];
+
+	for (const { provided, signed } of candidates) {
+		const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(signed));
+		const expected = toHex(sig);
+		const providedBytes = encoder.encode(provided);
+		const expectedBytes = encoder.encode(expected);
+		if (
+			providedBytes.byteLength === expectedBytes.byteLength &&
+			crypto.subtle.timingSafeEqual(providedBytes, expectedBytes)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
 Deno.serve(async (req: Request) => {
 	try {
 		const env = validateEnv({
@@ -275,31 +337,7 @@ Deno.serve(async (req: Request) => {
 			});
 		}
 
-		// HMAC-SHA256 verification using Web Crypto API
-		const encoder = new TextEncoder();
-		const key = await crypto.subtle.importKey(
-			"raw",
-			encoder.encode(webhookSecret),
-			{ name: "HMAC", hash: "SHA-256" },
-			false,
-			["sign"],
-		);
-		const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(rawBody));
-		const expectedSignature = Array.from(new Uint8Array(sig))
-			.map((b) => b.toString(16).padStart(2, "0"))
-			.join("");
-
-		// Constant-time comparison to prevent timing attacks
-		const sigBytes = encoder.encode(signature);
-		const expectedBytes = encoder.encode(expectedSignature);
-		if (sigBytes.byteLength !== expectedBytes.byteLength) {
-			return new Response(JSON.stringify({ error: "Unauthorized" }), {
-				status: 401,
-				headers: { "Content-Type": "application/json" },
-			});
-		}
-		const match = crypto.subtle.timingSafeEqual(sigBytes, expectedBytes);
-		if (!match) {
+		if (!(await verifySignature(signature, rawBody, webhookSecret))) {
 			return new Response(JSON.stringify({ error: "Unauthorized" }), {
 				status: 401,
 				headers: { "Content-Type": "application/json" },
@@ -311,9 +349,12 @@ Deno.serve(async (req: Request) => {
 			env["SUPABASE_SERVICE_ROLE_KEY"],
 		);
 
-		let body: Record<string, unknown>;
+		let body: { event_type?: string; data?: Record<string, unknown> };
 		try {
-			body = JSON.parse(rawBody) as Record<string, unknown>;
+			body = JSON.parse(rawBody) as {
+				event_type?: string;
+				data?: Record<string, unknown>;
+			};
 		} catch {
 			return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
 				status: 400,
@@ -321,18 +362,13 @@ Deno.serve(async (req: Request) => {
 			});
 		}
 
-		const eventType = body.event_type as string;
+		const eventType = body.event_type;
+		const data = body.data ?? {};
 
 		if (eventType === "form.completed") {
-			await handleFormCompleted(
-				supabase,
-				body as unknown as FormCompletedPayload,
-			);
+			await handleFormCompleted(supabase, data as FormCompletedData);
 		} else if (eventType === "submission.completed") {
-			await handleSubmissionCompleted(
-				supabase,
-				body as unknown as SubmissionCompletedPayload,
-			);
+			await handleSubmissionCompleted(supabase, data as SubmissionCompletedData);
 		} else {
 			logEvent("Unhandled DocuSeal event", { event_type: eventType });
 		}

--- a/supabase/functions/docuseal-webhook/index.ts
+++ b/supabase/functions/docuseal-webhook/index.ts
@@ -28,6 +28,9 @@ interface SubmissionRef {
 	status?: string;
 	combined_document_url?: string;
 	documents?: Array<{ name: string; url: string }>;
+	// Create-time submission metadata re-surfaces under `variables` in current
+	// DocuSeal webhook payloads; `metadata` is kept for older builds.
+	variables?: { lease_id?: string };
 	metadata?: { lease_id?: string };
 }
 
@@ -37,11 +40,48 @@ interface FormCompletedData {
 	external_id?: string | null;
 	email?: string;
 	completed_at?: string;
+	variables?: { lease_id?: string };
 	metadata?: { lease_id?: string };
 	submission?: SubmissionRef;
 }
 
 type SubmissionCompletedData = SubmissionRef;
+
+const leaseIdFrom = (
+	s: { variables?: { lease_id?: string }; metadata?: { lease_id?: string } } | undefined,
+): string | undefined => s?.variables?.lease_id ?? s?.metadata?.lease_id;
+
+/**
+ * Activate the lease + notify the owner, exactly once. The conditional UPDATE
+ * (`.neq lease_status active`) makes activation idempotent, and the notification
+ * is inserted only when this call is the one that flipped the row — so repeated
+ * form.completed/submission.completed deliveries never double-notify.
+ */
+async function activateLease(
+	supabase: SupabaseClient,
+	leaseId: string,
+	ownerUserId: string,
+): Promise<void> {
+	const { data: flipped, error } = await supabase
+		.from("leases")
+		.update({ lease_status: "active" })
+		.eq("id", leaseId)
+		.neq("lease_status", "active")
+		.select("id");
+	if (error) throw new Error(`Failed to activate lease: ${error.message}`);
+	if (!flipped || flipped.length === 0) return; // already active — no duplicate notify
+
+	// notification_type must be 'lease' per notifications_notification_type_check.
+	const { error: notifError } = await supabase.from("notifications").insert({
+		user_id: ownerUserId,
+		title: "Lease fully signed",
+		message: "Your lease has been signed by all parties and is now active.",
+		notification_type: "lease",
+	});
+	if (notifError)
+		throw new Error(`Failed to insert owner notification: ${notifError.message}`);
+	logEvent("Lease activated + owner notified", { lease_id: leaseId });
+}
 
 async function lookupLease(
 	supabase: SupabaseClient,
@@ -82,7 +122,7 @@ async function handleFormCompleted(
 	data: FormCompletedData,
 ): Promise<void> {
 	const submissionId = data.submission?.id;
-	const leaseId = data.submission?.metadata?.lease_id ?? data.metadata?.lease_id;
+	const leaseId = leaseIdFrom(data.submission) ?? leaseIdFrom(data);
 	const role = data.role ?? "";
 	const externalId = data.external_id ?? "";
 	const completed_at = data.completed_at;
@@ -96,6 +136,7 @@ async function handleFormCompleted(
 		id: string;
 		owner_signed_at: string | null;
 		tenant_signed_at: string | null;
+		owner_user_id: string;
 	} | null;
 
 	// Not our document; ignore gracefully (no 500 so DocuSeal stops retrying).
@@ -128,6 +169,12 @@ async function handleFormCompleted(
 		if (updateError)
 			throw new Error(`Failed to update owner signature: ${updateError.message}`);
 		logEvent("Owner signature recorded", { lease_id: lease.id });
+		// If the tenant had already signed, both parties are done -> activate.
+		// (submission.completed won't fire when the owner signs in-app, so order-
+		// independent activation has to happen here too.)
+		if (lease.tenant_signed_at) {
+			await activateLease(supabase, lease.id, lease.owner_user_id);
+		}
 	} else if (isTenant) {
 		if (lease.tenant_signed_at) {
 			logEvent("tenant_signed_at already set — duplicate delivery, skipping", {
@@ -147,6 +194,9 @@ async function handleFormCompleted(
 				`Failed to update tenant signature: ${updateError.message}`,
 			);
 		logEvent("Tenant signature recorded", { lease_id: lease.id });
+		if (lease.owner_signed_at) {
+			await activateLease(supabase, lease.id, lease.owner_user_id);
+		}
 	} else {
 		logEvent("Unrecognised role — no signature update performed", {
 			role,
@@ -160,7 +210,7 @@ async function handleSubmissionCompleted(
 	data: SubmissionCompletedData,
 ): Promise<void> {
 	const submissionId = data.id;
-	const leaseId = data.metadata?.lease_id;
+	const leaseId = leaseIdFrom(data);
 
 	const lease = (await lookupLease(
 		supabase,
@@ -182,12 +232,10 @@ async function handleSubmissionCompleted(
 		return;
 	}
 
-	// Activation is idempotent: only flip lease_status if not already active.
-	// URL persistence heals on redelivery: if the signed URL is missing on the
-	// existing row, write it even when lease_status is already 'active'.
-	// NOTE: combined_document_url is a (possibly short-lived) DocuSeal blob URL —
-	// the canonical reference is docuseal_submission_id; consumers should refresh
-	// the URL via the API rather than trusting this one long-term.
+	// Persist the signed-document URL if missing (heals on redelivery). NOTE:
+	// combined_document_url is a possibly short-lived DocuSeal blob URL — the
+	// canonical reference is docuseal_submission_id; refresh via the API rather
+	// than trusting this long-term.
 	const signedDocUrl =
 		(typeof data.combined_document_url === "string"
 			? data.combined_document_url
@@ -195,61 +243,20 @@ async function handleSubmissionCompleted(
 		(typeof data.documents?.[0]?.url === "string"
 			? data.documents[0].url
 			: null);
-	const updatePayload: {
-		lease_status?: "active";
-		docuseal_document_url?: string;
-	} = {};
-
-	if (lease.lease_status !== "active") {
-		updatePayload.lease_status = "active";
-	}
 	if (signedDocUrl && !lease.docuseal_document_url) {
-		updatePayload.docuseal_document_url = signedDocUrl;
-	}
-
-	if (Object.keys(updatePayload).length === 0) {
-		logEvent(
-			"Lease already active and signed URL already persisted — skipping",
-			{ lease_id: lease.id },
-		);
-		return;
-	}
-
-	const { error: leaseUpdateError } = await supabase
-		.from("leases")
-		.update(updatePayload)
-		.eq("id", lease.id);
-
-	if (leaseUpdateError) {
-		throw new Error(`Failed to update lease: ${leaseUpdateError.message}`);
-	}
-
-	logEvent("Lease updated", {
-		lease_id: lease.id,
-		activated: updatePayload.lease_status === "active",
-		persisted_signed_url: Boolean(updatePayload.docuseal_document_url),
-	});
-
-	// Only insert the activation notification when we actually just activated
-	// (not on URL-heal-only redeliveries).
-	if (updatePayload.lease_status === "active") {
-		// notification_type must be 'lease' per notifications_notification_type_check constraint
-		// (allowed: 'maintenance', 'lease', 'payment', 'system').
-		const { error: notifError } = await supabase.from("notifications").insert({
-			user_id: lease.owner_user_id,
-			title: "Lease fully signed",
-			message: "Your lease has been signed by all parties and is now active.",
-			notification_type: "lease",
-		});
-
-		if (notifError) {
+		const { error: urlError } = await supabase
+			.from("leases")
+			.update({ docuseal_document_url: signedDocUrl })
+			.eq("id", lease.id);
+		if (urlError)
 			throw new Error(
-				`Failed to insert owner notification: ${notifError.message}`,
+				`Failed to persist signed document URL: ${urlError.message}`,
 			);
-		}
-
-		logEvent("Owner notification inserted", { lease_id: lease.id });
 	}
+
+	// submission.completed means every DocuSeal submitter finished. Activate +
+	// notify exactly once (idempotent on redelivery and vs the form.completed path).
+	await activateLease(supabase, lease.id, lease.owner_user_id);
 }
 
 const toHex = (buf: ArrayBuffer): string =>
@@ -278,6 +285,15 @@ async function verifySignature(
 		["sign"],
 	);
 	const dotIdx = header.indexOf(".");
+	if (dotIdx > 0) {
+		// New scheme: reject a stale/non-numeric timestamp (±5 min) BEFORE the HMAC
+		// check — replay hardening per the DocuSeal webhook spec. A non-finite ts
+		// fails closed (Math.abs(NaN) > 300 is false, so guard it explicitly).
+		const ts = Number(header.slice(0, dotIdx));
+		if (!Number.isFinite(ts) || Math.abs(Date.now() / 1000 - ts) > 300) {
+			return false;
+		}
+	}
 	// New scheme: `<timestamp>.<signature>` — sign `<timestamp>.<raw_body>`.
 	// Legacy scheme: header is plain hex of the raw body.
 	const candidates: Array<{ provided: string; signed: string }> =

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -339,9 +339,13 @@ Deno.serve(async (req: Request) => {
 				// DocuSeal — but the owner signs in-app, so the tenant would never be
 				// emailed and the lease would never activate.
 				order: "random",
-				metadata: {
+				// lease_id is sent as a top-level submission `variable` (which
+				// /api/submissions/pdf accepts and round-trips to
+				// data.submission.variables in the webhook). It is only a FALLBACK —
+				// the webhook's primary join is docuseal_submission_id, written
+				// in-request below. (DocuSeal drops a top-level `metadata` param.)
+				variables: {
 					lease_id: leaseId,
-					source: "tenantflow",
 				},
 			};
 
@@ -415,9 +419,7 @@ Deno.serve(async (req: Request) => {
 
 			const { data: lease, error: leaseError } = await supabase
 				.from("leases")
-				.select(
-					"id, owner_user_id, docuseal_submission_id, owner_signed_at, tenant_signed_at",
-				)
+				.select("id, owner_user_id, owner_signed_at")
 				.eq("id", leaseId)
 				.single();
 
@@ -444,29 +446,42 @@ Deno.serve(async (req: Request) => {
 				});
 			}
 
-			// In-app owner signature (direct, IP-captured) -> method 'in_app'
-			// (the DocuSeal webhook records 'docuseal' for email-signed parties).
-			const ownerActivates = Boolean(lease.tenant_signed_at);
-			const updatePayload: Record<string, unknown> = {
-				owner_signed_at: new Date().toISOString(),
-				owner_signature_method: "in_app",
-			};
-			if (ownerActivates) {
-				updatePayload.lease_status = "active";
-			}
-
+			// In-app owner signature (direct) -> method 'in_app' (the DocuSeal
+			// webhook records 'docuseal' for email-signed parties).
 			const { error: updateError } = await supabase
 				.from("leases")
-				.update(updatePayload)
-				.eq("id", leaseId);
+				.update({
+					owner_signed_at: new Date().toISOString(),
+					owner_signature_method: "in_app",
+				})
+				.eq("id", leaseId)
+				.is("owner_signed_at", null);
 
 			if (updateError) {
 				return errorResponse(req, 500, updateError, { action: "sign_owner" });
 			}
 
-			// If this completed the lease, notify the owner (parity with the webhook
-			// activation path). Best-effort — never fail the signature on notify error.
-			if (ownerActivates) {
+			// Activate iff BOTH parties have now signed — decided atomically inside
+			// the UPDATE (re-checks both signed_at at flip time), so it is race-safe
+			// against a concurrent tenant webhook, and only the flipping request
+			// notifies (no double-activate / double-notify vs the webhook path).
+			const { data: flipped, error: flipError } = await supabase
+				.from("leases")
+				.update({ lease_status: "active" })
+				.eq("id", leaseId)
+				.neq("lease_status", "active")
+				.not("owner_signed_at", "is", null)
+				.not("tenant_signed_at", "is", null)
+				.select("id");
+
+			if (flipError) {
+				return errorResponse(req, 500, flipError, {
+					action: "sign_owner_activate",
+				});
+			}
+
+			// Best-effort notify — never fail the signature on a notify error.
+			if (flipped && flipped.length > 0) {
 				const { error: notifError } = await supabase
 					.from("notifications")
 					.insert({
@@ -477,11 +492,14 @@ Deno.serve(async (req: Request) => {
 						notification_type: "lease",
 					});
 				if (notifError) {
-					captureWebhookError(new Error("Owner activation notification failed"), {
-						message: notifError.message,
-						action: "sign_owner_notify",
-						lease_id: leaseId,
-					});
+					captureWebhookError(
+						new Error("Owner activation notification failed"),
+						{
+							message: notifError.message,
+							action: "sign_owner_notify",
+							lease_id: leaseId,
+						},
+					);
 				}
 			}
 

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -334,7 +334,11 @@ Deno.serve(async (req: Request) => {
 				],
 				submitters: [ownerSubmitter, tenantSubmitter],
 				send_email: true,
-				order: "preserved",
+				// "random" = email both parties immediately so they sign independently.
+				// "preserved" would email the tenant only AFTER the owner signs in
+				// DocuSeal — but the owner signs in-app, so the tenant would never be
+				// emailed and the lease would never activate.
+				order: "random",
 				metadata: {
 					lease_id: leaseId,
 					source: "tenantflow",

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -152,6 +152,27 @@ Deno.serve(async (req: Request) => {
 				"Tenant";
 			const tenantEmail = (tenantRow?.email as string | null) ?? "";
 
+			// DocuSeal emails the signing links, so both parties need a deliverable
+			// email. Tenant records are landlord-managed and may lack one — fail fast
+			// with a clear 400 instead of an opaque DocuSeal rejection.
+			const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+			if (!EMAIL_RE.test(ownerEmail)) {
+				return new Response(
+					JSON.stringify({
+						error: "Your account email is required to send for signature",
+					}),
+					{ status: 400, headers: getJsonHeaders(req) },
+				);
+			}
+			if (!EMAIL_RE.test(tenantEmail)) {
+				return new Response(
+					JSON.stringify({
+						error: "Tenant email is required to send for signature",
+					}),
+					{ status: 400, headers: getJsonHeaders(req) },
+				);
+			}
+
 			const property = unitRow
 				? (unitRow.properties as unknown as {
 						name: string | null;
@@ -286,12 +307,14 @@ Deno.serve(async (req: Request) => {
 
 			const ownerSubmitter: Record<string, unknown> = {
 				role: "Property Owner",
+				external_id: "owner",
 				email: ownerEmail,
 				name: ownerName,
 				order: 1,
 			};
 			const tenantSubmitter: Record<string, unknown> = {
 				role: "Tenant",
+				external_id: "tenant",
 				email: tenantEmail,
 				name: tenantName,
 				order: 2,
@@ -305,7 +328,8 @@ Deno.serve(async (req: Request) => {
 				documents: [
 					{
 						name: "Lease Agreement",
-						file: `data:application/pdf;base64,${base64Pdf}`,
+						// DocuSeal expects RAW base64 (no data: URI prefix).
+						file: base64Pdf,
 					},
 				],
 				submitters: [ownerSubmitter, tenantSubmitter],
@@ -317,14 +341,19 @@ Deno.serve(async (req: Request) => {
 				},
 			};
 
-			const submissionResponse = await fetch(`${docusealUrl}/api/submissions`, {
-				method: "POST",
-				headers: {
-					"X-Auth-Token": docusealApiKey,
-					"Content-Type": "application/json",
+			// /api/submissions/pdf is the inline-document endpoint (/api/submissions
+			// requires a template_id and rejects inline documents).
+			const submissionResponse = await fetch(
+				`${docusealUrl}/api/submissions/pdf`,
+				{
+					method: "POST",
+					headers: {
+						"X-Auth-Token": docusealApiKey,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify(docusealPayload),
 				},
-				body: JSON.stringify(docusealPayload),
-			});
+			);
 
 			if (!submissionResponse.ok) {
 				const errBody = await submissionResponse
@@ -464,10 +493,11 @@ Deno.serve(async (req: Request) => {
 
 			// Archive DocuSeal submission if one exists
 			if (submissionId) {
+				// Archive = DELETE /api/submissions/{id} (soft-archive) in current DocuSeal.
 				const archiveResponse = await fetch(
-					`${docusealUrl}/api/submissions/${submissionId}/archive`,
+					`${docusealUrl}/api/submissions/${submissionId}`,
 					{
-						method: "POST",
+						method: "DELETE",
 						headers: {
 							"X-Auth-Token": docusealApiKey,
 							"Content-Type": "application/json",
@@ -498,6 +528,13 @@ Deno.serve(async (req: Request) => {
 					docuseal_submission_id: null,
 					sent_for_signature_at: null,
 					lease_status: "draft",
+					// Clear signature state from the discarded submission so a later
+					// resend can't activate the lease against a stale signature.
+					owner_signed_at: null,
+					tenant_signed_at: null,
+					owner_signature_method: null,
+					tenant_signature_method: null,
+					docuseal_document_url: null,
 				})
 				.eq("id", leaseId);
 
@@ -578,10 +615,20 @@ Deno.serve(async (req: Request) => {
 			}
 
 			const submittersData = (await submittersResponse.json()) as {
-				data: Array<{ id: number; status: string }>;
+				data?: Array<{ id: number; status: string }>;
 			};
 
-			const submitters = submittersData.data ?? [];
+			// A misconfigured base URL can return a non-array body — fail loudly
+			// instead of silently "succeeding" with zero emails resent.
+			if (!Array.isArray(submittersData.data)) {
+				return errorResponse(
+					req,
+					502,
+					new Error("Unexpected submitters response from DocuSeal"),
+					{ action: "resend" },
+				);
+			}
+			const submitters = submittersData.data;
 			const pendingSubmitters = submitters.filter(
 				(s: { id: number; status: string }) => s.status !== "completed",
 			);

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -351,6 +351,9 @@ Deno.serve(async (req: Request) => {
 				.update({
 					docuseal_submission_id: String(submission.id),
 					sent_for_signature_at: new Date().toISOString(),
+					// Move draft -> pending_signature so the in-app "Sign as Owner" UI
+					// (gated on lease_status='pending_signature') becomes reachable.
+					lease_status: "pending_signature",
 				})
 				.eq("id", leaseId);
 

--- a/supabase/functions/docuseal/handler.ts
+++ b/supabase/functions/docuseal/handler.ts
@@ -415,7 +415,9 @@ Deno.serve(async (req: Request) => {
 
 			const { data: lease, error: leaseError } = await supabase
 				.from("leases")
-				.select("id, owner_user_id, docuseal_submission_id, tenant_signed_at")
+				.select(
+					"id, owner_user_id, docuseal_submission_id, owner_signed_at, tenant_signed_at",
+				)
 				.eq("id", leaseId)
 				.single();
 
@@ -434,13 +436,22 @@ Deno.serve(async (req: Request) => {
 				});
 			}
 
+			// Idempotent: already signed -> no-op success.
+			if (lease.owner_signed_at) {
+				return new Response(JSON.stringify({ success: true }), {
+					status: 200,
+					headers: getJsonHeaders(req),
+				});
+			}
+
+			// In-app owner signature (direct, IP-captured) -> method 'in_app'
+			// (the DocuSeal webhook records 'docuseal' for email-signed parties).
+			const ownerActivates = Boolean(lease.tenant_signed_at);
 			const updatePayload: Record<string, unknown> = {
 				owner_signed_at: new Date().toISOString(),
-				owner_signature_method: "docuseal",
+				owner_signature_method: "in_app",
 			};
-
-			// If tenant already signed, flip lease to active
-			if (lease.tenant_signed_at) {
+			if (ownerActivates) {
 				updatePayload.lease_status = "active";
 			}
 
@@ -451,6 +462,27 @@ Deno.serve(async (req: Request) => {
 
 			if (updateError) {
 				return errorResponse(req, 500, updateError, { action: "sign_owner" });
+			}
+
+			// If this completed the lease, notify the owner (parity with the webhook
+			// activation path). Best-effort — never fail the signature on notify error.
+			if (ownerActivates) {
+				const { error: notifError } = await supabase
+					.from("notifications")
+					.insert({
+						user_id: lease.owner_user_id,
+						title: "Lease fully signed",
+						message:
+							"Your lease has been signed by all parties and is now active.",
+						notification_type: "lease",
+					});
+				if (notifError) {
+					captureWebhookError(new Error("Owner activation notification failed"), {
+						message: notifError.message,
+						action: "sign_owner_notify",
+						lease_id: leaseId,
+					});
+				}
 			}
 
 			return new Response(JSON.stringify({ success: true }), {


### PR DESCRIPTION
Makes lease e-signature work **start-to-finish** again. The self-hosted DocuSeal on the owner's homelab is down, and the audit found the integration was *also* broken against any **current** DocuSeal (the code targeted an old self-hosted build and the API drifted). This PR fixes all of it; the owner-run Railway re-host steps are in `.planning/esign-railway-migration-runbook.md`.

Every API fix was **verified against DocuSeal's official docs + Node SDK + a real webhook payload** (not guessed).

## Blockers — flow was dead against current DocuSeal
- **B1 send:** inline PDF must POST to `/api/submissions/pdf` (not `/api/submissions`, which requires a `template_id`).
- **B2 send:** `documents[].file` must be **raw base64** — dropped the `data:application/pdf;base64,` prefix that corrupted the PDF.
- **B3 webhook:** current DocuSeal signs `X-Docuseal-Signature: <ts>.<hex>` over `<ts>.<raw_body>` with the raw `whsec_` secret; the old code did plain-HMAC of the body vs the whole header → **every webhook 401'd → leases never activated**. Now verifies the timestamped scheme **and** the legacy plain-hex scheme (works on any DocuSeal version).
- **B4 webhook:** current payloads nest under `data` (`data.submission.id`, `data.role`, `data.submission.metadata`, `data.combined_document_url`); the old flat reads were all `undefined`.

## Majors / minors
- **M1 cancel:** archive is `DELETE /api/submissions/{id}`, not `POST .../archive`.
- **M2 send:** clear **400** when owner/tenant email is missing/invalid (tenant records may lack one).
- **Min1:** stable submitter `external_id` `'owner'`/`'tenant'`, matched in the webhook (role-substring fallback kept).
- **Min2 cancel:** also clear `*_signed_at` / `*_signature_method` / `docuseal_document_url` so a resend can't activate against a stale signature.
- **Min3 resend:** fail loudly on a non-array submitters body.

## Also (the original 2 latent bugs)
- Removed the dead `sign-tenant` action path; `SignLeaseButton` is owner-only.
- `send-for-signature` now sets `lease_status='pending_signature'` (the in-app "Sign as Owner" UI was unreachable).

## Deploy / verify
- Edge-function-only + a planning doc — **no frontend type/runtime change**; `tsc` + `lint` + full unit suite (99,950) pass. Deno isn't installed locally, so the functions are type-checked at `supabase functions deploy` time.
- **Requires** the `docuseal` + `docuseal-webhook` + `generate-pdf` functions **redeployed** after merge, plus the Railway re-host of DocuSeal **and** Stirling PDF (M3 — `generate-pdf` calls Stirling, also on the dead homelab). Full steps + smoke test in the runbook.
- Deferred (noted in runbook): M4 (signed-doc URL freshness), FE polish (signature card on active, Realtime/poll).

[hudsor01]