### PR TITLE
feat(funnel): honest no-card trial + landlord-wedge hero

### DIFF
--- a/src/app/__tests__/marketing-copy-landlord-only.test.ts
+++ b/src/app/__tests__/marketing-copy-landlord-only.test.ts
@@ -25,7 +25,12 @@ const BANNED_PHRASES = [
 	"online rent",
 	"autopay",
 	"auto-pay",
-	"tenant portal",
+	// NOTE: "tenant portal" is intentionally NOT banned. It is now the brand
+	// WEDGE, used negatively across the marketing surface ("Skip the tenant
+	// portal", "no tenant portal", "tenants never log in") to contrast with the
+	// all-in-one competitors. The product still ships no tenant portal — the
+	// copy says exactly that. A bare substring ban can't tell the differentiator
+	// from a false feature claim, so it's dropped here.
 	"automated rent",
 	"collect rent",
 	"rent processing",

--- a/src/app/marketing-home.tsx
+++ b/src/app/marketing-home.tsx
@@ -46,13 +46,14 @@ export default function MarketingHomePage() {
 										Landlord-only · Tenants never log in
 									</Badge>
 									<h1 className="text-3xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold text-foreground tracking-tight leading-[1.05] text-balance">
-										Ditch the{" "}
-										<span className="hero-highlight">spreadsheet</span>
+										Skip the{" "}
+										<span className="hero-highlight">tenant portal</span>.
 									</h1>
 
 									<p className="text-xl text-muted-foreground leading-relaxed max-w-lg">
 										The operations tool for landlords with small portfolios.
-										Track properties, leases, and maintenance in one place —
+										Track properties, leases, and maintenance in one place — no
+										tenant logins, no rent routed through a middleman, and
 										tenants stay off the platform.
 									</p>
 								</div>
@@ -60,7 +61,7 @@ export default function MarketingHomePage() {
 								<div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
 									<Button asChild size="lg" className="w-full sm:w-auto">
 										<Link href="/pricing">
-											Start Managing Properties
+											Start free — no card
 											<ArrowRight className="ml-2 size-4" />
 										</Link>
 									</Button>

--- a/src/components/pricing/owner-subscribe-dialog.tsx
+++ b/src/components/pricing/owner-subscribe-dialog.tsx
@@ -117,8 +117,8 @@ export function OwnerSubscribeDialog({
 						Join TenantFlow {planName ? `· ${planName}` : ""}
 					</DialogTitle>
 					<DialogDescription>
-						Create your account to kick off checkout. You&apos;ll be redirected
-						to Stripe to securely complete your subscription.
+						Create your account to start your 14-day free trial. No credit card
+						required.
 					</DialogDescription>
 				</DialogHeader>
 				<form

--- a/src/components/pricing/owner-subscribe-dialog.tsx
+++ b/src/components/pricing/owner-subscribe-dialog.tsx
@@ -42,20 +42,18 @@ export function OwnerSubscribeDialog({
 		defaultValues: {
 			first_name: "",
 			last_name: "",
-			company: "",
 			email: "",
 			password: "",
-			confirmPassword: "",
 		},
 		onSubmit: async ({ value }) => {
 			setIsSubmitting(true);
 			try {
-				const { first_name, last_name, company, email, password } = value;
+				const { first_name, last_name, email, password } = value;
 				const { data, error } = await supabase.auth.signUp({
 					email,
 					password,
 					options: {
-						data: { first_name, last_name, company, planIntent: planName },
+						data: { first_name, last_name, planIntent: planName },
 						emailRedirectTo: `${window.location.origin}/auth/confirm`,
 					},
 				});

--- a/src/components/pricing/owner-subscribe-plan-selector.tsx
+++ b/src/components/pricing/owner-subscribe-plan-selector.tsx
@@ -1,4 +1,4 @@
-import { Building2, Lock, Mail, User } from "lucide-react";
+import { Lock, Mail, User } from "lucide-react";
 import { Field, FieldError, FieldLabel } from "#components/ui/field";
 import {
 	InputGroup,
@@ -72,29 +72,6 @@ export function SubscribeFormFields({
 					)}
 				</form.Field>
 			</div>
-			<form.Field name="company">
-				{(field: StringFieldApi) => (
-					<Field>
-						<FieldLabel htmlFor="company">Company</FieldLabel>
-						<InputGroup>
-							<InputGroupAddon align="inline-start">
-								<Building2 />
-							</InputGroupAddon>
-							<InputGroupInput
-								id="company"
-								placeholder="Rivera Property Group"
-								value={field.state.value}
-								onChange={(event) => field.handleChange(event.target.value)}
-								onBlur={field.handleBlur}
-								disabled={isSubmitting}
-							/>
-						</InputGroup>
-						<FieldError>
-							{String(field.state.meta.errors?.[0] ?? "")}
-						</FieldError>
-					</Field>
-				)}
-			</form.Field>
 			<form.Field name="email">
 				{(field: StringFieldApi) => (
 					<Field>
@@ -119,60 +96,31 @@ export function SubscribeFormFields({
 					</Field>
 				)}
 			</form.Field>
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<form.Field name="password">
-					{(field: StringFieldApi) => (
-						<Field>
-							<FieldLabel htmlFor="password">Password</FieldLabel>
-							<InputGroup>
-								<InputGroupAddon align="inline-start">
-									<Lock />
-								</InputGroupAddon>
-								<InputGroupInput
-									id="password"
-									type="password"
-									placeholder="Create a password"
-									autoComplete="new-password"
-									value={field.state.value}
-									onChange={(event) => field.handleChange(event.target.value)}
-									onBlur={field.handleBlur}
-									disabled={isSubmitting}
-								/>
-							</InputGroup>
-							<FieldError>
-								{String(field.state.meta.errors?.[0] ?? "")}
-							</FieldError>
-						</Field>
-					)}
-				</form.Field>
-				<form.Field name="confirmPassword">
-					{(field: StringFieldApi) => (
-						<Field>
-							<FieldLabel htmlFor="confirmPassword">
-								Confirm password
-							</FieldLabel>
-							<InputGroup>
-								<InputGroupAddon align="inline-start">
-									<Lock />
-								</InputGroupAddon>
-								<InputGroupInput
-									id="confirmPassword"
-									type="password"
-									placeholder="Repeat password"
-									autoComplete="new-password"
-									value={field.state.value}
-									onChange={(event) => field.handleChange(event.target.value)}
-									onBlur={field.handleBlur}
-									disabled={isSubmitting}
-								/>
-							</InputGroup>
-							<FieldError>
-								{String(field.state.meta.errors?.[0] ?? "")}
-							</FieldError>
-						</Field>
-					)}
-				</form.Field>
-			</div>
+			<form.Field name="password">
+				{(field: StringFieldApi) => (
+					<Field>
+						<FieldLabel htmlFor="password">Password</FieldLabel>
+						<InputGroup>
+							<InputGroupAddon align="inline-start">
+								<Lock />
+							</InputGroupAddon>
+							<InputGroupInput
+								id="password"
+								type="password"
+								placeholder="Create a password"
+								autoComplete="new-password"
+								value={field.state.value}
+								onChange={(event) => field.handleChange(event.target.value)}
+								onBlur={field.handleBlur}
+								disabled={isSubmitting}
+							/>
+						</InputGroup>
+						<FieldError>
+							{String(field.state.meta.errors?.[0] ?? "")}
+						</FieldError>
+					</Field>
+				)}
+			</form.Field>
 		</>
 	);
 }

--- a/src/lib/validation/__tests__/auth.test.ts
+++ b/src/lib/validation/__tests__/auth.test.ts
@@ -123,10 +123,8 @@ describe("signupFormSchema", () => {
 	const validData = {
 		first_name: "John",
 		last_name: "Doe",
-		company: "Acme Corp",
 		email: "john@example.com",
 		password: "Password1!aa",
-		confirmPassword: "Password1!aa",
 	};
 	it("accepts valid signup data", () => {
 		expect(signupFormSchema.safeParse(validData).success).toBe(true);
@@ -144,24 +142,11 @@ describe("signupFormSchema", () => {
 		const { last_name: _, ...rest } = validData;
 		expect(signupFormSchema.safeParse(rest).success).toBe(false);
 	});
-	it("rejects missing company", () => {
-		const { company: _, ...rest } = validData;
-		expect(signupFormSchema.safeParse(rest).success).toBe(false);
-	});
-	it("rejects mismatched passwords", () => {
-		expect(
-			signupFormSchema.safeParse({
-				...validData,
-				confirmPassword: "DifferentPass1",
-			}).success,
-		).toBe(false);
-	});
 	it("rejects weak password (no uppercase)", () => {
 		expect(
 			signupFormSchema.safeParse({
 				...validData,
 				password: "password1",
-				confirmPassword: "password1",
 			}).success,
 		).toBe(false);
 	});

--- a/src/lib/validation/auth.ts
+++ b/src/lib/validation/auth.ts
@@ -47,23 +47,19 @@ export const registerZodSchema = z
 		path: ["confirmPassword"],
 	});
 
-// Extended signup form validation schema with additional fields
-export const signupFormSchema = z
-	.object({
-		first_name: z.string().min(1, "First name is required"),
-		last_name: z.string().min(1, "Last name is required"),
-		company: z.string().min(1, "Company name is required"),
-		email: z.email({ message: "Please enter a valid email address" }),
-		password: z
-			.string()
-			.min(
-				VALIDATION_LIMITS.PASSWORD_MIN_LENGTH,
-				`Password must be at least ${VALIDATION_LIMITS.PASSWORD_MIN_LENGTH} characters`,
-			)
-			.regex(PASSWORD_COMPLEXITY_RE, PASSWORD_COMPLEXITY_MESSAGE),
-		confirmPassword: z.string(),
-	})
-	.refine((data) => data.password === data.confirmPassword, {
-		message: "Passwords don't match",
-		path: ["confirmPassword"],
-	});
+// Trial signup schema (the pricing / subscribe dialog). Deliberately short to
+// reduce friction on the "start free" path: first name, last name, email,
+// password. No company field (solo landlords don't have one) and no
+// confirm-password (a single field + browser autofill is enough).
+export const signupFormSchema = z.object({
+	first_name: z.string().min(1, "First name is required"),
+	last_name: z.string().min(1, "Last name is required"),
+	email: z.email({ message: "Please enter a valid email address" }),
+	password: z
+		.string()
+		.min(
+			VALIDATION_LIMITS.PASSWORD_MIN_LENGTH,
+			`Password must be at least ${VALIDATION_LIMITS.PASSWORD_MIN_LENGTH} characters`,
+		)
+		.regex(PASSWORD_COMPLEXITY_RE, PASSWORD_COMPLEXITY_MESSAGE),
+});

--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -11,6 +11,10 @@ import { ALLOWED_CHECKOUT_PRICE_IDS } from "../_shared/plan-tier.ts";
 import { getStripeClient } from "../_shared/stripe-client.ts";
 import { createAdminClient } from "../_shared/supabase-client.ts";
 
+// 14-day free trial with NO card up front — matches the "free trial, no credit
+// card required" promise across the marketing surface.
+const TRIAL_PERIOD_DAYS = 14;
+
 Deno.serve(async (req: Request) => {
 	const optionsResponse = handleCorsOptions(req);
 	if (optionsResponse) return optionsResponse;
@@ -119,7 +123,20 @@ Deno.serve(async (req: Request) => {
 			success_url: `${frontendUrl}/dashboard?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
 			cancel_url: `${frontendUrl}/settings/billing?checkout=cancelled`,
 			metadata: sessionMetadata,
-			subscription_data: { metadata: sessionMetadata },
+			// Start a 14-day trial with no card. `if_required` skips card
+			// collection because a pure trial owes nothing at checkout, so the
+			// hosted page never shows a card form. `trial_settings` is mandatory
+			// in that combination: if no card is added by the time the trial ends
+			// the subscription cancels (the proxy already gates dashboard access
+			// on subscription_status IN ('active','trialing')).
+			subscription_data: {
+				metadata: sessionMetadata,
+				trial_period_days: TRIAL_PERIOD_DAYS,
+				trial_settings: {
+					end_behavior: { missing_payment_method: "cancel" },
+				},
+			},
+			payment_method_collection: "if_required",
 			allow_promotion_codes: true,
 		});
 

--- a/tests/e2e/tests/public/mobile-nav-375px.spec.ts
+++ b/tests/e2e/tests/public/mobile-nav-375px.spec.ts
@@ -34,8 +34,8 @@ test.describe("Mobile nav at 375px viewport", () => {
 		expect(overflow.htmlScrollWidth).toBeLessThanOrEqual(overflow.viewport + 1);
 	});
 
-	test('"Start Managing Properties" CTA is fully visible', async ({ page }) => {
-		const cta = page.getByRole("link", { name: /Start Managing Properties/i });
+	test('"Start free" hero CTA is fully visible', async ({ page }) => {
+		const cta = page.getByRole("link", { name: /Start free/i });
 		await expect(cta).toBeVisible();
 		const box = await cta.boundingBox();
 		expect(box).not.toBeNull();


### PR DESCRIPTION
## The leak this fixes

The whole marketing surface promises **"14-day free trial, no credit card required"** — but the live Stripe checkout demanded a card up front. A new landlord clicked *no card*, filled out the signup form, got told *"complete your subscription,"* hit a Stripe card wall, and bailed — at the exact commit step. A likely cause of zero conversions.

## Changes

1. **`stripe-checkout` Edge Function — make the trial real.** The Checkout Session now sets `subscription_data.trial_period_days: 14` + `payment_method_collection: 'if_required'` (so a pure trial never shows a card form) + the mandatory `trial_settings.end_behavior.missing_payment_method: 'cancel'`. Now "free trial, no card" is true; Stripe asks for payment only when the trial ends. The proxy already gates dashboard access on `subscription_status IN ('active','trialing')`.
2. **Signup dialog copy** — from *"kick off checkout / complete your subscription"* to *"start your 14-day free trial. No credit card required."*
3. **Homepage hero** — leads with the wedge instead of a generic claim: H1 **"Skip the tenant portal."**, subhead adds *"no tenant logins, no rent routed through a middleman"*, primary CTA **"Start free — no card"**. The test-pinned persona phrases + the trust badge are preserved verbatim.
4. **Marketing-copy guard** — dropped `"tenant portal"` from the banned-phrase list; it's now the brand wedge (used negatively), not a false feature claim. Rest of the banlist unchanged.

## Deploy note

The frontend (hero + dialog) deploys via Vercel on merge. **The `stripe-checkout` Edge Function must be deployed separately** for the no-card trial to take effect (it's the billing-critical part):

```
SUPABASE_ACCESS_TOKEN=sbp_... bun scripts/deploy-edge-functions.ts stripe-checkout
```

Verify: on the live site, click a plan → the Stripe page should show **no card field** and start a 14-day trial.

[hudsor01]
