### PR TITLE
refactor(types): replace the last two form-field `any`s with typed form API

### DIFF
--- a/src/components/pricing/owner-subscribe-form-types.ts
+++ b/src/components/pricing/owner-subscribe-form-types.ts
@@ -14,12 +14,12 @@ import type { signupFormSchema } from "#lib/validation/auth";
 export type SubscribeFormValues = z.infer<typeof signupFormSchema>;
 
 /**
- * Typed form instance for the subscribe dialog, shared between
- * owner-subscribe-dialog.tsx and its extracted SubscribeFormFields section
- * (mirrors PropertyFormApi). Unused validator slots are widened to accept
- * either an unset validator or one added later; the onSubmit slot is pinned to
- * the schema the form is actually configured with (`validators.onSubmit`) so
- * the concrete `useForm` instance stays assignable to this type.
+ * Typed form instance for the subscribe dialog (mirrors PropertyFormApi).
+ * Consumed by the extracted SubscribeFormFields section; the dialog's own
+ * `useForm` instance is inferred structurally and must stay assignable to this
+ * type. Unused validator slots are widened to accept either an unset validator
+ * or one added later; the onSubmit slot is pinned to the schema the form is
+ * actually configured with (`validators.onSubmit`) so that assignment holds.
  */
 export type SubscribeFormApi = ReactFormExtendedApi<
 	SubscribeFormValues, // TFormData

--- a/src/components/pricing/owner-subscribe-form-types.ts
+++ b/src/components/pricing/owner-subscribe-form-types.ts
@@ -1,0 +1,37 @@
+import type {
+	FormAsyncValidateOrFn,
+	FormValidateOrFn,
+	ReactFormExtendedApi,
+} from "@tanstack/react-form";
+import type { z } from "zod";
+import type { signupFormSchema } from "#lib/validation/auth";
+
+/**
+ * Form values for the owner subscribe / signup dialog. Derived from the Zod
+ * schema the form validates against so the value shape and validator can never
+ * drift apart.
+ */
+export type SubscribeFormValues = z.infer<typeof signupFormSchema>;
+
+/**
+ * Typed form instance for the subscribe dialog, shared between
+ * owner-subscribe-dialog.tsx and its extracted SubscribeFormFields section
+ * (mirrors PropertyFormApi). Unused validator slots are widened to accept
+ * either an unset validator or one added later; the onSubmit slot is pinned to
+ * the schema the form is actually configured with (`validators.onSubmit`) so
+ * the concrete `useForm` instance stays assignable to this type.
+ */
+export type SubscribeFormApi = ReactFormExtendedApi<
+	SubscribeFormValues, // TFormData
+	undefined | FormValidateOrFn<SubscribeFormValues>, // TOnMount
+	undefined | FormValidateOrFn<SubscribeFormValues>, // TOnChange
+	undefined | FormAsyncValidateOrFn<SubscribeFormValues>, // TOnChangeAsync
+	undefined | FormValidateOrFn<SubscribeFormValues>, // TOnBlur
+	undefined | FormAsyncValidateOrFn<SubscribeFormValues>, // TOnBlurAsync
+	typeof signupFormSchema, // TOnSubmit
+	undefined | FormAsyncValidateOrFn<SubscribeFormValues>, // TOnSubmitAsync
+	undefined | FormValidateOrFn<SubscribeFormValues>, // TOnDynamic
+	undefined | FormAsyncValidateOrFn<SubscribeFormValues>, // TOnDynamicAsync
+	undefined | FormAsyncValidateOrFn<SubscribeFormValues>, // TOnServer
+	unknown // TSubmitMeta
+>;

--- a/src/components/pricing/owner-subscribe-plan-selector.tsx
+++ b/src/components/pricing/owner-subscribe-plan-selector.tsx
@@ -5,16 +5,10 @@ import {
 	InputGroupAddon,
 	InputGroupInput,
 } from "#components/ui/input-group";
-
-interface StringFieldApi {
-	state: { value: string; meta: { errors?: unknown[] } };
-	handleChange: (v: string) => void;
-	handleBlur: () => void;
-}
+import type { SubscribeFormApi } from "./owner-subscribe-form-types";
 
 interface SubscribeFormFieldsProps {
-	// biome-ignore lint/suspicious/noExplicitAny: TanStack Form's FieldComponent has 12 generic parameters; propagating them through extracted form sections would explode the API surface. Field shape is type-checked inside each callback.
-	form: { Field: React.ComponentType<any> };
+	form: SubscribeFormApi;
 	isSubmitting: boolean;
 }
 
@@ -26,7 +20,7 @@ export function SubscribeFormFields({
 		<>
 			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 				<form.Field name="first_name">
-					{(field: StringFieldApi) => (
+					{(field) => (
 						<Field>
 							<FieldLabel htmlFor="first_name">First name</FieldLabel>
 							<InputGroup>
@@ -49,7 +43,7 @@ export function SubscribeFormFields({
 					)}
 				</form.Field>
 				<form.Field name="last_name">
-					{(field: StringFieldApi) => (
+					{(field) => (
 						<Field>
 							<FieldLabel htmlFor="last_name">Last name</FieldLabel>
 							<InputGroup>
@@ -73,7 +67,7 @@ export function SubscribeFormFields({
 				</form.Field>
 			</div>
 			<form.Field name="email">
-				{(field: StringFieldApi) => (
+				{(field) => (
 					<Field>
 						<FieldLabel htmlFor="email">Work email</FieldLabel>
 						<InputGroup>
@@ -97,7 +91,7 @@ export function SubscribeFormFields({
 				)}
 			</form.Field>
 			<form.Field name="password">
-				{(field: StringFieldApi) => (
+				{(field) => (
 					<Field>
 						<FieldLabel htmlFor="password">Password</FieldLabel>
 						<InputGroup>

--- a/src/components/properties/property-form-fields.tsx
+++ b/src/components/properties/property-form-fields.tsx
@@ -1,9 +1,9 @@
 import { Input } from "#components/ui/input";
 import { Label } from "#components/ui/label";
+import type { PropertyFormApi } from "./property-form-types";
 
 interface AcquisitionDetailsSectionProps {
-	// biome-ignore lint/suspicious/noExplicitAny: TanStack Form's FieldComponent has 12 generic parameters (TFormData, TOnMount, TOnChange, TOnChangeAsync, TOnBlur, TOnBlurAsync, TOnSubmit, TOnSubmitAsync, TOnDynamic, TOnDynamicAsync, TOnServer, TSubmitMeta) — propagating those through every extracted form section would explode the API surface. The actual field shape is type-checked inside each form.Field callback below.
-	form: { Field: React.ComponentType<any> };
+	form: PropertyFormApi;
 }
 
 export function AcquisitionDetailsSection({
@@ -20,11 +20,7 @@ export function AcquisitionDetailsSection({
 			</div>
 			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
 				<form.Field name="acquisition_cost">
-					{(field: {
-						state: { value: number | null; meta: { errors: unknown[] } };
-						handleChange: (v: number | null) => void;
-						handleBlur: () => void;
-					}) => (
+					{(field) => (
 						<div className="space-y-2">
 							<Label htmlFor="acquisition_cost">Purchase Price</Label>
 							<Input
@@ -49,11 +45,7 @@ export function AcquisitionDetailsSection({
 					)}
 				</form.Field>
 				<form.Field name="acquisition_date">
-					{(field: {
-						state: { value: string; meta: { errors: unknown[] } };
-						handleChange: (v: string) => void;
-						handleBlur: () => void;
-					}) => (
+					{(field) => (
 						<div className="space-y-2">
 							<Label htmlFor="acquisition_date">Purchase Date</Label>
 							<Input


### PR DESCRIPTION
## Why

Follow-up to #867. Those two `React.ComponentType<any>` props on the extracted property and subscribe form sections were the **only remaining `noExplicitAny` suppressions in the app**. Turns out they didn't need the full `createFormHook`/`withForm` migration I'd flagged — the codebase already solved the "TanStack Form has 12 generic parameters" problem with the `PropertyFormApi` named instance type, and the property form's own sibling sections (`PropertyInfoSection`, `PropertyAddressSection`) already use it. `AcquisitionDetailsSection` was simply the odd one out.

## What changed

- **`AcquisitionDetailsSection`** now takes `form: PropertyFormApi` — the exact type its sibling sections already consume. The inline per-field type annotations are dropped; TanStack infers the `field` shape from the typed `form.Field`.
- **New `owner-subscribe-form-types.ts`** mirrors the `PropertyFormApi` pattern: `SubscribeFormValues` derived from `signupFormSchema` (`z.infer`, single source of truth) + a `SubscribeFormApi` instance type. The `onSubmit` generic slot is pinned to `typeof signupFormSchema` (the form sets `validators.onSubmit`) so the concrete `useForm` instance stays assignable.
- **`SubscribeFormFields`** now takes `form: SubscribeFormApi`; the local `StringFieldApi` shim and both `biome-ignore lint/suspicious/noExplicitAny` comments are deleted.

## Result

```
$ rg -c "React.ComponentType<any>" src/   → 0
$ rg -l "noExplicitAny" src/              → 0
```

Zero `noExplicitAny` suppressions remain in `src/`. No runtime behavior change — this is purely tightening the types of existing form sections.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test:unit` — **100,303 passing**

[hudsor01]
