### PR TITLE
chore(v6.0): resolve Final Canonical Cleanup residuals (RLS test, schema doc, FK index)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v6.0
 milestone_name: Final Canonical Cleanup
-status: planning
-last_updated: "2026-06-15T03:31:09.911Z"
-last_activity: 2026-06-15
+status: verifying
+last_updated: "2026-06-19T00:00:00.000Z"
+last_activity: 2026-06-19
 progress:
   total_phases: 5
-  completed_phases: 0
+  completed_phases: 5
   total_plans: 0
   completed_plans: 0
-  percent: 0
+  percent: 100
 ---
 
 # Project State
@@ -20,14 +20,14 @@ progress:
 See: .planning/PROJECT.md
 
 **Core value (v6.0):** The codebase is canonical to the current product — every surface, type, and DB object maps to what TenantFlow actually does (landlord-only; tenants are records, not users; billing is the landlord Stripe subscription). No surface promises a demolished feature. The last milestone before the project is considered fully complete.
-**Current focus:** v6.0 roadmap created (phases 15-19, 24 requirements). Next: `/gsd-plan-phase 15`. Grounded in `.planning/repo-audit/v6.0-LEGACY-AUDIT.md`.
+**Current focus:** v6.0 findings RESOLVED. A 2026-06-19 verification pass confirmed every audit finding (Connect UI/types, rent-facilitation types, tenant-as-user schemas, screening provider, dead DB column/RPC/config, `tenants.user_id`) was already implemented — folded into PR #841 + the e-sign rebuild + migrations `20260616040851`/`20260616161248`. The exhaustive re-sweep surfaced 4 residuals the audit missed (broken RLS pgTAP test, stale `SCHEMA.md`, unindexed `lease_signing_tokens.created_by` FK, stale test wording) — fixed on branch `chore/v6.0-canonical-cleanup`.
 
 ## Current Position
 
-Phase: Not started (roadmap defined — ready to plan Phase 15)
+Phase: All audit findings resolved (phases 15-18 work shipped in prior PRs; phase 19 fallow trim deferred/opt-in)
 Plan: —
-Status: Roadmap created (5 phases / 24 requirements)
-Last activity: 2026-06-15 — Milestone v6.0 started; forensic legacy audit + requirements + roadmap authored
+Status: Verifying — canonical-cleanup PR open
+Last activity: 2026-06-19 — Verified the full v6.0 legacy audit is already implemented; fixed 4 missed residuals (RLS test, SCHEMA.md, FK index, test wording). Remaining: opt-in fallow trim (~415 exports, mostly KEEP-CONTRACT) is explicitly deferred.
 
 ## Roadmap Summary (v6.0)
 
@@ -54,13 +54,9 @@ None. 5 INVESTIGATE items (lease-activation Connect gating RPC, `get_user_profil
 
 ## Next Action
 
-**v6.0 roadmap defined.** Plan the first phase:
+**v6.0 audit findings are resolved.** The product-boundary cleanup (Connect surfaces, rent/Connect/tenant-portal types, screening provider, dead DB column/RPC/`tenants.user_id`/app_config rows) was already implemented and verified against prod + the codebase on 2026-06-19; the 4 missed residuals are fixed in the open `chore/v6.0-canonical-cleanup` PR.
 
-```
-/gsd-plan-phase 15
-```
-
-Phase 15 = Connect + Rent-Facilitation Surface & Type Removal — the highest-value cluster: remove the 3 live customer-facing surfaces that promise demolished features (the `/profile` "receive payments from tenants" card, the `/financials` "Payouts" dead-link, the onboarding "payouts / invite tenant" copy) + every zero-consumer Connect/rent contract type.
+Optional remaining work (was Phase 19, explicitly deferred/opt-in): the fallow dead-code trim — currently ~415 unused exports/types, but ~111 are intentional KEEP-CONTRACT surface and many are framework/Deno false-positives, so a blind `fallow fix` is unsafe. Run as a separate, gated, per-item sweep if desired; otherwise close the milestone via `/gsd-complete-milestone v6.0`.
 
 ## Overrides
 

--- a/supabase/SCHEMA.md
+++ b/supabase/SCHEMA.md
@@ -1,679 +1,181 @@
 # TenantFlow Database Schema
 
 > **AI/Human-Readable Schema Reference**
-> Last updated: December 2024 | 63+ migrations | 30+ tables | 30+ RPC functions | 200+ RLS policies
+> Last updated: June 2026 | 230+ migrations | 48 public tables + `stripe` FDW | RLS on every table
+>
+> **Source of truth for columns/types is the generated `src/types/supabase.ts`** (run `bun run db:types`).
+> This document is a stable, hand-maintained *overview*; it deliberately does NOT enumerate every
+> column (those drift per migration). Verify exact columns against `supabase.ts` or the live DB
+> (Supabase MCP `list_tables` / `execute_sql`), never against a hand-written snapshot.
 
-## Quick Reference
+## Product Shape (read this first)
+
+TenantFlow is a **landlord-only** property-management SaaS. Tenants are **records the landlord
+manages, never user accounts** — there is no tenant portal, tenant auth, tenant login, or tenant
+invitation flow. The platform does **not** facilitate rent payments and has **no Stripe Connect /
+marketplace / payouts**. The only billing is the **landlord's own Stripe subscription** (denormalized
+onto `public.users.subscription_*`). The pre-pivot rent-facilitation + tenant-portal tables were
+demolished in `20260418183608_demolish_rent_and_tenant_portal.sql` and follow-ups; the dead Connect /
+`tenants.user_id` columns were dropped in `20260616040851` + `20260616161248`.
+
+## Conventions (stable invariants)
+
+| Convention | Rule |
+|-----------|------|
+| Owner column | `owner_user_id uuid` (references `users.id`) on `properties`, `units`, `tenants`, `leases`, `maintenance_requests`, `documents`, `inspections`, `vendors`, … — NOT `property_owner_id` |
+| Admin flag | `users.is_admin boolean` (the legacy `user_type` was migrated out) |
+| Enums | **No PostgreSQL ENUMs** — value sets are `text` columns with `CHECK` constraints |
+| Money | `amount` columns store **dollars** as `numeric(10,2)`; convert to cents only at the Stripe API boundary |
+| Soft delete | `properties.status = 'inactive'` (filter `.neq('status','inactive')`); `expenses` also soft-delete via `status` |
+| RLS | Enabled on **every** table; owner-scoped via `owner_user_id = (select auth.uid())`. `service_role` bypasses RLS for backend/Edge-Function work |
+| `updated_at` | maintained by the single `set_updated_at()` trigger function |
+
+## Quick Reference — Schemas
 
 | Schema | Purpose | Managed By |
 |--------|---------|------------|
-| `public` | Main application data | You |
-| `stripe` | Stripe sync (read-only mirror) | Stripe webhook sync |
+| `public` | Main application data (48 tables) | You (migrations) |
+| `stripe` | **Read-only Foreign Data Wrapper** (24 foreign tables proxying live Stripe API via the `wrappers` extension + vault-stored key — see `20260528223442_install_stripe_wrapper.sql`). Never write here; mutations go through the Stripe API in Edge Functions. | Stripe FDW |
 | `auth` | Users, sessions, tokens | Supabase Auth |
 | `storage` | File buckets, objects | Supabase Storage |
 
 ---
 
-## Core Domain Model
+## Public Schema Tables (by domain)
 
-```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│  users (auth)   │     │ property_owners │     │   properties    │
-│  ─────────────  │     │ ─────────────── │     │ ─────────────── │
-│  id (uuid, PK)  │◄────│ user_id (FK)    │◄────│ property_owner  │
-│  email          │     │ stripe_account  │     │ _id (FK)        │
-│  is_admin       │     │ business_name   │     │ name, address   │
-└─────────────────┘     └─────────────────┘     └────────┬────────┘
-                                                         │
-                        ┌────────────────────────────────┤
-                        ▼                                ▼
-              ┌─────────────────┐              ┌─────────────────┐
-              │     units       │              │ property_images │
-              │ ─────────────── │              │ ─────────────── │
-              │ property_id(FK) │              │ property_id(FK) │
-              │ unit_number     │              │ image_url       │
-              │ rent_amount     │              └─────────────────┘
-              │ status          │
-              └────────┬────────┘
-                       │
-        ┌──────────────┼──────────────┐
-        ▼              ▼              ▼
-┌───────────────┐ ┌──────────┐ ┌─────────────────────┐
-│    leases     │ │ rent_due │ │ tenant_invitations  │
-│ ───────────── │ │ ──────── │ │ ─────────────────── │
-│ unit_id (FK)  │ │ unit_id  │ │ unit_id (FK)        │
-│ tenant_id(FK) │ │ lease_id │ │ email               │
-│ start_date    │ │ due_date │ │ invitation_code     │
-│ end_date      │ │ amount   │ │ accepted_by_user_id │
-│ rent_amount   │ └──────────┘ └─────────────────────┘
-│ lease_status  │
-└───────┬───────┘
-        │
-        ├──────────────┬─────────────────┐
-        ▼              ▼                 ▼
-┌───────────────┐ ┌──────────────┐ ┌─────────────────────┐
-│ lease_tenants │ │rent_payments │ │maintenance_requests │
-│ ───────────── │ │ ──────────── │ │ ─────────────────── │
-│ lease_id (FK) │ │ lease_id(FK) │ │ unit_id (FK)        │
-│ tenant_id(FK) │ │ tenant_id    │ │ tenant_id (FK)      │
-│ is_primary    │ │ amount       │ │ status, priority    │
-└───────────────┘ │ status       │ │ description         │
-                  │ due_date     │ └─────────────────────┘
-                  └──────────────┘
-```
+> Exact columns: see `src/types/supabase.ts`. Each table below carries owner-scoped RLS unless noted.
 
----
+### Identity & billing
+- `users` — central user (synced from `auth.users`). Carries `is_admin` + the denormalized billing
+  fields `stripe_customer_id`, `subscription_status`, `subscription_id`, `subscription_plan`,
+  `subscription_current_period_end`, `subscription_cancel_at_period_end`, `subscription_source`,
+  `trial_ends_at`. Subscription status reads from here directly.
+- `user_preferences`, `notification_settings`, `user_tour_progress`, `user_feature_access`
 
-## Public Schema Tables
+### Properties & units
+- `properties` (soft-delete via `status`), `units`, `property_images`
 
-### Core Entities
+### Tenants & leases
+- `tenants` — **records, not users**: contact + emergency-contact fields, `status`. No `user_id`.
+- `leases` — `lease_status ∈ {draft, pending_signature, active, ended, terminated, expired}`;
+  e-signature columns (`owner/tenant_signed_at`, `*_signature_ip/_user_agent/_method`,
+  `tenant_signature_name`, `*_signature_consent_at`, `signed_document_path/hash`,
+  `landlord_notice_address`, `immediate_family_members`).
+- `lease_tenants` (owner-scoped via the `leases` join), `lease_signing_tokens` (single-use SHA-256
+  token hashes for tenant magic-link signing; service-role write only), `lease_reminders`
 
-#### `users`
-Central user table (synced from auth.users via trigger).
+### Maintenance & vendors
+- `maintenance_requests`, `maintenance_request_photos`, `vendors`, `expenses`
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | Matches auth.users.id |
-| `email` | text | User email |
-| `full_name` | text | Display name |
-| `first_name` | text | First name |
-| `last_name` | text | Last name |
-| `phone` | text | Phone number |
-| `is_admin` | boolean | Admin flag (landlord-only: everyone else is an owner) |
-| `stripe_customer_id` | text | Stripe customer for billing |
-| `status` | text | `active`, `inactive`, `suspended` |
-| `avatar_url` | text | Profile image URL |
-| `onboarding_status` | text | `not_started`, `in_progress`, `completed` |
+### Inspections
+- `inspections`, `inspection_rooms`, `inspection_photos`
 
-#### `property_owners`
-Stripe Connect account for property owners (1:1 with users).
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid (FK → users) | Owner's user ID |
-| `stripe_account_id` | text | Stripe Connect account `acct_xxx` |
-| `business_name` | text | Business display name |
-| `business_type` | text | `individual`, `company` |
-| `charges_enabled` | boolean | Can receive payments |
-| `payouts_enabled` | boolean | Can receive payouts |
-| `onboarding_status` | text | Connect onboarding status |
-
-#### `properties`
-Rental properties owned by property owners.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `property_owner_id` | uuid (FK → users) | Owner's user ID |
-| `name` | text | Property name |
-| `address_line1` | text | Street address |
-| `address_line2` | text | Apt/Suite (optional) |
-| `city`, `state`, `postal_code` | text | Location |
-| `country` | text | Default `US` |
-| `property_type` | text | `single_family`, `multi_family`, etc. |
-| `status` | text | `active`, `inactive`, `sold` |
-
-**Relationships**: Has many `units`, `property_images`, `tenant_invitations`
-
-#### `units`
-Individual rental units within properties.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `property_id` | uuid (FK → properties) | Parent property |
-| `property_owner_id` | uuid (FK → users) | Denormalized for RLS |
-| `unit_number` | text | Unit identifier (e.g., "101", "A") |
-| `bedrooms` | integer | Number of bedrooms |
-| `bathrooms` | numeric(3,1) | Number of bathrooms |
-| `square_feet` | integer | Unit size |
-| `rent_amount` | integer | Monthly rent in cents |
-| `status` | text | `available`, `occupied`, `maintenance` |
-
-**Relationships**: Has many `leases`, `maintenance_requests`, `rent_due`
-
-#### `tenants`
-Tenant profile (extends user with tenant-specific data).
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid (FK → users) | Tenant's user account |
-| `date_of_birth` | date | DOB for verification |
-| `ssn_last_four` | text | Last 4 of SSN (encrypted) |
-| `identity_verified` | boolean | ID verification status |
-| `emergency_contact_name` | text | Emergency contact |
-| `emergency_contact_phone` | text | Emergency phone |
-| `emergency_contact_relationship` | text | Relationship |
-
-**Relationships**: Has many `leases` (via `lease_tenants`), `rent_payments`, `maintenance_requests`
-
-#### `leases`
-Rental agreements between owners and tenants.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `unit_id` | uuid (FK → units) | Leased unit |
-| `primary_tenant_id` | uuid (FK → tenants) | Primary tenant |
-| `property_owner_id` | uuid (FK → users) | Owner (denormalized) |
-| `start_date` | date | Lease start |
-| `end_date` | date | Lease end |
-| `rent_amount` | integer | Monthly rent (cents) |
-| `security_deposit` | integer | Deposit amount (cents) |
-| `payment_day` | integer | Day of month rent is due (1-28) |
-| `late_fee_amount` | integer | Late fee (cents) |
-| `late_fee_days` | integer | Days before late fee applies |
-| `lease_status` | text | `pending`, `active`, `ended`, `terminated` |
-| `stripe_subscription_id` | text | For recurring payments |
-| `auto_pay_enabled` | boolean | Autopay status |
-
-**Relationships**: Has many `lease_tenants`, `rent_payments`
-
-#### `lease_tenants`
-Join table for multiple tenants on a lease.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `lease_id` | uuid (FK → leases) | Parent lease |
-| `tenant_id` | uuid (FK → tenants) | Tenant on lease |
-| `is_primary` | boolean | Primary tenant flag |
-| `responsibility_percentage` | integer | Rent split (default 100) |
-
-### Payments & Billing
-
-#### `rent_payments`
-Individual rent payment records.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `lease_id` | uuid (FK → leases) | Associated lease |
-| `tenant_id` | uuid (FK → tenants) | Paying tenant |
-| `stripe_payment_intent_id` | text | Stripe PI `pi_xxx` |
-| `amount` | integer | Payment amount (cents) |
-| `status` | text | `pending`, `processing`, `succeeded`, `failed`, `canceled` |
-| `payment_method_type` | text | `card`, `bank_account`, etc. |
-| `period_start` | date | Billing period start |
-| `period_end` | date | Billing period end |
-| `due_date` | date | When payment was due |
-| `paid_date` | timestamptz | When payment succeeded |
-| `late_fee_amount` | integer | Late fee applied (cents) |
-| `application_fee_amount` | integer | Platform fee (cents) |
-
-#### `payment_methods`
-Saved payment methods for tenants.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `tenant_id` | uuid (FK → tenants) | Owner of method |
-| `stripe_payment_method_id` | text | Stripe PM `pm_xxx` |
-| `type` | text | `card`, `bank_account`, `ach`, `sepa_debit` |
-| `last_four` | text | Last 4 digits |
-| `brand` | text | Card brand (Visa, etc.) |
-| `is_default` | boolean | Default payment method |
-
-#### `payment_transactions`
-Transaction attempts for payments.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `rent_payment_id` | uuid (FK → rent_payments) | Parent payment |
-| `payment_method_id` | uuid (FK → payment_methods) | Method used |
-| `stripe_payment_intent_id` | text | Stripe PI |
-| `status` | text | `pending`, `processing`, `succeeded`, `failed`, `canceled` |
-| `amount` | integer | Amount attempted (cents) |
-| `failure_reason` | text | Error message if failed |
-| `retry_count` | integer | Number of retries |
-
-### Maintenance
-
-#### `maintenance_requests`
-Maintenance tickets from tenants.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `unit_id` | uuid (FK → units) | Affected unit |
-| `tenant_id` | uuid (FK → tenants) | Requesting tenant |
-| `property_owner_id` | uuid (FK → users) | Owner (denormalized) |
-| `title` | text | Request title |
-| `description` | text | Issue description |
-| `status` | text | `open`, `in_progress`, `completed`, `cancelled` |
-| `priority` | text | `urgent`, `high`, `normal`, `low` |
-| `assigned_to` | uuid | Assigned contractor/staff |
-| `scheduled_date` | date | Scheduled repair date |
-| `completed_at` | timestamptz | Completion timestamp |
-| `estimated_cost` | integer | Estimated cost (cents) |
-| `actual_cost` | integer | Final cost (cents) |
-
-#### `expenses`
-Expenses related to maintenance.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `maintenance_request_id` | uuid (FK) | Related request |
-| `vendor_name` | text | Vendor/contractor |
-| `amount` | integer | Cost (cents) |
-| `expense_date` | date | Date of expense |
-
-### Invitations & Onboarding
-
-#### `tenant_invitations`
-Invitations sent to potential tenants.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `email` | text | Invitee email |
-| `unit_id` | uuid (FK → units) | Target unit |
-| `property_owner_id` | uuid (FK → users) | Inviting owner |
-| `invitation_code` | text | Unique code |
-| `invitation_url` | text | Accept link |
-| `status` | text | `pending`, `accepted`, `expired` |
-| `expires_at` | timestamptz | Expiration time |
-| `accepted_at` | timestamptz | When accepted |
-| `accepted_by_user_id` | uuid | User who accepted |
-
-### Documents & Storage
-
-#### `documents`
-File attachments for entities.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `entity_type` | text | `lease`, `property`, `tenant`, etc. |
-| `entity_id` | uuid | ID of parent entity |
-| `document_type` | text | CHECK-enforced enum: `lease`, `receipt`, `tax_return`, `inspection_report`, `maintenance_invoice`, `insurance`, `other`. Default `'other'`. |
-| `file_path` | text | Storage path |
-| `storage_url` | text | Public/signed URL |
-| `file_size` | integer | Size in bytes |
-
-#### `property_images`
-Images for properties.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `property_id` | uuid (FK → properties) | Parent property |
-| `image_url` | text | Image URL |
-| `display_order` | integer | Sort order |
+### Documents
+- `documents` — `document_type` is a soft FK to `document_categories.slug`, validated by the
+  `validate_document_category` trigger (the Phase-61 CHECK was dropped).
+- `document_categories` (per-owner taxonomy), `document_template_definitions`
 
 ### Notifications
+- `notifications`, `notification_logs`
 
-#### `notifications`
-In-app notifications for users.
+### Analytics, reporting & onboarding
+- `reports`, `report_runs`, `activity`, `onboarding_funnel_events`, `gate_events` (paid-feature gate hits)
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid (FK → users) | Recipient |
-| `notification_type` | text | Type code |
-| `title` | text | Notification title |
-| `message` | text | Body text |
-| `is_read` | boolean | Read status |
-| `action_url` | text | Link to action |
+### Blog / AI content engine
+- `blogs`, `blog_rag_chunks`
 
-#### `notification_logs`
-Delivery tracking for notifications.
+### Email deliverability
+- `email_deliverability` (+ `email_deliverability_archive`), `email_suppressions`
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `notification_id` | uuid (FK) | Parent notification |
-| `status` | text | `pending`, `sent`, `failed`, `bounced` |
-| `delivery_channel` | text | `email`, `sms`, `in_app`, `push` |
-| `attempt_count` | integer | Delivery attempts |
+### Webhooks & event processing
+- `webhook_events`, `webhook_attempts`, `webhook_metrics`, `processed_internal_events`,
+  `stripe_webhook_events` (+ `stripe_webhook_events_archive`, 90d/180d retention)
 
-### Analytics & Reporting
+### Security & audit (service-role / admin)
+- `security_events` (+ `security_events_archive`, 90d), `security_audit_log`, `user_access_log`,
+  `user_errors` (+ `user_errors_archive`, 90d)
 
-#### `reports`
-Saved report configurations.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `property_owner_id` | uuid (FK) | Report owner |
-| `report_type` | text | Report type code |
-| `title` | text | Report name |
-| `schedule_cron` | text | Cron schedule (if recurring) |
-| `is_active` | boolean | Active status |
-
-#### `report_runs`
-Execution history for reports.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `report_id` | uuid (FK) | Parent report |
-| `execution_status` | text | `pending`, `running`, `completed`, `failed` |
-| `file_path` | text | Output file path |
-| `execution_time_ms` | integer | Run time |
-
-#### `activity`
-Activity feed for dashboard.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid | Actor |
-| `activity_type` | text | Type code |
-| `entity_type` | text | Related entity type |
-| `entity_id` | uuid | Related entity ID |
-| `title` | text | Activity title |
-| `description` | text | Details |
-
-### Webhooks & Events
-
-#### `webhook_events`
-Incoming webhook payloads.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `webhook_source` | text | `stripe`, `auth`, `custom` |
-| `event_type` | text | Event type code |
-| `external_id` | text | External event ID (for idempotency) |
-| `raw_payload` | jsonb | Full payload |
-| `processed_at` | timestamptz | When processed |
-
-#### `webhook_attempts`
-Processing attempts for webhooks.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `webhook_event_id` | uuid (FK) | Parent event |
-| `status` | text | `pending`, `processing`, `succeeded`, `failed` |
-| `retry_count` | integer | Attempt number |
-| `failure_reason` | text | Error message |
-
-### Security & Audit
-
-#### `security_audit_log`
-Security event log.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid | Actor |
-| `event_type` | text | `login`, `logout`, `password_change`, etc. |
-| `entity_type` | text | Affected entity type |
-| `entity_id` | uuid | Affected entity ID |
-| `details` | jsonb | Event details |
-
-#### `user_access_log`
-API access log.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid | Actor |
-| `endpoint` | text | API endpoint |
-| `method` | text | HTTP method |
-| `status_code` | integer | Response status |
-| `ip_address` | text | Client IP |
-
-### User Settings
-
-#### `user_preferences`
-User settings and preferences.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid (FK) | Owner |
-| `theme` | text | `light`, `dark` |
-| `language` | text | Locale code |
-| `timezone` | text | IANA timezone |
-| `notifications_enabled` | boolean | Global notification toggle |
-
-#### `subscriptions`
-Platform subscriptions (owner billing).
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | uuid (PK) | |
-| `user_id` | uuid (FK) | Subscriber |
-| `stripe_subscription_id` | text | Stripe sub `sub_xxx` |
-| `stripe_customer_id` | text | Stripe customer |
-| `status` | text | `active`, `canceled`, `past_due`, `trialing` |
-| `current_period_start` | timestamptz | Billing period start |
-| `current_period_end` | timestamptz | Billing period end |
+### Config
+- `app_config` — keyed config (e.g. n8n webhook URLs)
 
 ---
 
-## Stripe Schema (Read-Only Mirror)
+## RPC Functions (selected; SECURITY DEFINER + `search_path=public`)
 
-The `stripe` schema contains tables synced from Stripe via webhooks. **Do not write directly** - data is managed by Stripe webhook handlers.
+> Full set: grep `CREATE OR REPLACE FUNCTION` in `supabase/migrations/`.
 
-### Key Tables
+### Lease e-signature (service_role only)
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `record_lease_signature(p_lease_id, p_signature_ip, p_signature_user_agent, p_signed_at, p_method)` | `TABLE(success, both_signed, error_message)` | Owner in-app signature; **durably** flips `lease_status → active` + inserts the owner notification atomically when both parties have signed. |
+| `sign_lease_with_token(p_token_hash, p_signature_ip, p_signature_user_agent, p_signed_at, p_signer_name)` | `TABLE(success, both_signed, lease_id, error_message)` | Tenant token-based signature; same durable activation. Rebinds to the lease's current primary-tenant email (`tenant_changed` on mismatch). |
+| `get_lease_signing_context(p_token_hash)` | `TABLE(valid, reason, lease_id, …)` | Read-only render context for the public `/sign/[token]` page. |
 
-| Table | Purpose |
-|-------|---------|
-| `stripe.customers` | Stripe Customer objects |
-| `stripe.subscriptions` | Stripe Subscription objects |
-| `stripe.invoices` | Stripe Invoice objects |
-| `stripe.payment_intents` | Stripe PaymentIntent objects |
-| `stripe.payment_methods` | Stripe PaymentMethod objects |
-| `stripe.charges` | Stripe Charge objects |
-| `stripe.products` | Stripe Product catalog |
-| `stripe.prices` | Stripe Price objects |
-| `stripe.events` | Raw Stripe events (for debugging) |
+### Dashboard, analytics & stats
+`get_dashboard_stats`, `get_dashboard_time_series`, consolidated stats RPCs
+(`get_maintenance_stats`, `get_lease_stats`, etc.), `get_*_trends_optimized`,
+`get_property_performance_*`. Admin-only RPCs gate on `is_admin()`.
 
----
+### User, auth & billing
+`is_admin`, `get_current_owner_user_id`, `get_user_profile`, `check_user_feature_access`,
+`get_user_plan_limits`, `get_subscription_status`, `get_user_invoices` (reads `stripe.invoices`
+through the FDW).
 
-## RPC Functions
-
-### Dashboard & Analytics
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `get_dashboard_stats` | `p_user_id uuid` | `json` | Comprehensive dashboard stats (properties, tenants, units, leases, maintenance, revenue) |
-| `get_dashboard_time_series` | `p_user_id uuid, p_metric_name text, p_days int` | `jsonb` | Time-series data for dashboard charts |
-| `get_billing_insights` | `owner_id uuid, start_date timestamp, end_date timestamp` | `jsonb` | Revenue, churn rate, MRR |
-| `get_maintenance_analytics` | `user_id uuid` | `jsonb` | Maintenance metrics (resolution time, completion rate) |
-| `get_occupancy_trends_optimized` | `p_user_id uuid, p_months int` | `jsonb` | Monthly occupancy trends |
-| `get_revenue_trends_optimized` | `p_user_id uuid, p_months int` | `jsonb` | Monthly revenue trends |
-| `get_property_performance_cached` | `p_user_id uuid` | `jsonb` | Property performance with caching |
-| `get_property_performance_trends` | `p_user_id uuid` | `jsonb` | Property performance over time |
-| `get_metric_trend` | `p_user_id uuid, p_metric_name text, p_period text` | `jsonb` | Generic metric trend calculation |
-
-### Lease Management
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `record_lease_signature` | `p_lease_id uuid, p_signature_ip text, p_signature_user_agent text, p_signed_at timestamptz, p_method text` | `TABLE(success bool, both_signed bool, error_message text)` | Owner in-app signature; durably flips to active + notifies when both signed (service_role only) |
-| `sign_lease_with_token` | `p_token_hash text, p_signature_ip text, p_signature_user_agent text, p_signed_at timestamptz, p_signer_name text` | `TABLE(success bool, both_signed bool, lease_id uuid, error_message text)` | Tenant token-based signature; durably flips to active + notifies when both signed (service_role only) |
-| `get_lease_signing_context` | `p_token_hash text` | `TABLE(valid bool, reason text, lease_id uuid, ...)` | Read-only render context for the public /sign/[token] page (service_role only) |
-| `activate_lease_with_pending_subscription` | `p_lease_id uuid` | `TABLE(success bool, error_message text)` | Activate lease after both parties sign |
-| `assert_can_create_lease` | `p_unit_id uuid, p_start_date date, p_end_date date` | `void` | Validate lease creation (throws on conflict) |
-
-### Tenant Queries
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `get_tenants_by_owner` | `p_user_id uuid` | `SETOF uuid` | Get tenant IDs for properties owned by user |
-| `get_tenants_with_lease_by_owner` | `p_user_id uuid` | `SETOF uuid` | Get tenant IDs with active leases for owner |
-| `get_tenant_accessible_lease_ids` | `p_user_id uuid` | `SETOF uuid` | Lease IDs accessible to tenant |
-| `get_owner_accessible_lease_tenant_ids` | `p_user_id uuid` | `SETOF uuid` | Lease-tenant IDs accessible to owner |
-
-### User & Auth
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `is_admin` | - | `boolean` | Reads is_admin from public.users via auth.uid() |
-| `get_current_property_owner_id` | - | `uuid` | Get current user's property_owner ID |
-| `get_user_profile` | `p_user_id text` | varies | Get user profile data |
-| `custom_access_token_hook` | `event jsonb` | `jsonb` | No-op (disabled post landlord-only pivot) |
-| `check_user_feature_access` | `p_user_id text, p_feature text` | `boolean` | Feature access check |
-| `get_user_plan_limits` | `p_user_id text` | `TABLE(...)` | Subscription plan limits |
-
-### Payment Processing
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `upsert_rent_payment` | varies | varies | Create or update rent payment |
-| `record_processed_stripe_event_lock` | `p_stripe_event_id text` | `TABLE(success bool)` | Idempotent event processing |
-
-### Webhook & Event Processing
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `acquire_webhook_event_lock` | varies | varies | Distributed lock for webhook processing |
-| `acquire_webhook_event_lock_with_id` | varies | varies | Lock with specific ID |
-| `acquire_internal_event_lock` | varies | varies | Internal event processing lock |
-| `cleanup_old_internal_events` | - | varies | Cleanup old events |
-
-### Health & Monitoring
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `health_check` | - | `jsonb` | Database health check |
-| `get_slow_rls_queries` | - | varies | Performance monitoring |
-| `get_common_errors` | - | varies | Error aggregation |
-| `log_user_error` | varies | varies | Error logging |
+### Webhook & event processing
+`acquire_webhook_event_lock*`, `acquire_internal_event_lock`, `record_processed_stripe_event_lock`,
+`cleanup_old_internal_events`.
 
 ---
 
-## CHECK-Constrained Text Values
+## CHECK-Constrained Text Values (examples)
 
-Per the "No PostgreSQL ENUMs" rule, value sets are enforced via `CHECK`
-constraints on `text` columns (not enum types).
+Per the "No PostgreSQL ENUMs" rule, value sets are enforced via `CHECK` constraints on `text` columns.
 
 | Column | Allowed values |
 |--------|----------------|
-| `leases.owner_signature_method` / `leases.tenant_signature_method` | `in_app` |
-
----
-
-## Key Indexes
-
-Performance-critical indexes (created in migrations):
-
-```sql
--- RLS performance indexes
-CREATE INDEX idx_properties_owner ON properties(property_owner_id);
-CREATE INDEX idx_units_property ON units(property_id);
-CREATE INDEX idx_units_owner ON units(property_owner_id);
-CREATE INDEX idx_leases_unit ON leases(unit_id);
-CREATE INDEX idx_leases_tenant ON leases(primary_tenant_id);
-CREATE INDEX idx_leases_owner ON leases(property_owner_id);
-CREATE INDEX idx_maintenance_unit ON maintenance_requests(unit_id);
-CREATE INDEX idx_maintenance_owner ON maintenance_requests(property_owner_id);
-CREATE INDEX idx_rent_payments_lease ON rent_payments(lease_id);
-CREATE INDEX idx_rent_payments_tenant ON rent_payments(tenant_id);
-
--- Webhook idempotency
-CREATE UNIQUE INDEX idx_webhook_events_external ON webhook_events(webhook_source, external_id);
-```
+| `leases.lease_status` | `draft`, `pending_signature`, `active`, `ended`, `terminated`, `expired` |
+| `leases.owner_signature_method` / `tenant_signature_method` | `in_app` |
+| `properties.status` | `active`, `inactive`, `sold` |
+| `tenants.status` | `active`, `inactive`, `pending`, `moved_out` |
+| `units.status` | `available`, `occupied`, `maintenance`, `reserved` |
 
 ---
 
 ## RLS Policy Summary
 
-All tables have Row Level Security enabled. Key patterns:
+Every table has RLS enabled. One policy per operation per role (never `FOR ALL` on authenticated tables).
 
-### Owner Access
 ```sql
--- Owners see their own properties
-USING ((select auth.uid()) = property_owner_id)
+-- Owner access (the universal pattern)
+USING (owner_user_id = (select auth.uid()))
 ```
 
-### Tenant Access
-```sql
--- Tenants see leases they're on
-USING (
-  id IN (
-    SELECT lease_id FROM lease_tenants lt
-    JOIN tenants t ON t.id = lt.tenant_id
-    WHERE t.user_id = (select auth.uid())
-  )
-)
-```
-
-### Service Role Bypass
-Service role (`service_role`) bypasses all RLS for backend operations.
+- Child tables (`lease_tenants`, `inspection_*`, `maintenance_request_photos`, …) are owner-scoped
+  via a join to their parent.
+- `service_role` bypasses RLS for Edge-Function / backend work.
+- Helper functions: `get_current_owner_user_id()`, `is_admin()`. `auth.uid()` is always wrapped in a
+  subselect for performance.
 
 ---
 
-## Storage Buckets
+## Storage
 
-| Bucket | Purpose | Public |
-|--------|---------|--------|
-| `property-images` | Property photos | Yes |
-| `profile-avatars` | User avatars | Yes |
-| `documents` | General documents | No |
+Lease PDFs: the finalized **signed** lease PDF is rendered by the signing flow (pdf-lib) and stored at
+`tenant-documents/lease/<lease_id>/signed-lease.pdf` (+ a sha256 pointer on the lease). The *unsigned*
+preview is streamed in-memory and never persisted. The legacy `lease-documents` bucket was demolished
+(PR #677, 2026-05-07).
 
-> **Note:** Lease PDFs are NOT stored in Supabase Storage. The `generate-pdf` Edge Function streams them to the caller in-memory; no persistence step. The previously-documented `lease-documents` bucket policies were demolished in PR #677 (2026-05-07); the bucket itself was deleted out-of-band before that PR (Supabase's `storage.protect_delete()` trigger blocks `DELETE FROM storage.buckets`, so the migration cannot reproduce the bucket deletion). See `supabase/migrations/20251110160000_create_lease_documents_bucket.sql` for the full audit trail.
-
----
-
-## Common Query Patterns
-
-### Get owner's properties with units
-```sql
-SELECT p.*,
-  (SELECT json_agg(u) FROM units u WHERE u.property_id = p.id) as units
-FROM properties p
-WHERE p.property_owner_id = auth.uid();
-```
-
-### Get tenant's active lease with unit/property
-```sql
-SELECT l.*,
-  u.unit_number, u.rent_amount,
-  p.name as property_name, p.address_line1
-FROM leases l
-JOIN units u ON u.id = l.unit_id
-JOIN properties p ON p.id = u.property_id
-JOIN lease_tenants lt ON lt.lease_id = l.id
-JOIN tenants t ON t.id = lt.tenant_id
-WHERE t.user_id = auth.uid()
-AND l.lease_status = 'active';
-```
-
-### Get overdue payments
-```sql
-SELECT rp.*, t.id as tenant_id, u.first_name, u.last_name
-FROM rent_payments rp
-JOIN tenants t ON t.id = rp.tenant_id
-JOIN users u ON u.id = t.user_id
-WHERE rp.status = 'pending'
-AND rp.due_date < CURRENT_DATE;
-```
-
----
-
-## Migrations
-
-63 migrations in `supabase/migrations/`. Key ones:
-
-| Migration | Description |
-|-----------|-------------|
-| `20251101000000_base_schema.sql` | Initial schema (125KB) |
-| `20251128100000_separate_tenant_invitation_from_lease.sql` | Tenant invitation refactor |
-| `20251128110000_sign_lease_atomic.sql` | Atomic lease signing RPC |
-| `20251202200000_webhook_idempotency_atomic.sql` | Webhook deduplication |
-| `20251223200000_database_optimization_suite.sql` | Performance indexes |
-| `20251225130000_optimize_rpc_functions.sql` | RPC optimization |
-| `20251225140000_add_financial_analytics_functions.sql` | Analytics RPCs |
-| `20251225182240_fix_rls_policy_security_and_performance.sql` | RLS optimization |
+For the live bucket list, use Supabase MCP `list_storage_buckets`. Storage objects cannot be deleted
+via SQL (`storage.protect_delete()` trigger) — use the Storage API.
 
 ---
 
 ## Updating This Document
 
-After schema changes:
-```bash
-# Regenerate TypeScript types
-bun run db:types
+This is a stable overview — update it only when a **domain** or **convention** changes (a new table
+group, a renamed owner column, a new top-level RPC family). For day-to-day column accuracy, regenerate
+and trust the types:
 
-# Review migration and update this document
+```bash
+bun run db:types   # regenerates src/types/supabase.ts (the column source of truth)
 ```

--- a/supabase/migrations/20260619132310_index_lease_signing_tokens_created_by.sql
+++ b/supabase/migrations/20260619132310_index_lease_signing_tokens_created_by.sql
@@ -1,0 +1,6 @@
+-- Covering index for the lease_signing_tokens.created_by foreign key.
+-- Flagged by the Supabase performance advisor (unindexed_foreign_keys 0001):
+-- without it, a delete/update on public.users must sequentially scan
+-- lease_signing_tokens to enforce the FK. Cheap insurance on a low-volume table.
+create index if not exists idx_lease_signing_tokens_created_by
+  on public.lease_signing_tokens (created_by);

--- a/supabase/tests/database/01-rls-enabled.test.sql
+++ b/supabase/tests/database/01-rls-enabled.test.sql
@@ -5,14 +5,20 @@
 -- user-specific or sensitive data. This prevents accidental data exposure.
 --
 -- Run with: supabase test db --linked
+--
+-- Asserts only on CURRENT product tables. The pre-pivot rent-facilitation
+-- (rent_payments, payment_methods, payment_transactions), tenant-portal
+-- (tenant_invitations) and property_owners tables were demolished
+-- (20260418140000_demolish_rent_and_tenant_portal.sql + follow-ups); the
+-- stripe.* schema is now a read-only FDW (foreign tables carry no RLS).
 
 -- Set search_path so pgTAP internal functions can find each other
 set search_path to extensions, public, tests;
 
 begin;
 
--- Plan: 1 test per table that should have RLS enabled (core tables)
-select plan(17);
+-- Plan: 1 test per table that should have RLS enabled (current core tables)
+select plan(15);
 
 -- =============================================================================
 -- CORE USER DATA TABLES - MUST HAVE RLS
@@ -21,10 +27,6 @@ select plan(17);
 select ok(
   (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'users'),
   'RLS should be enabled on public.users'
-);
-select ok(
-  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'property_owners'),
-  'RLS should be enabled on public.property_owners'
 );
 select ok(
   (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'tenants'),
@@ -60,30 +62,22 @@ select ok(
   (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'lease_tenants'),
   'RLS should be enabled on public.lease_tenants'
 );
+select ok(
+  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'lease_signing_tokens'),
+  'RLS should be enabled on public.lease_signing_tokens'
+);
 
 -- =============================================================================
 -- FINANCIAL TABLES - MUST HAVE RLS
 -- =============================================================================
 
 select ok(
-  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'rent_payments'),
-  'RLS should be enabled on public.rent_payments'
-);
-select ok(
-  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'payment_methods'),
-  'RLS should be enabled on public.payment_methods'
-);
-select ok(
-  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'payment_transactions'),
-  'RLS should be enabled on public.payment_transactions'
-);
-select ok(
   (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'expenses'),
   'RLS should be enabled on public.expenses'
 );
 
 -- =============================================================================
--- MAINTENANCE & DOCUMENTS - MUST HAVE RLS
+-- MAINTENANCE, DOCUMENTS & INSPECTIONS - MUST HAVE RLS
 -- =============================================================================
 
 select ok(
@@ -94,19 +88,23 @@ select ok(
   (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'documents'),
   'RLS should be enabled on public.documents'
 );
-
--- =============================================================================
--- USER-SCOPED TABLES - MUST HAVE RLS
--- =============================================================================
-
 select ok(
-  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'stripe' AND c.relname = 'subscriptions'),
-  'RLS should be enabled on stripe.subscriptions'
+  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'document_categories'),
+  'RLS should be enabled on public.document_categories'
 );
 select ok(
-  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'tenant_invitations'),
-  'RLS should be enabled on public.tenant_invitations'
+  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'inspections'),
+  'RLS should be enabled on public.inspections'
 );
+select ok(
+  (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'vendors'),
+  'RLS should be enabled on public.vendors'
+);
+
+-- =============================================================================
+-- NOTIFICATIONS - MUST HAVE RLS
+-- =============================================================================
+
 select ok(
   (SELECT relrowsecurity FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'notifications'),
   'RLS should be enabled on public.notifications'


### PR DESCRIPTION
## v6.0 "Final Canonical Cleanup" — findings resolved

**Headline:** the v6.0 legacy-remnant audit (`.planning/repo-audit/v6.0-LEGACY-AUDIT.md`, ~38 REMOVE + ~9 INVESTIGATE across Connect/payouts, rent-facilitation types, tenant-as-user, screening, dead DB objects) was **already fully implemented** — folded into PR #841 + the e-sign rebuild + migrations `20260616040851` (drop dead Connect + tenant-user columns) and `20260616161248` (drop `tenants.user_id`).

Verified exhaustively, not assumed:
- **DB layer (prod):** no surviving legacy tables (`rent_payments`, `payment_methods`, `tenant_invitations`, `rent_due`, `stripe_connected_accounts`, …); `properties.stripe_connected_account_id` + `tenants.user_id` dropped; `get_user_profile` has no `stripe_connected`; no Connect-gate-code RPCs; no orphan `app_config` rows; `tenants` policies clean.
- **App layer:** all cited symbols/surfaces gone (PaymentSettingsSection, `/financials/payouts`, onboarding payouts copy, `STRIPE_CONNECT_*` error codes, `stripeConnect.*`/`identityVerification` keys, `IdentityVerification*` types, `PayRent*`/`LateFee*`/`TenantPayment*`/`RENT_CHARGE_STATUS`/`TenantSummary`/tenant-portal types, `inviteToSignLeaseSchema`/`activateTenantSchema`, TransUnion provider). All 5 INVESTIGATE items resolved to already-gone / zero-consumer.

## What this PR fixes — 4 residuals the audit missed

The audit scoped to `src/` + the one missed column; an exhaustive re-sweep (concept grep + prod introspection + Supabase advisors) found 4 real residuals:

1. **Broken RLS pgTAP test** (`supabase/tests/database/01-rls-enabled.test.sql`) — asserted RLS on 6 demolished/foreign tables (`rent_payments`, `payment_methods`, `payment_transactions`, `tenant_invitations`, `property_owners`, the `stripe.subscriptions` FDW which carries `rls=false`). Rewritten to the **15 real current sensitive tables**, including the new e-sign `lease_signing_tokens` (all confirmed `rls_enabled=true` with policies).

2. **Stale `supabase/SCHEMA.md`** — a December-2024 snapshot ~170 migrations out of date: wrong owner column names (`property_owner_id` vs the canonical `owner_user_id`), `tenants.user_id`, a dropped `subscriptions` table, 4 demolished tables, Stripe Connect columns, an "overdue payments" query, and missing every current table. Replaced with an accurate, concise overview that documents the stable conventions + real table groupings and points to the generated `src/types/supabase.ts` as the column source of truth (so it won't instantly re-stale).

3. **Unindexed FK** — `lease_signing_tokens.created_by` had no covering index (Supabase performance advisor `unindexed_foreign_keys`). Added `idx_lease_signing_tokens_created_by` (migration `20260619132310`, already applied to prod; advisor finding confirmed cleared).

4. **`.planning/STATE.md`** — updated to reflect v6.0 findings resolved.

## Deferred (not in this PR)

The fallow dead-code export trim (was Phase 19) is currently ~415 unused exports/types, but ~111 are intentional KEEP-CONTRACT surface and many are framework/Deno import-map false-positives — a blind `fallow fix` would delete contract types against the audit's own guidance. Left as an explicit opt-in, per-item sweep.

## Notes
- DB changes are limited to one additive, idempotent `CREATE INDEX IF NOT EXISTS` (already applied to prod via MCP, repo file included for history).
- No `src/` changes — typecheck/lint/unit are unaffected; CI will confirm.

[hudsor01]
