### PR TITLE
refactor(types): compile-time exhaustiveness for inspection enums

### DIFF
--- a/src/components/inspections/__tests__/inspection-labels.test.ts
+++ b/src/components/inspections/__tests__/inspection-labels.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+	CONDITION_RATING_LABELS,
+	INSPECTION_STATUS_LABELS,
+	ROOM_TYPE_LABELS,
+} from "#components/inspections/inspection-labels";
+import {
+	CONDITION_RATINGS,
+	INSPECTION_STATUSES,
+	ROOM_TYPES,
+} from "#types/sections/inspections";
+
+describe("inspection label records", () => {
+	it("labels exactly the inspection statuses, each non-empty", () => {
+		expect(Object.keys(INSPECTION_STATUS_LABELS).sort()).toEqual(
+			[...INSPECTION_STATUSES].sort(),
+		);
+		for (const status of INSPECTION_STATUSES) {
+			expect(INSPECTION_STATUS_LABELS[status].length).toBeGreaterThan(0);
+		}
+	});
+
+	it("labels exactly the room types, each non-empty", () => {
+		expect(Object.keys(ROOM_TYPE_LABELS).sort()).toEqual(
+			[...ROOM_TYPES].sort(),
+		);
+		for (const roomType of ROOM_TYPES) {
+			expect(ROOM_TYPE_LABELS[roomType].length).toBeGreaterThan(0);
+		}
+	});
+
+	it("labels exactly the condition ratings, each non-empty", () => {
+		expect(Object.keys(CONDITION_RATING_LABELS).sort()).toEqual(
+			[...CONDITION_RATINGS].sort(),
+		);
+		for (const rating of CONDITION_RATINGS) {
+			expect(CONDITION_RATING_LABELS[rating].length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/components/inspections/inspection-detail-sections.tsx
+++ b/src/components/inspections/inspection-detail-sections.tsx
@@ -11,17 +11,15 @@ import {
 	SelectValue,
 } from "#components/ui/select";
 import { useCreateInspectionRoom } from "#hooks/api/use-inspection-room-mutations";
-
-const ROOM_TYPES = [
-	{ value: "bedroom", label: "Bedroom" },
-	{ value: "bathroom", label: "Bathroom" },
-	{ value: "kitchen", label: "Kitchen" },
-	{ value: "living_room", label: "Living Room" },
-	{ value: "dining_room", label: "Dining Room" },
-	{ value: "garage", label: "Garage" },
-	{ value: "outdoor", label: "Outdoor" },
-	{ value: "other", label: "Other" },
-];
+import {
+	CONDITION_RATINGS,
+	type ConditionRating,
+	isConditionRating,
+	isRoomType,
+	ROOM_TYPES,
+	type RoomType,
+} from "#types/sections/inspections";
+import { CONDITION_RATING_LABELS, ROOM_TYPE_LABELS } from "./inspection-labels";
 
 interface AddRoomFormProps {
 	inspectionId: string;
@@ -30,30 +28,27 @@ interface AddRoomFormProps {
 
 export function AddRoomForm({ inspectionId, onCancel }: AddRoomFormProps) {
 	const [roomName, setRoomName] = useState("");
-	const [roomType, setRoomType] = useState("other");
-	const [conditionRating, setConditionRating] = useState("good");
+	const [roomType, setRoomType] = useState<RoomType>("other");
+	const [conditionRating, setConditionRating] =
+		useState<ConditionRating>("good");
 	const createRoom = useCreateInspectionRoom();
+
+	// Select options are statically the union members; the guards narrow the
+	// `string` event payload back to the union without an `as` cast.
+	function handleRoomTypeChange(value: string) {
+		if (isRoomType(value)) setRoomType(value);
+	}
+	function handleConditionChange(value: string) {
+		if (isConditionRating(value)) setConditionRating(value);
+	}
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 		await createRoom.mutateAsync({
 			inspection_id: inspectionId,
 			room_name: roomName,
-			room_type: roomType as
-				| "bedroom"
-				| "bathroom"
-				| "kitchen"
-				| "living_room"
-				| "dining_room"
-				| "garage"
-				| "outdoor"
-				| "other",
-			condition_rating: conditionRating as
-				| "excellent"
-				| "good"
-				| "fair"
-				| "poor"
-				| "damaged",
+			room_type: roomType,
+			condition_rating: conditionRating,
 		});
 		onCancel();
 	}
@@ -81,14 +76,14 @@ export function AddRoomForm({ inspectionId, onCancel }: AddRoomFormProps) {
 
 				<div className="space-y-2">
 					<Label htmlFor="room-type">Room type</Label>
-					<Select value={roomType} onValueChange={setRoomType}>
+					<Select value={roomType} onValueChange={handleRoomTypeChange}>
 						<SelectTrigger id="room-type">
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
-							{ROOM_TYPES.map((t) => (
-								<SelectItem key={t.value} value={t.value}>
-									{t.label}
+							{ROOM_TYPES.map((value) => (
+								<SelectItem key={value} value={value}>
+									{ROOM_TYPE_LABELS[value]}
 								</SelectItem>
 							))}
 						</SelectContent>
@@ -97,16 +92,16 @@ export function AddRoomForm({ inspectionId, onCancel }: AddRoomFormProps) {
 
 				<div className="space-y-2">
 					<Label htmlFor="room-condition">Initial condition</Label>
-					<Select value={conditionRating} onValueChange={setConditionRating}>
+					<Select value={conditionRating} onValueChange={handleConditionChange}>
 						<SelectTrigger id="room-condition">
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
-							<SelectItem value="excellent">Excellent</SelectItem>
-							<SelectItem value="good">Good</SelectItem>
-							<SelectItem value="fair">Fair</SelectItem>
-							<SelectItem value="poor">Poor</SelectItem>
-							<SelectItem value="damaged">Damaged</SelectItem>
+							{CONDITION_RATINGS.map((value) => (
+								<SelectItem key={value} value={value}>
+									{CONDITION_RATING_LABELS[value]}
+								</SelectItem>
+							))}
 						</SelectContent>
 					</Select>
 				</div>

--- a/src/components/inspections/inspection-detail.client.tsx
+++ b/src/components/inspections/inspection-detail.client.tsx
@@ -15,17 +15,12 @@ import {
 	useSubmitForTenantReview,
 	useUpdateInspection,
 } from "#hooks/api/use-inspection-mutations";
+import { assertNever } from "#lib/assert-never";
 import { formatDate } from "#lib/formatters/date";
+import type { InspectionStatus } from "#types/sections/inspections";
 import { AddRoomForm } from "./inspection-detail-sections";
+import { INSPECTION_STATUS_LABELS } from "./inspection-labels";
 import { InspectionRoomCard } from "./inspection-room-card";
-
-const STATUS_LABELS: Record<string, string> = {
-	pending: "Pending",
-	in_progress: "In Progress",
-	completed: "Completed",
-	tenant_reviewing: "Tenant Reviewing",
-	finalized: "Finalized",
-};
 
 type StatusVariant =
 	| "secondary"
@@ -35,7 +30,7 @@ type StatusVariant =
 	| "warning"
 	| "outline";
 
-function statusVariant(status: string): StatusVariant {
+function statusVariant(status: InspectionStatus): StatusVariant {
 	switch (status) {
 		case "pending":
 			return "secondary";
@@ -48,7 +43,7 @@ function statusVariant(status: string): StatusVariant {
 		case "finalized":
 			return "info";
 		default:
-			return "outline";
+			return assertNever(status, "statusVariant");
 	}
 }
 
@@ -109,7 +104,7 @@ export function InspectionDetailClient({ id }: { id: string }) {
 					<div className="flex items-center gap-3 flex-wrap">
 						<h1 className="text-xl font-semibold">{typeLabel} Inspection</h1>
 						<Badge variant={statusVariant(inspection.status)}>
-							{STATUS_LABELS[inspection.status] ?? inspection.status}
+							{INSPECTION_STATUS_LABELS[inspection.status]}
 						</Badge>
 					</div>
 					<div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground flex-wrap">

--- a/src/components/inspections/inspection-detail.client.tsx
+++ b/src/components/inspections/inspection-detail.client.tsx
@@ -22,13 +22,7 @@ import { AddRoomForm } from "./inspection-detail-sections";
 import { INSPECTION_STATUS_LABELS } from "./inspection-labels";
 import { InspectionRoomCard } from "./inspection-room-card";
 
-type StatusVariant =
-	| "secondary"
-	| "default"
-	| "success"
-	| "info"
-	| "warning"
-	| "outline";
+type StatusVariant = "secondary" | "default" | "success" | "info" | "warning";
 
 function statusVariant(status: InspectionStatus): StatusVariant {
 	switch (status) {

--- a/src/components/inspections/inspection-labels.ts
+++ b/src/components/inspections/inspection-labels.ts
@@ -1,0 +1,41 @@
+/**
+ * Display labels for the inspection enums.
+ *
+ * Single source of truth for the human-readable copy of each DB
+ * CHECK-constrained inspection value. Typed as `Record<Union, string>` so the
+ * compiler forces a label for every member — adding a new status/room type/
+ * rating to the union in #types/sections/inspections is a build error here
+ * until its label is supplied.
+ */
+import type {
+	ConditionRating,
+	InspectionStatus,
+	RoomType,
+} from "#types/sections/inspections";
+
+export const INSPECTION_STATUS_LABELS: Record<InspectionStatus, string> = {
+	pending: "Pending",
+	in_progress: "In Progress",
+	completed: "Completed",
+	tenant_reviewing: "Tenant Reviewing",
+	finalized: "Finalized",
+};
+
+export const ROOM_TYPE_LABELS: Record<RoomType, string> = {
+	bedroom: "Bedroom",
+	bathroom: "Bathroom",
+	kitchen: "Kitchen",
+	living_room: "Living Room",
+	dining_room: "Dining Room",
+	garage: "Garage",
+	outdoor: "Outdoor",
+	other: "Other",
+};
+
+export const CONDITION_RATING_LABELS: Record<ConditionRating, string> = {
+	excellent: "Excellent",
+	good: "Good",
+	fair: "Fair",
+	poor: "Poor",
+	damaged: "Damaged",
+};

--- a/src/components/inspections/inspection-list.client.tsx
+++ b/src/components/inspections/inspection-list.client.tsx
@@ -16,7 +16,7 @@ import { INSPECTION_STATUS_LABELS } from "./inspection-labels";
 
 function statusBadgeVariant(
 	status: InspectionStatus,
-): "default" | "secondary" | "outline" | "destructive" {
+): "default" | "secondary" | "outline" {
 	switch (status) {
 		case "pending":
 			return "secondary";

--- a/src/components/inspections/inspection-list.client.tsx
+++ b/src/components/inspections/inspection-list.client.tsx
@@ -6,11 +6,16 @@ import { Badge } from "#components/ui/badge";
 import { Button } from "#components/ui/button";
 import { Skeleton } from "#components/ui/skeleton";
 import { useInspections } from "#hooks/api/use-inspections";
+import { assertNever } from "#lib/assert-never";
 import { formatDate } from "#lib/formatters/date";
-import type { InspectionListItem } from "#types/sections/inspections";
+import type {
+	InspectionListItem,
+	InspectionStatus,
+} from "#types/sections/inspections";
+import { INSPECTION_STATUS_LABELS } from "./inspection-labels";
 
 function statusBadgeVariant(
-	status: string,
+	status: InspectionStatus,
 ): "default" | "secondary" | "outline" | "destructive" {
 	switch (status) {
 		case "pending":
@@ -24,24 +29,7 @@ function statusBadgeVariant(
 		case "finalized":
 			return "outline";
 		default:
-			return "secondary";
-	}
-}
-
-function statusLabel(status: string): string {
-	switch (status) {
-		case "pending":
-			return "Pending";
-		case "in_progress":
-			return "In Progress";
-		case "completed":
-			return "Completed";
-		case "tenant_reviewing":
-			return "Tenant Reviewing";
-		case "finalized":
-			return "Finalized";
-		default:
-			return status;
+			return assertNever(status, "statusBadgeVariant");
 	}
 }
 
@@ -84,7 +72,7 @@ function InspectionRow({ inspection }: { inspection: InspectionListItem }) {
 					{formatDate(inspection.created_at, { relative: true })}
 				</span>
 				<Badge variant={statusBadgeVariant(inspection.status)}>
-					{statusLabel(inspection.status)}
+					{INSPECTION_STATUS_LABELS[inspection.status]}
 				</Badge>
 			</div>
 		</Link>

--- a/src/components/inspections/inspection-room-card.tsx
+++ b/src/components/inspections/inspection-room-card.tsx
@@ -17,7 +17,13 @@ import {
 	useDeleteInspectionRoom,
 	useUpdateInspectionRoom,
 } from "#hooks/api/use-inspection-room-mutations";
-import type { InspectionRoom } from "#types/sections/inspections";
+import { assertNever } from "#lib/assert-never";
+import {
+	type ConditionRating,
+	type InspectionRoom,
+	isConditionRating,
+} from "#types/sections/inspections";
+import { CONDITION_RATING_LABELS, ROOM_TYPE_LABELS } from "./inspection-labels";
 import { InspectionPhotoUpload } from "./inspection-photo-upload";
 
 interface InspectionRoomCardProps {
@@ -25,28 +31,9 @@ interface InspectionRoomCardProps {
 	inspectionId: string;
 }
 
-const CONDITION_LABELS: Record<string, string> = {
-	excellent: "Excellent",
-	good: "Good",
-	fair: "Fair",
-	poor: "Poor",
-	damaged: "Damaged",
-};
-
-const ROOM_TYPE_LABELS: Record<string, string> = {
-	bedroom: "Bedroom",
-	bathroom: "Bathroom",
-	kitchen: "Kitchen",
-	living_room: "Living Room",
-	dining_room: "Dining Room",
-	garage: "Garage",
-	outdoor: "Outdoor",
-	other: "Other",
-};
-
 function conditionVariant(
-	rating: string,
-): "success" | "info" | "warning" | "destructive" | "outline" {
+	rating: ConditionRating,
+): "success" | "info" | "warning" | "destructive" {
 	switch (rating) {
 		case "excellent":
 			return "success";
@@ -59,7 +46,7 @@ function conditionVariant(
 		case "damaged":
 			return "destructive";
 		default:
-			return "outline";
+			return assertNever(rating, "conditionVariant");
 	}
 }
 
@@ -76,17 +63,13 @@ export function InspectionRoomCard({
 	const deleteRoom = useDeleteInspectionRoom(inspectionId);
 
 	function handleConditionChange(value: string) {
+		// Select options are statically the five ratings; the guard narrows the
+		// `string` event payload to ConditionRating without an `as` cast.
+		if (!isConditionRating(value)) return;
 		setConditionRating(value);
 		updateRoom.mutate({
 			roomId: room.id,
-			dto: {
-				condition_rating: value as
-					| "excellent"
-					| "good"
-					| "fair"
-					| "poor"
-					| "damaged",
-			},
+			dto: { condition_rating: value },
 		});
 	}
 
@@ -130,12 +113,12 @@ export function InspectionRoomCard({
 								{room.room_name}
 							</span>
 							<span className="text-xs text-muted-foreground">
-								{ROOM_TYPE_LABELS[room.room_type] ?? room.room_type}
+								{ROOM_TYPE_LABELS[room.room_type]}
 							</span>
 						</div>
 						<div className="flex items-center gap-2 mt-1">
 							<Badge variant={conditionVariant(conditionRating)} size="sm">
-								{CONDITION_LABELS[conditionRating] ?? conditionRating}
+								{CONDITION_RATING_LABELS[conditionRating]}
 							</Badge>
 							{photos.length > 0 && (
 								<span className="text-xs text-muted-foreground flex items-center gap-1">

--- a/src/components/leases/wizard/lease-creation-wizard.tsx
+++ b/src/components/leases/wizard/lease-creation-wizard.tsx
@@ -18,6 +18,7 @@ import { propertyQueries } from "#hooks/api/query-keys/property-keys";
 import { tenantQueries } from "#hooks/api/query-keys/tenant-keys";
 import { unitQueries } from "#hooks/api/query-keys/unit-keys";
 import { useUnsavedChangesWarning } from "#hooks/use-unsaved-changes";
+import { assertNever } from "#lib/assert-never";
 import { omitUndefined } from "#lib/db-insert";
 import { requireOwnerUserId } from "#lib/require-owner-user-id";
 import { createClient } from "#lib/supabase/client";
@@ -220,7 +221,7 @@ export function LeaseCreationWizard({ onSuccess }: LeaseCreationWizardProps) {
 			case "review":
 				return true;
 			default:
-				return false;
+				return assertNever(step, "validateStep");
 		}
 	};
 

--- a/src/hooks/api/query-keys/inspection-keys.ts
+++ b/src/hooks/api/query-keys/inspection-keys.ts
@@ -16,6 +16,7 @@ import {
 	type Inspection,
 	type InspectionListItem,
 	narrowInspectionEnums,
+	narrowInspectionRoomEnums,
 } from "#types/sections/inspections";
 
 const INSPECTION_SELECT_COLUMNS =
@@ -121,7 +122,7 @@ export const inspectionQueries = {
 				// (photos resolved to publicUrl) instead.
 				const { inspection_rooms, ...rest } = data;
 				const rooms = (inspection_rooms ?? []).map((room) => ({
-					...room,
+					...narrowInspectionRoomEnums(room),
 					photos: (room.inspection_photos ?? []).map((photo) => {
 						const { data: urlData } = supabase.storage
 							.from("inspection-photos")

--- a/src/lib/__tests__/assert-never.test.ts
+++ b/src/lib/__tests__/assert-never.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { assertNever } from "#lib/assert-never";
+
+function thrownMessage(fn: () => unknown): string {
+	try {
+		fn();
+	} catch (err) {
+		return (err as Error).message;
+	}
+	throw new Error("expected assertNever to throw");
+}
+
+describe("assertNever", () => {
+	it("throws including the unhandled value", () => {
+		expect(thrownMessage(() => assertNever("surprise" as never))).toContain(
+			"Unhandled case: surprise",
+		);
+	});
+
+	it("includes the context label when provided", () => {
+		expect(
+			thrownMessage(() => assertNever("surprise" as never, "myMapper")),
+		).toContain("Unhandled case in myMapper: surprise");
+	});
+});

--- a/src/lib/assert-never.ts
+++ b/src/lib/assert-never.ts
@@ -1,0 +1,27 @@
+/**
+ * Compile-time exhaustiveness guard for switches over finite unions.
+ *
+ * Place a call in the `default` branch of a `switch` (or the final `else` of an
+ * if/else chain) that is meant to handle every member of a union. When all
+ * cases are handled, the argument narrows to `never` and the call typechecks;
+ * add a new union member without handling it and the compiler raises an error
+ * at the call site — turning a silent fallthrough into a build failure.
+ *
+ * At runtime the call should be unreachable (callers narrow the union at their
+ * data boundary), so it throws to surface drift loudly instead of returning a
+ * misleading fallback.
+ *
+ * @example
+ * function toBadge(status: InspectionStatus): BadgeVariant {
+ *   switch (status) {
+ *     case "pending": return "secondary";
+ *     // ...every other case...
+ *     default: return assertNever(status, "toBadge");
+ *   }
+ * }
+ */
+export function assertNever(value: never, context?: string): never {
+	throw new Error(
+		`Unhandled case${context ? ` in ${context}` : ""}: ${String(value)}`,
+	);
+}

--- a/src/lib/utils/currency.ts
+++ b/src/lib/utils/currency.ts
@@ -3,6 +3,8 @@
  * Consolidates multiple formatPrice implementations into a single shared utility
  */
 
+import { assertNever } from "#lib/assert-never";
+
 export type BillingInterval = "monthly" | "annual" | "month" | "year";
 export type CurrencyCode = "USD" | "EUR" | "GBP" | "CAD" | "AUD";
 
@@ -123,7 +125,7 @@ export const getIntervalSuffix = (interval: BillingInterval): string => {
 		case "year":
 			return "/yr";
 		default:
-			return "";
+			return assertNever(interval, "getIntervalSuffix");
 	}
 };
 

--- a/src/lib/validation/inspections.ts
+++ b/src/lib/validation/inspections.ts
@@ -6,35 +6,20 @@
  */
 
 import { z } from "zod";
+import {
+	CONDITION_RATINGS,
+	INSPECTION_STATUSES,
+	INSPECTION_TYPES,
+	ROOM_TYPES,
+} from "#types/sections/inspections";
 
-const inspectionTypeSchema = z.enum(["move_in", "move_out"]);
-
-const inspectionStatusSchema = z.enum([
-	"pending",
-	"in_progress",
-	"completed",
-	"tenant_reviewing",
-	"finalized",
-]);
-
-const roomTypeSchema = z.enum([
-	"bedroom",
-	"bathroom",
-	"kitchen",
-	"living_room",
-	"dining_room",
-	"garage",
-	"outdoor",
-	"other",
-]);
-
-const conditionRatingSchema = z.enum([
-	"excellent",
-	"good",
-	"fair",
-	"poor",
-	"damaged",
-]);
+// Derive Zod enums from the single source-of-truth const arrays in
+// #types/sections/inspections so the validation layer and the runtime type
+// guards / narrowers can never drift apart.
+const inspectionTypeSchema = z.enum(INSPECTION_TYPES);
+const inspectionStatusSchema = z.enum(INSPECTION_STATUSES);
+const roomTypeSchema = z.enum(ROOM_TYPES);
+const conditionRatingSchema = z.enum(CONDITION_RATINGS);
 
 const createInspectionSchema = z.object({
 	lease_id: z.string().uuid(),
@@ -85,10 +70,9 @@ const tenantReviewSchema = z.object({
 	tenant_signature_data: z.string().min(1, "Signature is required"),
 });
 
-export type InspectionType = z.infer<typeof inspectionTypeSchema>;
-export type InspectionStatus = z.infer<typeof inspectionStatusSchema>;
-export type RoomType = z.infer<typeof roomTypeSchema>;
-export type ConditionRating = z.infer<typeof conditionRatingSchema>;
+// Scalar enum types (InspectionType/InspectionStatus/RoomType/ConditionRating)
+// are the single source-of-truth exports in #types/sections/inspections — do
+// not re-declare them here.
 export type CreateInspectionInput = z.infer<typeof createInspectionSchema>;
 export type UpdateInspectionInput = z.infer<typeof updateInspectionSchema>;
 export type CreateInspectionRoomInput = z.infer<

--- a/src/types/sections/__tests__/inspections.test.ts
+++ b/src/types/sections/__tests__/inspections.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+	CONDITION_RATINGS,
+	INSPECTION_STATUSES,
+	INSPECTION_TYPES,
+	isConditionRating,
+	isInspectionStatus,
+	isInspectionType,
+	isRoomType,
+	narrowInspectionEnums,
+	narrowInspectionRoomEnums,
+	ROOM_TYPES,
+} from "#types/sections/inspections";
+
+function thrownMessage(fn: () => unknown): string {
+	try {
+		fn();
+	} catch (err) {
+		return (err as Error).message;
+	}
+	throw new Error("expected fn to throw");
+}
+
+describe("inspection enum type guards", () => {
+	it("accepts every valid union member", () => {
+		for (const v of INSPECTION_STATUSES)
+			expect(isInspectionStatus(v)).toBe(true);
+		for (const v of INSPECTION_TYPES) expect(isInspectionType(v)).toBe(true);
+		for (const v of ROOM_TYPES) expect(isRoomType(v)).toBe(true);
+		for (const v of CONDITION_RATINGS) expect(isConditionRating(v)).toBe(true);
+	});
+
+	it("rejects out-of-union values", () => {
+		expect(isInspectionStatus("archived")).toBe(false);
+		expect(isInspectionType("walkthrough")).toBe(false);
+		expect(isRoomType("attic")).toBe(false);
+		expect(isConditionRating("destroyed")).toBe(false);
+	});
+});
+
+describe("narrowInspectionEnums", () => {
+	it("narrows a valid row to the literal unions", () => {
+		const narrowed = narrowInspectionEnums({
+			id: "i1",
+			inspection_type: "move_in",
+			status: "pending",
+		});
+		expect(narrowed.inspection_type).toBe("move_in");
+		expect(narrowed.status).toBe("pending");
+	});
+
+	it("throws loudly on unexpected status / type", () => {
+		expect(
+			thrownMessage(() =>
+				narrowInspectionEnums({
+					id: "i1",
+					inspection_type: "move_in",
+					status: "bogus",
+				}),
+			),
+		).toContain('Unexpected status "bogus"');
+		expect(
+			thrownMessage(() =>
+				narrowInspectionEnums({
+					id: "i1",
+					inspection_type: "teleport",
+					status: "pending",
+				}),
+			),
+		).toContain('Unexpected inspection_type "teleport"');
+	});
+});
+
+describe("narrowInspectionRoomEnums", () => {
+	it("narrows a valid room to the literal unions", () => {
+		const narrowed = narrowInspectionRoomEnums({
+			id: "r1",
+			room_type: "kitchen",
+			condition_rating: "good",
+		});
+		expect(narrowed.room_type).toBe("kitchen");
+		expect(narrowed.condition_rating).toBe("good");
+	});
+
+	it("throws loudly on unexpected room_type / condition_rating", () => {
+		expect(
+			thrownMessage(() =>
+				narrowInspectionRoomEnums({
+					id: "r1",
+					room_type: "attic",
+					condition_rating: "good",
+				}),
+			),
+		).toContain('Unexpected room_type "attic"');
+		expect(
+			thrownMessage(() =>
+				narrowInspectionRoomEnums({
+					id: "r1",
+					room_type: "kitchen",
+					condition_rating: "ruined",
+				}),
+			),
+		).toContain('Unexpected condition_rating "ruined"');
+	});
+});

--- a/src/types/sections/__tests__/inspections.test.ts
+++ b/src/types/sections/__tests__/inspections.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
 	CONDITION_RATINGS,
@@ -19,6 +20,23 @@ function thrownMessage(fn: () => unknown): string {
 		return (err as Error).message;
 	}
 	throw new Error("expected fn to throw");
+}
+
+/**
+ * Pulls the value list out of a `check (<column> in ('a', 'b', ...))` clause in
+ * a migration so the union arrays can be pinned to the DB CHECK constraints.
+ */
+function checkConstraintMembers(sql: string, column: string): string[] {
+	const clause = sql.match(
+		new RegExp(`check\\s*\\(\\s*${column}\\s+in\\s*\\(([^)]*)\\)`, "i"),
+	);
+	const inner = clause?.[1];
+	if (inner === undefined) {
+		throw new Error(`CHECK constraint for "${column}" not found in migration`);
+	}
+	return Array.from(inner.matchAll(/'([a-z_]+)'/g))
+		.map((m) => m[1])
+		.filter((v): v is string => v !== undefined);
 }
 
 describe("inspection enum type guards", () => {
@@ -101,5 +119,41 @@ describe("narrowInspectionRoomEnums", () => {
 				}),
 			),
 		).toContain('Unexpected condition_rating "ruined"');
+	});
+});
+
+describe("union arrays are in lockstep with the DB CHECK constraints", () => {
+	// The fail-loud narrowers (narrowInspectionEnums / narrowInspectionRoomEnums)
+	// throw on any value outside these arrays, so a migration that widens a CHECK
+	// without updating the union would crash the whole inspection list/detail
+	// query on real rows. This pins the arrays to the create-table migration —
+	// drift becomes a build failure instead of a runtime crash.
+	const migrationSql = readFileSync(
+		"supabase/migrations/20260220110000_create_inspections_tables.sql",
+		"utf8",
+	);
+
+	it("INSPECTION_TYPES matches the inspection_type CHECK", () => {
+		expect(
+			checkConstraintMembers(migrationSql, "inspection_type").sort(),
+		).toEqual([...INSPECTION_TYPES].sort());
+	});
+
+	it("INSPECTION_STATUSES matches the status CHECK", () => {
+		expect(checkConstraintMembers(migrationSql, "status").sort()).toEqual(
+			[...INSPECTION_STATUSES].sort(),
+		);
+	});
+
+	it("ROOM_TYPES matches the room_type CHECK", () => {
+		expect(checkConstraintMembers(migrationSql, "room_type").sort()).toEqual(
+			[...ROOM_TYPES].sort(),
+		);
+	});
+
+	it("CONDITION_RATINGS matches the condition_rating CHECK", () => {
+		expect(
+			checkConstraintMembers(migrationSql, "condition_rating").sort(),
+		).toEqual([...CONDITION_RATINGS].sort());
 	});
 });

--- a/src/types/sections/inspections.ts
+++ b/src/types/sections/inspections.ts
@@ -13,9 +13,45 @@ export const INSPECTION_STATUSES = [
 	"tenant_reviewing",
 	"finalized",
 ] as const;
+export const ROOM_TYPES = [
+	"bedroom",
+	"bathroom",
+	"kitchen",
+	"living_room",
+	"dining_room",
+	"garage",
+	"outdoor",
+	"other",
+] as const;
+export const CONDITION_RATINGS = [
+	"excellent",
+	"good",
+	"fair",
+	"poor",
+	"damaged",
+] as const;
 
 export type InspectionType = (typeof INSPECTION_TYPES)[number];
 export type InspectionStatus = (typeof INSPECTION_STATUSES)[number];
+export type RoomType = (typeof ROOM_TYPES)[number];
+export type ConditionRating = (typeof CONDITION_RATINGS)[number];
+
+/**
+ * Runtime type guards for the DB CHECK-constrained inspection enums. Each
+ * narrows a raw `string` to its literal union so callers avoid `as` casts.
+ */
+export function isInspectionType(value: string): value is InspectionType {
+	return (INSPECTION_TYPES as readonly string[]).includes(value);
+}
+export function isInspectionStatus(value: string): value is InspectionStatus {
+	return (INSPECTION_STATUSES as readonly string[]).includes(value);
+}
+export function isRoomType(value: string): value is RoomType {
+	return (ROOM_TYPES as readonly string[]).includes(value);
+}
+export function isConditionRating(value: string): value is ConditionRating {
+	return (CONDITION_RATINGS as readonly string[]).includes(value);
+}
 
 /**
  * Narrows the DB row's `inspection_type` / `status: string` columns to the
@@ -27,20 +63,46 @@ export type InspectionStatus = (typeof INSPECTION_STATUSES)[number];
 export function narrowInspectionEnums<
 	T extends { id: string; inspection_type: string; status: string },
 >(row: T): T & { inspection_type: InspectionType; status: InspectionStatus } {
-	if (!INSPECTION_TYPES.includes(row.inspection_type as InspectionType)) {
+	if (!isInspectionType(row.inspection_type)) {
 		throw new Error(
 			`Unexpected inspection_type "${row.inspection_type}" on inspection ${row.id}`,
 		);
 	}
-	if (!INSPECTION_STATUSES.includes(row.status as InspectionStatus)) {
+	if (!isInspectionStatus(row.status)) {
 		throw new Error(
 			`Unexpected status "${row.status}" on inspection ${row.id}`,
 		);
 	}
 	return {
 		...row,
-		inspection_type: row.inspection_type as InspectionType,
-		status: row.status as InspectionStatus,
+		inspection_type: row.inspection_type,
+		status: row.status,
+	};
+}
+
+/**
+ * Narrows an inspection_rooms row's `room_type` / `condition_rating: string`
+ * columns to their literal unions. Both columns are DB CHECK-constrained, so
+ * reject drift loudly rather than silently passing an out-of-union value to
+ * the UI exhaustiveness switches.
+ */
+export function narrowInspectionRoomEnums<
+	T extends { id: string; room_type: string; condition_rating: string },
+>(room: T): T & { room_type: RoomType; condition_rating: ConditionRating } {
+	if (!isRoomType(room.room_type)) {
+		throw new Error(
+			`Unexpected room_type "${room.room_type}" on inspection room ${room.id}`,
+		);
+	}
+	if (!isConditionRating(room.condition_rating)) {
+		throw new Error(
+			`Unexpected condition_rating "${room.condition_rating}" on inspection room ${room.id}`,
+		);
+	}
+	return {
+		...room,
+		room_type: room.room_type,
+		condition_rating: room.condition_rating,
 	};
 }
 
@@ -62,8 +124,8 @@ export interface InspectionRoom {
 	id: string;
 	inspection_id: string;
 	room_name: string;
-	room_type: string;
-	condition_rating: string;
+	room_type: RoomType;
+	condition_rating: ConditionRating;
 	notes: string | null;
 	created_at: string;
 	updated_at: string;
@@ -97,7 +159,7 @@ export interface InspectionListItem {
 	lease_id: string;
 	property_id: string;
 	inspection_type: InspectionType;
-	status: string;
+	status: InspectionStatus;
 	scheduled_date: string | null;
 	completed_at: string | null;
 	created_at: string;


### PR DESCRIPTION
## Why

Reviewed the dev.to post _"TypeScript tips that actually matter in real projects (including the `satisfies` operator)."_ The codebase already applies **7 of the 8** techniques rigorously (and even guards `as unknown as` with a CI drift test). The one technique missing in practice was **compile-time exhaustiveness checking with `never`** — there was no `assertNever` helper anywhere, and several switches over DB `CHECK`-constrained unions widened their input to `string` and leaned on a runtime `default:` fallback.

Because the project bans Postgres ENUMs (text + `CHECK`), TS unions are the **only** exhaustiveness layer — so this gap mattered more here than in most codebases. This PR closes it and tightens the inspection type integration end to end.

## What changed

- **`assertNever` helper** (`src/lib/assert-never.ts`) — compile-time-exhaustive switch defaults; a new union member becomes a build error instead of a silent fallthrough.
- **Single source of truth** in `#types/sections/inspections`: added `ROOM_TYPES` / `CONDITION_RATINGS` const arrays + `RoomType` / `ConditionRating` types, `is*` type guards, and `narrowInspectionRoomEnums` (mirrors the existing `narrowInspectionEnums`).
- **Narrowed interface fields** from bare `string` to their literal unions: `InspectionListItem.status`, `InspectionRoom.room_type`, `InspectionRoom.condition_rating`. Values are already DB `CHECK`-constrained and validated at the query boundary, so this is pure precision recovery.
- **Exhaustive switches**: status → badge variant, rating → badge variant, billing interval suffix, and the lease-wizard step validator now `assertNever` in their defaults.
- **Type guards replace inline casts** — `value as "a" | "b" | …` in the room-card and add-room form are gone, narrowed via the new guards.
- **Zod enums derived from the shared const arrays** in `validation/inspections` (kills the duplicated string lists) and dropped 4 duplicate scalar type exports (zero-tolerance rule #3).
- **Precise index signatures** — loose `Record<string, string>` label maps tightened to `Record<Union, string>` and deduped into one `inspection-labels` module.

## Article techniques applied

`never` exhaustiveness · `as const` unions · type guards over casting · precise `Record<Union, T>` index signatures · `satisfies`-style exhaustive maps · dedup via derived types.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test:unit` — **100,446 passing** (added: `assert-never`, enum guards/narrowers, label drift guard)
- No new `any` / `as unknown as` introduced.

## Out of scope (deliberate)

The 2 remaining `React.ComponentType<any>` props are TanStack Form's render-prop `Field` with 12 generic parameters; a single `ComponentType` prop can't preserve per-field value types without the full `createFormHook`/`withForm` ceremony. They're already documented with `biome-ignore` rationale — forcing removal is a net negative.

[hudsor01]
