### PR TITLE
feat(forms): v7.0 phase 20 — shared TanStack Form composition foundation

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -15,19 +15,19 @@
 - **v2.0 Dashboard Command Center** (2026-06-02, 34/34) — `/dashboard` redesign.
 - **v1.0 Marketing Surface Honesty** (2026-05-22, 56/56 audit findings).
 
-## Current Milestone: v6.0 Final Canonical Cleanup
+## Current Milestone: v7.0 TanStack Form Composition Migration
 
-**Goal:** Make the codebase canonical to the current product — remove every orphaned remnant of the demolished offerings and finish the deferred dead-code trim, so no surface promises a feature TenantFlow does not have.
+**Goal:** Adopt TanStack Form's built-in composition API (`createFormHook` / `useAppForm` / `withForm` / `withFieldGroup` / `formOptions`) so the codebase never hand-rolls a form-instance type again — replacing 5 hand-rolled 12-generic `ReactFormExtendedApi` aliases, 10 `*FormApi`-prop sections, 14 raw `useForm` sites, and 123 per-field annotations with one shared form-hook module + a typed field-component library. Zero runtime/behavior change.
 
 **Target areas:**
-- Stripe Connect/payout surfaces + types — 3 live customer-facing surfaces still promise demolished features (`/profile` "receive payments from tenants" card, `/financials` "Payouts" dead-link, onboarding "payouts / invite your first tenant" copy)
-- Rent-payment facilitation type/config remnants (tables already demolished 2026-04-18)
-- Tenant-as-user / portal / invite-auth schemas + "invite"→"add" relabels
-- Never-built automated-screening provider strip (hardcoded TransUnion)
-- The one missed dead DB column (`properties.stripe_connected_account_id`) + lockstep readers
-- Deferred fallow dead-code sweep (~553 internal exports + `fast-check` dep)
+- One shared `form-hook` foundation (`createFormHook` → `useAppForm`/`withForm`/`withFieldGroup`) + a `formOptions()` convention — no hand-rolled generics anywhere
+- Typed field-component library wrapping the existing shadcn primitives (TextField/NumberField/TextareaField/SelectField/SwitchField/IconInputField/DateField) + a shared SubmitButton
+- Migrate all 5 typed forms (property, subscribe, lease, tenant, unit) + their 10 sections to `withForm`; delete the 5 `*-form-types.ts` aliases
+- Multi-step lease-creation wizard typed via `withFieldGroup`
+- Remaining standalone forms (login, maintenance-form hook, 4 document-template forms) on `useAppForm` + shared fields
+- Drift guard: zero `ReactFormExtendedApi` aliases remain in `src/`
 
-Grounded in `.planning/repo-audit/v6.0-LEGACY-AUDIT.md` (7-finder forensic audit). Requirements in [REQUIREMENTS.md](REQUIREMENTS.md); phases 15-19 in [ROADMAP.md](ROADMAP.md). Roadmaps + requirements for v1.0–v5.0 are archived in `.planning/milestones/`.
+Built on the framework already installed (`@tanstack/react-form@1.32`) — no new dependency. Requirements in [REQUIREMENTS.md](REQUIREMENTS.md); phases 20-24 in [ROADMAP.md](ROADMAP.md). Roadmaps + requirements for v1.0–v6.0 are archived in `.planning/milestones/`.
 
 ## What This Is
 
@@ -162,4 +162,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-06-14 — started v6.0 "Final Canonical Cleanup" (6 categories: LEGACY-CONNECT/RENT/TENANT/SCREENING + DEADDB + DEADCODE; phases 15-19, 24 requirements), grounded in the 7-finder forensic legacy audit (`.planning/repo-audit/v6.0-LEGACY-AUDIT.md`). v5.0 "AI Blog Content Engine" (9/9), v4.0 "Hardening & Hygiene" (20/21, advisor 44/0/1 via v3.0), v3.0 "Security Hardening" (12/12), v2.0 "Dashboard Command Center" (34/34), v1.0 "Marketing Surface Honesty" (56/56, PERFECT BY ALL MEASURES) shipped + archived.*
+*Last updated: 2026-06-25 — started v7.0 "TanStack Form Composition Migration" (FORM-01..13; phases 20-24), adopting the framework's `createFormHook`/`useAppForm`/`withForm`/`withFieldGroup`/`formOptions` composition API to delete all 5 hand-rolled `ReactFormExtendedApi` aliases. v6.0 "Final Canonical Cleanup" (24 reqs, phases 15-19) shipped + archived. v5.0 "AI Blog Content Engine" (9/9), v4.0 "Hardening & Hygiene" (20/21, advisor 44/0/1 via v3.0), v3.0 "Security Hardening" (12/12), v2.0 "Dashboard Command Center" (34/34), v1.0 "Marketing Surface Honesty" (56/56, PERFECT BY ALL MEASURES) shipped + archived.*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,103 +1,68 @@
-# Requirements: TenantFlow v6.0 — Final Canonical Cleanup
+# Requirements: TenantFlow v7.0 — TanStack Form Composition Migration
 
-**Defined:** 2026-06-14
-**Core Value:** The codebase is canonical to the current product and current paid offering — every surface, type, and DB object maps to what TenantFlow actually does (landlord-only property management; tenants are records, not users; billing is the landlord Stripe *subscription*). No surface promises a demolished feature. This is the last milestone before the project is considered fully complete.
+**Defined:** 2026-06-25
+**Core Value:** The codebase never hand-rolls a form-instance type again. TanStack Form ships a first-class composition API (`createFormHook` / `useAppForm` / `withForm` / `withFieldGroup` / `formOptions`) that auto-types extracted form sections and shared field components. Adopting it deletes the 5 hand-rolled 12-generic `ReactFormExtendedApi` aliases, the 10 `*FormApi`-prop section signatures, and the 123 per-field annotations — replacing them with one shared foundation. Built on `@tanstack/react-form@1.32`, already installed: no new dependency, no runtime behavior change.
 
-**Grounded in:** `.planning/repo-audit/v6.0-LEGACY-AUDIT.md` (7-finder forensic audit, 2026-06-14). The heavy demolition already shipped (`20260418140000_demolish_rent_and_tenant_portal.sql` + follow-ups) — prod has **0 surviving facilitation tables/functions/triggers/cron**. What remains is orphaned application-layer fog: dead UI, dead types, stale copy, and exactly one missed DB column.
+**Grounded in:** the official TanStack Form "Form Composition" guide + the v1.32 type surface verified in `node_modules` (`createFormHook` exports `useAppForm`/`withForm`/`withFieldGroup`; `formOptions` defines reusable options). Current surface: 5 `*-form-types.ts` aliases, 10 section components, 14 `useForm` sites, 123 `form.Field` usages, 0 existing `createFormHook`/`useAppForm`.
+
+**Constraint (applies to every requirement):** zero runtime/behavior change. Every form keeps its current validation schema, default values, submit handler, and field-level UX (number/null coercion, icon inputs, disabled states, autofocus). Each phase ships under the perfect-PR gate (two consecutive zero-finding review cycles); `tsc --noEmit` + `biome check` + full unit suite stay green.
 
 ## v1 Requirements
 
-### LEGACY-CONNECT — Stripe Connect / payouts / marketplace removal
+### FORM-FOUNDATION — shared composition foundation
 
-- [ ] **LEGACY-CONNECT-01**: The `/profile` page renders no "Payment Settings / receive payments from tenants" Connect card (remove `PaymentSettingsSection` + its profile-page/profile-card wiring + the `OwnerProfile.stripe_connected` / `UserProfileOwnerData.stripe_connected` / `UserProfile.owner_profile` contract fields)
-- [ ] **LEGACY-CONNECT-02**: The `/financials` page shows no "Payouts" quick-link to the non-existent `/financials/payouts` route
-- [ ] **LEGACY-CONNECT-03**: Onboarding welcome copy no longer mentions "connecting Stripe for payouts" or "inviting your first tenant"
-- [ ] **LEGACY-CONNECT-04**: Connect/marketplace types + mutation keys are gone — `stripeConnect.createAccount`/`dashboardLink` keys, `CreateConnectedPaymentRequest`, and the broken `seed.sql` `stripe_connected_accounts` insert
-- [ ] **LEGACY-CONNECT-05**: Lease activation references no demolished Stripe Connect gating (`STRIPE_CONNECT_NOT_SETUP` / `STRIPE_VERIFICATION_INCOMPLETE`) — removed only after verifying the activate/sign RPC no longer emits those SQLSTATE codes (INVESTIGATE, Phase 17)
-- [ ] **LEGACY-CONNECT-06**: Stripe Identity (Connect KYC) remnants resolved — `identityVerification.start` mutation key + `src/types/stripe.ts` Identity types removed after confirming zero hook/UI consumer (INVESTIGATE, Phase 17)
+- [ ] **FORM-01**: A single shared form foundation module exists (`createFormHookContexts()` + `createFormHook()` → `useAppForm`, `withForm`, `withFieldGroup`) with no hand-rolled `ReactFormExtendedApi` generics; it is the only place form-hook wiring lives.
+- [ ] **FORM-02**: A shared typed field-component library wraps the existing shadcn primitives — `TextField`, `NumberField` (null-coercing), `TextareaField`, `SelectField` (options-driven), `SwitchField`, `IconInputField` (InputGroup + leading icon), `DateField` — each consuming field context and usable via `form.AppField` + `field.X`.
+- [ ] **FORM-03**: A shared `SubmitButton` form component (driven by `form.Subscribe` / `form.AppForm`) replaces per-form submit-button + `canSubmit`/`isSubmitting` wiring.
+- [ ] **FORM-11**: Each migrated form defines its options once via `formOptions()` (default values + validators), shared between `useAppForm` and `withForm`, so `defaultValues` is never duplicated between a parent form and its sections.
 
-### LEGACY-RENT — rent-payment facilitation type/config removal
+### FORM-MIGRATE — per-domain form migration (delete the hand-rolled aliases)
 
-- [ ] **LEGACY-RENT-01**: All rent-payment facilitation contract types removed (`PayRentRequest`, `PayRentResponse`, `AmountDueResponse`, `FailedPaymentAttempt`, `TenantPayment`, `TenantPaymentRecord`, `TenantPaymentHistoryResponse`, `LateFeeConfig`, `ApiOverduePayment`, `ProcessLateFeesResult`, `ApplyLateFeeResult`, `SendPaymentReminderRequest`, `SendPaymentReminderResponse`)
-- [ ] **LEGACY-RENT-02**: `RENT_CHARGE_STATUS` constant + `RentChargeStatus` type removed
-- [ ] **LEGACY-RENT-03**: `sendPaymentReminderSchema` (tenant payment reminder) removed
-- [ ] **LEGACY-RENT-04**: `TenantStats.currentPayments`/`latePayments` counters + the unconsumed `TenantSummary` interface removed; the dead `if (table === "rent_payments")` test-mock arm removed
-- [ ] **LEGACY-RENT-05**: Orphan `app_config` rows `n8n.webhook.rent_payment_url` + `n8n.webhook.payment_reminder_url` deleted (new migration — folds into Phase 18)
+- [ ] **FORM-04**: The property create/edit form + its 3 sections (info, address, acquisition-details) use `useAppForm`/`withForm`; `PropertyFormApi` and `src/components/properties/property-form-types.ts` are deleted; create/edit behavior, validation, and image upload unchanged.
+- [ ] **FORM-05**: The owner-subscribe dialog + `SubscribeFormFields` use `useAppForm`/`withForm`; `SubscribeFormApi` and `src/components/pricing/owner-subscribe-form-types.ts` are deleted; signup validation (`signupFormSchema`) and submit flow unchanged.
+- [ ] **FORM-06**: The lease form + its financial / tenant-date / property-unit sections use `useAppForm`/`withForm`; `LeaseFormApi` and `src/components/leases/lease-form-types.ts` are deleted; lease-create behavior unchanged.
+- [ ] **FORM-07**: The add-tenant form + its info/property sections and the tenant-edit form use `useAppForm`/`withForm`; `AddTenantFormApi` and `src/components/tenants/add-tenant-form-types.ts` are deleted; tenant record create/edit behavior unchanged.
+- [ ] **FORM-08**: The unit form (+ add-unit / edit-unit panels) + `unit-form-fields` use `useAppForm`/`withForm`; `UnitFormApi` and `src/components/units/unit-form-types.ts` are deleted; unit create/edit behavior unchanged.
 
-### LEGACY-TENANT — tenant-as-user / portal / invite-auth removal
+### FORM-SPECIAL — multi-step + standalone forms
 
-- [ ] **LEGACY-TENANT-01**: Tenant-as-user activation removed — `activateTenantSchema` (and the dead `authuser_id` / "public invitation acceptance" framing) + its tests
-- [ ] **LEGACY-TENANT-02**: Tenant-portal view types removed (`TenantMaintenanceRequest`, `TenantMaintenanceStats`, `TenantLease`, `TenantDocument`, `TenantSettings`, `TenantProfile`)
-- [ ] **LEGACY-TENANT-03**: The duplicate `useCurrentUser` export in `use-auth.ts` removed (canonical is `#hooks/use-current-user`; the duplicate has 0 importers)
-- [ ] **LEGACY-TENANT-04**: Stale "invite/invited" tenant wording relabeled to record-create framing — funnel-chart "Invited Tenant" → "Added Tenant"; lease-wizard "Invite New Tenant" / `InlineTenantInvite` → "Add Tenant" / `InlineTenantCreate` (behavior unchanged — it is a plain record insert); `tenants/layout.tsx` metadata drops "invitations"; `addTenantRequestSchema` stale `InviteWithLeaseDto` comment dropped
-- [ ] **LEGACY-TENANT-05**: `inviteToSignLeaseSchema` / `InviteToSignLease` resolved — kept if it backs a real DocuSeal e-sign "invite recipient to sign" send path, removed (with tests) if not (INVESTIGATE, Phase 17)
-- [ ] **LEGACY-TENANT-06**: `tenants.user_id` DB column dropped after stripping it from the 6 `tenants.ts` schema references and confirming no RLS policy / RPC joins on it (DB — folds into Phase 18)
+- [ ] **FORM-09**: The multi-step lease-creation wizard's steps are typed via `withFieldGroup` (or `withForm` sharing `formOptions`) with no hand-rolled per-step form types; step validation, navigation, and the unsaved-changes guard are unchanged.
+- [ ] **FORM-10**: The remaining standalone forms — `login-form`, the `use-maintenance-form` hook, and the 4 document-template forms (property-inspection, tenant-notice, maintenance-request, rental-application) — migrate to `useAppForm` and the shared field components where they share field shapes; each keeps its current validation and submit behavior.
 
-### LEGACY-SCREENING — never-built automated screening removal
+### FORM-GUARD — zero-drift verification
 
-- [ ] **LEGACY-SCREENING-01**: Hardcoded `provider: "TransUnion SmartMove"` removed from the rental-application PDF payload (the integration was never built)
-- [ ] **LEGACY-SCREENING-02**: "third-party screening provider" authorization copy reworded to clearly third-party / landlord paperwork; the legitimate `backgroundCheck` consent checkbox + printable rental-application form are kept
-
-### DEADDB — dead database object + lockstep readers (final phase)
-
-- [ ] **DEADDB-01**: `public.properties.stripe_connected_account_id` column dropped via a new cleanup migration (0 non-null rows, no FK/index/RLS/RPC reader; the 2026-04-18 demolish dropped the `leases` twin but missed this one)
-- [ ] **DEADDB-02**: `PROPERTY_SELECT_COLUMNS`, the 6 pinning test fixtures, and a regenerated `supabase.ts` (`bun run db:types`) all updated in the **same PR** as the column drop — no partial-deploy 400s on property list/detail queries
-- [ ] **DEADDB-03**: `get_user_profile()` RPC's `stripe_connected` jsonb key removed/adjusted in the same migration (after confirming whether it is hardcoded `false` or derives from the dropped column)
-
-### DEADCODE — deferred fallow dead-code sweep (opt-in, last)
-
-- [ ] **DEADCODE-01**: `fast-check` unused dev-dependency removed after confirming no e2e spec imports it
-- [ ] **DEADCODE-02**: The ~553 internal SAFE-TRIM dead exports trimmed via an opt-in fallow sweep gated behind `bun run validate:quick`; confirmed false-positives added to fallow ignore config so the next `fallow dead-code` run is clean
+- [ ] **FORM-12**: Zero hand-rolled `ReactFormExtendedApi` aliases remain in `src/` — all 5 `*-form-types.ts` files are deleted, and a drift-guard test (or CI grep) asserts `ReactFormExtendedApi` and `React.ComponentType<any>` appear nowhere in app form code.
+- [ ] **FORM-13**: Behavior preservation is pinned — existing form unit tests pass unchanged (or are extended, never skipped); new tests cover the shared field components; `bun run typecheck` + `bun run lint` + the full unit suite are green; zero new `any` / `as unknown as`.
 
 ## v2 Requirements
 
-None. v6.0 is the final cleanup — there is no deferred follow-on scope after it.
+None scoped. Optional future follow-on (NOT this milestone): a `<form.AppForm>`-level shared error-summary component, and field-level async-validation helpers — deferred until the foundation lands.
 
 ## Out of Scope
 
-| Feature | Reason |
-|---------|--------|
-| 111 KEEP-CONTRACT type-surface items (`api-contracts.ts`/`core.ts`/`relations.ts`/generated `supabase.ts`) | Unused *today* but part of the contract API surface — trimming risks future-RPC breakage. Not dead code. |
-| 28 of 29 fallow "duplicate exports" | Intentional Zod-schema ↔ inferred-type / constant ↔ derived-type co-location, not real duplication. |
-| Deps `sharp`, `babel-plugin-react-compiler`, `lighthouse`/`@lhci/cli`, `@sentry/deno`, `@upstash/ratelimit`, `@upstash/redis`, `@zip.js/zip.js` | Verified fallow false-positives: Next image opt, the enabled React Compiler, `bunx lhci` CLI, and import-map-resolved Deno Edge-Function imports. |
-| `public/sw.js`, `scripts/*.ts` owner CLIs, `supabase/functions/tests/*-test.ts` | Runtime / CLI / Deno-test entry points static analysis can't see. |
-| Re-introducing any demolished feature (tenant portal/auth, rent-payment facilitation, Stripe Connect/payouts, automated screening) | Pre-pivot decisions, never re-add (PROJECT.md Out-of-Scope). This milestone removes their *remnants*, it does not revive them. |
-| The blog/n8n factory | Paused via PR #840 kill-switch (`~/.tenantflow-blog-factory.off`). Not touched by this milestone. |
-| Lease-document rent clauses, the `application_fee` lease term, `stripe.*` FDW payouts/transfers tables, demolition-documenting copy + guard tests | KEEP — legitimate current-product surfaces and correct guardrails (see audit §4). |
+| Item | Reason |
+|------|--------|
+| Migrating away from TanStack Form to React 19 native forms (`useActionState` / Server Actions) | Architectural pivot away from the client-side Supabase/PostgREST + TanStack Query mutation model the app is built on; native forms are built for server actions. Not a typing fix. |
+| Changing any form's validation rules, default values, fields, or submit behavior | This milestone is a pure typing/composition refactor — zero functional change is a hard constraint, not a goal to expand. |
+| Rebuilding the shadcn UI primitives (`Input`, `Select`, `Textarea`, `Switch`, `InputGroup`, `Field`) | The new field components *wrap* the existing primitives; the primitives themselves are unchanged. |
+| Form devtools (`@tanstack/react-form-devtools`) | Nice-to-have observability, not required to delete the hand-rolled types; can be added later without rework. |
 
 ## Traceability
 
-| Requirement | Phase | Status |
-|-------------|-------|--------|
-| LEGACY-CONNECT-01 | Phase 15 | Pending |
-| LEGACY-CONNECT-02 | Phase 15 | Pending |
-| LEGACY-CONNECT-03 | Phase 15 | Pending |
-| LEGACY-CONNECT-04 | Phase 15 | Pending |
-| LEGACY-RENT-01 | Phase 15 | Pending |
-| LEGACY-RENT-02 | Phase 15 | Pending |
-| LEGACY-RENT-03 | Phase 15 | Pending |
-| LEGACY-RENT-04 | Phase 15 | Pending |
-| LEGACY-TENANT-01 | Phase 16 | Pending |
-| LEGACY-TENANT-02 | Phase 16 | Pending |
-| LEGACY-TENANT-03 | Phase 16 | Pending |
-| LEGACY-TENANT-04 | Phase 16 | Pending |
-| LEGACY-SCREENING-01 | Phase 16 | Pending |
-| LEGACY-SCREENING-02 | Phase 16 | Pending |
-| LEGACY-CONNECT-05 | Phase 17 | Pending |
-| LEGACY-CONNECT-06 | Phase 17 | Pending |
-| LEGACY-TENANT-05 | Phase 17 | Pending |
-| DEADDB-01 | Phase 18 | Pending |
-| DEADDB-02 | Phase 18 | Pending |
-| DEADDB-03 | Phase 18 | Pending |
-| LEGACY-RENT-05 | Phase 18 | Pending |
-| LEGACY-TENANT-06 | Phase 18 | Pending |
-| DEADCODE-01 | Phase 19 | Pending |
-| DEADCODE-02 | Phase 19 | Pending |
+| REQ-ID | Phase |
+|--------|-------|
+| FORM-01 | 20 — Form Foundation |
+| FORM-02 | 20 — Form Foundation |
+| FORM-03 | 20 — Form Foundation |
+| FORM-11 | 20 — Form Foundation |
+| FORM-04 | 21 — Single-Section Forms |
+| FORM-05 | 21 — Single-Section Forms |
+| FORM-08 | 21 — Single-Section Forms |
+| FORM-06 | 22 — Multi-Section & Tenant Forms |
+| FORM-07 | 22 — Multi-Section & Tenant Forms |
+| FORM-09 | 23 — Wizard & Standalone Forms |
+| FORM-10 | 23 — Wizard & Standalone Forms |
+| FORM-12 | 24 — Cleanup, Drift Guard & Verify |
+| FORM-13 | 24 — Cleanup, Drift Guard & Verify |
 
-**Coverage:**
-- v1 requirements: 24 total
-- Mapped to phases: 24
-- Unmapped: 0 ✓
-
----
-*Requirements defined: 2026-06-14 — v6.0 Final Canonical Cleanup, grounded in `.planning/repo-audit/v6.0-LEGACY-AUDIT.md`*
+All 13 requirements mapped to exactly one phase ✓

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -7,103 +7,90 @@
 - ✅ **v3.0 Security Hardening** — Phases 1-3 (shipped 2026-06-02, 12/12 requirements) — see [milestones/v3.0-ROADMAP.md](milestones/v3.0-ROADMAP.md)
 - ✅ **v4.0 Hardening & Hygiene** — Phases 1-8 (shipped 2026-06-07, 20/21 requirements; SEO-01 carried to v5.0) — see [milestones/v4.0-ROADMAP.md](milestones/v4.0-ROADMAP.md)
 - ✅ **v5.0 AI Blog Content Engine** — Phases 9-14 (shipped 2026-06-10, 9/9 requirements) — see [milestones/v5.0-ROADMAP.md](milestones/v5.0-ROADMAP.md)
-- 🔨 **v6.0 Final Canonical Cleanup** — Phases 15-19 (active, started 2026-06-14, 24 requirements) — this file
+- ✅ **v6.0 Final Canonical Cleanup** — Phases 15-19 (resolved/verified 2026-06-19, 24 requirements) — see [milestones/v6.0-ROADMAP.md](milestones/v6.0-ROADMAP.md)
+- 🔨 **v7.0 TanStack Form Composition Migration** — Phases 20-24 (active, started 2026-06-25, 13 requirements) — this file
 
 ---
 
-## v6.0 Final Canonical Cleanup
+## v7.0 TanStack Form Composition Migration
 
-**Goal:** Make the codebase canonical to the current product — remove every orphaned remnant of the demolished offerings (tenant-as-user/portal, rent-payment facilitation, Stripe Connect/payouts, automated screening) and finish the deferred dead-code trim, so no surface promises a feature TenantFlow does not have. The last milestone before the project is considered fully complete.
+**Goal:** Adopt TanStack Form's built-in composition API (`createFormHook` / `useAppForm` / `withForm` / `withFieldGroup` / `formOptions`) so the codebase never hand-rolls a form-instance type again — delete all 5 hand-rolled 12-generic `ReactFormExtendedApi` aliases, the 10 `*FormApi`-prop section signatures, and the 123 per-field annotations, replacing them with one shared form-hook module + a typed field-component library. Built on `@tanstack/react-form@1.32` (already installed). Zero runtime/behavior change.
 
-**Grounded in:** `.planning/repo-audit/v6.0-LEGACY-AUDIT.md`. Sequencing rule: zero-runtime-risk surface/type deletes first, INVESTIGATE resolution next, the one coordinated DB migration last (it must ship lockstep), the opt-in dead-code sweep last of all.
+**Sequencing rule:** foundation first (pure addition, nothing migrated), then migrate forms in increasing complexity (single-section → multi-section/tenant → multi-step wizard + standalone), then a final drift-guard + verification phase. Every phase is an independently shippable PR under the perfect-PR gate; each migrated form's behavior is pinned by its existing (or extended) tests so "zero functional change" is observable, not asserted.
 
-**5 phases** | **24 requirements mapped** | All covered ✓
+**5 phases** | **13 requirements mapped** | All covered ✓
 
 | # | Phase | Goal | Requirements | Success Criteria |
 |---|-------|------|--------------|------------------|
-| 15 | Connect + Rent-Facilitation Surface & Type Removal | Kill the 3 customer-facing Connect surfaces + all dead Connect/rent contract types | LEGACY-CONNECT-01..04, LEGACY-RENT-01..04 | 4 |
-| 16 | Tenant-as-User & Screening Cleanup | Remove tenant-portal/invite-auth schemas+types, relabel "invite"→"add", strip the never-built screening provider | LEGACY-TENANT-01..04, LEGACY-SCREENING-01..02 | 4 |
-| 17 | Legacy-Remnant Investigation & Resolution | Resolve the 5 INVESTIGATE open questions against the live DB/RPCs, then remove what's confirmed dead | LEGACY-CONNECT-05..06, LEGACY-TENANT-05 | 4 |
-| 18 | Dead-DB Coordinated Cleanup Migration | Drop the one missed column + orphan config rows + RPC key in one lockstep PR; no prod 400s | DEADDB-01..03, LEGACY-RENT-05, LEGACY-TENANT-06 | 4 |
-| 19 | Deferred Dead-Code Sweep | Opt-in fallow trim of the ~553 internal SAFE-TRIM exports + `fast-check` dep, behind validate:quick | DEADCODE-01..02 | 4 |
+| 20 | Form Foundation | One shared `form-hook` module + typed field-component library + SubmitButton + `formOptions` convention — zero hand-rolled generics | FORM-01, FORM-02, FORM-03, FORM-11 | 4 |
+| 21 | Single-Section Forms | Migrate property / subscribe / unit forms + sections to `useAppForm`/`withForm`; delete 3 type aliases | FORM-04, FORM-05, FORM-08 | 4 |
+| 22 | Multi-Section & Tenant Forms | Migrate lease + tenant (+ tenant-edit) forms + their sections; delete 2 type aliases | FORM-06, FORM-07 | 4 |
+| 23 | Wizard & Standalone Forms | Lease wizard via `withFieldGroup`; login + maintenance hook + 4 document-template forms | FORM-09, FORM-10 | 4 |
+| 24 | Cleanup, Drift Guard & Verify | Delete residual type files; drift-guard test; behavior preservation pinned; full verify | FORM-12, FORM-13 | 4 |
 
 ### Phase Details
 
-**Phase 15: Connect + Rent-Facilitation Surface & Type Removal**
-Goal: Remove the highest-value cluster — the 3 live customer-facing surfaces that promise demolished features (the `/profile` "receive payments from tenants" Connect card, the `/financials` "Payouts" 404 dead-link, the onboarding "payouts / invite your first tenant" copy) plus every zero-consumer Connect and rent-facilitation contract type. All zero-runtime-risk once `owner_profile` is confirmed to never render.
-Requirements: LEGACY-CONNECT-01, LEGACY-CONNECT-02, LEGACY-CONNECT-03, LEGACY-CONNECT-04, LEGACY-RENT-01, LEGACY-RENT-02, LEGACY-RENT-03, LEGACY-RENT-04
+**Phase 20: Form Foundation**
+Goal: Build the single shared foundation — `src/lib/forms/form-hook.tsx` (`createFormHookContexts()` + `createFormHook()` → `useAppForm`/`withForm`/`withFieldGroup`) plus the typed field-component library wrapping the existing shadcn primitives (`TextField`, `NumberField` with null coercion, `TextareaField`, `SelectField`, `SwitchField`, `IconInputField`, `DateField`) and a `SubmitButton` form component, plus the `formOptions()` convention. Pure addition: no existing form is migrated yet, so nothing can regress.
+Requirements: FORM-01, FORM-02, FORM-03, FORM-11
 Success criteria:
-1. `/profile` and `/financials` render with no Connect/payout UI; onboarding copy mentions no payouts or tenant invites; grep for the removed surfaces returns zero
-2. `stripeConnect.*` mutation keys, `CreateConnectedPaymentRequest`, all `PayRent*`/late-fee/`TenantPayment` types, `RENT_CHARGE_STATUS`, `sendPaymentReminderSchema`, `TenantSummary`, and the broken `seed.sql` insert are deleted
-3. `tsc --noEmit` + `biome check` + `next build` clean; full unit suite green (drift-guard tests updated, not skipped)
+1. `form-hook.tsx` exports `useAppForm`/`withForm`/`withFieldGroup` with zero hand-rolled `ReactFormExtendedApi` generics; field components render through field context
+2. Each field component matches the visual + behavioral output of its current ad-hoc equivalent (number/null coercion, leading-icon input, disabled state) — covered by new unit tests
+3. The foundation is unused by production forms this phase (no behavior change anywhere); `tsc` + `lint` + unit suite green
 4. Two consecutive zero-finding review cycles (perfect-PR gate)
 
-**Phase 16: Tenant-as-User & Screening Cleanup**
-Goal: Remove tenant-as-user activation/portal schemas + types, de-duplicate `useCurrentUser`, relabel all "invite/invited" tenant wording to record-create framing (behavior unchanged), and strip the hardcoded TransUnion screening provider while keeping the legitimate landlord rental-application form.
-Requirements: LEGACY-TENANT-01, LEGACY-TENANT-02, LEGACY-TENANT-03, LEGACY-TENANT-04, LEGACY-SCREENING-01, LEGACY-SCREENING-02
+**Phase 21: Single-Section Forms**
+Goal: Migrate the three lowest-complexity typed forms — property (3 sections), owner-subscribe (1 section), unit (1 section incl. add/edit panels) — onto `useAppForm` + `withForm` + `formOptions`, converting their `form.Field` render-props to `form.AppField` + shared field components, and delete `property-form-types.ts`, `owner-subscribe-form-types.ts`, and `unit-form-types.ts`.
+Requirements: FORM-04, FORM-05, FORM-08
 Success criteria:
-1. `activateTenantSchema` + tenant-portal types + the duplicate `useCurrentUser` export are gone; their tests removed/updated
-2. No UI label or metadata says "invite/invited tenant"; the lease-wizard still creates tenant records (behavior pinned by test); `provider: "TransUnion SmartMove"` is gone and the screening-authorization copy reads as third-party landlord paperwork
-3. `tsc` + lint + `next build` clean; unit suite green
+1. Property / subscribe / unit forms create + edit exactly as before (validation, defaults, image upload, signup flow all unchanged) — pinned by existing/extended tests
+2. `PropertyFormApi`, `SubscribeFormApi`, `UnitFormApi` and their 3 `*-form-types.ts` files are deleted; no `*FormApi` prop remains on their sections
+3. `tsc` + `lint` + `next build` + full unit suite green; zero new `any` / `as unknown as`
 4. Two consecutive zero-finding review cycles
 
-**Phase 17: Legacy-Remnant Investigation & Resolution**
-Goal: Resolve the audit's 5 INVESTIGATE open questions against the live database/RPCs with evidence, then remove what is confirmed dead. Introspect the `activate_lease`/lease-sign RPC for `STRIPE_CONNECT_NOT_SETUP`/`STRIPE_VERIFICATION_INCOMPLETE` emission; confirm `get_user_profile()`'s `stripe_connected` source; trace whether `inviteToSignLeaseSchema` backs a DocuSeal send path; confirm `identityVerification` + Identity types have no consumer; map `tenants.user_id` readers ahead of Phase 18.
-Requirements: LEGACY-CONNECT-05, LEGACY-CONNECT-06, LEGACY-TENANT-05
+**Phase 22: Multi-Section & Tenant Forms**
+Goal: Migrate the lease form (financial / tenant-date / property-unit sections) and the tenant forms (add-tenant info/property sections + tenant-edit) onto `useAppForm`/`withForm`, and delete `lease-form-types.ts` + `add-tenant-form-types.ts`.
+Requirements: FORM-06, FORM-07
 Success criteria:
-1. Each INVESTIGATE item has a recorded prod-introspection verdict (REMOVE-safe or KEEP-with-reason) before any deletion
-2. Lease-signature Connect gating codes removed iff the RPC no longer emits them (else a coordinated RPC+constant change is scheduled into Phase 18); `identityVerification` key + Identity types removed iff zero consumer; `inviteToSignLeaseSchema` kept-or-removed per the DocuSeal trace
-3. A documented `tenants.user_id` reader map handed to Phase 18; `tsc` + lint + build + tests green
+1. Lease create and tenant record create/edit behave identically (validation, defaults, submit) — pinned by existing/extended tests
+2. `LeaseFormApi`, `AddTenantFormApi` and their 2 `*-form-types.ts` files are deleted; no `*FormApi` prop remains on their sections
+3. `tsc` + `lint` + `next build` + full unit suite green
 4. Two consecutive zero-finding review cycles
 
-**Phase 18: Dead-DB Coordinated Cleanup Migration**
-Goal: Ship the one and only DB cleanup as a single lockstep PR — drop `properties.stripe_connected_account_id`, delete the 2 orphan `app_config` webhook rows, adjust the `get_user_profile()` jsonb, and (if Phase 17 cleared it) drop `tenants.user_id` — together with `PROPERTY_SELECT_COLUMNS`, the 6 test fixtures, and a regenerated `supabase.ts`, so no deploy window 400s.
-Requirements: DEADDB-01, DEADDB-02, DEADDB-03, LEGACY-RENT-05, LEGACY-TENANT-06
+**Phase 23: Wizard & Standalone Forms**
+Goal: Type the multi-step lease-creation wizard via `withFieldGroup` (per-step field groups sharing `formOptions`), and migrate the remaining standalone forms — `login-form`, the `use-maintenance-form` hook, and the 4 document-template forms — onto `useAppForm` + the shared field components.
+Requirements: FORM-09, FORM-10
 Success criteria:
-1. New cleanup migration drops the column(s) + config rows + RPC key; `PROPERTY_SELECT_COLUMNS` + fixtures + `supabase.ts` updated in the same PR (no select-after-drop mismatch)
-2. Migration reconciled via `mcp__supabase__list_migrations` after apply (prod timestamp drift); no historical migration edited
-3. Property list/detail + profile + settings queries verified against prod (no 400s); `rls-security` + `e2e-smoke` + unit suite green
+1. The lease wizard's step validation, navigation, rent-autofill, and unsaved-changes guard are unchanged; no hand-rolled per-step form type remains
+2. Login, maintenance-form, and the 4 document-template forms keep their current validation + submit behavior on the shared foundation
+3. `tsc` + `lint` + `next build` + `e2e-smoke` + full unit suite green
 4. Two consecutive zero-finding review cycles
 
-**Phase 19: Deferred Dead-Code Sweep**
-Goal: Finish the dead-code trim deferred from PR #841 — remove the `fast-check` unused dev-dep and run an opt-in fallow sweep on the ~553 internal SAFE-TRIM dead exports, gated behind `bun run validate:quick`, without touching the 111 contract types or 28 intentional Zod↔type duplicates.
-Requirements: DEADCODE-01, DEADCODE-02
+**Phase 24: Cleanup, Drift Guard & Verify**
+Goal: Remove any residual hand-rolled form typing, add a drift guard so it can't return, and do the milestone-wide behavior-preservation verification.
+Requirements: FORM-12, FORM-13
 Success criteria:
-1. `fast-check` removed (no e2e spec imports it); lockfile + lockfile-verify hook green
-2. The ~553 SAFE-TRIM exports trimmed in reviewable batches, each batch `validate:quick`-clean; KEEP-CONTRACT + intentional-duplicate items untouched; confirmed false-positives added to fallow ignore config so `fallow dead-code` runs clean
-3. `tsc` + lint + `next build` + full unit suite green
+1. `rg "ReactFormExtendedApi" src/` and `rg "React.ComponentType<any>" src/` both return zero; all 5 `*-form-types.ts` files are gone
+2. A drift-guard test (CI-enforced) fails the build if a hand-rolled `ReactFormExtendedApi` alias or a form-field `any` is reintroduced
+3. Full verification: `bun run typecheck` + `bun run lint` + the full unit suite green; every pre-existing form test passes unchanged or extended (none skipped); shared field components covered
 4. Two consecutive zero-finding review cycles
 
-### Traceability
+## Requirement Coverage (Traceability)
 
-| Requirement | Phase | Status |
-|-------------|-------|--------|
-| LEGACY-CONNECT-01 | 15 | Pending |
-| LEGACY-CONNECT-02 | 15 | Pending |
-| LEGACY-CONNECT-03 | 15 | Pending |
-| LEGACY-CONNECT-04 | 15 | Pending |
-| LEGACY-RENT-01 | 15 | Pending |
-| LEGACY-RENT-02 | 15 | Pending |
-| LEGACY-RENT-03 | 15 | Pending |
-| LEGACY-RENT-04 | 15 | Pending |
-| LEGACY-TENANT-01 | 16 | Pending |
-| LEGACY-TENANT-02 | 16 | Pending |
-| LEGACY-TENANT-03 | 16 | Pending |
-| LEGACY-TENANT-04 | 16 | Pending |
-| LEGACY-SCREENING-01 | 16 | Pending |
-| LEGACY-SCREENING-02 | 16 | Pending |
-| LEGACY-CONNECT-05 | 17 | Pending |
-| LEGACY-CONNECT-06 | 17 | Pending |
-| LEGACY-TENANT-05 | 17 | Pending |
-| DEADDB-01 | 18 | Pending |
-| DEADDB-02 | 18 | Pending |
-| DEADDB-03 | 18 | Pending |
-| LEGACY-RENT-05 | 18 | Pending |
-| LEGACY-TENANT-06 | 18 | Pending |
-| DEADCODE-01 | 19 | Pending |
-| DEADCODE-02 | 19 | Pending |
+| Requirement | Phase |
+|-------------|-------|
+| FORM-01 | 20 |
+| FORM-02 | 20 |
+| FORM-03 | 20 |
+| FORM-11 | 20 |
+| FORM-04 | 21 |
+| FORM-05 | 21 |
+| FORM-08 | 21 |
+| FORM-06 | 22 |
+| FORM-07 | 22 |
+| FORM-09 | 23 |
+| FORM-10 | 23 |
+| FORM-12 | 24 |
+| FORM-13 | 24 |
 
-**Coverage:** 24 requirements · 24 mapped · 0 unmapped ✓
-
----
-*v6.0 roadmap created 2026-06-14 — 5 phases (15-19), grounded in `.planning/repo-audit/v6.0-LEGACY-AUDIT.md`. Phase numbering continues from v5.0 (ended at 14).*
+**Coverage:** 13/13 requirements mapped to exactly one phase ✓

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v7.0
 milestone_name: TanStack Form Composition Migration
-status: planning
+status: executing
 last_updated: "2026-06-25T00:00:00.000Z"
 last_activity: 2026-06-25
 progress:
   total_phases: 5
-  completed_phases: 0
-  total_plans: 0
-  completed_plans: 0
-  percent: 0
+  completed_phases: 1
+  total_plans: 1
+  completed_plans: 1
+  percent: 20
 ---
 
 # Project State
@@ -24,10 +24,10 @@ See: .planning/PROJECT.md
 
 ## Current Position
 
-Phase: Not started (defining requirements)
-Plan: —
-Status: Defining requirements
-Last activity: 2026-06-25 — Milestone v7.0 started
+Phase: 20 — Form Foundation (built + verified; PR open for review)
+Plan: shared form-hook + 7 field components + SubmitButton + tests
+Status: Executing — phase 20 shipped to PR; phase 21 next (gated on phase 20 merge)
+Last activity: 2026-06-25 — Phase 20 foundation built: `src/lib/forms/{form-contexts,form-hook,fields/*,form-components/submit-button}`; 4 field-component tests; typecheck + lint + 101,910 unit tests green; zero existing forms touched
 
 ## Roadmap Summary (v7.0)
 
@@ -55,7 +55,7 @@ None.
 
 ## Next Action
 
-Plan Phase 20 (Form Foundation): `/gsd-plan-phase 20`. Build the shared `src/lib/forms/form-hook.tsx` (`createFormHookContexts` + `createFormHook` → `useAppForm`/`withForm`/`withFieldGroup`) + the field-component library (TextField/NumberField/TextareaField/SelectField/SwitchField/IconInputField/DateField) + SubmitButton, wrapping the existing shadcn primitives. Pure addition — no form migrated yet, no behavior change.
+Phase 20 (Form Foundation) is built + verified and open as a PR. On merge, start **Phase 21** (single-section forms: property / subscribe / unit) — migrate each onto `useAppForm`/`withForm` + the shared field components and delete `property-form-types.ts`, `owner-subscribe-form-types.ts`, `unit-form-types.ts`. Phases 21-24 each build on the prior, so they ship sequentially under the perfect-PR gate.
 
 ## Overrides
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,16 +1,16 @@
 ---
 gsd_state_version: 1.0
-milestone: v6.0
-milestone_name: Final Canonical Cleanup
-status: verifying
-last_updated: "2026-06-19T00:00:00.000Z"
-last_activity: 2026-06-19
+milestone: v7.0
+milestone_name: TanStack Form Composition Migration
+status: planning
+last_updated: "2026-06-25T00:00:00.000Z"
+last_activity: 2026-06-25
 progress:
   total_phases: 5
-  completed_phases: 5
+  completed_phases: 0
   total_plans: 0
   completed_plans: 0
-  percent: 100
+  percent: 0
 ---
 
 # Project State
@@ -19,29 +19,29 @@ progress:
 
 See: .planning/PROJECT.md
 
-**Core value (v6.0):** The codebase is canonical to the current product — every surface, type, and DB object maps to what TenantFlow actually does (landlord-only; tenants are records, not users; billing is the landlord Stripe subscription). No surface promises a demolished feature. The last milestone before the project is considered fully complete.
-**Current focus:** v6.0 findings RESOLVED. A 2026-06-19 verification pass confirmed every audit finding (Connect UI/types, rent-facilitation types, tenant-as-user schemas, screening provider, dead DB column/RPC/config, `tenants.user_id`) was already implemented — folded into PR #841 + the e-sign rebuild + migrations `20260616040851`/`20260616161248`. The exhaustive re-sweep surfaced 4 residuals the audit missed (broken RLS pgTAP test, stale `SCHEMA.md`, unindexed `lease_signing_tokens.created_by` FK, stale test wording) — fixed on branch `chore/v6.0-canonical-cleanup`.
+**Core value (v7.0):** The codebase never hand-rolls a form-instance type again. TanStack Form's built-in composition API (`createFormHook` / `useAppForm` / `withForm` / `withFieldGroup` / `formOptions`) becomes the single typed foundation for every form — extracted sections are auto-typed by `withForm`, fields render through a shared typed component library, and the 5 hand-rolled 12-generic `ReactFormExtendedApi` aliases are deleted. Zero runtime/behavior change.
+**Current focus:** Milestone defined. Branch `milestone/v7.0-form-composition` off `main` (includes merged PRs #867 inspection-exhaustiveness + #868 form-`any` removal). Built on `@tanstack/react-form@1.32` (already installed — no new dependency). Next: plan Phase 20 (Form Foundation).
 
 ## Current Position
 
-Phase: All audit findings resolved (phases 15-18 work shipped in prior PRs; phase 19 fallow trim deferred/opt-in)
+Phase: Not started (defining requirements)
 Plan: —
-Status: Verifying — canonical-cleanup PR open
-Last activity: 2026-06-19 — Verified the full v6.0 legacy audit is already implemented; fixed 4 missed residuals (RLS test, SCHEMA.md, FK index, test wording). Remaining: opt-in fallow trim (~415 exports, mostly KEEP-CONTRACT) is explicitly deferred.
+Status: Defining requirements
+Last activity: 2026-06-25 — Milestone v7.0 started
 
-## Roadmap Summary (v6.0)
+## Roadmap Summary (v7.0)
 
 | Phase | Goal | Requirements |
 |-------|------|--------------|
-| 15. Connect + Rent-Facilitation Surface & Type Removal | Kill the 3 customer-facing Connect surfaces + all dead Connect/rent contract types | LEGACY-CONNECT-01..04, LEGACY-RENT-01..04 |
-| 16. Tenant-as-User & Screening Cleanup | Remove tenant-portal/invite-auth schemas+types, relabel "invite"→"add", strip never-built screening provider | LEGACY-TENANT-01..04, LEGACY-SCREENING-01..02 |
-| 17. Legacy-Remnant Investigation & Resolution | Resolve 5 INVESTIGATE open questions against live DB/RPCs, then remove what's confirmed dead | LEGACY-CONNECT-05..06, LEGACY-TENANT-05 |
-| 18. Dead-DB Coordinated Cleanup Migration | Drop the 1 missed column + orphan config rows + RPC key in one lockstep PR; no prod 400s | DEADDB-01..03, LEGACY-RENT-05, LEGACY-TENANT-06 |
-| 19. Deferred Dead-Code Sweep | Opt-in fallow trim of ~553 internal SAFE-TRIM exports + `fast-check` dep | DEADCODE-01..02 |
+| 20. Form Foundation | One shared `form-hook` module + typed field-component library + SubmitButton + `formOptions` convention; zero hand-rolled generics | FORM-01..03, FORM-11 |
+| 21. Single-Section Forms | Migrate property / subscribe / unit forms + sections to `useAppForm`/`withForm`; delete those 3 type aliases | FORM-04, FORM-05, FORM-08 |
+| 22. Multi-Section & Tenant Forms | Migrate lease + tenant (+ tenant-edit) forms + their sections; delete those 2 type aliases | FORM-06, FORM-07 |
+| 23. Wizard & Standalone Forms | Lease wizard via `withFieldGroup`; login + maintenance hook + 4 document-template forms | FORM-09, FORM-10 |
+| 24. Cleanup, Drift Guard & Verify | Delete residual type files; drift-guard test; full verify; behavior preservation pinned | FORM-12, FORM-13 |
 
 ## Blockers
 
-None. 5 INVESTIGATE items (lease-activation Connect gating RPC, `get_user_profile` `stripe_connected` source, `tenants.user_id` readers, `InviteToSignLease` DocuSeal-vs-login, `identityVerification` consumers) are scheduled into Phase 17 for prod introspection before any dependent removal — they gate, but do not block, the milestone.
+None.
 
 ## Roadmap Evolution
 
@@ -50,17 +50,16 @@ None. 5 INVESTIGATE items (lease-activation Connect gating RPC, `get_user_profil
 - 2026-06-02: v3.0 "Security Hardening" shipped + archived (3 phases, 12/12).
 - 2026-06-07: v4.0 "Hardening & Hygiene" shipped + archived (8 phases, 20/21).
 - 2026-06-10: v5.0 "AI Blog Content Engine" shipped + archived (6 phases 9-14, 9/9).
-- 2026-06-14: v6.0 "Final Canonical Cleanup" roadmap created (5 phases 15-19, 24 requirements). Heavy demolition already shipped (`20260418140000_demolish_rent_and_tenant_portal.sql`); this milestone removes the orphaned application-layer fog + finishes the PR #841 deferred dead-code trim. Grounded in a 7-finder forensic audit (`.planning/repo-audit/v6.0-LEGACY-AUDIT.md`). Two cleanup PRs precede it: #840 (blog-factory kill-switch), #841 (106 dead files + chart cycle).
+- 2026-06-14: v6.0 "Final Canonical Cleanup" roadmap created (5 phases 15-19, 24 requirements); audit findings resolved/verified 2026-06-19. Archived to `.planning/milestones/v6.0-{REQUIREMENTS,ROADMAP}.md`.
+- 2026-06-25: v7.0 "TanStack Form Composition Migration" started (5 phases 20-24, FORM-01..13). Preceded by merged PRs #867 (inspection compile-time exhaustiveness) + #868 (last form-field `any`s removed via hand-rolled typed API — superseded by this milestone's composition-API adoption).
 
 ## Next Action
 
-**v6.0 audit findings are resolved.** The product-boundary cleanup (Connect surfaces, rent/Connect/tenant-portal types, screening provider, dead DB column/RPC/`tenants.user_id`/app_config rows) was already implemented and verified against prod + the codebase on 2026-06-19; the 4 missed residuals are fixed in the open `chore/v6.0-canonical-cleanup` PR.
-
-Optional remaining work (was Phase 19, explicitly deferred/opt-in): the fallow dead-code trim — currently ~415 unused exports/types, but ~111 are intentional KEEP-CONTRACT surface and many are framework/Deno false-positives, so a blind `fallow fix` is unsafe. Run as a separate, gated, per-item sweep if desired; otherwise close the milestone via `/gsd-complete-milestone v6.0`.
+Plan Phase 20 (Form Foundation): `/gsd-plan-phase 20`. Build the shared `src/lib/forms/form-hook.tsx` (`createFormHookContexts` + `createFormHook` → `useAppForm`/`withForm`/`withFieldGroup`) + the field-component library (TextField/NumberField/TextareaField/SelectField/SwitchField/IconInputField/DateField) + SubmitButton, wrapping the existing shadcn primitives. Pure addition — no form migrated yet, no behavior change.
 
 ## Overrides
 
 (none active)
 
 ---
-*Last updated: 2026-06-14 — v6.0 "Final Canonical Cleanup" started; forensic legacy audit + REQUIREMENTS + ROADMAP authored. Integer phase numbers continue across milestones (15-19). Trust `git log main` + `gh pr list --state merged` + `.planning/ROADMAP.md` as source of truth over this cache.*
+*Last updated: 2026-06-25 — v7.0 "TanStack Form Composition Migration" started; REQUIREMENTS + ROADMAP authored on branch `milestone/v7.0-form-composition`. Integer phase numbers continue across milestones (20-24). Trust `git log main` + `gh pr list --state merged` + `.planning/ROADMAP.md` as source of truth over this cache.*

--- a/.planning/milestones/v6.0-REQUIREMENTS.md
+++ b/.planning/milestones/v6.0-REQUIREMENTS.md
@@ -1,0 +1,103 @@
+# Requirements: TenantFlow v6.0 — Final Canonical Cleanup
+
+**Defined:** 2026-06-14
+**Core Value:** The codebase is canonical to the current product and current paid offering — every surface, type, and DB object maps to what TenantFlow actually does (landlord-only property management; tenants are records, not users; billing is the landlord Stripe *subscription*). No surface promises a demolished feature. This is the last milestone before the project is considered fully complete.
+
+**Grounded in:** `.planning/repo-audit/v6.0-LEGACY-AUDIT.md` (7-finder forensic audit, 2026-06-14). The heavy demolition already shipped (`20260418140000_demolish_rent_and_tenant_portal.sql` + follow-ups) — prod has **0 surviving facilitation tables/functions/triggers/cron**. What remains is orphaned application-layer fog: dead UI, dead types, stale copy, and exactly one missed DB column.
+
+## v1 Requirements
+
+### LEGACY-CONNECT — Stripe Connect / payouts / marketplace removal
+
+- [ ] **LEGACY-CONNECT-01**: The `/profile` page renders no "Payment Settings / receive payments from tenants" Connect card (remove `PaymentSettingsSection` + its profile-page/profile-card wiring + the `OwnerProfile.stripe_connected` / `UserProfileOwnerData.stripe_connected` / `UserProfile.owner_profile` contract fields)
+- [ ] **LEGACY-CONNECT-02**: The `/financials` page shows no "Payouts" quick-link to the non-existent `/financials/payouts` route
+- [ ] **LEGACY-CONNECT-03**: Onboarding welcome copy no longer mentions "connecting Stripe for payouts" or "inviting your first tenant"
+- [ ] **LEGACY-CONNECT-04**: Connect/marketplace types + mutation keys are gone — `stripeConnect.createAccount`/`dashboardLink` keys, `CreateConnectedPaymentRequest`, and the broken `seed.sql` `stripe_connected_accounts` insert
+- [ ] **LEGACY-CONNECT-05**: Lease activation references no demolished Stripe Connect gating (`STRIPE_CONNECT_NOT_SETUP` / `STRIPE_VERIFICATION_INCOMPLETE`) — removed only after verifying the activate/sign RPC no longer emits those SQLSTATE codes (INVESTIGATE, Phase 17)
+- [ ] **LEGACY-CONNECT-06**: Stripe Identity (Connect KYC) remnants resolved — `identityVerification.start` mutation key + `src/types/stripe.ts` Identity types removed after confirming zero hook/UI consumer (INVESTIGATE, Phase 17)
+
+### LEGACY-RENT — rent-payment facilitation type/config removal
+
+- [ ] **LEGACY-RENT-01**: All rent-payment facilitation contract types removed (`PayRentRequest`, `PayRentResponse`, `AmountDueResponse`, `FailedPaymentAttempt`, `TenantPayment`, `TenantPaymentRecord`, `TenantPaymentHistoryResponse`, `LateFeeConfig`, `ApiOverduePayment`, `ProcessLateFeesResult`, `ApplyLateFeeResult`, `SendPaymentReminderRequest`, `SendPaymentReminderResponse`)
+- [ ] **LEGACY-RENT-02**: `RENT_CHARGE_STATUS` constant + `RentChargeStatus` type removed
+- [ ] **LEGACY-RENT-03**: `sendPaymentReminderSchema` (tenant payment reminder) removed
+- [ ] **LEGACY-RENT-04**: `TenantStats.currentPayments`/`latePayments` counters + the unconsumed `TenantSummary` interface removed; the dead `if (table === "rent_payments")` test-mock arm removed
+- [ ] **LEGACY-RENT-05**: Orphan `app_config` rows `n8n.webhook.rent_payment_url` + `n8n.webhook.payment_reminder_url` deleted (new migration — folds into Phase 18)
+
+### LEGACY-TENANT — tenant-as-user / portal / invite-auth removal
+
+- [ ] **LEGACY-TENANT-01**: Tenant-as-user activation removed — `activateTenantSchema` (and the dead `authuser_id` / "public invitation acceptance" framing) + its tests
+- [ ] **LEGACY-TENANT-02**: Tenant-portal view types removed (`TenantMaintenanceRequest`, `TenantMaintenanceStats`, `TenantLease`, `TenantDocument`, `TenantSettings`, `TenantProfile`)
+- [ ] **LEGACY-TENANT-03**: The duplicate `useCurrentUser` export in `use-auth.ts` removed (canonical is `#hooks/use-current-user`; the duplicate has 0 importers)
+- [ ] **LEGACY-TENANT-04**: Stale "invite/invited" tenant wording relabeled to record-create framing — funnel-chart "Invited Tenant" → "Added Tenant"; lease-wizard "Invite New Tenant" / `InlineTenantInvite` → "Add Tenant" / `InlineTenantCreate` (behavior unchanged — it is a plain record insert); `tenants/layout.tsx` metadata drops "invitations"; `addTenantRequestSchema` stale `InviteWithLeaseDto` comment dropped
+- [ ] **LEGACY-TENANT-05**: `inviteToSignLeaseSchema` / `InviteToSignLease` resolved — kept if it backs a real DocuSeal e-sign "invite recipient to sign" send path, removed (with tests) if not (INVESTIGATE, Phase 17)
+- [ ] **LEGACY-TENANT-06**: `tenants.user_id` DB column dropped after stripping it from the 6 `tenants.ts` schema references and confirming no RLS policy / RPC joins on it (DB — folds into Phase 18)
+
+### LEGACY-SCREENING — never-built automated screening removal
+
+- [ ] **LEGACY-SCREENING-01**: Hardcoded `provider: "TransUnion SmartMove"` removed from the rental-application PDF payload (the integration was never built)
+- [ ] **LEGACY-SCREENING-02**: "third-party screening provider" authorization copy reworded to clearly third-party / landlord paperwork; the legitimate `backgroundCheck` consent checkbox + printable rental-application form are kept
+
+### DEADDB — dead database object + lockstep readers (final phase)
+
+- [ ] **DEADDB-01**: `public.properties.stripe_connected_account_id` column dropped via a new cleanup migration (0 non-null rows, no FK/index/RLS/RPC reader; the 2026-04-18 demolish dropped the `leases` twin but missed this one)
+- [ ] **DEADDB-02**: `PROPERTY_SELECT_COLUMNS`, the 6 pinning test fixtures, and a regenerated `supabase.ts` (`bun run db:types`) all updated in the **same PR** as the column drop — no partial-deploy 400s on property list/detail queries
+- [ ] **DEADDB-03**: `get_user_profile()` RPC's `stripe_connected` jsonb key removed/adjusted in the same migration (after confirming whether it is hardcoded `false` or derives from the dropped column)
+
+### DEADCODE — deferred fallow dead-code sweep (opt-in, last)
+
+- [ ] **DEADCODE-01**: `fast-check` unused dev-dependency removed after confirming no e2e spec imports it
+- [ ] **DEADCODE-02**: The ~553 internal SAFE-TRIM dead exports trimmed via an opt-in fallow sweep gated behind `bun run validate:quick`; confirmed false-positives added to fallow ignore config so the next `fallow dead-code` run is clean
+
+## v2 Requirements
+
+None. v6.0 is the final cleanup — there is no deferred follow-on scope after it.
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| 111 KEEP-CONTRACT type-surface items (`api-contracts.ts`/`core.ts`/`relations.ts`/generated `supabase.ts`) | Unused *today* but part of the contract API surface — trimming risks future-RPC breakage. Not dead code. |
+| 28 of 29 fallow "duplicate exports" | Intentional Zod-schema ↔ inferred-type / constant ↔ derived-type co-location, not real duplication. |
+| Deps `sharp`, `babel-plugin-react-compiler`, `lighthouse`/`@lhci/cli`, `@sentry/deno`, `@upstash/ratelimit`, `@upstash/redis`, `@zip.js/zip.js` | Verified fallow false-positives: Next image opt, the enabled React Compiler, `bunx lhci` CLI, and import-map-resolved Deno Edge-Function imports. |
+| `public/sw.js`, `scripts/*.ts` owner CLIs, `supabase/functions/tests/*-test.ts` | Runtime / CLI / Deno-test entry points static analysis can't see. |
+| Re-introducing any demolished feature (tenant portal/auth, rent-payment facilitation, Stripe Connect/payouts, automated screening) | Pre-pivot decisions, never re-add (PROJECT.md Out-of-Scope). This milestone removes their *remnants*, it does not revive them. |
+| The blog/n8n factory | Paused via PR #840 kill-switch (`~/.tenantflow-blog-factory.off`). Not touched by this milestone. |
+| Lease-document rent clauses, the `application_fee` lease term, `stripe.*` FDW payouts/transfers tables, demolition-documenting copy + guard tests | KEEP — legitimate current-product surfaces and correct guardrails (see audit §4). |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| LEGACY-CONNECT-01 | Phase 15 | Pending |
+| LEGACY-CONNECT-02 | Phase 15 | Pending |
+| LEGACY-CONNECT-03 | Phase 15 | Pending |
+| LEGACY-CONNECT-04 | Phase 15 | Pending |
+| LEGACY-RENT-01 | Phase 15 | Pending |
+| LEGACY-RENT-02 | Phase 15 | Pending |
+| LEGACY-RENT-03 | Phase 15 | Pending |
+| LEGACY-RENT-04 | Phase 15 | Pending |
+| LEGACY-TENANT-01 | Phase 16 | Pending |
+| LEGACY-TENANT-02 | Phase 16 | Pending |
+| LEGACY-TENANT-03 | Phase 16 | Pending |
+| LEGACY-TENANT-04 | Phase 16 | Pending |
+| LEGACY-SCREENING-01 | Phase 16 | Pending |
+| LEGACY-SCREENING-02 | Phase 16 | Pending |
+| LEGACY-CONNECT-05 | Phase 17 | Pending |
+| LEGACY-CONNECT-06 | Phase 17 | Pending |
+| LEGACY-TENANT-05 | Phase 17 | Pending |
+| DEADDB-01 | Phase 18 | Pending |
+| DEADDB-02 | Phase 18 | Pending |
+| DEADDB-03 | Phase 18 | Pending |
+| LEGACY-RENT-05 | Phase 18 | Pending |
+| LEGACY-TENANT-06 | Phase 18 | Pending |
+| DEADCODE-01 | Phase 19 | Pending |
+| DEADCODE-02 | Phase 19 | Pending |
+
+**Coverage:**
+- v1 requirements: 24 total
+- Mapped to phases: 24
+- Unmapped: 0 ✓
+
+---
+*Requirements defined: 2026-06-14 — v6.0 Final Canonical Cleanup, grounded in `.planning/repo-audit/v6.0-LEGACY-AUDIT.md`*

--- a/.planning/milestones/v6.0-ROADMAP.md
+++ b/.planning/milestones/v6.0-ROADMAP.md
@@ -1,0 +1,109 @@
+# Roadmap: TenantFlow
+
+## Milestones
+
+- ✅ **v1.0 Marketing Surface Honesty** — Phases 1-15 (shipped 2026-05-22) — see [milestones/v1.0-ROADMAP.md](milestones/v1.0-ROADMAP.md)
+- ✅ **v2.0 Dashboard Command Center** — Phases 1-7 (shipped 2026-06-02, 34/34 requirements) — see [milestones/v2.0-ROADMAP.md](milestones/v2.0-ROADMAP.md)
+- ✅ **v3.0 Security Hardening** — Phases 1-3 (shipped 2026-06-02, 12/12 requirements) — see [milestones/v3.0-ROADMAP.md](milestones/v3.0-ROADMAP.md)
+- ✅ **v4.0 Hardening & Hygiene** — Phases 1-8 (shipped 2026-06-07, 20/21 requirements; SEO-01 carried to v5.0) — see [milestones/v4.0-ROADMAP.md](milestones/v4.0-ROADMAP.md)
+- ✅ **v5.0 AI Blog Content Engine** — Phases 9-14 (shipped 2026-06-10, 9/9 requirements) — see [milestones/v5.0-ROADMAP.md](milestones/v5.0-ROADMAP.md)
+- 🔨 **v6.0 Final Canonical Cleanup** — Phases 15-19 (active, started 2026-06-14, 24 requirements) — this file
+
+---
+
+## v6.0 Final Canonical Cleanup
+
+**Goal:** Make the codebase canonical to the current product — remove every orphaned remnant of the demolished offerings (tenant-as-user/portal, rent-payment facilitation, Stripe Connect/payouts, automated screening) and finish the deferred dead-code trim, so no surface promises a feature TenantFlow does not have. The last milestone before the project is considered fully complete.
+
+**Grounded in:** `.planning/repo-audit/v6.0-LEGACY-AUDIT.md`. Sequencing rule: zero-runtime-risk surface/type deletes first, INVESTIGATE resolution next, the one coordinated DB migration last (it must ship lockstep), the opt-in dead-code sweep last of all.
+
+**5 phases** | **24 requirements mapped** | All covered ✓
+
+| # | Phase | Goal | Requirements | Success Criteria |
+|---|-------|------|--------------|------------------|
+| 15 | Connect + Rent-Facilitation Surface & Type Removal | Kill the 3 customer-facing Connect surfaces + all dead Connect/rent contract types | LEGACY-CONNECT-01..04, LEGACY-RENT-01..04 | 4 |
+| 16 | Tenant-as-User & Screening Cleanup | Remove tenant-portal/invite-auth schemas+types, relabel "invite"→"add", strip the never-built screening provider | LEGACY-TENANT-01..04, LEGACY-SCREENING-01..02 | 4 |
+| 17 | Legacy-Remnant Investigation & Resolution | Resolve the 5 INVESTIGATE open questions against the live DB/RPCs, then remove what's confirmed dead | LEGACY-CONNECT-05..06, LEGACY-TENANT-05 | 4 |
+| 18 | Dead-DB Coordinated Cleanup Migration | Drop the one missed column + orphan config rows + RPC key in one lockstep PR; no prod 400s | DEADDB-01..03, LEGACY-RENT-05, LEGACY-TENANT-06 | 4 |
+| 19 | Deferred Dead-Code Sweep | Opt-in fallow trim of the ~553 internal SAFE-TRIM exports + `fast-check` dep, behind validate:quick | DEADCODE-01..02 | 4 |
+
+### Phase Details
+
+**Phase 15: Connect + Rent-Facilitation Surface & Type Removal**
+Goal: Remove the highest-value cluster — the 3 live customer-facing surfaces that promise demolished features (the `/profile` "receive payments from tenants" Connect card, the `/financials` "Payouts" 404 dead-link, the onboarding "payouts / invite your first tenant" copy) plus every zero-consumer Connect and rent-facilitation contract type. All zero-runtime-risk once `owner_profile` is confirmed to never render.
+Requirements: LEGACY-CONNECT-01, LEGACY-CONNECT-02, LEGACY-CONNECT-03, LEGACY-CONNECT-04, LEGACY-RENT-01, LEGACY-RENT-02, LEGACY-RENT-03, LEGACY-RENT-04
+Success criteria:
+1. `/profile` and `/financials` render with no Connect/payout UI; onboarding copy mentions no payouts or tenant invites; grep for the removed surfaces returns zero
+2. `stripeConnect.*` mutation keys, `CreateConnectedPaymentRequest`, all `PayRent*`/late-fee/`TenantPayment` types, `RENT_CHARGE_STATUS`, `sendPaymentReminderSchema`, `TenantSummary`, and the broken `seed.sql` insert are deleted
+3. `tsc --noEmit` + `biome check` + `next build` clean; full unit suite green (drift-guard tests updated, not skipped)
+4. Two consecutive zero-finding review cycles (perfect-PR gate)
+
+**Phase 16: Tenant-as-User & Screening Cleanup**
+Goal: Remove tenant-as-user activation/portal schemas + types, de-duplicate `useCurrentUser`, relabel all "invite/invited" tenant wording to record-create framing (behavior unchanged), and strip the hardcoded TransUnion screening provider while keeping the legitimate landlord rental-application form.
+Requirements: LEGACY-TENANT-01, LEGACY-TENANT-02, LEGACY-TENANT-03, LEGACY-TENANT-04, LEGACY-SCREENING-01, LEGACY-SCREENING-02
+Success criteria:
+1. `activateTenantSchema` + tenant-portal types + the duplicate `useCurrentUser` export are gone; their tests removed/updated
+2. No UI label or metadata says "invite/invited tenant"; the lease-wizard still creates tenant records (behavior pinned by test); `provider: "TransUnion SmartMove"` is gone and the screening-authorization copy reads as third-party landlord paperwork
+3. `tsc` + lint + `next build` clean; unit suite green
+4. Two consecutive zero-finding review cycles
+
+**Phase 17: Legacy-Remnant Investigation & Resolution**
+Goal: Resolve the audit's 5 INVESTIGATE open questions against the live database/RPCs with evidence, then remove what is confirmed dead. Introspect the `activate_lease`/lease-sign RPC for `STRIPE_CONNECT_NOT_SETUP`/`STRIPE_VERIFICATION_INCOMPLETE` emission; confirm `get_user_profile()`'s `stripe_connected` source; trace whether `inviteToSignLeaseSchema` backs a DocuSeal send path; confirm `identityVerification` + Identity types have no consumer; map `tenants.user_id` readers ahead of Phase 18.
+Requirements: LEGACY-CONNECT-05, LEGACY-CONNECT-06, LEGACY-TENANT-05
+Success criteria:
+1. Each INVESTIGATE item has a recorded prod-introspection verdict (REMOVE-safe or KEEP-with-reason) before any deletion
+2. Lease-signature Connect gating codes removed iff the RPC no longer emits them (else a coordinated RPC+constant change is scheduled into Phase 18); `identityVerification` key + Identity types removed iff zero consumer; `inviteToSignLeaseSchema` kept-or-removed per the DocuSeal trace
+3. A documented `tenants.user_id` reader map handed to Phase 18; `tsc` + lint + build + tests green
+4. Two consecutive zero-finding review cycles
+
+**Phase 18: Dead-DB Coordinated Cleanup Migration**
+Goal: Ship the one and only DB cleanup as a single lockstep PR — drop `properties.stripe_connected_account_id`, delete the 2 orphan `app_config` webhook rows, adjust the `get_user_profile()` jsonb, and (if Phase 17 cleared it) drop `tenants.user_id` — together with `PROPERTY_SELECT_COLUMNS`, the 6 test fixtures, and a regenerated `supabase.ts`, so no deploy window 400s.
+Requirements: DEADDB-01, DEADDB-02, DEADDB-03, LEGACY-RENT-05, LEGACY-TENANT-06
+Success criteria:
+1. New cleanup migration drops the column(s) + config rows + RPC key; `PROPERTY_SELECT_COLUMNS` + fixtures + `supabase.ts` updated in the same PR (no select-after-drop mismatch)
+2. Migration reconciled via `mcp__supabase__list_migrations` after apply (prod timestamp drift); no historical migration edited
+3. Property list/detail + profile + settings queries verified against prod (no 400s); `rls-security` + `e2e-smoke` + unit suite green
+4. Two consecutive zero-finding review cycles
+
+**Phase 19: Deferred Dead-Code Sweep**
+Goal: Finish the dead-code trim deferred from PR #841 — remove the `fast-check` unused dev-dep and run an opt-in fallow sweep on the ~553 internal SAFE-TRIM dead exports, gated behind `bun run validate:quick`, without touching the 111 contract types or 28 intentional Zod↔type duplicates.
+Requirements: DEADCODE-01, DEADCODE-02
+Success criteria:
+1. `fast-check` removed (no e2e spec imports it); lockfile + lockfile-verify hook green
+2. The ~553 SAFE-TRIM exports trimmed in reviewable batches, each batch `validate:quick`-clean; KEEP-CONTRACT + intentional-duplicate items untouched; confirmed false-positives added to fallow ignore config so `fallow dead-code` runs clean
+3. `tsc` + lint + `next build` + full unit suite green
+4. Two consecutive zero-finding review cycles
+
+### Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| LEGACY-CONNECT-01 | 15 | Pending |
+| LEGACY-CONNECT-02 | 15 | Pending |
+| LEGACY-CONNECT-03 | 15 | Pending |
+| LEGACY-CONNECT-04 | 15 | Pending |
+| LEGACY-RENT-01 | 15 | Pending |
+| LEGACY-RENT-02 | 15 | Pending |
+| LEGACY-RENT-03 | 15 | Pending |
+| LEGACY-RENT-04 | 15 | Pending |
+| LEGACY-TENANT-01 | 16 | Pending |
+| LEGACY-TENANT-02 | 16 | Pending |
+| LEGACY-TENANT-03 | 16 | Pending |
+| LEGACY-TENANT-04 | 16 | Pending |
+| LEGACY-SCREENING-01 | 16 | Pending |
+| LEGACY-SCREENING-02 | 16 | Pending |
+| LEGACY-CONNECT-05 | 17 | Pending |
+| LEGACY-CONNECT-06 | 17 | Pending |
+| LEGACY-TENANT-05 | 17 | Pending |
+| DEADDB-01 | 18 | Pending |
+| DEADDB-02 | 18 | Pending |
+| DEADDB-03 | 18 | Pending |
+| LEGACY-RENT-05 | 18 | Pending |
+| LEGACY-TENANT-06 | 18 | Pending |
+| DEADCODE-01 | 19 | Pending |
+| DEADCODE-02 | 19 | Pending |
+
+**Coverage:** 24 requirements · 24 mapped · 0 unmapped ✓
+
+---
+*v6.0 roadmap created 2026-06-14 — 5 phases (15-19), grounded in `.planning/repo-audit/v6.0-LEGACY-AUDIT.md`. Phase numbering continues from v5.0 (ended at 14).*

--- a/src/lib/forms/__tests__/form-hook.test.tsx
+++ b/src/lib/forms/__tests__/form-hook.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Mail } from "lucide-react";
+import { describe, expect, it } from "vitest";
+import { useAppForm } from "#lib/forms/form-hook";
+
+function Harness() {
+	const form = useAppForm({
+		defaultValues: {
+			name: "",
+			cost: null as number | null,
+			active: false,
+			color: "red",
+			note: "",
+			email: "",
+			born: "",
+		},
+	});
+	return (
+		<form aria-label="harness">
+			<form.AppField name="name">
+				{(field) => <field.TextField label="Name" />}
+			</form.AppField>
+			<form.AppField name="cost">
+				{(field) => <field.NumberField label="Cost" />}
+			</form.AppField>
+			<form.AppField name="active">
+				{(field) => <field.SwitchField label="Active" />}
+			</form.AppField>
+			<form.AppField name="color">
+				{(field) => (
+					<field.SelectField
+						label="Color"
+						options={[
+							{ value: "red", label: "Red" },
+							{ value: "blue", label: "Blue" },
+						]}
+					/>
+				)}
+			</form.AppField>
+			<form.AppField name="note">
+				{(field) => <field.TextareaField label="Note" />}
+			</form.AppField>
+			<form.AppField name="email">
+				{(field) => <field.IconInputField label="Email" icon={Mail} />}
+			</form.AppField>
+			<form.AppField name="born">
+				{(field) => <field.DateField label="Born" />}
+			</form.AppField>
+			<form.AppForm>
+				<form.SubmitButton label="Save" />
+			</form.AppForm>
+		</form>
+	);
+}
+
+describe("shared form field components", () => {
+	it("renders every registered field component plus the submit button", () => {
+		render(<Harness />);
+		expect(screen.getByLabelText("Name")).toBeInTheDocument();
+		expect(screen.getByLabelText("Cost")).toBeInTheDocument();
+		expect(screen.getByRole("switch", { name: "Active" })).toBeInTheDocument();
+		expect(screen.getByLabelText("Note")).toBeInTheDocument();
+		expect(screen.getByLabelText("Email")).toBeInTheDocument();
+		expect(screen.getByLabelText("Born")).toBeInTheDocument();
+		expect(screen.getByText("Color")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+	});
+
+	it("binds a text input to field state", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+		const name = screen.getByLabelText("Name");
+		await user.type(name, "Acme");
+		expect(name).toHaveValue("Acme");
+	});
+
+	it("coerces empty number input to null and parses numbers", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+		const cost = screen.getByLabelText("Cost");
+		await user.type(cost, "250");
+		expect(cost).toHaveValue(250);
+		await user.clear(cost);
+		expect(cost).toHaveValue(null);
+	});
+
+	it("toggles the boolean switch field", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+		const toggle = screen.getByRole("switch", { name: "Active" });
+		expect(toggle).toHaveAttribute("aria-checked", "false");
+		await user.click(toggle);
+		expect(toggle).toHaveAttribute("aria-checked", "true");
+	});
+});

--- a/src/lib/forms/__tests__/form-hook.test.tsx
+++ b/src/lib/forms/__tests__/form-hook.test.tsx
@@ -57,6 +57,25 @@ function Harness() {
 	);
 }
 
+function ValidatedHarness() {
+	const form = useAppForm({ defaultValues: { name: "" } });
+	return (
+		<form aria-label="validated">
+			<form.AppField
+				name="name"
+				validators={{
+					onChange: ({ value }) => (value.length < 2 ? "Too short" : undefined),
+				}}
+			>
+				{(field) => <field.TextField label="Name" />}
+			</form.AppField>
+			<form.AppForm>
+				<form.SubmitButton label="Save" />
+			</form.AppForm>
+		</form>
+	);
+}
+
 describe("shared form field components", () => {
 	it("renders every registered field component plus the submit button", () => {
 		render(<Harness />);
@@ -95,5 +114,33 @@ describe("shared form field components", () => {
 		expect(toggle).toHaveAttribute("aria-checked", "false");
 		await user.click(toggle);
 		expect(toggle).toHaveAttribute("aria-checked", "true");
+	});
+
+	it("forwards the selected option to the field (SelectField)", async () => {
+		const user = userEvent.setup();
+		render(<Harness />);
+		const select = screen.getByRole("combobox", { name: "Color" });
+		expect(select).toHaveTextContent("Red");
+		await user.click(select);
+		await user.click(await screen.findByRole("option", { name: "Blue" }));
+		expect(select).toHaveTextContent("Blue");
+	});
+
+	it("renders a field validation error through FieldError", async () => {
+		const user = userEvent.setup();
+		render(<ValidatedHarness />);
+		await user.type(screen.getByLabelText("Name"), "a");
+		expect(await screen.findByRole("alert")).toHaveTextContent("Too short");
+	});
+
+	it("disables the submit button while the form cannot submit", async () => {
+		const user = userEvent.setup();
+		render(<ValidatedHarness />);
+		const submit = screen.getByRole("button", { name: "Save" });
+		const name = screen.getByLabelText("Name");
+		await user.type(name, "a");
+		expect(submit).toBeDisabled();
+		await user.type(name, "bc");
+		expect(submit).toBeEnabled();
 	});
 });

--- a/src/lib/forms/fields/date-field.tsx
+++ b/src/lib/forms/fields/date-field.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Field, FieldError, FieldLabel } from "#components/ui/field";
+import { Input } from "#components/ui/input";
+import { useFieldContext } from "../form-contexts";
+
+type DateFieldProps = Omit<
+	ComponentProps<typeof Input>,
+	"value" | "onChange" | "onBlur" | "name" | "type"
+> & {
+	label: string;
+};
+
+/** `<input type="date">` bound to the active TanStack field (string value). */
+export function DateField({ label, id, ...inputProps }: DateFieldProps) {
+	const field = useFieldContext<string>();
+	const fieldId = id ?? field.name;
+	return (
+		<Field>
+			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<Input
+				id={fieldId}
+				name={field.name}
+				type="date"
+				value={field.state.value}
+				onChange={(event) => field.handleChange(event.target.value)}
+				onBlur={field.handleBlur}
+				{...inputProps}
+			/>
+			<FieldError errors={field.state.meta.errors} />
+		</Field>
+	);
+}

--- a/src/lib/forms/fields/icon-input-field.tsx
+++ b/src/lib/forms/fields/icon-input-field.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+import { Field, FieldError, FieldLabel } from "#components/ui/field";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "#components/ui/input-group";
+import { useFieldContext } from "../form-contexts";
+
+type IconInputFieldProps = Omit<
+	ComponentProps<typeof InputGroupInput>,
+	"value" | "onChange" | "onBlur" | "name"
+> & {
+	label: string;
+	icon: LucideIcon;
+};
+
+/**
+ * Text input with a leading icon (InputGroup) bound to the active field —
+ * the pattern the owner-subscribe form hand-rolled for first/last/email/password.
+ */
+export function IconInputField({
+	label,
+	icon: Icon,
+	id,
+	...inputProps
+}: IconInputFieldProps) {
+	const field = useFieldContext<string>();
+	const fieldId = id ?? field.name;
+	return (
+		<Field>
+			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<InputGroup>
+				<InputGroupAddon align="inline-start">
+					<Icon />
+				</InputGroupAddon>
+				<InputGroupInput
+					id={fieldId}
+					name={field.name}
+					value={field.state.value}
+					onChange={(event) => field.handleChange(event.target.value)}
+					onBlur={field.handleBlur}
+					{...inputProps}
+				/>
+			</InputGroup>
+			<FieldError errors={field.state.meta.errors} />
+		</Field>
+	);
+}

--- a/src/lib/forms/fields/number-field.tsx
+++ b/src/lib/forms/fields/number-field.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Field, FieldError, FieldLabel } from "#components/ui/field";
+import { Input } from "#components/ui/input";
+import { useFieldContext } from "../form-contexts";
+
+type NumberFieldProps = Omit<
+	ComponentProps<typeof Input>,
+	"value" | "onChange" | "onBlur" | "name" | "type"
+> & {
+	label: string;
+};
+
+/**
+ * Numeric input for a nullable number field. Empty input maps to `null`
+ * (not `NaN`) — the coercion the property acquisition-cost field hand-rolled.
+ */
+export function NumberField({ label, id, ...inputProps }: NumberFieldProps) {
+	const field = useFieldContext<number | null>();
+	const fieldId = id ?? field.name;
+	return (
+		<Field>
+			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<Input
+				id={fieldId}
+				name={field.name}
+				type="number"
+				value={field.state.value ?? ""}
+				onChange={(event) => {
+					const raw = event.target.value;
+					field.handleChange(raw === "" ? null : Number.parseFloat(raw));
+				}}
+				onBlur={field.handleBlur}
+				{...inputProps}
+			/>
+			<FieldError errors={field.state.meta.errors} />
+		</Field>
+	);
+}

--- a/src/lib/forms/fields/number-field.tsx
+++ b/src/lib/forms/fields/number-field.tsx
@@ -29,7 +29,13 @@ export function NumberField({ label, id, ...inputProps }: NumberFieldProps) {
 				value={field.state.value ?? ""}
 				onChange={(event) => {
 					const raw = event.target.value;
-					field.handleChange(raw === "" ? null : Number.parseFloat(raw));
+					// `<input type="number">` sanitizes invalid/partial input to "",
+					// so parseFloat only sees "" or a valid float; guard NaN anyway so
+					// the field never holds NaN if the input type ever changes.
+					const parsed = Number.parseFloat(raw);
+					field.handleChange(
+						raw === "" || Number.isNaN(parsed) ? null : parsed,
+					);
 				}}
 				onBlur={field.handleBlur}
 				{...inputProps}

--- a/src/lib/forms/fields/select-field.tsx
+++ b/src/lib/forms/fields/select-field.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Field, FieldError, FieldLabel } from "#components/ui/field";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "#components/ui/select";
+import { useFieldContext } from "../form-contexts";
+
+type SelectFieldProps = {
+	label: string;
+	options: ReadonlyArray<{ value: string; label: string }>;
+	placeholder?: string;
+	id?: string;
+	disabled?: boolean;
+};
+
+/**
+ * Single-select bound to the active TanStack field. `onValueChange` resolves
+ * the chosen option from `options` (which constrains the valid values) so the
+ * value is forwarded without an `as` cast.
+ */
+export function SelectField({
+	label,
+	options,
+	placeholder,
+	id,
+	disabled,
+}: SelectFieldProps) {
+	const field = useFieldContext<string>();
+	const fieldId = id ?? field.name;
+	return (
+		<Field>
+			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<Select
+				value={field.state.value}
+				onValueChange={(value) => {
+					const option = options.find((candidate) => candidate.value === value);
+					if (option) field.handleChange(option.value);
+				}}
+				disabled={disabled ?? false}
+			>
+				<SelectTrigger id={fieldId}>
+					<SelectValue placeholder={placeholder} />
+				</SelectTrigger>
+				<SelectContent>
+					{options.map((option) => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+			<FieldError errors={field.state.meta.errors} />
+		</Field>
+	);
+}

--- a/src/lib/forms/fields/switch-field.tsx
+++ b/src/lib/forms/fields/switch-field.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldLabel,
+} from "#components/ui/field";
+import { Switch } from "#components/ui/switch";
+import { useFieldContext } from "../form-contexts";
+
+type SwitchFieldProps = {
+	label: string;
+	description?: string;
+	id?: string;
+	disabled?: boolean;
+};
+
+/** Boolean toggle bound to the active TanStack field (shadcn Switch). */
+export function SwitchField({
+	label,
+	description,
+	id,
+	disabled,
+}: SwitchFieldProps) {
+	const field = useFieldContext<boolean>();
+	const fieldId = id ?? field.name;
+	return (
+		<Field orientation="horizontal">
+			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<Switch
+				id={fieldId}
+				checked={field.state.value}
+				onCheckedChange={(checked) => field.handleChange(checked)}
+				disabled={disabled}
+			/>
+			{description ? <FieldDescription>{description}</FieldDescription> : null}
+			<FieldError errors={field.state.meta.errors} />
+		</Field>
+	);
+}

--- a/src/lib/forms/fields/switch-field.tsx
+++ b/src/lib/forms/fields/switch-field.tsx
@@ -32,7 +32,7 @@ export function SwitchField({
 				id={fieldId}
 				checked={field.state.value}
 				onCheckedChange={(checked) => field.handleChange(checked)}
-				disabled={disabled}
+				disabled={disabled ?? false}
 			/>
 			{description ? <FieldDescription>{description}</FieldDescription> : null}
 			<FieldError errors={field.state.meta.errors} />

--- a/src/lib/forms/fields/text-field.tsx
+++ b/src/lib/forms/fields/text-field.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Field, FieldError, FieldLabel } from "#components/ui/field";
+import { Input } from "#components/ui/input";
+import { useFieldContext } from "../form-contexts";
+
+type TextFieldProps = Omit<
+	ComponentProps<typeof Input>,
+	"value" | "onChange" | "onBlur" | "name"
+> & {
+	label: string;
+};
+
+/**
+ * Text input bound to the active TanStack field. Mirrors the plain
+ * `Input` + `Label` + error pattern the hand-rolled form sections used.
+ */
+export function TextField({ label, id, ...inputProps }: TextFieldProps) {
+	const field = useFieldContext<string>();
+	const fieldId = id ?? field.name;
+	return (
+		<Field>
+			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<Input
+				id={fieldId}
+				name={field.name}
+				value={field.state.value}
+				onChange={(event) => field.handleChange(event.target.value)}
+				onBlur={field.handleBlur}
+				{...inputProps}
+			/>
+			<FieldError errors={field.state.meta.errors} />
+		</Field>
+	);
+}

--- a/src/lib/forms/fields/textarea-field.tsx
+++ b/src/lib/forms/fields/textarea-field.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Field, FieldError, FieldLabel } from "#components/ui/field";
+import { Textarea } from "#components/ui/textarea";
+import { useFieldContext } from "../form-contexts";
+
+type TextareaFieldProps = Omit<
+	ComponentProps<typeof Textarea>,
+	"value" | "onChange" | "onBlur" | "name"
+> & {
+	label: string;
+};
+
+/** Multi-line text input bound to the active TanStack field. */
+export function TextareaField({
+	label,
+	id,
+	...textareaProps
+}: TextareaFieldProps) {
+	const field = useFieldContext<string>();
+	const fieldId = id ?? field.name;
+	return (
+		<Field>
+			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<Textarea
+				id={fieldId}
+				name={field.name}
+				value={field.state.value}
+				onChange={(event) => field.handleChange(event.target.value)}
+				onBlur={field.handleBlur}
+				{...textareaProps}
+			/>
+			<FieldError errors={field.state.meta.errors} />
+		</Field>
+	);
+}

--- a/src/lib/forms/form-components/submit-button.tsx
+++ b/src/lib/forms/form-components/submit-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Button } from "#components/ui/button";
+import { useFormContext } from "../form-contexts";
+
+type SubmitButtonProps = Omit<
+	ComponentProps<typeof Button>,
+	"type" | "disabled"
+> & {
+	label: string;
+	submittingLabel?: string;
+};
+
+/**
+ * Submit button wired to form state via `form.Subscribe` — disabled until the
+ * form `canSubmit`, swaps to `submittingLabel` while submitting. Replaces the
+ * per-form `canSubmit`/`isSubmitting` button wiring.
+ */
+export function SubmitButton({
+	label,
+	submittingLabel = "Saving...",
+	...buttonProps
+}: SubmitButtonProps) {
+	const form = useFormContext();
+	return (
+		<form.Subscribe
+			selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+		>
+			{([canSubmit, isSubmitting]) => (
+				<Button type="submit" disabled={!canSubmit} {...buttonProps}>
+					{isSubmitting ? submittingLabel : label}
+				</Button>
+			)}
+		</form.Subscribe>
+	);
+}

--- a/src/lib/forms/form-contexts.ts
+++ b/src/lib/forms/form-contexts.ts
@@ -1,0 +1,12 @@
+import { createFormHookContexts } from "@tanstack/react-form";
+
+/**
+ * Field/form contexts for the shared TanStack Form composition layer.
+ *
+ * Kept in its own module (not `form-hook.tsx`) so the field components can
+ * import `useFieldContext` without creating a cycle: `form-hook.tsx` imports
+ * the field components to register them, and the field components import only
+ * these contexts.
+ */
+export const { fieldContext, formContext, useFieldContext, useFormContext } =
+	createFormHookContexts();

--- a/src/lib/forms/form-contexts.ts
+++ b/src/lib/forms/form-contexts.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { createFormHookContexts } from "@tanstack/react-form";
 
 /**

--- a/src/lib/forms/form-hook.tsx
+++ b/src/lib/forms/form-hook.tsx
@@ -26,6 +26,16 @@ import { fieldContext, formContext } from "./form-contexts";
  *
  * Define each form's options once with `formOptions({ defaultValues, validators })`
  * from `@tanstack/react-form` and spread into both `useAppForm` and `withForm`.
+ *
+ * CAVEAT — field component ↔ field value type: each field component asserts the
+ * value type it binds (`useFieldContext<string>()`, `<number | null>()`,
+ * `<boolean>()`). TanStack's `fieldComponents` registry does NOT cross-check that
+ * assertion against the field's real type, so mounting e.g. `<field.NumberField>`
+ * on a `string` field compiles clean and silently writes the wrong type.
+ * Convention: mount each field component only on a field of its asserted value
+ * type — TextField / SelectField / IconInputField / DateField → `string`,
+ * NumberField → `number | null`, SwitchField → `boolean` — and let each form's
+ * own tests pin the binding.
  */
 export const { useAppForm, withForm, withFieldGroup } = createFormHook({
 	fieldContext,

--- a/src/lib/forms/form-hook.tsx
+++ b/src/lib/forms/form-hook.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createFormHook } from "@tanstack/react-form";
+import { DateField } from "./fields/date-field";
+import { IconInputField } from "./fields/icon-input-field";
+import { NumberField } from "./fields/number-field";
+import { SelectField } from "./fields/select-field";
+import { SwitchField } from "./fields/switch-field";
+import { TextField } from "./fields/text-field";
+import { TextareaField } from "./fields/textarea-field";
+import { SubmitButton } from "./form-components/submit-button";
+import { fieldContext, formContext } from "./form-contexts";
+
+/**
+ * Shared TanStack Form composition layer for the whole app.
+ *
+ * - `useAppForm` — the typed form hook every form uses (replaces raw `useForm`).
+ * - `withForm` — wrap an extracted form section; it receives a fully typed
+ *   `form` from the `defaultValues` (or shared `formOptions`) passed to it, so
+ *   sections never hand-roll a `ReactFormExtendedApi` alias.
+ * - `withFieldGroup` — type a reusable group of fields (e.g. a wizard step).
+ *
+ * Fields render through the registered components via `form.AppField`:
+ *   <form.AppField name="email">{(field) => <field.IconInputField .../>}</form.AppField>
+ * Form-level chrome renders via `form.AppForm` (e.g. `<form.SubmitButton .../>`).
+ *
+ * Define each form's options once with `formOptions({ defaultValues, validators })`
+ * from `@tanstack/react-form` and spread into both `useAppForm` and `withForm`.
+ */
+export const { useAppForm, withForm, withFieldGroup } = createFormHook({
+	fieldContext,
+	formContext,
+	fieldComponents: {
+		TextField,
+		NumberField,
+		TextareaField,
+		SelectField,
+		SwitchField,
+		IconInputField,
+		DateField,
+	},
+	formComponents: {
+		SubmitButton,
+	},
+});


### PR DESCRIPTION
Opens milestone **v7.0 — TanStack Form Composition Migration** and delivers **Phase 20 (Form Foundation)**.

## Why

The codebase hand-rolled **5** identical 12-generic `ReactFormExtendedApi` type aliases (property/subscribe/lease/tenant/unit) plus 123 per-field annotations across 14 `useForm` sites — because extracted form sections couldn't otherwise be typed. TanStack Form ships the purpose-built fix (`createFormHook` / `useAppForm` / `withForm` / `withFieldGroup` / `formOptions`), already in our installed `@tanstack/react-form@1.32`. This milestone adopts it; this PR lays the shared foundation every form migrates onto in phases 21-24.

## What this PR contains

**Planning (GSD milestone kickoff):** `PROJECT.md` / `STATE.md` → v7.0, `REQUIREMENTS.md` (13 `FORM-*` requirements), `ROADMAP.md` (5 phases, 20-24), v6.0 docs archived.

**Phase 20 — Form Foundation** (`FORM-01/02/03/11`), all under `src/lib/forms/`:
- `form-contexts.ts` — `createFormHookContexts()` (split out so field components import `useFieldContext` without a cycle through `form-hook`)
- `form-hook.tsx` — `createFormHook()` → `useAppForm` / `withForm` / `withFieldGroup`, registering the field + form components. **Zero hand-rolled generics.**
- 7 typed field components wrapping the **existing** shadcn primitives (no UI rebuilt): `TextField`, `NumberField` (empty→`null` coercion, the property acquisition-cost pattern), `TextareaField`, `SelectField`, `SwitchField`, `IconInputField` (InputGroup + leading icon, the subscribe-form pattern), `DateField`
- `SubmitButton` form component (`form.Subscribe`-driven `canSubmit`/`isSubmitting`)
- `form-hook.test.tsx` — pins rendering + text / number-null / switch binding

## Behavior change

**None.** No production form is migrated in this PR — it is a pure addition. Phases 21-24 migrate the forms onto this foundation (each its own PR under the perfect-PR gate) and delete the 5 `*-form-types.ts` aliases.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test:unit` — **101,910 pass** (incl. 4 new foundation tests)
- No new `any` / `as unknown as`; no hand-rolled `ReactFormExtendedApi` in the new code

[hudsor01]
