### PR TITLE
fix: resolve UI/UX audit findings (CTA consistency, blog 503s, login render)

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { Building2, Home, Lock, Smartphone, Zap } from "lucide-react";
+import { Home, Lock, Smartphone, Zap } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { ForgotPasswordModal } from "#components/auth/forgot-password-modal";
 import { MfaVerificationDialog } from "#components/auth/mfa-verification-dialog";
 import { authKeys } from "#hooks/api/use-auth";
@@ -42,17 +42,19 @@ function LoginPageContent() {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const router = useRouter();
-	const searchParams = useSearchParams();
 	const queryClient = useQueryClient();
 
-	// Handle OAuth error from URL params
+	// F1: read URL params lazily from window.location instead of
+	// useSearchParams(). useSearchParams() forces a prerender bailout that ships
+	// only the "Loading..." Suspense fallback in the initial HTML (no form). The
+	// params are only needed in this client-only effect + the submit handler, so
+	// reading them lazily lets the whole form render server-side into the HTML.
 	useEffect(() => {
-		if (!searchParams) return;
-		const error = searchParams.get("error");
+		const error = new URLSearchParams(window.location.search).get("error");
 		if (error === "oauth_failed") {
 			router.replace("/login");
 		}
-	}, [searchParams, router]);
+	}, [router]);
 
 	const handleCredentialSubmit = async (value: {
 		email: string;
@@ -88,7 +90,9 @@ function LoginPageContent() {
 				queryClient.setQueryData(authKeys.session(), data.session);
 				queryClient.setQueryData(authKeys.user(), data.session.user);
 
-				const redirectTo = searchParams?.get("redirect");
+				const redirectTo = new URLSearchParams(window.location.search).get(
+					"redirect",
+				);
 				let destination = "/dashboard";
 
 				if (redirectTo && isValidRedirect(redirectTo)) {
@@ -286,25 +290,6 @@ function LoginPageContent() {
 	);
 }
 
-function LoginFallback() {
-	return (
-		<div className="flex min-h-screen items-center justify-center bg-background">
-			<div className="flex flex-col items-center gap-4">
-				<div className="flex items-center justify-center w-12 h-12 rounded-xl bg-primary animate-pulse">
-					<Building2 className="w-6 h-6 text-primary-foreground" />
-				</div>
-				<span className="text-sm text-muted-foreground animate-pulse">
-					Loading...
-				</span>
-			</div>
-		</div>
-	);
-}
-
 export default function LoginPage() {
-	return (
-		<Suspense fallback={<LoginFallback />}>
-			<LoginPageContent />
-		</Suspense>
-	);
+	return <LoginPageContent />;
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -62,7 +62,7 @@ export default function AboutPage() {
 				title="Property management"
 				titleHighlight="built for landlords"
 				subtitle="One platform for property records, leases, maintenance, and the document vault. Tenants are records you keep for your own tracking — never users on the platform."
-				primaryCta={{ label: "Start Free Trial", href: "/pricing" }}
+				primaryCta={{ label: "Start free — no card", href: "/pricing" }}
 				secondaryCta={{ label: "Contact Sales", href: "/contact" }}
 				image={{
 					src: "https://images.unsplash.com/photo-1522071820081-009f0129c71c?q=80&w=2070&auto=format&fit=crop",
@@ -266,7 +266,7 @@ export default function AboutPage() {
 							<div className="flex flex-col sm:flex-row gap-4 justify-center">
 								<Button asChild size="lg" className="group">
 									<Link href="/pricing">
-										Start Free Trial
+										Start free — no card
 										<ArrowRight className="size-4 ml-2 transition-transform group-hover:translate-x-1" />
 									</Link>
 								</Button>

--- a/src/app/blog/[slug]/blog-post-page.tsx
+++ b/src/app/blog/[slug]/blog-post-page.tsx
@@ -302,8 +302,8 @@ export default function BlogPostPage({ post, slug }: BlogPostProps) {
 						tax-ready reports.
 					</p>
 					<Button size="lg" className="px-8" asChild>
-						<Link href="/login">
-							Start Free Trial
+						<Link href="/pricing">
+							Start free — no card
 							<ArrowRight className="size-5 ml-2" />
 						</Link>
 					</Button>

--- a/src/app/blog/category/[category]/page.test.tsx
+++ b/src/app/blog/category/[category]/page.test.tsx
@@ -11,15 +11,17 @@ import { render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockCreateClient = vi.hoisted(() => vi.fn());
+const mockBlogAnonClient = vi.hoisted(() => vi.fn());
+const mockGetBlogCategories = vi.hoisted(() => vi.fn());
 const mockNotFound = vi.hoisted(() =>
 	vi.fn(() => {
 		throw new Error("NEXT_NOT_FOUND");
 	}),
 );
 
-vi.mock("#lib/supabase/server", () => ({
-	createClient: mockCreateClient,
+vi.mock("#lib/blog/blog-queries", () => ({
+	blogAnonClient: mockBlogAnonClient,
+	getBlogCategories: mockGetBlogCategories,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -166,7 +168,8 @@ async function renderPage(
 	categorySlug: string,
 	opts?: MockBuilderOpts,
 ): Promise<ReactElement> {
-	mockCreateClient.mockResolvedValue(makeClient(opts));
+	mockBlogAnonClient.mockReturnValue(makeClient(opts));
+	mockGetBlogCategories.mockResolvedValue(opts?.categories ?? mockCategories);
 	const ui = await BlogCategoryPage({
 		params: Promise.resolve({ category: categorySlug }),
 		searchParams: Promise.resolve({}),
@@ -209,7 +212,8 @@ describe("BlogCategoryPage (server component)", () => {
 	});
 
 	it("generateMetadata humanizes the category slug in the title", async () => {
-		mockCreateClient.mockResolvedValue(makeClient({ postsCount: 9 }));
+		mockBlogAnonClient.mockReturnValue(makeClient({ postsCount: 9 }));
+		mockGetBlogCategories.mockResolvedValue(mockCategories);
 		const meta = await generateMetadata({
 			params: Promise.resolve({ category: "lease-law" }),
 			searchParams: Promise.resolve({}),
@@ -248,7 +252,8 @@ describe("BlogCategoryPage (server component)", () => {
 	});
 
 	it("calls notFound() when slug not in categories", async () => {
-		mockCreateClient.mockResolvedValue(makeClient());
+		mockBlogAnonClient.mockReturnValue(makeClient());
+		mockGetBlogCategories.mockResolvedValue(mockCategories);
 		await expect(
 			BlogCategoryPage({
 				params: Promise.resolve({ category: "does-not-exist" }),
@@ -275,7 +280,8 @@ describe("BlogCategoryPage generateMetadata (SEO-03 empty-category noindex)", ()
 		categorySlug: string,
 		opts?: MockBuilderOpts,
 	): Promise<import("next").Metadata> {
-		mockCreateClient.mockResolvedValue(makeClient(opts));
+		mockBlogAnonClient.mockReturnValue(makeClient(opts));
+		mockGetBlogCategories.mockResolvedValue(opts?.categories ?? mockCategories);
 		return generateMetadata({
 			params: Promise.resolve({ category: categorySlug }),
 			searchParams: Promise.resolve({}),
@@ -294,7 +300,8 @@ describe("BlogCategoryPage generateMetadata (SEO-03 empty-category noindex)", ()
 	});
 
 	it("noindexes paginated pages regardless of count", async () => {
-		mockCreateClient.mockResolvedValue(makeClient({ postsCount: 5 }));
+		mockBlogAnonClient.mockReturnValue(makeClient({ postsCount: 5 }));
+		mockGetBlogCategories.mockResolvedValue(mockCategories);
 		const meta = await generateMetadata({
 			params: Promise.resolve({ category: "software-comparisons" }),
 			searchParams: Promise.resolve({ page: "2" }),

--- a/src/app/blog/category/[category]/page.tsx
+++ b/src/app/blog/category/[category]/page.tsx
@@ -17,10 +17,10 @@ import {
 	BreadcrumbSeparator,
 } from "#components/ui/breadcrumb";
 import type { BlogListItem } from "#hooks/api/query-keys/blog-keys";
+import { blogAnonClient, getBlogCategories } from "#lib/blog/blog-queries";
 import { categoryLabel } from "#lib/seo/blog-categories";
 import { createBreadcrumbJsonLd } from "#lib/seo/breadcrumbs";
 import { createPageMetadata } from "#lib/seo/page-metadata";
-import { createClient } from "#lib/supabase/server";
 
 const PAGE_LIMIT = 9;
 
@@ -41,11 +41,8 @@ interface ValidCategory {
 /** Deduplicated category validation — shared by generateMetadata and Page */
 const getValidCategory = cache(
 	async (slug: string): Promise<ValidCategory | null> => {
-		const supabase = await createClient();
-		const { data } = await supabase.rpc("get_blog_categories");
-		return (
-			((data ?? []) as ValidCategory[]).find((c) => c.slug === slug) ?? null
-		);
+		const cats = await getBlogCategories();
+		return cats.find((c) => c.slug === slug) ?? null;
 	},
 );
 
@@ -57,7 +54,7 @@ const getValidCategory = cache(
  */
 const getCategoryPublishedCount = cache(
 	async (categoryName: string): Promise<number> => {
-		const supabase = await createClient();
+		const supabase = blogAnonClient();
 		const { count } = await supabase
 			.from("blogs")
 			.select("*", { count: "exact", head: true })
@@ -113,7 +110,7 @@ export default async function BlogCategoryPage({
 		notFound();
 	}
 
-	const supabase = await createClient();
+	const supabase = blogAnonClient();
 	const postsResult = await supabase
 		.from("blogs")
 		.select(BLOG_LIST_COLUMNS, { count: "exact" })

--- a/src/app/blog/page.test.tsx
+++ b/src/app/blog/page.test.tsx
@@ -12,10 +12,12 @@ import { render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockCreateClient = vi.hoisted(() => vi.fn());
+const mockBlogAnonClient = vi.hoisted(() => vi.fn());
+const mockGetBlogCategories = vi.hoisted(() => vi.fn());
 
-vi.mock("#lib/supabase/server", () => ({
-	createClient: mockCreateClient,
+vi.mock("#lib/blog/blog-queries", () => ({
+	blogAnonClient: mockBlogAnonClient,
+	getBlogCategories: mockGetBlogCategories,
 }));
 
 vi.mock("@sentry/nextjs", () => ({
@@ -257,7 +259,10 @@ function makeFromBuilder({
 }
 
 async function renderPage(opts?: MockBuilderOpts): Promise<ReactElement> {
-	mockCreateClient.mockResolvedValue(makeFromBuilder(opts));
+	mockBlogAnonClient.mockReturnValue(makeFromBuilder(opts));
+	mockGetBlogCategories.mockResolvedValue(
+		opts?.categoriesError ? [] : mockCategories,
+	);
 	const ui = await BlogPage({ searchParams: Promise.resolve({}) });
 	return ui;
 }
@@ -297,7 +302,7 @@ describe("BlogPage (server component)", () => {
 	});
 
 	it("returns a 404 (notFound) for an out-of-range ?page — PostgREST 416 — without logging a Sentry error", async () => {
-		mockCreateClient.mockResolvedValue(
+		mockBlogAnonClient.mockReturnValue(
 			makeFromBuilder({
 				postsError: {
 					code: "PGRST103",
@@ -305,6 +310,7 @@ describe("BlogPage (server component)", () => {
 				},
 			}),
 		);
+		mockGetBlogCategories.mockResolvedValue(mockCategories);
 		await expect(
 			BlogPage({ searchParams: Promise.resolve({ page: "11" }) }),
 		).rejects.toMatchObject({ digest: "NEXT_NOT_FOUND" });
@@ -384,26 +390,24 @@ describe("BlogPage (server component)", () => {
 		);
 	});
 
-	it("routes categoriesResult.error to Sentry and degrades to empty state", async () => {
-		render(
-			await renderPage({
-				categoriesError: { message: "RPC failure" },
-			}),
-		);
-		expect(screen.getByTestId("blog-empty-state")).toBeInTheDocument();
-		expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledTimes(1);
-		expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({
-				tags: { surface: "blog-index" },
-			}),
-		);
+	it("degrades gracefully when categories are unavailable: posts still render, no category pills, no Sentry error", async () => {
+		// getBlogCategories() fails soft (returns []), so a categories outage just
+		// hides the category nav — the post grid still renders and nothing is
+		// reported as a blog-index error.
+		render(await renderPage({ categoriesError: { message: "RPC failure" } }));
+		expect(screen.getAllByTestId("blog-card").length).toBeGreaterThan(0);
+		const categoryLinks = screen
+			.queryAllByRole("link")
+			.filter((l) => l.getAttribute("href")?.startsWith("/blog/category/"));
+		expect(categoryLinks).toHaveLength(0);
+		expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
 	});
 
 	it("passes extra.page to Sentry matching the requested pagination cursor", async () => {
-		mockCreateClient.mockResolvedValue(
+		mockBlogAnonClient.mockReturnValue(
 			makeFromBuilder({ postsError: { message: "fail" } }),
 		);
+		mockGetBlogCategories.mockResolvedValue(mockCategories);
 		await BlogPage({ searchParams: Promise.resolve({ page: "3" }) });
 		expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(
 			expect.anything(),
@@ -424,7 +428,7 @@ describe("BlogPage generateMetadata", () => {
 		searchParams: Record<string, string | string[] | undefined>,
 		opts?: MockBuilderOpts,
 	): Promise<import("next").Metadata> {
-		mockCreateClient.mockResolvedValue(makeFromBuilder(opts));
+		mockBlogAnonClient.mockReturnValue(makeFromBuilder(opts));
 		return generateMetadata({ searchParams: Promise.resolve(searchParams) });
 	}
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -17,9 +17,9 @@ import {
 	BreadcrumbSeparator,
 } from "#components/ui/breadcrumb";
 import type { BlogListItem } from "#hooks/api/query-keys/blog-keys";
+import { blogAnonClient, getBlogCategories } from "#lib/blog/blog-queries";
 import { createBreadcrumbJsonLd } from "#lib/seo/breadcrumbs";
 import { createPageMetadata } from "#lib/seo/page-metadata";
-import { createClient } from "#lib/supabase/server";
 
 const PAGE_LIMIT = 9;
 
@@ -57,7 +57,7 @@ export async function generateMetadata({
 	// hoisting a shared `cache()`-wrapped count, which trades clarity
 	// for the saved round-trip. Accepted as-is until the count is
 	// measured as actually expensive.
-	const supabase = await createClient();
+	const supabase = blogAnonClient();
 	const { count, error: countError } = await supabase
 		.from("blogs")
 		.select("id", { count: "exact", head: true })
@@ -84,7 +84,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 	const params = await searchParams;
 	const page = Math.max(1, Number(params.page) || 1);
 	const offset = (page - 1) * PAGE_LIMIT;
-	const supabase = await createClient();
+	const supabase = blogAnonClient();
 
 	let posts: BlogListItem[] = [];
 	let categories: CategoryRow[] = [];
@@ -92,23 +92,22 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 	let totalPages = 1;
 
 	try {
-		const [postsResult, categoriesResult, comparisonsResult] =
-			await Promise.all([
-				supabase
-					.from("blogs")
-					.select(BLOG_LIST_COLUMNS, { count: "exact" })
-					.eq("status", "published")
-					.order("published_at", { ascending: false })
-					.range(offset, offset + PAGE_LIMIT - 1),
-				supabase.rpc("get_blog_categories"),
-				supabase
-					.from("blogs")
-					.select(BLOG_LIST_COLUMNS)
-					.eq("status", "published")
-					.contains("tags", ["comparison"])
-					.order("published_at", { ascending: false })
-					.limit(6),
-			]);
+		const [postsResult, categoriesData, comparisonsResult] = await Promise.all([
+			supabase
+				.from("blogs")
+				.select(BLOG_LIST_COLUMNS, { count: "exact" })
+				.eq("status", "published")
+				.order("published_at", { ascending: false })
+				.range(offset, offset + PAGE_LIMIT - 1),
+			getBlogCategories(),
+			supabase
+				.from("blogs")
+				.select(BLOG_LIST_COLUMNS)
+				.eq("status", "published")
+				.contains("tags", ["comparison"])
+				.order("published_at", { ascending: false })
+				.limit(6),
+		]);
 
 		// An out-of-range ?page=N (offset past the last row) makes PostgREST
 		// return 416 "Requested range not satisfiable" (code PGRST103). That's
@@ -124,21 +123,16 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
 			notFound();
 		}
 
-		if (
-			postsResult.error ||
-			categoriesResult.error ||
-			comparisonsResult.error
-		) {
+		if (postsResult.error || comparisonsResult.error) {
 			throw new Error(
 				postsResult.error?.message ??
-					categoriesResult.error?.message ??
 					comparisonsResult.error?.message ??
 					"Unknown Supabase error",
 			);
 		}
 
 		posts = (postsResult.data ?? []) as BlogListItem[];
-		categories = (categoriesResult.data ?? []) as CategoryRow[];
+		categories = categoriesData;
 		comparisons = (comparisonsResult.data ?? []) as BlogListItem[];
 		totalPages = Math.max(1, Math.ceil((postsResult.count ?? 0) / PAGE_LIMIT));
 	} catch (err) {

--- a/src/app/compare/[competitor]/compare-sections.tsx
+++ b/src/app/compare/[competitor]/compare-sections.tsx
@@ -216,7 +216,7 @@ export function BottomCta() {
 					<div className="flex flex-col sm:flex-row gap-4 justify-center">
 						<Button size="lg" className="px-8" asChild>
 							<Link href="/pricing">
-								Start Free Trial
+								Start free — no card
 								<ArrowRight className="size-5 ml-2" />
 							</Link>
 						</Button>

--- a/src/app/compare/[competitor]/page.tsx
+++ b/src/app/compare/[competitor]/page.tsx
@@ -119,7 +119,7 @@ export default async function ComparePage({ params }: PageProps) {
 					<div className="flex flex-col sm:flex-row gap-4 justify-center">
 						<Button size="lg" className="px-8" asChild>
 							<Link href="/pricing">
-								Start Free Trial
+								Start free — no card
 								<ArrowRight className="size-5 ml-2" />
 							</Link>
 						</Button>

--- a/src/app/features/features-client.tsx
+++ b/src/app/features/features-client.tsx
@@ -46,7 +46,7 @@ export default function FeaturesClient() {
 					asChild
 				>
 					<Link href="/pricing" aria-label="Get started free">
-						Start Free Trial
+						Start free — no card
 						<ArrowRight className="size-4 ml-2" />
 					</Link>
 				</Button>

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -204,7 +204,7 @@ export default function HelpPage() {
 					<div className="flex flex-col sm:flex-row gap-4 justify-center">
 						<Button size="lg" variant="secondary" className="px-8" asChild>
 							<Link href="/pricing">
-								Start 14-day free trial
+								Start free — no card
 								<ArrowRight className="size-5 ml-2" />
 							</Link>
 						</Button>

--- a/src/app/pricing/pricing-content.tsx
+++ b/src/app/pricing/pricing-content.tsx
@@ -175,7 +175,7 @@ export function PricingCtaSection() {
 						<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
 							<Button size="lg" className="px-8" asChild>
 								<Link href="#plans">
-									Start your free trial
+									Start free — no card
 									<ArrowRight className="ml-2 h-4 w-4" />
 								</Link>
 							</Button>

--- a/src/app/resources/landlord-tax-deduction-tracker/page.tsx
+++ b/src/app/resources/landlord-tax-deduction-tracker/page.tsx
@@ -212,7 +212,7 @@ export default function TaxDeductionTrackerPage() {
 						Track expenses automatically with TenantFlow financial reporting
 					</p>
 					<Button asChild>
-						<Link href="/pricing">Start Free Trial</Link>
+						<Link href="/pricing">Start free — no card</Link>
 					</Button>
 				</div>
 			</div>

--- a/src/app/resources/seasonal-maintenance-checklist/page.tsx
+++ b/src/app/resources/seasonal-maintenance-checklist/page.tsx
@@ -398,7 +398,7 @@ export default function SeasonalMaintenanceChecklistPage() {
 						Track maintenance requests digitally with TenantFlow
 					</p>
 					<Button asChild>
-						<Link href="/pricing">Start Free Trial</Link>
+						<Link href="/pricing">Start free — no card</Link>
 					</Button>
 				</div>
 			</div>

--- a/src/app/resources/security-deposit-reference-card/page.tsx
+++ b/src/app/resources/security-deposit-reference-card/page.tsx
@@ -693,7 +693,7 @@ export default function SecurityDepositReferenceCardPage() {
 						TenantFlow
 					</p>
 					<Button asChild>
-						<Link href="/pricing">Start Free Trial</Link>
+						<Link href="/pricing">Start free — no card</Link>
 					</Button>
 				</div>
 			</div>

--- a/src/components/blog/blog-inline-cta.tsx
+++ b/src/components/blog/blog-inline-cta.tsx
@@ -36,7 +36,7 @@ export function BlogInlineCta() {
 				<div className="mt-2">
 					<Button asChild>
 						<Link href="/pricing">
-							Start Free Trial
+							Start free
 							<ArrowRight className="size-4 ml-2" />
 						</Link>
 					</Button>

--- a/src/components/landing/final-cta-section.tsx
+++ b/src/components/landing/final-cta-section.tsx
@@ -45,9 +45,9 @@ export function FinalCtaSection() {
 									className="group relative overflow-hidden shadow-2xl shadow-primary/25 hover:shadow-3xl hover:shadow-primary/40 transform hover:scale-[1.02] transition-all duration-300 typography-large px-10 py-5"
 									asChild
 								>
-									<Link href="/pricing" aria-label="Start free trial">
+									<Link href="/pricing" aria-label="Start free — no card">
 										<span className="relative z-10 flex items-center">
-											Start Free Trial
+											Start free — no card
 											<ArrowRight className="size-5 ml-3 transition-transform group-hover:translate-x-1" />
 										</span>
 									</Link>

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -32,9 +32,9 @@ export function HeroSection() {
 								className="group relative overflow-hidden shadow-2xl shadow-primary/25 hover:shadow-3xl hover:shadow-primary/40 transform hover:scale-[1.02] transition-all duration-300 typography-large px-8 py-4"
 								asChild
 							>
-								<Link href="/pricing" aria-label="Start free trial">
+								<Link href="/pricing" aria-label="Start free — no card">
 									<span className="relative z-10 flex items-center">
-										Start Free Trial
+										Start free — no card
 										<ArrowRight className="size-5 ml-3 transition-transform group-hover:translate-x-1" />
 									</span>
 								</Link>

--- a/src/components/layout/__tests__/navbar.test.tsx
+++ b/src/components/layout/__tests__/navbar.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Battle-test Session 6 P1 regression guard: the marketing navbar must
- * render the signed-out CTA pair ("Sign In" + "Get Started") synchronously
+ * render the signed-out CTA pair ("Sign In" + "Start free") synchronously
  * when no auth cookie is present, regardless of the supabase-session
  * query's pending state. Pre-fix, a stuck `isPending: true` on cold-start
  * (PersistQueryClientProvider restoration race) left the CTA slot empty.
@@ -69,7 +69,7 @@ describe("Navbar — auth CTA branch", () => {
 		clearAuthCookie();
 	});
 
-	it("renders Sign In + Get Started synchronously when no auth cookie (cold-start fast-path)", async () => {
+	it("renders Sign In + Start free synchronously when no auth cookie (cold-start fast-path)", async () => {
 		clearAuthCookie();
 		// Simulate the PersistQueryClient restoration race that pre-fix
 		// left isPending stuck: the query never settles.
@@ -82,7 +82,7 @@ describe("Navbar — auth CTA branch", () => {
 
 		expect(screen.getByRole("link", { name: /Sign In/i })).toBeInTheDocument();
 		expect(
-			screen.getByRole("link", { name: /Get Started/i }),
+			screen.getByRole("link", { name: /Start free/i }),
 		).toBeInTheDocument();
 		expect(screen.queryByRole("link", { name: /Dashboard/i })).toBeNull();
 	});
@@ -123,7 +123,7 @@ describe("Navbar — auth CTA branch", () => {
 
 		expect(screen.getByRole("link", { name: /Sign In/i })).toBeInTheDocument();
 		expect(
-			screen.getByRole("link", { name: /Get Started/i }),
+			screen.getByRole("link", { name: /Start free/i }),
 		).toBeInTheDocument();
 		expect(screen.queryByRole("link", { name: /Dashboard/i })).toBeNull();
 	});

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -19,7 +19,7 @@ export function Navbar({
 	className,
 	logo = "TenantFlow",
 	navItems = DEFAULT_NAV_ITEMS,
-	ctaText = "Get Started",
+	ctaText = "Start free",
 	ctaHref = "/pricing",
 	ref,
 	...props

--- a/src/components/marketing/sticky-conversion-cta.tsx
+++ b/src/components/marketing/sticky-conversion-cta.tsx
@@ -30,7 +30,7 @@ const DISMISS_TTL_MS = 24 * 60 * 60 * 1000;
  */
 export function StickyConversionCta({
 	primaryHref = "/pricing",
-	primaryLabel = "Start free trial",
+	primaryLabel = "Start free",
 	secondaryHref,
 	secondaryLabel,
 	scrollThresholdPx = 600,

--- a/src/components/pricing/pricing-card-featured.tsx
+++ b/src/components/pricing/pricing-card-featured.tsx
@@ -245,7 +245,7 @@ export function PricingCardFeatured({
 								</>
 							) : (
 								<>
-									Start 14-Day Free Trial
+									Start free
 									<ArrowRight className="ml-2 size-4 transition-transform group-hover:translate-x-1" />
 								</>
 							)}

--- a/src/components/pricing/pricing-card-standard.tsx
+++ b/src/components/pricing/pricing-card-standard.tsx
@@ -276,7 +276,7 @@ export function PricingCardStandard({
 						</>
 					) : (
 						<>
-							Start Free
+							Start free
 							<ArrowRight className="ml-2 size-4 transition-transform group-hover:translate-x-1" />
 						</>
 					)}

--- a/src/components/sections/how-it-works.tsx
+++ b/src/components/sections/how-it-works.tsx
@@ -105,7 +105,7 @@ export function HowItWorks({ className }: HowItWorksProps) {
 							asChild
 						>
 							<Link href="/pricing">
-								Start Your Free Trial
+								Start free — no card
 								<ArrowRight className="size-5 ml-2" />
 							</Link>
 						</Button>

--- a/src/components/sections/premium-cta.tsx
+++ b/src/components/sections/premium-cta.tsx
@@ -61,10 +61,10 @@ export function PremiumCta({ className }: PremiumCtaProps) {
 									className="relative overflow-hidden bg-primary hover:bg-primary/90 text-primary-foreground text-lg font-bold px-10 py-6 rounded shadow-2xl hover:shadow-primary/25 transform hover:scale-[1.02] transition-all duration-500 group"
 									asChild
 								>
-									<Link href="/pricing" aria-label="Start free trial">
+									<Link href="/pricing" aria-label="Start free — no card">
 										<div className="absolute inset-0 bg-linear-to-r from-primary to-primary/80 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
 										<span className="relative z-10 flex items-center">
-											Start Free Trial
+											Start free — no card
 											<ArrowRight className="size-6 ml-3 transition-transform group-hover:translate-x-2 duration-500" />
 										</span>
 									</Link>

--- a/src/lib/blog/blog-queries.ts
+++ b/src/lib/blog/blog-queries.ts
@@ -1,0 +1,40 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { unstable_cache } from "next/cache";
+import { env } from "#env";
+
+/**
+ * Cookie-less anon client for PUBLIC blog reads. `status = 'published'` is the
+ * anon RLS gate, so no session/cookies are needed — exactly the pattern
+ * `/blog/[slug]/page.tsx` uses. Using the cookie-aware `#lib/supabase/server`
+ * client here adds per-request cookie work to the (heavily prefetched/crawled)
+ * dynamic blog list routes, which contributed to the F2 intermittent 503s.
+ */
+export function blogAnonClient() {
+	return createSupabaseClient(
+		env.NEXT_PUBLIC_SUPABASE_URL,
+		env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+	);
+}
+
+export interface BlogCategoryRow {
+	name: string;
+	slug: string;
+	post_count: number;
+}
+
+/**
+ * `get_blog_categories` returns the same data for every blog request and is
+ * called on the hub AND every category page (+ their metadata). Cache it across
+ * requests (revalidate 300) so a prefetch/crawler burst shares one cached
+ * result instead of each request spawning its own Supabase round-trip — a
+ * primary driver of the F2 503 saturation. Returns [] on error (fail-soft: the
+ * category nav just hides, the page still renders).
+ */
+export const getBlogCategories = unstable_cache(
+	async (): Promise<BlogCategoryRow[]> => {
+		const { data } = await blogAnonClient().rpc("get_blog_categories");
+		return (data ?? []) as BlogCategoryRow[];
+	},
+	["blog-categories"],
+	{ revalidate: 300 },
+);

--- a/src/lib/supabase/__tests__/middleware-routing.test.ts
+++ b/src/lib/supabase/__tests__/middleware-routing.test.ts
@@ -150,8 +150,6 @@ describe("proxy routing", () => {
 		it.each([
 			"/login",
 			"/pricing",
-			"/blog",
-			"/blog/some-post",
 			"/",
 		])("bypasses auth check for %s", async (route) => {
 			const supabaseResponse = makeSupabaseResponse();
@@ -164,6 +162,21 @@ describe("proxy routing", () => {
 
 			expect(result).toBe(supabaseResponse);
 			expect(NextResponse.redirect).not.toHaveBeenCalled();
+		});
+
+		it.each([
+			"/blog",
+			"/blog/some-post",
+		])("skips updateSession entirely for %s (F2: public, never reads the session)", async (route) => {
+			const result = await proxy(buildRequest(route));
+
+			// /blog/* returns NextResponse.next() WITHOUT the per-request
+			// Supabase session-refresh round-trip — that round-trip saturated
+			// Supabase under prefetch/crawler bursts (the F2 intermittent 503).
+			expect(mockUpdateSession).not.toHaveBeenCalled();
+			expect(NextResponse.next).toHaveBeenCalled();
+			expect(NextResponse.redirect).not.toHaveBeenCalled();
+			expect(result).toBeDefined();
 		});
 	});
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -155,6 +155,18 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 		requestHeaders.set("x-nonce", nonce);
 	}
 
+	// F2: /blog and /blog/* are public and never read the session, so the
+	// per-request Supabase session-refresh in updateSession is pure waste here.
+	// Running it on every (heavily prefetched + crawler-hit) request is what
+	// saturated Supabase and produced the intermittent 503s on the dynamic blog
+	// list routes. Skip it; the pages use the cookie-less anon client, the
+	// browser Supabase client refreshes the token client-side, and every private
+	// route below still runs updateSession + the auth gates. /blog is never
+	// private- or auth-gated, so nothing here depends on the refreshed session.
+	if (pathname === "/blog" || pathname.startsWith("/blog/")) {
+		return NextResponse.next();
+	}
+
 	const { user, supabaseResponse } = await updateSession(
 		request,
 		requestHeaders,

--- a/tests/e2e/tests/public/mobile-nav-375px.spec.ts
+++ b/tests/e2e/tests/public/mobile-nav-375px.spec.ts
@@ -75,7 +75,7 @@ test.describe("Mobile nav at 375px viewport", () => {
 		).toBeVisible();
 		await expect(drawer.getByRole("link", { name: /^Sign In$/ })).toBeVisible();
 		await expect(
-			drawer.getByRole("link", { name: /Get Started/i }),
+			drawer.getByRole("link", { name: /Start free/i }),
 		).toBeVisible();
 	});
 


### PR DESCRIPTION
Resolves three findings from the public-pages UI/UX audit. Each was root-caused (F1/F2 via a parallel investigation workflow), verified against the code, and fixed with tests updated in lockstep.

## F4 (P1) — primary CTA had 8 different labels
The same start-trial action used "Get Started" (navbar, every page), "Start Free Trial", "Start Your Free Trial", "Start 14-Day Free Trial", etc., and the canonical "Start free — no card" appeared nowhere in the navbar. Standardized to one system: **prominent CTAs → "Start free — no card"**, **compact spots (navbar, sticky bar, pricing cards, inline) → "Start free"**. Aligned the 3 redundant aria-labels, fixed the one destination outlier (blog-post CTA pointed at `/login`; now `/pricing`), and updated the navbar + mobile-nav tests that pinned `/Get Started/i`. 21 files.

## F2 (P0) — `/blog` intermittent 503 under burst
`/blog` + `/blog/category/*` read `searchParams` (`?page`) so they're dynamically rendered: every full-page load AND every RSC prefetch booted a serverless function doing **4 Supabase round-trips**. Prefetch + crawler bursts saturated Fluid-compute concurrency and Vercel shed the extras as 503s, breaking client-side navigation into the blog. (`/blog/[slug]` is immune — static+ISR with a cookie-less client.) Fix, three parts:
- **proxy**: skip `updateSession` for `/blog/*` (public, never reads the session — removes a per-request `getUser` round-trip).
- **both list pages**: cookie-less anon client (the `/blog/[slug]` pattern).
- **`get_blog_categories`** (identical for every blog request) cached via `unstable_cache` (revalidate 300, fail-soft to []) so a burst shares one result.

Blog page tests + the proxy routing test updated for the new behavior.

## F1 (P0) — `/login` stuck on "Loading…"
The page wrapped the whole form in a Suspense fallback because `LoginPageContent` called `useSearchParams()`, forcing a prerender bailout — the static HTML shipped only a "Loading…" spinner (no `<h1>`, no inputs). `searchParams` was only read in two client-only spots (oauth-error effect + post-login redirect), so I read them lazily from `window.location.search` and dropped the `useSearchParams()` hook + Suspense wrapper. The full form now renders into the initial HTML.

## Not touched (deliberately)
- **F6** (the "Janet Shur" testimonial) — a **false positive**; Janet + Jacob are real landlords with approved quotes. The audit prompt has been corrected.
- **F7** (tenant-screening blog category) — intentional SEO content, a KEEP from the v6.0 cleanup.
- The P2/P3 polish (h1-size drift, spacing, breadcrumb casing) — deferred.

Validated: typecheck + lint + the full unit suite pass on every commit (lefthook gate). CI will run e2e + rls-security.

[hudsor01]
