### PR TITLE
fix: force-dynamic on /login + /auth/* so the per-request nonce CSP works

### DIFF
--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -1,5 +1,15 @@
 import { createPageMetadata } from "#lib/seo/page-metadata";
 
+// CISEC-02: the proxy serves /login with a per-request nonce CSP
+// (`script-src 'self' 'nonce-…' 'strict-dynamic'`). Next only injects that
+// nonce into the hydration scripts when the route is rendered per-request, so
+// /login MUST be dynamic — otherwise the statically-baked, un-nonced scripts
+// are all CSP-blocked and the page never hydrates. (This dynamic render used
+// to be provided incidentally by the root NuqsAdapter's useSearchParams, which
+// was scoped out in #858; make it explicit.) Dynamic SSR still emits the full
+// form HTML, so the page stays usable even before/without JS.
+export const dynamic = "force-dynamic";
+
 export const metadata = createPageMetadata({
 	title: "Log In to Your Property Management Dashboard",
 	description:

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+// CISEC-02: the proxy serves every /auth/* route with a per-request nonce CSP
+// (`script-src 'self' 'nonce-…' 'strict-dynamic'`). Next only injects that
+// nonce into the hydration scripts when the route renders per-request, so
+// these routes MUST be dynamic — otherwise their statically-baked, un-nonced
+// scripts are all CSP-blocked and the page never hydrates. A `useSearchParams`
+// CSR bailout is NOT sufficient (the route can still be statically prerendered
+// with the client part deferred), so force it explicitly here. This dynamic
+// render used to be provided incidentally by the root NuqsAdapter, scoped out
+// in #858. Dynamic SSR still emits full HTML, so pages stay usable without JS.
+export const dynamic = "force-dynamic";
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+	return children;
+}


### PR DESCRIPTION
## The bug (regression from #858)

`/login` rendered the form HTML but **never hydrated** — every `_next` chunk + inline script was CSP-blocked:

```
Loading the script '<URL>' violates ... "script-src 'self' 'nonce-…' 'strict-dynamic'"
```

CISEC-02 (the proxy, `src/proxy.ts`) intentionally serves `/login` + `/auth/*` with a **per-request nonce CSP**. Next only injects that nonce into hydration scripts when the route renders **per-request**. #858 scoped out the root `NuqsAdapter`, whose `useSearchParams()` had been *incidentally* forcing these routes dynamic — so they became statically prerendered (`○`), their baked scripts carry **no nonce**, and `strict-dynamic` blocked all 25 chunk scripts.

Verified live: `content-security-policy: … 'nonce-…' 'strict-dynamic'` on `/login`, but the served HTML had **0 `nonce=` on 25 `_next` scripts**.

## Fix

Make the dynamic render explicit (it's what CISEC-02 always assumed):
- `export const dynamic = "force-dynamic"` on `(auth)/login/layout.tsx`
- new `auth/layout.tsx` with `force-dynamic` covering all `/auth/*`

`(admin)` already renders dynamically via `cookies()`; `(owner)` is already `force-dynamic`. `/pricing` etc. are **not** in the nonce-CSP set, so they stay static.

Build confirms `/login`, `/auth/*`, `/admin/*` are all `ƒ` dynamic. Dynamic SSR still emits the full form HTML (keeps the #858 "content without JS" win) **and** injects the per-request nonce so hydration works.

## Verify after deploy
`curl -s https://tenantflow.app/login | grep -c 'nonce='` should be > 0 (every script nonced), and the browser console should be free of CSP script-src violations.

[hudsor01]