### PR TITLE
fix: render marketing/auth content into static HTML (drop JS-gated loading overlay)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,211 +1,36 @@
 /* eslint-env serviceworker, browser */
-/* global caches, fetch, Response, self, URL, console */
+/* global caches, self */
 /*
-TenantFlow service worker
+TenantFlow service worker — KILL SWITCH.
 
-Goals:
-- Precache critical shell assets for fast first load
-- Runtime caching: cache-first for static assets, network-first for API
-- Navigation fallback for SPA routing
-- Cache size limits and safe cleanup
-- Safe update flow: support skipWaiting via message and notify clients
+The previous version was cache-first on `/_next/` + `.js` assets. Because the
+cache key is the request URL and hashed chunk filenames change every deploy, a
+client holding a populated cache could serve a STALE chunk after a deploy —
+producing a JS version skew that fails hydration and strands the user on the
+root "Loading TenantFlow…" overlay. Vercel's CDN already serves immutable
+hashed assets with long-lived cache headers, so this worker was redundant as
+well as risky.
 
-This worker is intentionally small and conservative to avoid surprising
-behavior. It does not attempt to cache every request; it focuses on
-assets that meaningfully improve performance and resilience.
+This build neutralizes any previously-installed worker: it registers no fetch
+handler (never intercepts a request), purges every cache, and unregisters
+itself on activation. Browsers with the old worker pick this up via their
+automatic SW update check; `register-sw.tsx` also unregisters proactively on
+load. Once cleared, no service worker controls the origin.
 */
 
-const swConsole = globalThis["console"];
-const swLogger = {
-	info: (...args) => {
-		if (swConsole?.info) {
-			swConsole.info("[TenantFlowSW]", ...args);
-		}
-	},
-	warn: (...args) => {
-		if (swConsole?.warn) {
-			swConsole.warn("[TenantFlowSW]", ...args);
-		}
-	},
-	error: (...args) => {
-		if (swConsole?.error) {
-			swConsole.error("[TenantFlowSW]", ...args);
-		}
-	},
-};
-
-const CACHE_VERSION = "v1";
-const PRECACHE = `tenantflow-precache-${CACHE_VERSION}`;
-const RUNTIME = `tenantflow-runtime-${CACHE_VERSION}`;
-
-// Files we want to precache. Keep this list conservative — avoid large files.
-// Note: Don't precache '/' as it redirects based on auth status (causes cache.addAll to fail)
-const PRECACHE_URLS = ["/manifest.json", "/favicon.ico"];
-
-// Limit entries in runtime caches to avoid unbounded growth
-const MAX_RUNTIME_ENTRIES = 100;
-
-// Utility: trim cache to max entries (LRU-ish by deletion order)
-async function trimCache(cacheName, maxEntries) {
-	const cache = await caches.open(cacheName);
-	const keys = await cache.keys();
-	if (keys.length <= maxEntries) return;
-	const deletions = keys.slice(0, keys.length - maxEntries);
-	await Promise.all(deletions.map((k) => cache.delete(k)));
-}
-
-// Utility: respond with network-first strategy for APIs
-async function networkFirst(request) {
-	const cache = await caches.open(RUNTIME);
-	try {
-		const response = await fetch(request);
-		// Only cache successful GET responses
-		if (request.method === "GET" && response && response.status === 200) {
-			cache.put(request, response.clone());
-			// Trim cache in background
-			trimCache(RUNTIME, MAX_RUNTIME_ENTRIES);
-		}
-		return response;
-	} catch {
-		const cached = await cache.match(request);
-		if (cached) return cached;
-		return new Response("Network error", { status: 503 });
-	}
-}
-
-// Utility: cache-first for static assets
-async function cacheFirst(request) {
-	const cache = await caches.open(RUNTIME);
-	const cached = await cache.match(request);
-	if (cached) return cached;
-	try {
-		const response = await fetch(request);
-		if (response && response.status === 200 && request.method === "GET") {
-			cache.put(request, response.clone());
-			trimCache(RUNTIME, MAX_RUNTIME_ENTRIES);
-		}
-		return response;
-	} catch {
-		return new Response("Offline", { status: 503 });
-	}
-}
-
-self.addEventListener("install", (event) => {
-	event.waitUntil(
-		(async () => {
-			const cache = await caches.open(PRECACHE);
-			try {
-				await cache.addAll(PRECACHE_URLS);
-			} catch (e) {
-				// If precache fails, continue — runtime caching still works
-				swLogger.warn("SW: precache failed", e);
-			}
-			// Activate immediately
-			await self.skipWaiting();
-		})(),
-	);
+self.addEventListener("install", () => {
+	self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
 	event.waitUntil(
 		(async () => {
-			// Delete old caches that don't match our current names
 			const keys = await caches.keys();
-			await Promise.all(
-				keys
-					.filter((k) => k !== PRECACHE && k !== RUNTIME)
-					.map((k) => caches.delete(k)),
-			);
-			await self.clients.claim();
+			await Promise.all(keys.map((k) => caches.delete(k)));
+			await self.registration.unregister();
 		})(),
 	);
 });
 
-// Handle messages from client (e.g., skipWaiting)
-self.addEventListener("message", (event) => {
-	// Only accept messages from same-origin controlled clients
-	if (!event.source || !(event.source instanceof Client)) return;
-	if (event.origin && event.origin !== self.location.origin) return;
-	if (!event.data) return;
-	if (event.data.type === "SKIP_WAITING") {
-		self.skipWaiting();
-	}
-});
-
-// Navigation fallback response from precache
-async function navigationFallback() {
-	const cache = await caches.open(PRECACHE);
-	const cached = await cache.match("/");
-	return (
-		cached ||
-		new Response(
-			'<!doctype html><meta charset="utf-8"><title>Offline</title><h1>Offline</h1>',
-			{ headers: { "Content-Type": "text/html" } },
-		)
-	);
-}
-
-self.addEventListener("fetch", (event) => {
-	const { request } = event;
-
-	// Only handle GET requests in service worker to be safe
-	if (request.method !== "GET") return;
-
-	const url = new URL(request.url);
-
-	// Bypass cross-origin requests (e.g., analytics, third-party) — let network handle them
-	if (url.origin !== self.location.origin) return;
-
-	// Prefer cache-first for static resources (by extension or _next static)
-	if (
-		url.pathname.startsWith("/_next/") ||
-		url.pathname.endsWith(".js") ||
-		url.pathname.endsWith(".css") ||
-		url.pathname.endsWith(".woff2") ||
-		url.pathname.endsWith(".png") ||
-		url.pathname.endsWith(".jpg") ||
-		url.pathname.endsWith(".svg")
-	) {
-		event.respondWith(cacheFirst(request));
-		return;
-	}
-
-	// Network-first for API requests under /api/
-	if (url.pathname.startsWith("/api/")) {
-		event.respondWith(networkFirst(request));
-		return;
-	}
-
-	// Navigation requests (HTML) -> use navigation fallback on failure
-	if (request.mode === "navigate") {
-		event.respondWith(
-			(async () => {
-				try {
-					const response = await fetch(request);
-					// Update precache index if fetched successfully
-					if (response && response.status === 200) {
-						const cache = await caches.open(RUNTIME);
-						cache.put(request, response.clone());
-					}
-					return response;
-				} catch {
-					return navigationFallback();
-				}
-			})(),
-		);
-		return;
-	}
-
-	// Default: network-first then fallback to cache
-	event.respondWith(networkFirst(request));
-});
-
-// Periodic cleanup: trim runtime cache on message request
-self.addEventListener("message", (event) => {
-	// Only accept messages from same-origin controlled clients
-	if (!event.source || !(event.source instanceof Client)) return;
-	if (event.origin && event.origin !== self.location.origin) return;
-	if (event.data && event.data.type === "TRIM_CACHES") {
-		event.waitUntil(trimCache(RUNTIME, MAX_RUNTIME_ENTRIES));
-	}
-});
+// Intentionally no "fetch" handler: this worker never intercepts or caches
+// any request, so it cannot serve a stale asset while it waits to deactivate.

--- a/src/app/(admin)/loading.tsx
+++ b/src/app/(admin)/loading.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "#components/ui/skeleton";
+
+/**
+ * Admin Routes Loading State
+ *
+ * Scoped to the authenticated (admin) segment, which fetches data server-side
+ * (the layout validates is_admin() and analytics awaits three RPCs). Restores
+ * the streamed fallback the deleted root app/loading.tsx used to provide here —
+ * without re-imposing a loading overlay on the static public marketing pages.
+ */
+export default function AdminLoading() {
+	return (
+		<div className="space-y-6 p-6">
+			<div className="space-y-2">
+				<Skeleton className="h-8 w-40" />
+				<Skeleton className="h-4 w-72" />
+			</div>
+
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				{Array.from({ length: 4 }).map((_, i) => (
+					<div key={i} className="rounded-lg border border-border/50 p-4">
+						<Skeleton className="mb-2 h-4 w-24" />
+						<Skeleton className="h-8 w-16" />
+					</div>
+				))}
+			</div>
+
+			<div className="rounded-lg border border-border/50 p-4">
+				<Skeleton className="mb-4 h-5 w-48" />
+				{Array.from({ length: 5 }).map((_, i) => (
+					<div key={i} className="flex gap-4 py-2">
+						<Skeleton className="h-5 w-40" />
+						<Skeleton className="h-5 w-32" />
+						<Skeleton className="h-5 w-24" />
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/app/(owner)/layout.tsx
+++ b/src/app/(owner)/layout.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import type { Metadata } from "next";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type { ReactNode } from "react";
 import ModalLayout from "#components/layout/modal-layout";
 import { OwnerDashboardLayout } from "./owner-dashboard-layout";
@@ -62,9 +63,16 @@ export default function OwnerLayout({
 	children: ReactNode;
 	modal?: ReactNode;
 }) {
+	// NuqsAdapter is scoped here (not the root layout) so it does not force
+	// static marketing/auth pages to client-defer their content. The (owner)
+	// segment is already `force-dynamic`, so useSearchParams() renders
+	// server-side here with no CSR bailout. Covers the dashboard data tables,
+	// document vault, preset menu, and property image lightbox.
 	return (
-		<OwnerDashboardLayout>
-			<ModalLayout modal={modal}>{children}</ModalLayout>
-		</OwnerDashboardLayout>
+		<NuqsAdapter>
+			<OwnerDashboardLayout>
+				<ModalLayout modal={modal}>{children}</ModalLayout>
+			</OwnerDashboardLayout>
+		</NuqsAdapter>
 	);
 }

--- a/src/app/auth/post-checkout/page.tsx
+++ b/src/app/auth/post-checkout/page.tsx
@@ -3,12 +3,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { Mail, RefreshCw } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 
 import { Alert, AlertDescription } from "#components/ui/alert";
 import { Button } from "#components/ui/button";
 import { CardLayout } from "#components/ui/card-layout";
-import { Spinner } from "#components/ui/loading-spinner";
+import { PageLoader, Spinner } from "#components/ui/loading-spinner";
 import { createClient } from "#lib/supabase/client";
 
 /**
@@ -22,7 +22,7 @@ import { createClient } from "#lib/supabase/client";
  * 3. User sees "Check your email" message
  * 4. User can explicitly click "Resend" to trigger a magic link if needed
  */
-export default function PostCheckoutPage() {
+function PostCheckoutContent() {
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const [email, setEmail] = useState<string>("");
@@ -206,5 +206,16 @@ export default function PostCheckoutPage() {
 				</div>
 			</CardLayout>
 		</div>
+	);
+}
+
+// useSearchParams() inside PostCheckoutContent forces a client bailout; this
+// own Suspense boundary keeps it scoped here instead of relying on a root
+// loading.tsx (which previously made every static page wait on hydration).
+export default function PostCheckoutPage() {
+	return (
+		<Suspense fallback={<PageLoader text="Setting up your account..." />}>
+			<PostCheckoutContent />
+		</Suspense>
 	);
 }

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,18 @@
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import type { ReactNode } from "react";
+
+/**
+ * Blog layout. Hosts NuqsAdapter for the only nuqs consumer outside the
+ * (owner) segment: <BlogPagination> (uses useQueryState for the `?page` param)
+ * on /blog and /blog/category/[category].
+ *
+ * The adapter is deliberately scoped here instead of the root layout. At the
+ * root it wrapped every page and forced static marketing/auth routes to defer
+ * their content to the client (rendering behind the "Loading TenantFlow…"
+ * Suspense fallback until hydration). Server-rendered blog content is
+ * unaffected — NuqsAdapter is a transparent client boundary and the page
+ * bodies stream through it as RSC children.
+ */
+export default function BlogLayout({ children }: { children: ReactNode }) {
+	return <NuqsAdapter>{children}</NuqsAdapter>;
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,6 +1,0 @@
-import { PageLoader } from "#components/ui/loading-spinner";
-
-// Global App Loading State
-export default function AppLoading() {
-	return <PageLoader text="Loading TenantFlow..." />;
-}

--- a/src/app/pricing/complete/page.tsx
+++ b/src/app/pricing/complete/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
+import { PageLoader } from "#components/ui/loading-spinner";
 import CompleteClient from "./complete-client";
 
 // Stripe-checkout result page — verifies session and shows status. No SEO
@@ -9,5 +11,11 @@ export const metadata: Metadata = {
 };
 
 export default function CompletePage() {
-	return <CompleteClient />;
+	// CompleteClient reads useSearchParams(); its own Suspense boundary keeps
+	// that client bailout scoped here instead of relying on a root loading.tsx.
+	return (
+		<Suspense fallback={<PageLoader text="Verifying your subscription..." />}>
+			<CompleteClient />
+		</Suspense>
+	);
 }

--- a/src/app/pricing/success/page.tsx
+++ b/src/app/pricing/success/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
 import { PageLayout } from "#components/layout/page-layout";
+import { PageLoader } from "#components/ui/loading-spinner";
 import { createPageMetadata } from "#lib/seo/page-metadata";
 import { SuccessClient } from "./success-client";
 
@@ -12,9 +14,13 @@ export const metadata: Metadata = createPageMetadata({
 });
 
 export default function CheckoutSuccessPage() {
+	// SuccessClient reads useSearchParams(); its own Suspense boundary keeps
+	// that client bailout scoped here instead of relying on a root loading.tsx.
 	return (
 		<PageLayout>
-			<SuccessClient />
+			<Suspense fallback={<PageLoader text="Confirming your payment..." />}>
+				<SuccessClient />
+			</Suspense>
 		</PageLayout>
 	);
 }

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type { ReactNode } from "react";
 import { GlobalLoadingIndicator } from "#components/ui/global-loading-indicator";
 import { DEFAULT_THEME_MODE, THEME_MODE_STORAGE_KEY } from "#lib/theme-utils";
@@ -39,12 +38,22 @@ export function Providers({
 		>
 			<PreferencesStoreProvider themeMode={initialThemeMode}>
 				<QueryProvider>
-					<NuqsAdapter>
-						<AuthStoreProvider>
-							{children}
-							<GlobalLoadingIndicator />
-						</AuthStoreProvider>
-					</NuqsAdapter>
+					{/*
+					 * NuqsAdapter is intentionally NOT at the root. It calls
+					 * useSearchParams() internally, which — wrapping the whole
+					 * app from the shared root layout — forces EVERY static
+					 * marketing/auth page to defer its content to the client
+					 * (the page renders behind the root `app/loading.tsx`
+					 * "Loading TenantFlow…" Suspense fallback until hydration).
+					 * Any JS hiccup (slow network, a 503'd chunk, an ad-blocker)
+					 * then leaves the user stuck on the spinner. The adapter is
+					 * scoped to the only subtrees that use nuqs query state:
+					 * `app/(owner)/layout.tsx` and `app/blog/layout.tsx`.
+					 */}
+					<AuthStoreProvider>
+						{children}
+						<GlobalLoadingIndicator />
+					</AuthStoreProvider>
 				</QueryProvider>
 			</PreferencesStoreProvider>
 		</ThemeProvider>

--- a/src/components/sw/register-sw.tsx
+++ b/src/components/sw/register-sw.tsx
@@ -1,90 +1,42 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
+/**
+ * Unregisters any previously-installed service worker and purges its caches.
+ *
+ * TenantFlow used to ship a cache-first worker (`public/sw.js`) that cached
+ * `/_next/` + `.js` assets by URL. After a deploy, hashed chunk filenames
+ * change, so a client holding a populated cache could serve a stale chunk →
+ * JS version skew → hydration failure → stuck on the "Loading TenantFlow…"
+ * overlay. Vercel's CDN already caches immutable assets, so the worker was
+ * redundant. We now actively tear it down on every load. `public/sw.js` is a
+ * matching kill-switch for browsers that only re-check the worker via their
+ * own update cycle.
+ */
 export default function RegisterServiceWorker() {
-	const router = useRouter();
-
 	useEffect(() => {
 		if (typeof window === "undefined") return;
 		if (!("serviceWorker" in navigator)) return;
-		// Only register service worker in production
-		if (process.env.NODE_ENV !== "production") return;
-
-		let refreshing = false;
 
 		navigator.serviceWorker
-			.register("/sw.js")
-			.then(async (registration) => {
-				// Ask the SW to skipWaiting if there's an update waiting
-				if (registration.waiting) {
-					try {
-						registration.waiting.postMessage({ type: "SKIP_WAITING" });
-					} catch {
-						// ignore postMessage failures - best-effort
-					}
-				}
-
-				// When an update is found, attempt to skip waiting to activate
-				registration.addEventListener("updatefound", () => {
-					const newWorker = registration.installing;
-					if (!newWorker) return;
-					newWorker.addEventListener("statechange", () => {
-						if (newWorker.state === "installed" && registration.waiting) {
-							try {
-								registration.waiting.postMessage({ type: "SKIP_WAITING" });
-							} catch {
-								// ignore
-							}
-						}
-					});
-				});
-			})
+			.getRegistrations()
+			.then((registrations) =>
+				Promise.all(registrations.map((r) => r.unregister())),
+			)
 			.catch(() => {
-				// Fail silently; service worker is optional
+				// best-effort teardown; ignore failures
 			});
 
-		// When the new worker takes control, soft-refresh to ensure clients get latest
-		const handleControllerChange = () => {
-			if (refreshing) return;
-			refreshing = true;
-			try {
-				router.refresh();
-			} catch {
-				// ignore refresh failures in uncommon scenarios
-			}
-		};
-		navigator.serviceWorker.addEventListener(
-			"controllerchange",
-			handleControllerChange,
-		);
-
-		// Periodically message SW to trim caches (best-effort)
-		const trimInterval = setInterval(
-			() => {
-				if (navigator.serviceWorker.controller) {
-					try {
-						navigator.serviceWorker.controller.postMessage({
-							type: "TRIM_CACHES",
-						});
-					} catch (err) {
-						// best-effort trim; ignore errors
-						void err;
-					}
-				}
-			},
-			1000 * 60 * 60,
-		);
-
-		return () => {
-			clearInterval(trimInterval);
-			navigator.serviceWorker.removeEventListener(
-				"controllerchange",
-				handleControllerChange,
-			);
-		};
-	}, [router]);
+		if ("caches" in window) {
+			caches
+				.keys()
+				.then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+				.catch(() => {
+					// best-effort cache purge; ignore failures
+				});
+		}
+	}, []);
 
 	return null;
 }


### PR DESCRIPTION
## Why

The live site got **permanently stuck on the "Loading TenantFlow…" overlay** for a real browser (homepage + login + every page). Diagnosed live via the Chrome extension:

- All `_next/static/chunks/*.js` returned **503**, while CSS/fonts/images returned 200 — load-shedding/rate-limiting on a single heavily-hammered IP (a single chunk fetch = 200; the ~25-chunk concurrent burst = 503). **Not** the service worker (unregistering it didn't help), **not** a broken deploy (chunks serve 200 individually).
- The deeper, recurring problem: **every page hid its content behind a JS-gated loading overlay.** The root `app/loading.tsx` wrapped all routes in a full-screen `<Suspense fallback>`. Static marketing/auth pages streamed their content through it, so the real content only appeared once client JS completed the boundary. With the chunks 503'd, the form/hero sat in the DOM at **0×0** behind a spinner that never cleared.

This made the site fragile: any JS hiccup (rate-limit, slow network, ad-blocker, one failed chunk) = stuck, instead of degrading to visible-but-not-yet-interactive content.

## What

- **Remove root `app/loading.tsx`** so static pages render content straight into the prerendered HTML.
- **Scope `NuqsAdapter`** out of the root providers into `(owner)/layout.tsx` + a new `blog/layout.tsx` — the only subtrees using nuqs query state. At the root, its internal `useSearchParams()` forced otherwise-static pages to client-defer.
- **Bound the three bare `useSearchParams` pages** in their own `<Suspense>` (`pricing/success`, `pricing/complete`, `auth/post-checkout`) since they no longer inherit the root boundary.
- **Replace the cache-first `public/sw.js` with a self-unregistering kill switch** + make `register-sw.tsx` tear down any existing worker/caches. The old SW cached hashed `/_next/*.js` cache-first and could serve stale chunks after a deploy (version skew → hydration failure). Vercel's CDN already caches immutable assets.

## Verification

Production build inspected — prerendered HTML now ships **0 loading overlays and 0 pending Suspense boundaries** on every static page:

| page | "Loading TenantFlow" | pending `<!--$?-->` |
|------|---------------------|---------------------|
| `/` (homepage) | 0 | 0 |
| `/login` | 0 | 0 (form + email in HTML) |
| `/pricing` `/features` `/about` | 0 | 0 |
| `/pricing/success` `/pricing/complete` | 0 | 0 |

`bun run typecheck` + lint clean, production build passes, blog tests (44) green, full pre-commit unit suite green.

> Note on the immediate stuck screen: the 503s themselves are rate-limiting on the test IP (hammered all session) and reset on their own / from a fresh network. This PR fixes the architecture so a JS hiccup no longer produces a *permanent* stuck overlay.

[hudsor01]
