### PR TITLE
fix: override browser autofill background on form inputs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -399,6 +399,30 @@
 			"calt" 1;
 	}
 
+	/* Browser autofill: Chrome paints a heavy gray/blue fill on autofilled
+	   fields that ignores the input's transparent background, so a saved
+	   login looked dark on the white card. The box-shadow inset is the only
+	   way to override -webkit-autofill's background; the long transition
+	   suppresses the autofill color flash. Keyed to --color-background +
+	   --color-foreground, which are redefined under .dark, so it adapts to
+	   both themes. */
+	input:-webkit-autofill,
+	input:-webkit-autofill:hover,
+	input:-webkit-autofill:focus,
+	input:-webkit-autofill:active,
+	textarea:-webkit-autofill,
+	textarea:-webkit-autofill:hover,
+	textarea:-webkit-autofill:focus,
+	select:-webkit-autofill,
+	select:-webkit-autofill:hover,
+	select:-webkit-autofill:focus {
+		-webkit-text-fill-color: var(--color-foreground);
+		caret-color: var(--color-foreground);
+		-webkit-box-shadow: 0 0 0 1000px var(--color-background) inset;
+		box-shadow: 0 0 0 1000px var(--color-background) inset;
+		transition: background-color 9999s ease-in-out 0s;
+	}
+
 	/* ============================================================================
 	   Heading Hierarchy - Premium Typography
 	   ============================================================================ */


### PR DESCRIPTION
## Why
Saved-credential autofill rendered the login email/password inputs as a heavy gray/blue fill on the white card. Chrome's `-webkit-autofill` background ignores the input's `bg-transparent` style, and `globals.css` had no autofill handling — so the resting (empty) input is white, but an autofilled one looked dark.

## What
Global `-webkit-autofill` override in `globals.css` (`@layer base`):
- `box-shadow: 0 0 0 1000px var(--color-background) inset` — the only reliable way to override the UA autofill background.
- `-webkit-text-fill-color` + `caret-color` = `var(--color-foreground)`.
- `transition: background-color 9999s` to suppress the autofill color flash.
- Keyed to `--color-background` / `--color-foreground`, which are redefined under `.dark`, so it adapts to both themes. Covers `input`/`textarea`/`select` autofill (+hover/focus/active).

## Verify
Production build compiles clean; the rule is present in the compiled CSS bundle. Resting inputs unchanged (white + border); autofilled inputs now match the surface instead of the browser's gray.

[hudsor01]