### PR TITLE
fix(esign): abort in-flight lease preview on dialog close

### DIFF
--- a/src/components/leases/__tests__/send-for-signature-button.test.tsx
+++ b/src/components/leases/__tests__/send-for-signature-button.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * SendForSignatureButton — preview-abort race coverage (issue #853).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "#test/utils/test-render";
+import { SendForSignatureButton } from "../send-for-signature-button";
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockSendForSignature = { mutateAsync: vi.fn(), isPending: false };
+const mockResendSignature = { mutateAsync: vi.fn(), isPending: false };
+vi.mock("#hooks/api/use-lease-signature-mutations", () => ({
+	useSendLeaseForSignatureMutation: () => mockSendForSignature,
+	useResendSignatureRequestMutation: () => mockResendSignature,
+}));
+
+vi.mock("#lib/supabase/client", () => ({
+	createClient: () => ({
+		auth: {
+			getSession: async () => ({
+				data: { session: { access_token: "token" } },
+			}),
+		},
+	}),
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+const openSpy = vi.fn();
+vi.stubGlobal("open", openSpy);
+URL.createObjectURL = vi.fn(() => "blob:mock");
+URL.revokeObjectURL = vi.fn();
+
+/** A promise plus its resolver, so the test controls when the fetch settles. */
+function deferred<T>() {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+const pdfResponse = {
+	ok: true,
+	blob: async () => new Blob(["%PDF"], { type: "application/pdf" }),
+};
+
+describe("SendForSignatureButton preview", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	async function openDialogAndPreview() {
+		render(<SendForSignatureButton leaseId="lease-1" />);
+		fireEvent.click(screen.getByTestId("send-for-signature-button"));
+		const previewBtn = await screen.findByRole("button", {
+			name: /preview pdf/i,
+		});
+		fireEvent.click(previewBtn);
+	}
+
+	it("opens the preview tab when the dialog stays open", async () => {
+		fetchMock.mockResolvedValue(pdfResponse);
+		await openDialogAndPreview();
+
+		await waitFor(() => expect(openSpy).toHaveBeenCalled());
+		expect(openSpy).toHaveBeenCalledWith(
+			"blob:mock",
+			"_blank",
+			"noopener,noreferrer",
+		);
+	});
+
+	it("does NOT open a tab when the dialog is closed before the preview resolves", async () => {
+		const d = deferred<typeof pdfResponse>();
+		fetchMock.mockReturnValue(d.promise);
+		await openDialogAndPreview();
+
+		// Close the dialog mid-fetch (Cancel), then let the fetch resolve.
+		fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+		d.resolve(pdfResponse);
+
+		// Give the resolved chain a tick; window.open must stay un-called.
+		await new Promise((r) => setTimeout(r, 0));
+		expect(openSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/leases/__tests__/send-for-signature-button.test.tsx
+++ b/src/components/leases/__tests__/send-for-signature-button.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "#test/utils/test-render";
 import { SendForSignatureButton } from "../send-for-signature-button";
@@ -37,13 +38,17 @@ vi.stubGlobal("open", openSpy);
 URL.createObjectURL = vi.fn(() => "blob:mock");
 URL.revokeObjectURL = vi.fn();
 
-/** A promise plus its resolver, so the test controls when the fetch settles. */
+/** A promise plus its settlers, so the test controls when the fetch settles. */
 function deferred<T>() {
 	let resolve!: (v: T) => void;
-	const promise = new Promise<T>((r) => {
-		resolve = r;
+	let reject!: (e: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
 	});
-	return { promise, resolve };
+	// Swallow the default unhandled-rejection if a test only rejects.
+	promise.catch(() => {});
+	return { promise, resolve, reject };
 }
 
 const pdfResponse = {
@@ -89,5 +94,20 @@ describe("SendForSignatureButton preview", () => {
 		// Give the resolved chain a tick; window.open must stay un-called.
 		await new Promise((r) => setTimeout(r, 0));
 		expect(openSpy).not.toHaveBeenCalled();
+	});
+
+	it("stays silent (no error toast) when the aborted fetch rejects with AbortError", async () => {
+		const d = deferred<typeof pdfResponse>();
+		fetchMock.mockReturnValue(d.promise);
+		await openDialogAndPreview();
+
+		// Close mid-fetch (aborts the controller), then reject the in-flight fetch
+		// the way a real aborted fetch does — the catch-path guard must stay silent.
+		fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+		d.reject(new DOMException("aborted", "AbortError"));
+
+		await new Promise((r) => setTimeout(r, 0));
+		expect(openSpy).not.toHaveBeenCalled();
+		expect(toast.error).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/leases/send-for-signature-button.tsx
+++ b/src/components/leases/send-for-signature-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FileText, Send } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "#components/ui/button";
 import {
@@ -51,10 +51,14 @@ export function SendForSignatureButton({
 	const [immediateFamilyMembers, setImmediateFamilyMembers] = useState("");
 	const [landlordNoticeAddress, setLandlordNoticeAddress] = useState("");
 	const [isPreviewing, setIsPreviewing] = useState(false);
+	const previewAbortRef = useRef<AbortController | null>(null);
 	const sendForSignature = useSendLeaseForSignatureMutation();
 	const resendSignature = useResendSignatureRequestMutation();
 
 	const isResend = action === "resend";
+
+	// Abort any in-flight preview on unmount.
+	useEffect(() => () => previewAbortRef.current?.abort(), []);
 
 	const handleSend = async () => {
 		try {
@@ -100,10 +104,8 @@ export function SendForSignatureButton({
 						: "The tenant will receive a notification to sign the lease.",
 				},
 			);
-			setOpen(false);
-			setMessage("");
-			setImmediateFamilyMembers("");
-			setLandlordNoticeAddress("");
+			// Close + reset + abort any in-flight preview via the shared handler.
+			handleOpenChange(false);
 		} catch (error) {
 			toast.error(
 				isResend
@@ -118,6 +120,9 @@ export function SendForSignatureButton({
 	};
 
 	const handlePreview = async () => {
+		previewAbortRef.current?.abort();
+		const controller = new AbortController();
+		previewAbortRef.current = controller;
 		try {
 			setIsPreviewing(true);
 			const supabase = createClient();
@@ -134,6 +139,7 @@ export function SendForSignatureButton({
 					"Content-Type": "application/json",
 				},
 				body: JSON.stringify({ action: "preview", leaseId }),
+				signal: controller.signal,
 			});
 
 			if (!response.ok) {
@@ -149,16 +155,23 @@ export function SendForSignatureButton({
 			}
 
 			const blob = await response.blob();
+			// Don't surface a tab if the dialog was closed mid-fetch.
+			if (controller.signal.aborted) return;
 			const url = URL.createObjectURL(blob);
 			window.open(url, "_blank", "noopener,noreferrer");
 			setTimeout(() => URL.revokeObjectURL(url), 60_000);
 		} catch (error) {
+			// An aborted preview (dialog closed) is expected — stay silent.
+			if (controller.signal.aborted) return;
 			toast.error("Failed to preview PDF", {
 				description:
 					error instanceof Error ? error.message : "Please try again.",
 			});
 		} finally {
-			setIsPreviewing(false);
+			if (previewAbortRef.current === controller) {
+				setIsPreviewing(false);
+				previewAbortRef.current = null;
+			}
 		}
 	};
 
@@ -167,6 +180,9 @@ export function SendForSignatureButton({
 		// Reset typed fields when the dialog closes without a successful send so a
 		// later open (possibly on a different lease) doesn't show stale input.
 		if (!next) {
+			// Abort an in-flight preview so its window.open can't surface a stray
+			// PDF tab over the now-dismissed dialog.
+			previewAbortRef.current?.abort();
 			setMessage("");
 			setImmediateFamilyMembers("");
 			setLandlordNoticeAddress("");
@@ -266,7 +282,7 @@ export function SendForSignatureButton({
 					)}
 					<Button
 						variant="outline"
-						onClick={() => setOpen(false)}
+						onClick={() => handleOpenChange(false)}
 						disabled={sendForSignature.isPending || resendSignature.isPending}
 					>
 						Cancel


### PR DESCRIPTION
Resolves item 3 of #853 (P3): a "Preview PDF" fetch in flight could surface a stray PDF tab over an already-dismissed dialog if the user clicked Cancel/Send mid-fetch.

## Fix
- Track the preview with an `AbortController`; abort it whenever the dialog closes (Cancel, Escape, backdrop, post-send) and guard `window.open` on the signal — no tab opens after close. Aborted previews fail silently.
- Route the **Cancel** button and the **post-send close** through `handleOpenChange` (they previously called `setOpen(false)` directly, bypassing the handler — which also silently defeated the earlier field-reset-on-close).
- Tests: preview opens a tab when the dialog stays open; no tab when the dialog is closed before the preview resolves.

Closes #853 (the other two items in that issue are owner-run deploy/ops actions, not code).

[hudsor01]