### PR TITLE
v8.0 Phase 28: tenant domain (TEN-01..06)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -28,7 +28,7 @@
 | 25 | Critical: Corruption & Broken Deletes | 5/5 | Complete   | 2026-07-02 |
 | 26 | Lease Domain Correctness | 9/9 | Complete   | 2026-07-05 |
 | 27 | Maintenance & Inspections | 6/7 | In Progress|  |
-| 28 | Tenant Domain | Real deletes, correct lease navigation, status persistence, current-lease selection | TEN-01..06 | 4 |
+| 28 | Tenant Domain | 5/6 | In Progress|  |
 | 29 | Billing, Stripe & Financial Reports | Correct period-end, period-scoped statements, invoice amounts, matching PDFs | BILL-01..06 | 6 |
 | 30 | Analytics & Data-Layer Correctness | Occupancy analytics, soft-delete filtering, stale-cache invalidation, virtualizer | DATA-01..03, PROP-01..03 | 5 |
 | 31 | Forms Behavior Correctness | Unsaved-guard, contact send, no render loop, saved fields, validators, single toast | FORMFIX-01..08 | 5 |
@@ -95,13 +95,13 @@ Requirements: TEN-01, TEN-02, TEN-03, TEN-04, TEN-05, TEN-06
 3. Emergency-contact fields can be left empty or cleared, and name-only edits save
 4. Two consecutive zero-finding review cycles
 
-**Plans:** 6 plans
+**Plans:** 5/6 plans executed
 Plans:
-- [ ] 28-01-PLAN.md — TEN-04: mapTenantRow prefers the active lease (current-lease selection + test)
-- [ ] 28-02-PLAN.md — TEN-01: wire real tenant delete (row/grid/bulk) behind confirm dialogs
-- [ ] 28-03-PLAN.md — TEN-05: empty-safe emergency-contact edit validator
-- [ ] 28-04-PLAN.md — TEN-06: fix moved-out optimistic update (drop wrong-key/shape list step)
-- [ ] 28-05-PLAN.md — TEN-02/TEN-03: View-lease by leaseId + read-only status badge
+- [x] 28-01-PLAN.md — TEN-04: mapTenantRow prefers the active lease (current-lease selection + test)
+- [x] 28-02-PLAN.md — TEN-01: wire real tenant delete (row/grid/bulk) behind confirm dialogs
+- [x] 28-03-PLAN.md — TEN-05: empty-safe emergency-contact edit validator
+- [x] 28-04-PLAN.md — TEN-06: fix moved-out optimistic update (drop wrong-key/shape list step)
+- [x] 28-05-PLAN.md — TEN-02/TEN-03: View-lease by leaseId + read-only status badge
 - [ ] 28-06-PLAN.md — verification: full gate + human-verify the six tenant flows
 
 ### Phase 29: Billing, Stripe & Financial Reports

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -95,6 +95,15 @@ Requirements: TEN-01, TEN-02, TEN-03, TEN-04, TEN-05, TEN-06
 3. Emergency-contact fields can be left empty or cleared, and name-only edits save
 4. Two consecutive zero-finding review cycles
 
+**Plans:** 6 plans
+Plans:
+- [ ] 28-01-PLAN.md — TEN-04: mapTenantRow prefers the active lease (current-lease selection + test)
+- [ ] 28-02-PLAN.md — TEN-01: wire real tenant delete (row/grid/bulk) behind confirm dialogs
+- [ ] 28-03-PLAN.md — TEN-05: empty-safe emergency-contact edit validator
+- [ ] 28-04-PLAN.md — TEN-06: fix moved-out optimistic update (drop wrong-key/shape list step)
+- [ ] 28-05-PLAN.md — TEN-02/TEN-03: View-lease by leaseId + read-only status badge
+- [ ] 28-06-PLAN.md — verification: full gate + human-verify the six tenant flows
+
 ### Phase 29: Billing, Stripe & Financial Reports
 **Goal:** Correct the billing and financial-reporting numbers — read Stripe's period-end from the right SDK location (fixing the null billing date and the cancel/reactivate crash), scope financial statements to their selected period, show real invoice amounts, surface RPC errors instead of zeroing expenses, and build the year-end/tax PDFs from the financial RPCs.
 Requirements: BILL-01, BILL-02, BILL-03, BILL-04, BILL-05, BILL-06

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v8.0
 milestone_name: Correctness Restoration
 status: executing
-last_updated: "2026-07-07T02:57:08.843Z"
-last_activity: 2026-07-07 -- Phase 27 execution started
+last_updated: "2026-07-08T00:41:09.891Z"
+last_activity: 2026-07-08 -- Phase 28 execution started
 progress:
   total_phases: 11
   completed_phases: 2
-  total_plans: 21
-  completed_plans: 14
+  total_plans: 27
+  completed_plans: 20
   percent: 18
 ---
 
@@ -20,14 +20,14 @@ progress:
 See: .planning/PROJECT.md
 
 **Core value (v8.0):** Every core operation an owner performs — create a lease, delete a unit, view the leases list, sign a document, pay an invoice, upload a photo, run a report — produces correct data and correct behavior. This milestone eradicates the full set of real bugs surfaced by the 2026-07-02 whole-codebase hunt (12 parallel domain agents; every P0 and every cross-owner/DB claim verified against source + the live Supabase DB). Nothing new is built; every requirement restores an existing feature to correct behavior.
-**Current focus:** Phase 27 — maintenance-inspections
+**Current focus:** Phase 28 — tenant-domain
 
 ## Current Position
 
-Phase: 27 (maintenance-inspections) — REVIEW-PASSED (perfect-PR gate met, cycles 10+11)
-Plan: 7 of 7 (execution + review complete)
-Status: Executing Phase 27
-Last activity: 2026-07-07 -- Phase 27 execution started
+Phase: 28 (tenant-domain) — REVIEW-PASSED (perfect-PR gate met, cycles 3+4)
+Plan: 1 of 6
+Status: Executing Phase 28
+Last activity: 2026-07-08 -- Phase 28 execution started
 
 ## Roadmap Summary (v8.0)
 

--- a/.planning/phases/28-tenant-domain/28-01-PLAN.md
+++ b/.planning/phases/28-tenant-domain/28-01-PLAN.md
@@ -1,0 +1,114 @@
+---
+phase: 28-tenant-domain
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/hooks/api/query-keys/tenant-mappers.ts
+  - src/hooks/api/query-keys/tenant-mappers.test.ts
+autonomous: true
+requirements: [TEN-04]
+
+must_haves:
+  truths:
+    - "A tenant whose primary lease_tenants row is on a terminated/ended lease but who also has a separate active lease shows the active lease as current"
+    - "currentLease, unit, property, and leaseStatus all derive from the same chosen (active-preferred) lease"
+    - "Selection is deterministic when no lease is active (is_primary, then latest start_date)"
+  artifacts:
+    - path: "src/hooks/api/query-keys/tenant-mappers.ts"
+      provides: "active-preferring current-lease selection in mapTenantRow"
+      contains: "lease_status"
+    - path: "src/hooks/api/query-keys/tenant-mappers.test.ts"
+      provides: "regression test proving active lease wins over a terminated is_primary lease"
+  key_links:
+    - from: "src/hooks/api/query-keys/tenant-mappers.ts"
+      to: "TenantWithLeaseInfo.currentLease"
+      via: "chosen lease drives currentLease/unit/property/lease_status"
+      pattern: "lease_status.*===.*active"
+---
+
+<objective>
+Fix `mapTenantRow` so the "current" lease is the ACTIVE lease, not merely the `is_primary` row. Today a tenant with a primary row on a terminated lease plus a separate active lease displays the terminated lease as current, which cascades into a wrong `leaseStatus` and (via `tenant-transforms.ts`) a wrong `leaseId` for TEN-02's "View lease" button.
+
+Purpose: TEN-04 is the upstream dependency for TEN-02 — `currentLease.id` must be the active lease before the row's View button (Plan 05) is trustworthy.
+Output: Corrected selection logic in `mapTenantRow` + a regression test.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/28-tenant-domain/28-CONTEXT.md
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Prefer the active lease in mapTenantRow current-lease selection (TEN-04)</name>
+  <files>src/hooks/api/query-keys/tenant-mappers.ts, src/hooks/api/query-keys/tenant-mappers.test.ts</files>
+  <read_first>
+    - src/hooks/api/query-keys/tenant-mappers.ts (lines 157-279 — `mapTenantRow`; the buggy selection is lines 179-182: `primaryLeaseTenant = leaseRows.find((lt) => lt.is_primary) ?? leaseRows[0]`; `activeLease`, `activeUnit`, `activeProperty` derive from it; `currentLease`/`leases`/`unit`/`property`/`lease_status` are built from those below)
+    - src/hooks/api/query-keys/tenant-mappers.ts (lines 105-155 — `TenantPostgrestRow`: each `lease_tenants[]` element has `is_primary`, and `leases` with `lease_status`, `start_date`, `units.properties`)
+    - src/hooks/api/query-keys/tenant-mappers.test.ts (existing test structure + row fixtures to extend)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-04 LOCKED decision: prefer `leases.lease_status === 'active'` first, then `is_primary`, then deterministic latest `start_date`; keep null-safety + NOT-NULL throws)
+  </read_first>
+  <behavior>
+    - Given lease_tenants with a terminated is_primary lease AND a separate active lease: chosen lease is the active one; currentLease.id, currentLease.status ('active'), unit, property, and lease_status all come from the active lease.
+    - Given only a terminated is_primary lease (no active): chosen lease is that is_primary lease (fallback preserved); leaseStatus reflects it.
+    - Given two active leases: tie-break by latest start_date (deterministic); currentLease.id is the newer one.
+    - Given no lease_tenants rows: currentLease is null, unit/property null, no lease_status/monthlyRent keys (existing null-safe behavior preserved).
+    - Existing NOT-NULL `id` throw and `status` validation are unchanged.
+  </behavior>
+  <action>
+    Replace the `primaryLeaseTenant`/`activeLease` selection (lines 179-182) with a helper that scores each `lease_tenants` entry (whose `leases` is non-null) and picks in priority order: (1) `lt.leases?.lease_status === "active"`, (2) `lt.is_primary === true`, (3) deterministic tie-break by latest `leases.start_date` (descending; ISO date strings compare lexicographically, but sort by parsed value for safety). Reduce over `leaseRows` to a single `chosenLeaseTenant`, then keep the existing derivations: `activeLease = chosenLeaseTenant?.leases ?? null`, `activeUnit = activeLease?.units ?? null`, `activeProperty = activeUnit?.properties ?? null`. Do NOT alter the `leases[]` mapping (lines 227-245 — that stays the full history), only the single "current" pick. Keep every `?? null` guard and the two throws (id, status). Name the helper descriptively (e.g. `pickCurrentLeaseTenant`) inside the module; no new exports required.
+
+    Extend tenant-mappers.test.ts with cases matching the behavior block: (a) terminated is_primary + separate active → currentLease is the active lease + `lease_status: "active"`; (b) only terminated is_primary → that lease chosen; (c) two active leases → latest start_date wins; (d) empty lease_tenants → currentLease null. Build fixtures against the real `TenantPostgrestRow` shape (nested `leases.units.properties`).
+  </action>
+  <verify>
+    <automated>bun run test:unit -- src/hooks/api/query-keys/tenant-mappers.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - A tenant with a terminated `is_primary` lease and a separate active lease maps to `currentLease` = the active lease and `lease_status === "active"` (asserted by a new test).
+    - No `is_primary`-only or `leaseRows[0]`-only selection remains in `mapTenantRow`.
+    - Null-safety (`?? null`) and the NOT-NULL `id` + `status` throws are unchanged.
+    - `bun run typecheck` and the mapper test file pass.
+  </acceptance_criteria>
+  <done>mapTenantRow selects the active lease as current with a deterministic fallback, proven by the new regression test; no migrations added.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| PostgREST → mapper | untrusted nested-join rows shaped into TenantWithLeaseInfo |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-28-01 | Tampering | mapTenantRow selection | accept | Owner-scoped RLS on `tenants`/`lease_tenants`/`leases` unchanged; selection reorders already-authorized rows, introduces no new data exposure |
+| T-28-01-I | Information Disclosure | leaked wrong lease | mitigate | Existing NOT-NULL `id` throw + `status` Zod validation retained; no cross-owner rows can enter the join (RLS) |
+</threat_model>
+
+<verification>
+- `bun run typecheck` passes.
+- `bun run test:unit -- src/hooks/api/query-keys/tenant-mappers.test.ts` passes including the new active-preference cases.
+- No new migration files created under `supabase/migrations/`.
+</verification>
+
+<success_criteria>
+mapTenantRow's current-lease selection prefers the active lease with a deterministic fallback; the regression test covers terminated-primary-plus-active, fallback, tie-break, and empty cases.
+</success_criteria>
+
+<output>
+Create `.planning/phases/28-tenant-domain/28-01-SUMMARY.md` when done
+</output>

--- a/.planning/phases/28-tenant-domain/28-01-SUMMARY.md
+++ b/.planning/phases/28-tenant-domain/28-01-SUMMARY.md
@@ -1,0 +1,78 @@
+---
+phase: 28-tenant-domain
+plan: 01
+subsystem: api
+tags: [tenants, mapper, postgrest, lease, current-lease, tanstack-query]
+
+# Dependency graph
+requires: []
+provides:
+  - "mapTenantRow selects the current lease by active > is_primary > latest start_date (not is_primary/first)"
+  - "currentLease, unit, property, and lease_status all derive from the same chosen lease"
+  - "pickCurrentLeaseTenant helper scores lease_tenants deterministically"
+affects: [TEN-02, TEN-04, tenant list, tenant detail, onViewLease]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "pickCurrentLeaseTenant: reduce-over-lease_tenants with a layered comparator (active, then is_primary, then latest start_date via Date.parse) filtering out null-lease rows"
+
+key-files:
+  created: []
+  modified:
+    - src/hooks/api/query-keys/tenant-mappers.ts
+    - src/hooks/api/query-keys/tenant-mappers.test.ts
+
+key-decisions:
+  - "Layered comparator: active status wins first, is_primary breaks ties among same-active-status, latest start_date breaks the remaining ties — matches the TEN-04 LOCKED priority order"
+  - "Only lease_tenants whose joined leases is non-null are considered; empty/all-null yields undefined -> currentLease null (existing behavior preserved)"
+  - "start_date tie-break parses via Date.parse and sorts malformed/absent dates last rather than corrupting the order"
+
+patterns-established:
+  - "Deterministic single-row selection from a nested-join array via reduce, not find/[0]"
+
+requirements-completed: [TEN-04]
+
+# Metrics
+duration: ~10min
+completed: 2026-07-07
+---
+
+# Phase 28 Plan 01: Active-preferring current-lease selection in mapTenantRow
+
+**A tenant whose primary lease_tenants row sits on a terminated lease but who also holds a separate active lease now shows the ACTIVE lease as current — currentLease.id, leaseStatus, unit, and property all derive from that one chosen lease, with a deterministic is_primary -> latest-start_date fallback.**
+
+## Accomplishments
+
+### Task 1 — prefer the active lease in current-lease selection (TEN-04)
+- Replaced the buggy `leaseRows.find((lt) => lt.is_primary) ?? leaseRows[0]` selection with a new module-local `pickCurrentLeaseTenant(leaseRows)` helper.
+- The helper filters to lease_tenants with a non-null `leases`, then reduces to one winner via a layered comparator: (1) `lease_status === "active"`, (2) `is_primary === true`, (3) latest `start_date` (parsed via `Date.parse`, NaN sorts last).
+- `activeLease`/`activeUnit`/`activeProperty` still derive from the chosen row, so `currentLease`, `leases[]` history (unchanged), `unit`, `property`, `monthlyRent`, and `lease_status` all stay consistent with the chosen lease.
+- Preserved every `?? null` guard and both NOT-NULL throws (`id`, `status`).
+- Added a `mapTenantRow current-lease selection (TEN-04)` describe block with 4 cases: terminated-primary + separate active (active wins + `lease_status: "active"` + matching unit/property), no-active fallback to is_primary, two-active tie-break by latest start_date, and empty lease_tenants -> null currentLease/unit/property.
+
+## Task Commits
+
+1. **Task 1: Prefer the active lease in mapTenantRow current-lease selection (TEN-04)** — `97d05bf01` (fix)
+
+## Verification
+
+- `bun run test:unit -- src/hooks/api/query-keys/tenant-mappers.test.ts` — 13 tests pass (9 existing + 4 new TEN-04 cases).
+- Full pre-commit gate (gitleaks, lockfile-verify, lint, typecheck, unit-tests, commitlint) passed on the commit.
+
+## Deviations from Plan
+
+None — plan executed as written. One test-fixture correction during authoring: the start_date tie-break case initially set the two active leases to differing `is_primary` values, which (correctly) let is_primary decide before start_date; the fixture was fixed to equal `is_primary` so it exercises the intended start_date tie-break.
+
+## Issues Encountered
+
+None.
+
+## Next Phase Readiness
+
+- `currentLease.id` is now the active lease, which is the upstream dependency for TEN-02's `onViewLease(currentLease.id)` (Plan 28-05, a different agent).
+
+---
+*Phase: 28-tenant-domain*
+*Completed: 2026-07-07*

--- a/.planning/phases/28-tenant-domain/28-02-PLAN.md
+++ b/.planning/phases/28-tenant-domain/28-02-PLAN.md
@@ -1,0 +1,166 @@
+---
+phase: 28-tenant-domain
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/types/sections/tenants.ts
+  - src/app/(owner)/tenants/page.tsx
+  - src/components/tenants/tenants.tsx
+autonomous: true
+requirements: [TEN-01]
+
+must_haves:
+  truths:
+    - "Deleting a tenant from a table row removes it (or surfaces the active-lease block error via toast)"
+    - "Deleting a tenant from a grid card removes it (or surfaces the block error)"
+    - "Bulk-deleting the selected set removes each (blocked ones surface the error, others still delete)"
+    - "No tenant delete control remains a logger.info-only no-op"
+  artifacts:
+    - path: "src/types/sections/tenants.ts"
+      provides: "onDeleteTenant + onBulkDelete on TenantsProps"
+      contains: "onDeleteTenant"
+    - path: "src/app/(owner)/tenants/page.tsx"
+      provides: "row/grid confirm + bulk confirm wired to useDeleteTenantMutation"
+      contains: "useDeleteTenantMutation"
+    - path: "src/components/tenants/tenants.tsx"
+      provides: "row/grid/bulk onDelete call the props (no logger.info no-op)"
+      contains: "onDeleteTenant"
+  key_links:
+    - from: "src/components/tenants/tenants.tsx"
+      to: "src/app/(owner)/tenants/page.tsx"
+      via: "onDeleteTenant / onBulkDelete props"
+      pattern: "onDeleteTenant|onBulkDelete"
+    - from: "src/app/(owner)/tenants/page.tsx"
+      to: "useDeleteTenantMutation"
+      via: "confirm handlers call deleteTenant"
+      pattern: "deleteTenant\\("
+---
+
+<objective>
+Wire the tenant delete controls (table row, grid card, bulk action bar) to the REAL `useDeleteTenantMutation` behind confirm dialogs. Today all three are `logger.info` no-ops in `tenants.tsx` (lines 94, 199-200, 211-212); the single-tenant delete dialog + mutation already exist in `page.tsx` but are orphaned because `TenantsProps` exposes no delete callbacks.
+
+Purpose: TEN-01 — deletes must actually delete (subject to the Phase-26 active-lease guard), not silently log.
+Output: `onDeleteTenant` + `onBulkDelete` props threaded from page → Tenants → row/grid/bulk, plus a bulk-confirm dialog.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/28-tenant-domain/28-CONTEXT.md
+
+<interfaces>
+From src/hooks/api/use-tenant-mutations.ts:
+  export function useDeleteTenantMutation();  // mutate(tenantId: string); already invalidates tenantQueries.lists() + leaseQueries.lists() + ownerDashboardKeys.all; toasts success + error (active-lease block surfaces via errorContext "Delete tenant")
+
+From src/types/sections/tenants.ts (current TenantsProps — extend it):
+  onViewTenant, onEditTenant, onContactTenant, onViewLease  // no delete callbacks today
+
+From src/app/(owner)/tenants/page.tsx (already present, currently orphaned):
+  const [tenantToDelete, setTenantToDelete] = useState<string | null>(null);
+  const { mutate: deleteTenant } = useDeleteTenantMutation();
+  const confirmDeleteTenant = () => { if (tenantToDelete) { deleteTenant(tenantToDelete); setTenantToDelete(null); } };
+  // A single-tenant AlertDialog bound to tenantToDelete already renders at the bottom of the JSX.
+
+From src/components/tenants/tenants.tsx:
+  handleBulkDelete() // currently logs + clearSelection; TenantActionBar onDelete={handleBulkDelete}
+  <TenantTable ... onDelete={(id) => logger.info(...)} />   // line 199-201
+  <TenantGrid  ... onDelete={(id) => logger.info(...)} />   // line 211-213
+
+From src/components/tenants/tenant-action-bar.tsx:
+  interface TenantActionBarProps { selectedCount, onDelete: () => void, onExport, onClose, ... }
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add delete callbacks to TenantsProps and thread them through Tenants (TEN-01)</name>
+  <files>src/types/sections/tenants.ts, src/components/tenants/tenants.tsx</files>
+  <read_first>
+    - src/types/sections/tenants.ts (lines 4-13 — TenantsProps has onViewTenant/onEditTenant/onContactTenant/onViewLease, NO delete callback)
+    - src/components/tenants/tenants.tsx (lines 21-28 destructured props; 93-98 `handleBulkDelete` logger.info no-op; 199-201 table `onDelete` no-op; 211-213 grid `onDelete` no-op; 235-241 `<TenantActionBar onDelete={handleBulkDelete} />`)
+    - src/hooks/api/use-tenant-mutations.ts (lines 62-78 — `useDeleteTenantMutation` already invalidates lists + dashboard and toasts the active-lease block error; do NOT modify this file)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-01 LOCKED: wire row + grid + bulk to useDeleteTenantMutation behind a destructive confirm; respect the active-lease guard, surface the server error, do not swallow)
+  </read_first>
+  <action>
+    In src/types/sections/tenants.ts add two required callbacks to `TenantsProps`: `onDeleteTenant: (tenantId: string) => void` and `onBulkDelete: (tenantIds: string[]) => void`. Keep the existing callbacks.
+
+    In src/components/tenants/tenants.tsx: destructure the two new props. Replace the table `onDelete={(id) => logger.info(...)}` (lines 199-201) with `onDelete={onDeleteTenant}`, and the grid `onDelete` (lines 211-213) with `onDelete={onDeleteTenant}`. Rewrite `handleBulkDelete` to call `onBulkDelete(Array.from(selectedIds))` then `clearSelection()` (drop the `logger.info("Bulk delete initiated", ...)` line). If `logger`/`createLogger` becomes unused after removing the two no-op log calls (note `handleBulkExport` still logs — keep the import), leave the import; otherwise remove it. Do not change `TenantActionBar`'s `onDelete={handleBulkDelete}` wiring — `handleBulkDelete` now delegates to the prop.
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `TenantsProps` declares `onDeleteTenant` and `onBulkDelete`; the row and grid `onDelete` both reference `onDeleteTenant`; `handleBulkDelete` calls `onBulkDelete(Array.from(selectedIds))`.
+    - No `logger.info("Delete tenant requested", ...)` or `logger.info("Bulk delete initiated", ...)` calls remain in tenants.tsx.
+    - `bun run typecheck` passes (page.tsx will now be required to pass the new props — done in Task 2).
+  </acceptance_criteria>
+  <done>Delete callbacks are declared on TenantsProps and consumed by row/grid/bulk controls; the log-only no-ops are gone.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Wire page-level single + bulk delete confirm to useDeleteTenantMutation (TEN-01)</name>
+  <files>src/app/(owner)/tenants/page.tsx</files>
+  <read_first>
+    - src/app/(owner)/tenants/page.tsx (full file — `tenantToDelete` state 28, `deleteTenant` 53, `confirmDeleteTenant` 64-69, the single-tenant AlertDialog 116-139; note the `<Tenants>` render at 105-114 does NOT yet pass delete callbacks)
+    - src/components/ui/alert-dialog.tsx (AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction — already imported in page.tsx)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-01 LOCKED + Claude's Discretion: single AlertDialog vs per-control; bulk sequential vs Promise.all — sequential mutate calls are fine, each invalidates)
+  </read_first>
+  <action>
+    Pass the two new callbacks to `<Tenants>`: `onDeleteTenant={(id) => setTenantToDelete(id)}` (reuses the existing single-tenant dialog + `confirmDeleteTenant`) and `onBulkDelete={(ids) => setBulkDeleteIds(ids)}`.
+
+    Add bulk-delete state + confirm: `const [bulkDeleteIds, setBulkDeleteIds] = useState<string[] | null>(null);` and `const confirmBulkDelete = () => { if (bulkDeleteIds) { bulkDeleteIds.forEach((id) => deleteTenant(id)); setBulkDeleteIds(null); } };`. Sequential `deleteTenant(id)` calls are correct — the mutation already invalidates lists per success and toasts the active-lease block per failure, so blocked tenants surface an error toast while the rest delete (do NOT try/catch-swallow).
+
+    Render a SECOND destructive AlertDialog (mirroring the existing one) bound to `bulkDeleteIds !== null`, with `onOpenChange={(open) => !open && setBulkDeleteIds(null)}`, a title like "Delete {bulkDeleteIds?.length ?? 0} tenants", a description noting the soft-delete + retention + that tenants with an active lease will be skipped with an error, and an `AlertDialogAction onClick={confirmBulkDelete}` styled destructive (same classes as the existing action). Keep the existing single-tenant dialog untouched.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - `<Tenants>` receives `onDeleteTenant` (opens the single-tenant dialog) and `onBulkDelete` (opens a bulk dialog).
+    - `confirmBulkDelete` calls `deleteTenant(id)` for each selected id; no swallowing of the active-lease error (the mutation's error toast is the surface).
+    - Both AlertDialogs render; `bun run typecheck && bun run lint` pass.
+    - No new migration files created.
+  </acceptance_criteria>
+  <done>Row/grid delete opens the existing confirm and deletes via the real mutation; bulk delete opens its own confirm and deletes the selected set, with the active-lease guard surfaced via toast.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client UI → tenant delete mutation | owner triggers a destructive soft-delete |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-28-02 | Elevation of Privilege | delete another owner's tenant | accept | `tenantMutations.delete` is owner-scoped; RLS on `tenants` blocks cross-owner deletes server-side; UI only sends an id |
+| T-28-02-D | Denial of Service | destructive delete without intent | mitigate | Every delete (row/grid/bulk) is gated behind a destructive AlertDialog confirm |
+| T-28-02-A | Repudiation | active-lease tenant deleted silently | mitigate | Phase-26 active-lease guard blocks server-side; the mutation's error toast surfaces the block (not swallowed) |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint` pass.
+- Manual (covered by Plan 06 human-verify): delete from a row, a grid card, and the bulk bar; an active-lease tenant shows the block error toast; a non-lease tenant disappears from the list.
+- No new migration files created under `supabase/migrations/`.
+</verification>
+
+<success_criteria>
+All three delete controls invoke `useDeleteTenantMutation` behind a destructive confirm; the active-lease guard is surfaced, not swallowed; no logger.info-only delete path remains.
+</success_criteria>
+
+<output>
+Create `.planning/phases/28-tenant-domain/28-02-SUMMARY.md` when done
+</output>

--- a/.planning/phases/28-tenant-domain/28-02-SUMMARY.md
+++ b/.planning/phases/28-tenant-domain/28-02-SUMMARY.md
@@ -1,0 +1,86 @@
+---
+phase: 28-tenant-domain
+plan: 02
+subsystem: ui
+tags: [tenants, delete, mutation, alert-dialog, bulk, tanstack-query, toast]
+
+# Dependency graph
+requires: []
+provides:
+  - "TenantsProps gains required onDeleteTenant + onBulkDelete callbacks"
+  - "row/grid/bulk delete controls invoke useDeleteTenantMutation behind destructive confirms"
+  - "the Phase-26 active-lease delete guard surfaces via the mutation's error toast (not swallowed)"
+affects: [TEN-01, tenant list, tenant delete, bulk delete]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Prop-thread a destructive action from the page (owns the confirm dialog + mutation) down through a presentational section into row/grid/bulk controls"
+    - "Bulk delete = sequential mutate() per id; each mutation invalidates lists on success and toasts the server guard on failure, so partial failure surfaces per-item without swallowing"
+
+key-files:
+  created: []
+  modified:
+    - src/types/sections/tenants.ts
+    - src/components/tenants/tenants.tsx
+    - src/app/(owner)/tenants/page.tsx
+
+key-decisions:
+  - "Reused the existing single-tenant AlertDialog + confirmDeleteTenant for row/grid delete (onDeleteTenant -> setTenantToDelete); added a SECOND AlertDialog for bulk"
+  - "Bulk deletes sequentially via bulkDeleteIds.forEach((id) => deleteTenant(id)) — the mutation already invalidates per success and toasts the active-lease block per failure, so no try/catch swallow"
+  - "handleBulkDelete now delegates to onBulkDelete(Array.from(selectedIds)) then clearSelection(); the logger import stays because handleBulkExport still uses it"
+
+patterns-established:
+  - "New required props on a shared section interface are landed with their consumer in the same working-tree state; commits split per task but the pre-commit typecheck sees the whole consistent tree"
+
+requirements-completed: [TEN-01]
+
+# Metrics
+duration: ~20min
+completed: 2026-07-07
+---
+
+# Phase 28 Plan 02: Wire tenant delete controls to the real mutation
+
+**Row, grid, and bulk-action-bar tenant deletes now invoke `useDeleteTenantMutation` behind destructive AlertDialog confirms instead of `logger.info` no-ops; the Phase-26 active-lease guard surfaces via the mutation's error toast, and bulk delete removes the whole selected set (skipping active-lease tenants with an error).**
+
+## Accomplishments
+
+### Task 1 — declare + consume delete callbacks (TEN-01)
+- `src/types/sections/tenants.ts`: added required `onDeleteTenant: (tenantId: string) => void` and `onBulkDelete: (tenantIds: string[]) => void` to `TenantsProps`.
+- `src/components/tenants/tenants.tsx`: destructured the two props; replaced the table and grid `onDelete={(id) => logger.info("Delete tenant requested", ...)}` no-ops with `onDelete={onDeleteTenant}`; rewrote `handleBulkDelete` to `onBulkDelete(Array.from(selectedIds))` then `clearSelection()` (dropped the `logger.info("Bulk delete initiated", ...)` line). The `createLogger`/`logger` import stays — `handleBulkExport` still logs.
+
+### Task 2 — page-level single + bulk confirm wiring (TEN-01)
+- `src/app/(owner)/tenants/page.tsx`: passed `onDeleteTenant={(id) => setTenantToDelete(id)}` (reuses the existing single-tenant dialog + `confirmDeleteTenant`) and `onBulkDelete={(ids) => setBulkDeleteIds(ids)}` to `<Tenants>`.
+- Added `bulkDeleteIds` state + `confirmBulkDelete` (fires `deleteTenant(id)` per selected id, then clears).
+- Rendered a second destructive `AlertDialog` bound to `bulkDeleteIds !== null` with a count-aware title ("Delete N tenant(s)"), a soft-delete + retention + active-lease-skip description, and a destructive-styled action calling `confirmBulkDelete`. The existing single-tenant dialog is untouched.
+
+## Task Commits
+
+1. **Task 1: Thread delete callbacks through Tenants (TEN-01)** — `230a2446f` (fix)
+2. **Task 2: Wire single + bulk delete to useDeleteTenantMutation (TEN-01)** — `07a1d56fc` (fix)
+
+## Verification
+
+- `bun run typecheck` — clean (confirms the new required props are supplied by the sole consumer, page.tsx; no test renders `<Tenants>`).
+- `bun run lint` — exit 0.
+- `grep` confirms no `logger.info("Delete tenant requested"` / `logger.info("Bulk delete initiated"` remains in tenants.tsx.
+- Full pre-commit gate passed on both commits.
+
+## Deviations from Plan
+
+None in substance. Ordering note: adding required interface props (Task 1) and satisfying them in page.tsx (Task 2) is one indivisible compile unit, so both edits were applied to the working tree before committing. The pre-commit `tsc --noEmit` checks the on-disk working tree (not the index), so each per-task commit still passed the gate with the tree fully consistent — the same pattern used in Plan 28-04.
+
+## Issues Encountered
+
+None.
+
+## Next Phase Readiness
+
+- All three tenant delete controls are live behind destructive confirms with the active-lease guard surfaced. Manual verify (delete from row / grid / bulk; active-lease tenant shows the block toast) is covered by Plan 06.
+- Plan 28-05 (a separate agent) owns tenant-table-row.tsx / tenant-grid.tsx / tenant-table-helpers.tsx (TEN-02 View-lease id + TEN-03 status dropdown) — untouched here.
+
+---
+*Phase: 28-tenant-domain*
+*Completed: 2026-07-07*

--- a/.planning/phases/28-tenant-domain/28-03-PLAN.md
+++ b/.planning/phases/28-tenant-domain/28-03-PLAN.md
@@ -1,0 +1,151 @@
+---
+phase: 28-tenant-domain
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/lib/validation/tenants.ts
+  - src/app/(owner)/tenants/components/tenant-edit-form.client.tsx
+  - src/lib/validation/__tests__/tenants.test.ts
+autonomous: true
+requirements: [TEN-05]
+
+must_haves:
+  truths:
+    - "Editing a tenant and clearing the emergency-contact phone (empty string) still submits and saves"
+    - "A name-only emergency-contact edit (phone + relationship empty) submits"
+    - "A non-empty phone still must match the phone format"
+  artifacts:
+    - path: "src/lib/validation/tenants.ts"
+      provides: "emergency-contact edit schema that accepts empty strings, validates phone only when non-empty"
+      contains: "emergency_contact_phone"
+    - path: "src/app/(owner)/tenants/components/tenant-edit-form.client.tsx"
+      provides: "form uses the optional schema (no .required())"
+    - path: "src/lib/validation/__tests__/tenants.test.ts"
+      provides: "tests asserting empty + partial values validate and bad phone rejects"
+  key_links:
+    - from: "src/app/(owner)/tenants/components/tenant-edit-form.client.tsx"
+      to: "src/lib/validation/tenants.ts"
+      via: "validators.onChange schema import"
+      pattern: "validators"
+---
+
+<objective>
+Stop the tenant-edit emergency-contact validator from making all three fields mandatory. `emergencyContactSchema = tenantInputSchema.pick({...}).required()` (tenant-edit-form.client.tsx:30-36, used at line 64 as `validators.onChange`) forces presence, so `canSubmit` stays false when an owner clears the phone or does a name-only edit. Note the deeper bug: `phoneSchema` is `.min(10)` and the form always submits a string (`""`, never `undefined`), so simply dropping `.required()` still rejects a cleared phone — the phone validator must accept empty string.
+
+Purpose: TEN-05 — owners must be able to clear/leave-empty emergency-contact fields and save partial edits.
+Output: an exported optional edit schema (empty-safe phone) + the form consuming it + unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/28-tenant-domain/28-CONTEXT.md
+
+<interfaces>
+From src/lib/validation/tenants.ts:
+  export const tenantInputSchema = z.object({ ... emergency_contact_name: z.string().max(100).optional(), emergency_contact_phone: phoneSchema.optional(), emergency_contact_relationship: z.string().max(50).optional() });
+
+From src/lib/validation/common.ts:
+  export const phoneSchema = z.string().regex(/^[\d+()-\s]+$/, ...).min(10, ...).max(...);  // REJECTS "" because of .min(10)
+
+From src/app/(owner)/tenants/components/tenant-edit-form.client.tsx:
+  const emergencyContactSchema = tenantInputSchema.pick({ emergency_contact_name: true, emergency_contact_phone: true, emergency_contact_relationship: true }).required();  // line 30-36
+  useAppForm({ defaultValues: { emergency_contact_name: "" , emergency_contact_phone: "", emergency_contact_relationship: "" }, validators: { onChange: emergencyContactSchema } });  // form values are always strings, never undefined
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add an empty-safe emergency-contact edit schema and unit-test it (TEN-05)</name>
+  <files>src/lib/validation/tenants.ts, src/lib/validation/__tests__/tenants.test.ts</files>
+  <read_first>
+    - src/lib/validation/tenants.ts (lines 43-84 `tenantInputSchema`; line 60/71 `phoneSchema.optional()`; existing `emergencyContactSchema` export at ~120 is a DIFFERENT schema — do not repurpose it)
+    - src/lib/validation/common.ts (lines 98-113 `phoneSchema` — `.min(10)` rejects empty string)
+    - src/lib/validation/__tests__/tenants.test.ts (existing test layout to append to)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-05 LOCKED: make fields OPTIONAL so empty/cleared values validate; keep phone-shape validation when NON-empty; do not require presence)
+  </read_first>
+  <behavior>
+    - `{ emergency_contact_name: "", emergency_contact_phone: "", emergency_contact_relationship: "" }` → valid.
+    - `{ emergency_contact_name: "Jane", emergency_contact_phone: "", emergency_contact_relationship: "" }` → valid (name-only edit).
+    - `{ emergency_contact_phone: "555-123-4567", ... }` → valid.
+    - `{ emergency_contact_phone: "123", ... }` (non-empty but too short) → invalid.
+    - name > 100 chars → invalid; relationship > 50 chars → invalid.
+  </behavior>
+  <action>
+    In src/lib/validation/tenants.ts export a new `tenantEmergencyContactEditSchema` (do NOT mutate the existing `emergencyContactSchema` at line ~120, which validates a required contact elsewhere). Shape it as a `z.object` with: `emergency_contact_name: z.string().max(100, "...")`, `emergency_contact_relationship: z.string().max(50, "...")`, and `emergency_contact_phone` accepting empty OR a valid phone — use `z.union([z.literal(""), phoneSchema])`. Empty string passes name/relationship (they are only max-bounded) and passes the phone union, while a non-empty phone still runs `phoneSchema`. Do NOT call `.required()`; do NOT wrap in `.partial()` (values are always present strings from the form). Reuse the imported `phoneSchema` from `./common`.
+
+    Append tests to src/lib/validation/__tests__/tenants.test.ts covering the five behavior cases via `tenantEmergencyContactEditSchema.safeParse(...)` (assert `.success` true/false).
+  </action>
+  <verify>
+    <automated>bun run test:unit -- src/lib/validation/__tests__/tenants.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `tenantEmergencyContactEditSchema` accepts all-empty and name-only inputs and a valid phone; rejects a non-empty too-short phone and over-length name/relationship.
+    - The existing `emergencyContactSchema` export is unchanged.
+    - The new tests pass.
+  </acceptance_criteria>
+  <done>An empty-safe emergency-contact edit schema exists and is proven by unit tests.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Point the tenant-edit form at the optional schema (TEN-05)</name>
+  <files>src/app/(owner)/tenants/components/tenant-edit-form.client.tsx</files>
+  <read_first>
+    - src/app/(owner)/tenants/components/tenant-edit-form.client.tsx (lines 16 import from #lib/validation/tenants; 30-36 local `emergencyContactSchema` with `.required()`; 43-65 `useAppForm` with `validators: { onChange: emergencyContactSchema }`; 50-63 onSubmit sends the three fields)
+    - src/lib/validation/tenants.ts (the new `tenantEmergencyContactEditSchema` from Task 1)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-05: empty strings persist as empty/null per column nullability — onSubmit already sends the three fields; no submit change needed)
+  </read_first>
+  <action>
+    Import `tenantEmergencyContactEditSchema` from `#lib/validation/tenants` and delete the local `emergencyContactSchema` constant (lines 30-36) along with its now-stale doc comment about `.required()`. Set `validators: { onChange: tenantEmergencyContactEditSchema }`. Leave `onSubmit` untouched — it already sends the three fields, which persist as empty strings/null per the nullable columns. Confirm no other reference to the removed local const remains.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - The form's `validators.onChange` references `tenantEmergencyContactEditSchema`; the local `.required()` schema is deleted (no commented-out remnant).
+    - Clearing the phone or submitting a name-only edit no longer blocks `canSubmit` (validator accepts empty strings).
+    - `bun run typecheck && bun run lint` pass.
+  </acceptance_criteria>
+  <done>The tenant-edit form validates with the empty-safe schema; cleared/partial emergency-contact edits can submit.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client form → tenant update mutation | owner-supplied emergency-contact strings |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-28-03 | Tampering | relaxed validator | mitigate | Still enforces phone format on non-empty values + max-length on name/relationship; only presence is relaxed |
+| T-28-03-I | Information Disclosure | emergency-contact PII | accept | Owner-scoped RLS on `tenants` unchanged; no new field exposed |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint` pass.
+- `bun run test:unit -- src/lib/validation/__tests__/tenants.test.ts` passes.
+- Manual (Plan 06): edit a tenant, clear the emergency-contact phone, Save succeeds and the value persists empty.
+- No new migration files created.
+</verification>
+
+<success_criteria>
+Emergency-contact fields can be empty or cleared and name-only edits submit, while non-empty phones still validate; proven by unit tests + a passing typecheck/lint.
+</success_criteria>
+
+<output>
+Create `.planning/phases/28-tenant-domain/28-03-SUMMARY.md` when done
+</output>

--- a/.planning/phases/28-tenant-domain/28-03-SUMMARY.md
+++ b/.planning/phases/28-tenant-domain/28-03-SUMMARY.md
@@ -1,0 +1,83 @@
+---
+phase: 28-tenant-domain
+plan: 03
+subsystem: ui
+tags: [tenants, zod, validation, forms, emergency-contact, tanstack-form]
+
+# Dependency graph
+requires: []
+provides:
+  - "tenantEmergencyContactEditSchema — empty-safe edit schema (name/relationship max-bounded, phone accepts '' OR a valid phone)"
+  - "tenant-edit form uses the empty-safe schema so cleared/name-only edits submit"
+affects: [TEN-05, tenant edit form, emergency-contact editing]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Empty-safe form field for an always-present string: z.union([z.literal(''), fieldSchema]) — because a bare .optional() does not accept '' when the value is never undefined and the inner schema (phoneSchema.min(10)) rejects ''"
+
+key-files:
+  created: []
+  modified:
+    - src/lib/validation/tenants.ts
+    - src/lib/validation/__tests__/tenants.test.ts
+    - src/app/(owner)/tenants/components/tenant-edit-form.client.tsx
+
+key-decisions:
+  - "New exported tenantEmergencyContactEditSchema rather than mutating the required-contact emergencyContactSchema (which validates a required contact elsewhere)"
+  - "phone uses z.union([z.literal(''), phoneSchema]); a bare .optional() would still reject '' because phoneSchema.min(10) does and the form value is never undefined"
+  - "onSubmit left untouched — the update mutation does not re-validate (only omitUndefined), so empty strings persist as-is per the nullable columns"
+
+patterns-established:
+  - "For form validators over always-present string fields, model 'clearable' as z.union([z.literal(''), innerSchema]) not innerSchema.optional()"
+
+requirements-completed: [TEN-05]
+
+# Metrics
+duration: ~15min
+completed: 2026-07-07
+---
+
+# Phase 28 Plan 03: Empty-safe emergency-contact edit validation
+
+**An owner can now clear the emergency-contact phone or save a name-only edit — `canSubmit` no longer stays false — while a non-empty phone still must match the phone format and name/relationship stay length-bounded.**
+
+## Accomplishments
+
+### Task 1 — empty-safe edit schema + unit tests (TEN-05)
+- Added `tenantEmergencyContactEditSchema` to `src/lib/validation/tenants.ts`: `emergency_contact_name` (`z.string().max(100)`), `emergency_contact_relationship` (`z.string().max(50)`), and `emergency_contact_phone` (`z.union([z.literal(""), phoneSchema])`). Not `.required()`, not `.partial()`.
+- Left the existing required-contact `emergencyContactSchema` unchanged.
+- Appended 6 tests: all-empty valid, name-only valid, valid non-empty phone valid, too-short non-empty phone invalid, name > 100 invalid, relationship > 50 invalid.
+
+### Task 2 — point the form at the schema (TEN-05)
+- `tenant-edit-form.client.tsx`: imported `tenantEmergencyContactEditSchema`, deleted the local `.required()` `emergencyContactSchema` const + its stale doc comment, and set `validators: { onChange: tenantEmergencyContactEditSchema }`.
+- Left `onSubmit` untouched (already sends the three fields; empty strings persist as-is — verified the update `mutationFn` only `omitUndefined`s, it does not re-validate through a Zod schema that would reject `""`).
+
+## Task Commits
+
+1. **Task 1: Empty-safe emergency-contact edit schema + tests (TEN-05)** — `d2942487b` (fix)
+2. **Task 2: Point the form at the empty-safe schema (TEN-05)** — `8ae21d276` (fix)
+
+## Verification
+
+- `bun run test:unit -- src/lib/validation/__tests__/tenants.test.ts` — 44 tests pass (38 existing + 6 new TEN-05 cases).
+- `bun run typecheck` — clean.
+- `bun run lint` — exit 0 (only a biome config-migration info notice, unrelated).
+- Full pre-commit gate passed on both commits.
+
+## Deviations from Plan
+
+None — plan executed as written.
+
+## Issues Encountered
+
+None. Confirmed the update mutation boundary (`tenantMutations.update`) does not re-validate with Zod, so empty-string emergency-contact fields survive to PostgREST and persist per the nullable columns — no onSubmit change was needed.
+
+## Next Phase Readiness
+
+- Emergency-contact edits (clear / name-only / partial) submit and persist. Manual verify covered by Plan 06.
+
+---
+*Phase: 28-tenant-domain*
+*Completed: 2026-07-07*

--- a/.planning/phases/28-tenant-domain/28-04-PLAN.md
+++ b/.planning/phases/28-tenant-domain/28-04-PLAN.md
@@ -1,0 +1,147 @@
+---
+phase: 28-tenant-domain
+plan: 04
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/hooks/api/use-tenant-mutations.ts
+  - src/hooks/api/__tests__/use-tenant.test.tsx
+autonomous: true
+requirements: [TEN-06]
+
+must_haves:
+  truths:
+    - "Marking a tenant moved-out updates the list cleanly (after invalidation) with no console error and no thrown exception"
+    - "The optimistic block no longer writes to a non-existent list key with the wrong shape"
+    - "The detail + withLease optimistic updates (correct key + shape) still apply"
+  artifacts:
+    - path: "src/hooks/api/use-tenant-mutations.ts"
+      provides: "corrected useMarkTenantAsMovedOutMutation optimistic block"
+      contains: "useMarkTenantAsMovedOutMutation"
+  key_links:
+    - from: "src/hooks/api/use-tenant-mutations.ts"
+      to: "tenantQueries.lists()"
+      via: "invalidate refreshes the list (optimistic list step removed)"
+      pattern: "invalidate"
+---
+
+<objective>
+Fix `useMarkTenantAsMovedOutMutation`'s optimistic block (use-tenant-mutations.ts:112-166). Two bugs: (1) KEY — it reads/writes `tenantQueries.lists()` = `['tenants','list']`, but the list is cached under the exact key `[...lists(), filters ?? {}]` = `['tenants','list',{}]` (tenant-keys.ts:50-52), so `getQueryData`/`setQueryData` no-op; (2) SHAPE — it types the list as `TenantWithLeaseInfo[]` and calls `old.filter(...)`, but the list is a `PaginatedResponse<TenantWithLeaseInfo>` object (`.data[]`), so it would throw if the key ever matched.
+
+Per the LOCKED decision (prefer the simplest correct fix): DROP the optimistic list step and rely on the existing `invalidate` (which already includes `tenantQueries.lists()`); keep the detail + withLease optimistic updates, whose keys and single-object shapes are correct.
+
+Purpose: TEN-06 — no silent no-op / no throw on moved-out.
+Output: corrected mutation + a regression test.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/28-tenant-domain/28-CONTEXT.md
+
+<interfaces>
+From src/hooks/api/query-keys/tenant-keys.ts:
+  tenantQueries.lists()  => ['tenants','list']
+  tenantQueries.list(filters).queryKey => [...lists(), filters ?? {}]  // list cached HERE, shape PaginatedResponse<TenantWithLeaseInfo> ({ data, total, pagination })
+  tenantQueries.detail(id).queryKey    => ['tenants','detail', id]     // shape Tenant (single object) — optimistic OK
+  tenantQueries.withLease(id).queryKey => ['tenants','with-lease', id] // shape TenantWithLeaseInfo (single object) — optimistic OK
+
+From src/hooks/api/use-tenant-mutations.ts (current, buggy):
+  optimistic.snapshot returns previousList = qc.getQueryData<TenantWithLeaseInfo[]>(tenantQueries.lists())   // wrong key + wrong shape
+  optimistic.apply    does qc.setQueryData<TenantWithLeaseInfo[]>(tenantQueries.lists(), old => old.filter(...))  // wrong key + would throw on object
+  optimistic.rollback restores previousList to tenantQueries.lists()  // wrong key
+  // detail + withLease apply/rollback use updateFn(TenantWithLeaseInfoWithVersion) — correct, keep
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Drop the broken optimistic list step in useMarkTenantAsMovedOutMutation (TEN-06)</name>
+  <files>src/hooks/api/use-tenant-mutations.ts</files>
+  <read_first>
+    - src/hooks/api/use-tenant-mutations.ts (lines 84-169 — the whole `useMarkTenantAsMovedOutMutation`; the generic context type param `{ previousDetail, previousWithLease, previousList, id }` at 89-98; `invalidate` at 99-104 already lists `tenantQueries.lists()`; `snapshot` 118-129 reads `previousList` at 125-127; `apply` 130-151 writes the list at 147-150; `rollback` 152-165 restores the list at 163-164)
+    - src/hooks/api/query-keys/tenant-keys.ts (lines 40-96 — `lists()` vs `list(filters).queryKey = [...lists(), filters ?? {}]`; `PaginatedResponse` return shape)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-06 LOCKED + discretion: "simpler and safe — DROP the optimistic list mutation and rely on the existing invalidate"; keep detail/withLease optimistic since their key+shape are correct)
+  </read_first>
+  <action>
+    Remove the list step from the optimistic block only:
+    - Delete `previousList: TenantWithLeaseInfo[] | undefined;` from the generic context type param (leave `previousDetail`, `previousWithLease`, `id`).
+    - In `snapshot`, remove the `previousList: qc.getQueryData<TenantWithLeaseInfo[]>(tenantQueries.lists())` entry (keep `previousDetail`, `previousWithLease`, `id`).
+    - In `apply`, remove the `qc.setQueryData<TenantWithLeaseInfo[]>(tenantQueries.lists(), (old) => ...)` block (lines 147-150). Keep the two single-object `updateFn` writes to `tenantQueries.detail(id)` and `tenantQueries.withLease(id)`.
+    - In `rollback`, remove the `if (context.previousList) qc.setQueryData(tenantQueries.lists(), context.previousList)` block. Keep the detail + withLease restores.
+    - Leave `cancel` as-is: cancelling `tenantQueries.lists()` prefix-matches the real `['tenants','list',{}]` key and prevents an in-flight refetch from racing the invalidation — that is desirable.
+    - Keep `invalidate` unchanged — it already refreshes the list post-settle. Confirm `TenantWithLeaseInfo` remains imported (still used by `previousWithLease` / the callback generics); only drop imports that become genuinely unused (verify via typecheck).
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - No `getQueryData`/`setQueryData` call in the moved-out mutation targets `tenantQueries.lists()` (the wrong key); `previousList` is fully removed from the context type, snapshot, and rollback.
+    - The detail + withLease optimistic writes and their rollbacks remain intact.
+    - `invalidate` still includes `tenantQueries.lists()`.
+    - `bun run typecheck` passes.
+  </acceptance_criteria>
+  <done>The moved-out optimistic block no longer writes a wrong-key/wrong-shape list entry; the list refreshes via invalidation; detail/withLease optimism preserved.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Regression test — moved-out does not throw and does not touch the list key (TEN-06)</name>
+  <files>src/hooks/api/__tests__/use-tenant.test.tsx</files>
+  <read_first>
+    - src/hooks/api/__tests__/use-tenant.test.tsx (existing QueryClient + renderHook harness + mocking patterns for the tenant mutation factories)
+    - src/hooks/api/use-tenant-mutations.ts (the corrected mutation from Task 1)
+    - src/hooks/api/query-keys/tenant-keys.ts (real list key `[...lists(), {}]` and PaginatedResponse shape for seeding the cache)
+    - CLAUDE.md (Vitest 4 + chai 6: use `.rejects.toMatchObject({ message: expect.stringContaining(...) })`, not `.rejects.toThrow('string')`; `vi.hoisted()` for mocked vars referenced in `vi.mock()`)
+  </read_first>
+  <action>
+    Add a focused test: seed the QueryClient list cache under the REAL key (`tenantQueries.list().queryKey`, i.e. `['tenants','list',{}]`) with a `PaginatedResponse` object shape (`{ data: [...], total, pagination }`), mock `tenantMutations.markMovedOut` to resolve, render `useMarkTenantAsMovedOutMutation`, call `mutateAsync({ id })`, and assert: (a) it resolves without throwing (the old code would have thrown `old.filter is not a function` only if the key matched — assert the promise settles and the seeded object shape is not corrupted into a non-object), and (b) the detail/withLease optimistic path still applies (optional: seed detail cache and assert `updated_at` bumped). Keep the test aligned with the existing mock style in the file. If full optimistic assertions are impractical with the current harness, at minimum assert `mutateAsync` resolves and the list cache entry remains a `PaginatedResponse` object (not overwritten/thrown).
+  </action>
+  <verify>
+    <automated>bun run test:unit -- src/hooks/api/__tests__/use-tenant.test.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - A test seeds the list cache under the real `['tenants','list',{}]` key and asserts `mutateAsync` resolves with no throw and the list entry stays a `PaginatedResponse` object.
+    - The test passes under `bun run test:unit`.
+  </acceptance_criteria>
+  <done>A regression test proves marking moved-out neither throws nor mishandles the real list cache key/shape.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client cache → optimistic update | in-memory TanStack Query cache mutation |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-28-04 | Tampering | optimistic cache write | accept | Client-only cache; server truth restored by the existing `invalidate`; no data crosses a trust boundary |
+| T-28-04-D | Denial of Service | runtime throw on wrong shape | mitigate | Removing the wrong-key/wrong-shape write eliminates the latent `old.filter` throw path |
+</threat_model>
+
+<verification>
+- `bun run typecheck` passes.
+- `bun run test:unit -- src/hooks/api/__tests__/use-tenant.test.tsx` passes.
+- Manual (Plan 06): mark a tenant moved-out; the list updates after invalidation with no console error.
+- No new migration files created.
+</verification>
+
+<success_criteria>
+The moved-out optimistic update no longer targets a non-existent list key/shape; the list refreshes via invalidation with no console error, proven by a regression test.
+</success_criteria>
+
+<output>
+Create `.planning/phases/28-tenant-domain/28-04-SUMMARY.md` when done
+</output>

--- a/.planning/phases/28-tenant-domain/28-04-SUMMARY.md
+++ b/.planning/phases/28-tenant-domain/28-04-SUMMARY.md
@@ -1,0 +1,85 @@
+---
+phase: 28-tenant-domain
+plan: 04
+subsystem: api
+tags: [tenants, tanstack-query, optimistic-update, mutation, cache-key, moved-out]
+
+# Dependency graph
+requires: []
+provides:
+  - "useMarkTenantAsMovedOutMutation no longer writes a wrong-key/wrong-shape optimistic list entry"
+  - "the moved-out list refresh now flows through the existing invalidate (prefix-matches ['tenants','list',{}])"
+  - "detail + withLease optimistic writes (correct key + single-object shape) retained"
+affects: [TEN-06, tenant list, mark-moved-out flow]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "When an optimistic list write targets the wrong exact cache key AND the wrong shape, prefer dropping it and relying on the existing invalidate (which prefix-matches) over patching setQueriesData"
+
+key-files:
+  created: []
+  modified:
+    - src/hooks/api/use-tenant-mutations.ts
+    - src/hooks/api/__tests__/use-tenant.test.tsx
+
+key-decisions:
+  - "Dropped the optimistic list step entirely (LOCKED: simplest correct fix) rather than switching to setQueriesData with the ['tenants','list'] prefix + PaginatedResponse .data mapping"
+  - "Kept cancel({ ...lists() }) — cancelling the ['tenants','list'] prefix stops an in-flight refetch racing the invalidation, which is desirable"
+  - "Regression test seeds the real ['tenants','list',{}] key with a PaginatedResponse object and asserts it stays an object, not an array"
+
+patterns-established:
+  - "Regression test for cache-key/shape bugs: seed the REAL key with the REAL shape, run the mutation, assert the shape survives"
+
+requirements-completed: [TEN-06]
+
+# Metrics
+duration: ~20min
+completed: 2026-07-07
+---
+
+# Phase 28 Plan 04: Fix mark-moved-out optimistic list write (wrong key + wrong shape)
+
+**`useMarkTenantAsMovedOutMutation` no longer reads/writes the wrong `['tenants','list']` key with a bare-array shape (a latent `old.filter is not a function` throw path); the moved-out list refresh now comes purely from the existing `invalidate`, while the correct detail + withLease optimistic writes are preserved.**
+
+## Accomplishments
+
+### Task 1 — drop the broken optimistic list step (TEN-06)
+- Removed `previousList: TenantWithLeaseInfo[] | undefined` from the mutation's context type param, leaving `previousDetail`, `previousWithLease`, `id`.
+- Removed the `previousList: qc.getQueryData<TenantWithLeaseInfo[]>(tenantQueries.lists())` read from `snapshot` (wrong key + wrong shape).
+- Removed the `qc.setQueryData<TenantWithLeaseInfo[]>(tenantQueries.lists(), (old) => old.filter(...))` write from `apply`; the two single-object `updateFn` writes to `detail` and `withLease` remain.
+- Removed the `if (context.previousList)` restore from `rollback`; detail + withLease restores remain.
+- Left `cancel` (cancels the `['tenants','list']` prefix, which correctly halts an in-flight refetch) and `invalidate` (already lists `tenantQueries.lists()`) unchanged. `TenantWithLeaseInfo` stays imported (still used by `previousWithLease` + callback generics).
+
+### Task 2 — regression test (TEN-06)
+- Added a `useMarkTenantAsMovedOutMutation (TEN-06)` describe block in `use-tenant.test.tsx`.
+- Mocks the two `tenants` chains markMovedOut needs (`update(...).eq()` then `select(...).eq().single()`), seeds the list cache under the REAL `tenantQueries.list().queryKey` (`['tenants','list',{}]`) with a `PaginatedResponse` object, and seeds the detail cache.
+- Asserts `mutateAsync` resolves without throwing, the list cache entry stays a `PaginatedResponse` object (`Array.isArray === false`, `.data` still an array), and the detail optimistic write bumped `updated_at` off the seeded value.
+
+## Task Commits
+
+1. **Task 1: Drop the broken optimistic list step (TEN-06)** — `27adc33f9` (fix)
+2. **Task 2: Regression test (TEN-06)** — `f958669ac` (test)
+
+## Verification
+
+- `bun run typecheck` — clean (confirms `previousList` fully removed from the context type + `TenantWithLeaseInfo` still legitimately imported).
+- `bun run test:unit -- src/hooks/api/__tests__/use-tenant.test.tsx` — 15 tests pass (13 existing + the 2-assertion TEN-06 regression, counted as 15 with the new case).
+- Full pre-commit gate passed on both commits.
+
+## Deviations from Plan
+
+None — plan executed as written. One authoring correction: the detail cache seed initially carried a `version: 1` field, which the whole-tree typecheck rejected because the detail key's data type is `Tenant` (no `version`); removed it — `incrementVersion` defaults an absent version to 0, so the optimistic bump still applies.
+
+## Issues Encountered
+
+- The pre-commit typecheck (`tsc --noEmit`) checks the whole tree, so the unstaged Task 2 test file's transient `version` type error blocked the Task 1 commit until the test was corrected. Fixed the test, then committed Task 1 (clean tree) and Task 2 in order.
+
+## Next Phase Readiness
+
+- Moved-out flow is correct; no console error / no throw. Manual verify is covered by Plan 06.
+
+---
+*Phase: 28-tenant-domain*
+*Completed: 2026-07-07*

--- a/.planning/phases/28-tenant-domain/28-05-PLAN.md
+++ b/.planning/phases/28-tenant-domain/28-05-PLAN.md
@@ -8,6 +8,7 @@ files_modified:
   - src/components/tenants/tenant-table-row.tsx
   - src/components/tenants/tenant-grid.tsx
   - src/components/tenants/tenant-table-helpers.tsx
+  - src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
 autonomous: true
 requirements: [TEN-02, TEN-03]
 
@@ -87,7 +88,7 @@ Status label map already present in both files:
     - src/components/dashboard/components/lease-status-badge.tsx (chip-class pattern to mirror)
   </read_first>
   <action>
-    TEN-02: change the View button to pass the current lease id — `onClick={() => onViewLease(tenant.leaseId)}` is only valid when `tenant.leaseId` is a defined string, so change the render guard from `tenant.leaseStatus === "active"` to `tenant.leaseStatus === "active" && tenant.leaseId` and pass `tenant.leaseId` (now narrowed to `string`) into `onViewLease`. Do NOT pass `tenant.id`. Keep the "—" fallback span for the non-active/no-lease case.
+    TEN-02: change the View button to pass the current lease id. IMPORTANT: TypeScript does NOT narrow a property-access (`tenant.leaseId`) into a nested arrow closure, so extract a local first — `const leaseId = tenant.leaseId;` — then guard on the LOCAL (`tenant.leaseStatus === "active" && leaseId`) and pass the LOCAL into the closure (`onClick={() => onViewLease(leaseId)}`). Referencing `tenant.leaseId` directly inside `onClick` would produce `TS2345 (string | undefined not assignable to string)`. Do NOT pass `tenant.id`. Keep the "—" fallback span for the non-active/no-lease case.
 
     TEN-03: replace the `<StatusSelectCell value={tenant.leaseStatus} onChange={... logger.info ...} />` cell with a read-only badge that renders the human label for `tenant.leaseStatus` (map draft/pending_signature/active/ended/terminated → Draft/Pending/Active/Ended/Terminated) using either the shadcn `Badge` from `#components/ui/badge` or a `<span>` mirroring `LeaseStatusBadge`'s chip classes (`status-active` for active, `status-pending` for draft/pending_signature, `status-inactive` for ended/terminated). No `<select>`, no `onChange`. Handle undefined `leaseStatus` with a neutral "—".
 
@@ -106,25 +107,29 @@ Status label map already present in both files:
 </task>
 
 <task type="auto">
-  <name>Task 2: Read-only status badge in the grid card (TEN-03)</name>
-  <files>src/components/tenants/tenant-grid.tsx</files>
+  <name>Task 2: Read-only status badge in the grid card + update its a11y test (TEN-03)</name>
+  <files>src/components/tenants/tenant-grid.tsx, src/components/tenants/__tests__/tenant-grid.a11y.test.tsx</files>
   <read_first>
     - src/components/tenants/tenant-grid.tsx (full file — imports 1-19 incl. `ChevronDown`, `createLogger`, `LeaseStatus`; local `StatusDropdown` 31-63; usage 128-140 with onChange logger.info; note the card already shows an "Active" pill at 121-126)
+    - src/components/tenants/__tests__/tenant-grid.a11y.test.tsx (the test `"exposes an accessible name on the per-row status select"` at ~line 41-55 asserts `getByRole("combobox", { name: /lease status for jane doe/i })` — this WILL fail once the `<select>` is removed and MUST be updated in this task, not left for 28-06)
     - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-03 LOCKED: remove the log-only control → read-only badge)
     - src/components/dashboard/components/lease-status-badge.tsx (chip-class pattern)
   </read_first>
   <action>
-    Replace the `<div className="w-24"><StatusDropdown ... onChange={... logger.info ...} /></div>` block (lines 128-140) with the SAME read-only badge used in Task 1 (label map + chip classes / shadcn Badge) for `tenant.leaseStatus`. Delete the local `StatusDropdown` component (31-63) and `StatusDropdownProps` interface. Keep the existing green "Active" pill at 121-126 as-is (it is a separate decorative element) — the new badge shows the full status. Remove now-unused imports: `ChevronDown` (only used by StatusDropdown), `createLogger`/`logger` (only used by the status onChange — verify no other logger.info remains in this file), and `LeaseStatus` if unused after removal. Let typecheck/lint confirm.
+    Replace the `<div className="w-24"><StatusDropdown ... onChange={... logger.info ...} /></div>` block (lines 128-140) with the SAME read-only badge used in Task 1 (label map + chip classes / shadcn Badge) for `tenant.leaseStatus`. Give the badge an `aria-label={`Lease status for ${tenant.name}`}` so the accessible name survives the dropdown removal (a11y coverage is preserved, not lost). Delete the local `StatusDropdown` component (31-63) and `StatusDropdownProps` interface. Keep the existing green "Active" pill at 121-126 as-is (it is a separate decorative element) — the new badge shows the full status. Remove now-unused imports: `ChevronDown` (only used by StatusDropdown), `createLogger`/`logger` (only used by the status onChange — verify no other logger.info remains in this file), and `LeaseStatus` if unused after removal.
+
+    Then UPDATE `tenant-grid.a11y.test.tsx`: the `"exposes an accessible name on the per-row status select"` test currently resolves `getByRole("combobox", { name: /lease status for jane doe/i })`. Since there is no longer a combobox, change it to assert the read-only badge's accessible name — e.g. `screen.getByLabelText(/lease status for jane doe/i)` (matches the badge `aria-label`) or `screen.getByText("Active")` — and rename the test to reflect "read-only status badge". Keep the first test (`checkbox` select) unchanged. Let typecheck/lint confirm no unused symbols remain.
   </action>
   <verify>
-    <automated>bun run typecheck && bun run lint</automated>
+    <automated>bun run typecheck && bun run lint && bun run test:unit -- src/components/tenants/__tests__/tenant-grid.a11y.test.tsx</automated>
   </verify>
   <acceptance_criteria>
-    - The grid card renders a read-only status badge for `tenant.leaseStatus`; the `StatusDropdown` component + its props interface are deleted; no `<select>`/`onChange`/`logger.info` for status remains.
+    - The grid card renders a read-only status badge for `tenant.leaseStatus` carrying an `aria-label` "Lease status for {name}"; the `StatusDropdown` component + its props interface are deleted; no `<select>`/`onChange`/`logger.info` for status remains.
+    - The `tenant-grid.a11y.test.tsx` status test asserts the read-only badge's accessible name (not a combobox role) and PASSES; the checkbox a11y test is unchanged.
     - No unused imports (`ChevronDown`, `createLogger`, `LeaseStatus`) remain.
-    - `bun run typecheck && bun run lint` pass.
+    - `bun run typecheck && bun run lint && bun run test:unit -- <the a11y test>` pass.
   </acceptance_criteria>
-  <done>The grid card shows a read-only status badge; the log-only dropdown is removed.</done>
+  <done>The grid card shows a read-only status badge with a preserved accessible name; the log-only dropdown is removed; the a11y test asserts the badge and passes.</done>
 </task>
 
 </tasks>

--- a/.planning/phases/28-tenant-domain/28-05-PLAN.md
+++ b/.planning/phases/28-tenant-domain/28-05-PLAN.md
@@ -1,0 +1,159 @@
+---
+phase: 28-tenant-domain
+plan: 05
+type: execute
+wave: 2
+depends_on: [28-01]
+files_modified:
+  - src/components/tenants/tenant-table-row.tsx
+  - src/components/tenants/tenant-grid.tsx
+  - src/components/tenants/tenant-table-helpers.tsx
+autonomous: true
+requirements: [TEN-02, TEN-03]
+
+must_haves:
+  truths:
+    - "Clicking View on an active-lease tenant navigates to that tenant's lease detail (/leases/{leaseId})"
+    - "The View button passes the current lease id (tenant.leaseId), never tenant.id"
+    - "The View button only renders/enables when tenant.leaseId exists"
+    - "Per-tenant status is displayed as a read-only badge — no dropdown that logs and snaps back on refetch"
+  artifacts:
+    - path: "src/components/tenants/tenant-table-row.tsx"
+      provides: "onViewLease(tenant.leaseId) + read-only status badge"
+      contains: "tenant.leaseId"
+    - path: "src/components/tenants/tenant-grid.tsx"
+      provides: "read-only status badge (StatusDropdown removed)"
+    - path: "src/components/tenants/tenant-table-helpers.tsx"
+      provides: "StatusSelectCell removed (dead export deleted)"
+  key_links:
+    - from: "src/components/tenants/tenant-table-row.tsx"
+      to: "onViewLease -> /leases/{leaseId}"
+      via: "tenant.leaseId (populated from currentLease.id in tenant-transforms.ts)"
+      pattern: "onViewLease\\(tenant\\.leaseId"
+---
+
+<objective>
+Two row/grid control fixes:
+
+- TEN-02: `tenant-table-row.tsx:92` passes `tenant.id` to `onViewLease(leaseId)`, navigating to `/leases/{tenantId}` (404). The row's `tenant` is a `TenantItem`; its current-lease id lives in `tenant.leaseId` (set from `currentLease.id` in `tenant-transforms.ts:39`, which TEN-04/Plan 01 makes the ACTIVE lease). Pass `tenant.leaseId` and only render/enable the button when it exists.
+- TEN-03: the per-tenant status controls (`tenant-table-row.tsx:76-84` `StatusSelectCell`, `tenant-grid.tsx:129-140` `StatusDropdown`) are bound to `tenant.leaseStatus` — a lease-DERIVED value (not a tenant column), and their `onChange` only `logger.info`s, so the select snaps back on refetch. There is no mutation that can persist a lease status from the tenant list (`useUpdateTenantMutation` writes tenant columns; lease status transitions go through the Phase-26 lease flows). Per the LOCKED decision, REMOVE the control and render a read-only status badge.
+
+Purpose: TEN-02 correct lease navigation; TEN-03 no snapping-back control.
+Output: corrected View button + read-only status badges + removal of the dead select components.
+
+Depends on Plan 01 (TEN-04) so `tenant.leaseId` resolves to the active lease before the View button is verified.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/28-tenant-domain/28-CONTEXT.md
+
+<interfaces>
+From src/types/sections/tenants.ts:
+  interface TenantItem { id: string; leaseStatus?: LeaseStatus; leaseId?: string; ... }  // NOTE: leaseId (NOT currentLease) is the current lease id on TenantItem
+  onViewLease: (leaseId: string) => void
+
+From src/app/(owner)/tenants/components/tenant-transforms.ts (line 39):
+  ...(tenant.currentLease?.id ? { leaseId: tenant.currentLease.id } : {})   // leaseId <- currentLease.id (Plan 01 makes currentLease the active lease)
+
+Existing pattern to mirror for the read-only badge (do NOT reuse directly — different status union):
+From src/components/dashboard/components/lease-status-badge.tsx:
+  chip classes: "status-active" | "status-pending" | "status-inactive"; span with "inline-flex items-center rounded border px-2 py-0.5 font-medium text-xs"
+From src/components/ui/badge.tsx:
+  export { Badge };  // shadcn badge, acceptable alternative
+
+Status label map already present in both files:
+  { draft: "Draft", pending_signature: "Pending", active: "Active", ended: "Ended", terminated: "Terminated" }  // Record<LeaseStatus, string>
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Fix View-lease navigation + read-only status badge in the table row (TEN-02, TEN-03)</name>
+  <files>src/components/tenants/tenant-table-row.tsx, src/components/tenants/tenant-table-helpers.tsx</files>
+  <read_first>
+    - src/components/tenants/tenant-table-row.tsx (full file — line 11 `logger`, line 76-84 `StatusSelectCell` onChange logger.info, line 87-99 the `leaseStatus === "active"` View button passing `tenant.id` at line 92; imports at 1-9)
+    - src/components/tenants/tenant-table-helpers.tsx (lines 21-53 `StatusSelectCell` — the only consumer is this row; safe to delete once unused)
+    - src/types/sections/tenants.ts (TenantItem has `leaseId?: string`, NOT `currentLease`; `onViewLease(leaseId: string)`)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-02 LOCKED: pass the current lease id, guard on its presence, never `tenant.id`; TEN-03 LOCKED + discretion: remove the log-only control → read-only badge)
+    - src/components/dashboard/components/lease-status-badge.tsx (chip-class pattern to mirror)
+  </read_first>
+  <action>
+    TEN-02: change the View button to pass the current lease id — `onClick={() => onViewLease(tenant.leaseId)}` is only valid when `tenant.leaseId` is a defined string, so change the render guard from `tenant.leaseStatus === "active"` to `tenant.leaseStatus === "active" && tenant.leaseId` and pass `tenant.leaseId` (now narrowed to `string`) into `onViewLease`. Do NOT pass `tenant.id`. Keep the "—" fallback span for the non-active/no-lease case.
+
+    TEN-03: replace the `<StatusSelectCell value={tenant.leaseStatus} onChange={... logger.info ...} />` cell with a read-only badge that renders the human label for `tenant.leaseStatus` (map draft/pending_signature/active/ended/terminated → Draft/Pending/Active/Ended/Terminated) using either the shadcn `Badge` from `#components/ui/badge` or a `<span>` mirroring `LeaseStatusBadge`'s chip classes (`status-active` for active, `status-pending` for draft/pending_signature, `status-inactive` for ended/terminated). No `<select>`, no `onChange`. Handle undefined `leaseStatus` with a neutral "—".
+
+    Remove now-dead code: delete the `StatusSelectCell` import (line 9) and, since this row is its only consumer, delete the `StatusSelectCell` export from tenant-table-helpers.tsx (keep `SortableHeader` + the `Sort*` types). Remove the `createLogger`/`logger` (line 11) and the `LeaseStatus` import (line 7) if they become unused after dropping the onChange (verify — `LeaseStatus` was only used by StatusSelectCell's onChange type). Let typecheck/lint confirm no unused symbols remain.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - The row's View button passes `tenant.leaseId` (never `tenant.id`) and only renders when `tenant.leaseStatus === "active" && tenant.leaseId`.
+    - The status cell is a read-only badge (no `<select>`, no `onChange`, no `logger.info`).
+    - `StatusSelectCell` is deleted from tenant-table-helpers.tsx and no longer imported; no unused imports remain.
+    - `bun run typecheck && bun run lint` pass.
+  </acceptance_criteria>
+  <done>Table-row View navigates to the tenant's lease via leaseId; status is a read-only badge; the dead select cell is removed.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Read-only status badge in the grid card (TEN-03)</name>
+  <files>src/components/tenants/tenant-grid.tsx</files>
+  <read_first>
+    - src/components/tenants/tenant-grid.tsx (full file — imports 1-19 incl. `ChevronDown`, `createLogger`, `LeaseStatus`; local `StatusDropdown` 31-63; usage 128-140 with onChange logger.info; note the card already shows an "Active" pill at 121-126)
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (TEN-03 LOCKED: remove the log-only control → read-only badge)
+    - src/components/dashboard/components/lease-status-badge.tsx (chip-class pattern)
+  </read_first>
+  <action>
+    Replace the `<div className="w-24"><StatusDropdown ... onChange={... logger.info ...} /></div>` block (lines 128-140) with the SAME read-only badge used in Task 1 (label map + chip classes / shadcn Badge) for `tenant.leaseStatus`. Delete the local `StatusDropdown` component (31-63) and `StatusDropdownProps` interface. Keep the existing green "Active" pill at 121-126 as-is (it is a separate decorative element) — the new badge shows the full status. Remove now-unused imports: `ChevronDown` (only used by StatusDropdown), `createLogger`/`logger` (only used by the status onChange — verify no other logger.info remains in this file), and `LeaseStatus` if unused after removal. Let typecheck/lint confirm.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - The grid card renders a read-only status badge for `tenant.leaseStatus`; the `StatusDropdown` component + its props interface are deleted; no `<select>`/`onChange`/`logger.info` for status remains.
+    - No unused imports (`ChevronDown`, `createLogger`, `LeaseStatus`) remain.
+    - `bun run typecheck && bun run lint` pass.
+  </acceptance_criteria>
+  <done>The grid card shows a read-only status badge; the log-only dropdown is removed.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client UI → router navigation | owner-triggered navigation by lease id |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-28-05 | Information Disclosure | navigate to another owner's lease | accept | `leaseId` originates from the owner's own tenant row (RLS-scoped); `/leases/{id}` page is itself RLS-guarded |
+| T-28-05-T | Tampering | read-only badge vs writable control | mitigate | Removing the writable-but-inert status control eliminates a misleading write affordance; lease status changes only via the guarded lease flows |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint` pass.
+- Manual (Plan 06): click View on an active-lease tenant → lands on that tenant's lease detail; status shows as a read-only badge in both table and grid views.
+- No new migration files created.
+</verification>
+
+<success_criteria>
+The tenant View button navigates to the tenant's lease via `leaseId`; per-tenant status is a read-only badge in both views with no log-only control that snaps back.
+</success_criteria>
+
+<output>
+Create `.planning/phases/28-tenant-domain/28-05-SUMMARY.md` when done
+</output>

--- a/.planning/phases/28-tenant-domain/28-05-SUMMARY.md
+++ b/.planning/phases/28-tenant-domain/28-05-SUMMARY.md
@@ -1,0 +1,88 @@
+---
+phase: 28-tenant-domain
+plan: 05
+subsystem: ui
+tags: [tenants, navigation, lease-status, a11y, badge]
+
+# Dependency graph
+requires: [28-01]
+provides:
+  - "TenantLeaseStatusBadge — shared read-only lease-status chip (label + status-* class map) in tenant-table-helpers.tsx, consumed by both the table row and the grid card"
+  - "tenant table-row View button navigates to /leases/{leaseId} via a narrowed local const (never tenant.id)"
+  - "read-only lease-status badge replaces the log-only StatusSelectCell (row) and StatusDropdown (grid)"
+affects: [TEN-02, TEN-03, tenant table row, tenant grid card, tenant-grid a11y test]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "TS does NOT narrow a property access (tenant.leaseId) into a nested arrow closure — extract `const leaseId = tenant.leaseId` first, guard on the local, pass the local into onClick to avoid TS2345"
+    - "One shared chip component (TenantLeaseStatusBadge) for both views so table + grid status rendering can never drift; fallback '—' span carries the aria-label so the accessible name survives"
+
+key-files:
+  created: []
+  modified:
+    - src/components/tenants/tenant-table-row.tsx
+    - src/components/tenants/tenant-table-helpers.tsx
+    - src/components/tenants/tenant-grid.tsx
+    - src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
+
+key-decisions:
+  - "Placed the read-only badge as a single exported TenantLeaseStatusBadge in tenant-table-helpers.tsx and imported it into both row and grid (the plan's 'SAME read-only badge') rather than duplicating a span in each file"
+  - "Badge param typed `status: LeaseStatus | undefined`; STATUS_LABELS/STATUS_CHIP keep the LeaseStatus import legitimately used in helpers. In the row and grid the LeaseStatus import became unused and was removed (strict noUnusedLocals)"
+  - "Chip classes mirror LeaseStatusBadge: active -> status-active, draft/pending_signature -> status-pending, ended/terminated -> status-inactive; undefined -> neutral '—'"
+  - "Grid a11y test asserts the badge accessible name via getByLabelText (stub tenant has no leaseStatus, so it renders the '—' fallback which still carries aria-label) — getByText('Active') would not apply to the stub"
+
+patterns-established:
+  - "Clearable/optional property used in a closure: bind to a local const first so control-flow narrowing reaches the closure"
+
+requirements-completed: [TEN-02, TEN-03]
+
+# Metrics
+duration: ~20min
+completed: 2026-07-07
+---
+
+# Phase 28 Plan 05: Correct lease navigation + read-only tenant status badge
+
+**Clicking View on an active-lease tenant now navigates to that tenant's lease detail (`/leases/{leaseId}`) instead of `/leases/{tenantId}` (404), and per-tenant lease status is a read-only badge in both the table and grid views — the log-only control that snapped back on refetch is gone.**
+
+## Accomplishments
+
+### Task 1 — View-lease navigation + read-only status badge in the table row (TEN-02, TEN-03)
+- `tenant-table-helpers.tsx`: deleted the dead `StatusSelectCell` and its shadcn `Select` imports; added the shared `TenantLeaseStatusBadge` (STATUS_LABELS + STATUS_CHIP maps, `cn` from `#lib/utils`, `—` fallback for undefined status). Kept `SortableHeader` + the `Sort*` types + the Chevron icons.
+- `tenant-table-row.tsx` (TEN-02): extracted `const leaseId = tenant.leaseId` before the return so TypeScript narrows it into the `onClick` closure, guarded the View button on `tenant.leaseStatus === "active" && leaseId`, and passed the local `leaseId` to `onViewLease(leaseId)` (never `tenant.id`). Kept the `—` fallback for the non-active / no-lease case.
+- `tenant-table-row.tsx` (TEN-03): replaced the `StatusSelectCell` cell with `<TenantLeaseStatusBadge status={tenant.leaseStatus} />`; removed the now-unused `createLogger`/`logger` and `LeaseStatus` imports.
+
+### Task 2 — Read-only status badge in the grid card + a11y test (TEN-03)
+- `tenant-grid.tsx`: deleted the local `StatusDropdown` component and its `StatusDropdownProps` interface; replaced the dropdown block with `<TenantLeaseStatusBadge status={tenant.leaseStatus} ariaLabel={`Lease status for ${tenant.fullName}`} />` so the accessible name survives. Removed the now-unused `ChevronDown`, `createLogger`/`logger`, and `LeaseStatus`; kept the existing decorative green "Active" pill.
+- `tenant-grid.a11y.test.tsx`: renamed the status test to "exposes an accessible name on the read-only status badge" and changed the assertion from `getByRole("combobox", …)` to `getByLabelText(/lease status for jane doe/i)` (the badge's aria-label, carried through the `—` fallback). The checkbox a11y test is unchanged.
+
+## Task Commits
+
+1. **Task 1: tenant view-lease via leaseId + read-only status badge (TEN-02, TEN-03)** — `ea14a4ea1` (fix)
+2. **Task 2: read-only status badge in tenant grid card (TEN-03)** — `3bd5bf11a` (fix)
+
+## Verification
+
+- `bun run typecheck` — exit 0.
+- `bun run lint` — exit 0 (only the pre-existing biome 2.4.15 vs 2.4.16 schema-migration info notice, unrelated).
+- `bun run test:unit -- src/components/tenants/__tests__/tenant-grid.a11y.test.tsx` — exit 0, 2/2 tests pass (checkbox + read-only badge).
+- Full pre-commit gate (gitleaks, lockfile-verify, lint, typecheck, ~102k unit tests) passed on both commits.
+
+## Deviations from Plan
+
+- The plan's illustrative `${tenant.name}` for the grid aria-label was written against the actual `TenantItem` field `fullName` (there is no `name`); this matches the a11y test's stub (`fullName: "Jane Doe"`).
+- The shared badge kept the `LeaseStatus` import in `tenant-table-helpers.tsx` (used by its label/chip maps) — legitimately used, so no unused-symbol violation. `LeaseStatus` was removed from the row and grid where it became unused, exactly as the plan intended.
+
+## Issues Encountered
+
+- Commitlint rejected the first Task-1 subject at 102 chars (>100). Shortened the subject; content unchanged.
+
+## Next Phase Readiness
+
+- View navigates by `leaseId` (resolves to the active lease via 28-01's TEN-04 transform) and status is read-only in both views. Manual click-through verification is Plan 06.
+
+---
+*Phase: 28-tenant-domain*
+*Completed: 2026-07-07*

--- a/.planning/phases/28-tenant-domain/28-06-PLAN.md
+++ b/.planning/phases/28-tenant-domain/28-06-PLAN.md
@@ -1,0 +1,121 @@
+---
+phase: 28-tenant-domain
+plan: 06
+type: execute
+wave: 3
+depends_on: [28-01, 28-02, 28-03, 28-04, 28-05]
+files_modified: []
+autonomous: false
+requirements: [TEN-01, TEN-02, TEN-03, TEN-04, TEN-05, TEN-06]
+
+must_haves:
+  truths:
+    - "Full quality gate (typecheck + lint + unit tests) passes across all Phase-28 changes"
+    - "Deleting a tenant from row / grid / bulk removes it, subject to the active-lease guard"
+    - "View lease opens the tenant's lease; the current-lease display prefers the active lease"
+    - "Emergency-contact fields can be empty/cleared and name-only edits save"
+    - "Marking a tenant moved-out updates the list with no console error"
+    - "No migration files were added this phase"
+  artifacts: []
+  key_links: []
+---
+
+<objective>
+Verify Phase 28 end-to-end: run the full quality gate and human-verify each restored tenant flow. This phase is pure frontend + one mapper fix — confirm no migrations were introduced and every TEN-0x behavior is correct.
+
+Purpose: gate the phase before review (perfect-PR gate = two consecutive zero-finding cycles).
+Output: a passing quality gate + a human confirmation of the six flows.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/28-tenant-domain/28-CONTEXT.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Full quality gate + no-migration guard</name>
+  <files>(no source changes — verification only)</files>
+  <read_first>
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (phase boundary: NO migrations this phase; verify via exercising flows + unit tests, not DB proofs)
+    - .planning/ROADMAP.md (Phase 28 success criteria)
+    - The five plan SUMMARYs (28-01..28-05) if present, to confirm each requirement was implemented
+  </read_first>
+  <action>
+    Run `bun run typecheck && bun run lint && bun run test:unit`. All must pass. Then confirm no migration was added this phase: `git status --porcelain supabase/migrations/` returns nothing new (grep gate: list added files, expect zero). If any check fails, fix within the owning plan's files or report the failure — do not paper over it.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint && bun run test:unit && test -z "$(git status --porcelain supabase/migrations/)"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `bun run typecheck && bun run lint && bun run test:unit` all pass.
+    - No new or modified files under `supabase/migrations/`.
+    - The new tests from Plans 01/03/04 are present and green.
+  </acceptance_criteria>
+  <done>The full quality gate passes and no migration was introduced.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Human-verify the six restored tenant flows</name>
+  <read_first>
+    - .planning/phases/28-tenant-domain/28-CONTEXT.md (the six TEN-0x "Verify" lines)
+    - .planning/ROADMAP.md (Phase 28 success criteria)
+  </read_first>
+  <what-built>
+    Wired real tenant delete (row/grid/bulk) behind confirm dialogs (TEN-01); fixed View-lease to navigate by lease id (TEN-02); made per-tenant status a read-only badge (TEN-03); made mapTenantRow prefer the active lease (TEN-04); made emergency-contact edit fields optional/empty-safe (TEN-05); fixed the moved-out optimistic update (TEN-06).
+  </what-built>
+  <how-to-verify>
+    Run `bun run dev` (port 3050), sign in as an owner with tenant data, go to /tenants:
+    1. TEN-01 row: delete a tenant with NO active lease from the table row → confirm dialog → it disappears. Delete a tenant WITH an active lease → an error toast surfaces the active-lease block (it is NOT removed).
+    2. TEN-01 grid: switch to grid view, repeat a delete from a card.
+    3. TEN-01 bulk: select 2+ tenants, use the bulk action bar Delete → bulk confirm → selected non-lease tenants disappear; any active-lease one shows the block toast.
+    4. TEN-02: on an active-lease tenant, click View (table view) → lands on THAT tenant's lease at /leases/{leaseId} (not a 404, not /leases/{tenantId}).
+    5. TEN-03: confirm the per-tenant status shows as a read-only badge in BOTH table and grid (no dropdown; nothing snaps back on refresh).
+    6. TEN-04: for a tenant whose primary lease is terminated/ended but who has a separate active lease, confirm the row/detail shows the ACTIVE lease as current and status "Active".
+    7. TEN-05: edit a tenant, CLEAR the emergency-contact phone (and/or leave all three empty) → Save succeeds; reopen and confirm it persisted empty. Also do a name-only emergency-contact edit → saves.
+    8. TEN-06: mark a tenant moved-out → the list updates cleanly; open devtools console and confirm NO error (no "old.filter is not a function", no cache warning).
+  </how-to-verify>
+  <acceptance_criteria>
+    - All eight checks pass as described; the active-lease guard surfaces an error (never a silent no-op) on delete.
+    - No console errors during the moved-out flow.
+  </acceptance_criteria>
+  <resume-signal>Type "approved" or describe any flow that failed.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| n/a (verification-only) | no code changes; exercises existing owner-scoped, RLS-guarded flows |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-28-06 | (verification) | phase gate | accept | No new code/trust boundary; confirms prior plans' mitigations hold and no migration slipped in |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint && bun run test:unit` all pass.
+- No files added/modified under `supabase/migrations/`.
+- Human confirms the six TEN-0x flows behave per the CONTEXT "Verify" lines.
+</verification>
+
+<success_criteria>
+The full quality gate is green, no migrations were added, and a human has confirmed all six restored tenant flows.
+</success_criteria>
+
+<output>
+Create `.planning/phases/28-tenant-domain/28-06-SUMMARY.md` when done
+</output>

--- a/.planning/phases/28-tenant-domain/28-CONTEXT.md
+++ b/.planning/phases/28-tenant-domain/28-CONTEXT.md
@@ -1,0 +1,78 @@
+# Phase 28: Tenant Domain - Context
+
+**Gathered:** 2026-07-08
+**Status:** Ready for planning
+**Source:** 2026-07-02 whole-codebase bug hunt (TEN-01..06), re-verified against current source on `phase/28-tenant-domain` (off merged main w/ Phases 25-27).
+
+<domain>
+## Phase Boundary
+Restore the tenant list/detail controls + the tenant mappers to correct behavior. Scope is exactly TEN-01..06 — all frontend + one mapper-logic fix; NO migrations (the tenant delete + update mutations already exist, they are just not wired). Builds on Phases 25-27; do not regress the dollars money model, soft-delete filters, or the `lease_tenants` reads that Phase 26 fixed. **Out of scope:** phases 29-35; the `@modal/(.)tenants/[id]/edit` parallel-route tree beyond what TEN-05 touches; any tenant-portal / tenant-auth concept (tenants are records, not users).
+</domain>
+
+<decisions>
+## Implementation Decisions (each verified against current source)
+
+### TEN-01 — tenant delete is a no-op from every control (P1)
+Every delete control just logs: `tenants.tsx:199-200` (table row `onDelete`) + `tenants.tsx:211-212` (grid card `onDelete`) both call `logger.info("Delete tenant requested", { tenantId: id })`; `tenants.tsx:94` `handleBulkDelete` logs `"Bulk delete initiated"`. A REAL mutation already exists: `useDeleteTenantMutation()` (`use-tenant-mutations.ts:62`, wraps `tenantMutations.delete()`).
+**LOCKED:** wire the row + grid `onDelete` and the bulk-action-bar delete to `useDeleteTenantMutation`, gated behind a confirm dialog (AlertDialog — destructive). Row/grid delete one id; bulk deletes the selected set (sequential or batched). On success invalidate `tenantQueries.lists()` + `ownerDashboardKeys.all` (the mutation already does). Respect the tenant-delete guard Phase 26 restored (active-lease tenants can't be deleted — surface the server error via toast, don't swallow).
+**Verify:** deleting a tenant from row, grid card, and bulk bar removes it (or shows the active-lease block error); no `logger.info`-only path remains.
+
+### TEN-02 — "View lease" navigates to the wrong entity (P1)
+`tenant-table-row.tsx:92` `onClick={() => onViewLease(tenant.id)}` passes the TENANT id to `onViewLease(leaseId)`, so it navigates to `/leases/<tenantId>` → wrong/404. The button only renders when `tenant.leaseStatus === "active"`, so a current lease exists. (The detail-sheet callers are already correct — they pass `tenant.currentLease!.id` / `lease.id`.)
+**LOCKED:** pass the tenant's current lease id — `onViewLease(tenant.currentLease?.id)` (guard: only render/enable the button when `currentLease?.id` exists, which aligns with the `leaseStatus === "active"` gate). Do NOT pass `tenant.id`.
+**Verify:** clicking View on an active-lease tenant lands on that tenant's lease detail.
+
+### TEN-03 — per-tenant status dropdowns don't persist (P2)
+`tenant-table-row.tsx:79` and `tenant-grid.tsx:134` `onChange` handlers only `logger.info("Status change", …)` — the select snaps back on refetch. `useUpdateTenantMutation()` exists (`use-tenant-mutations.ts:42`).
+**LOCKED:** persist the change — wire the dropdown `onChange` to `useUpdateTenantMutation` (update the tenant `status`), invalidating the list so the value sticks; OR, if the tenant `status` field is not a safe free-set from this control (e.g. it collides with the moved-out flow / lease-derived `leaseStatus`), REMOVE the dropdown and render read-only status. Decide by checking what `status` values are valid + whether `useMarkTenantAsMovedOutMutation` is the intended path for active→inactive. Whichever: no onChange-logs-only control that visually snaps back.
+**Verify:** changing status persists after refetch, OR the control is gone (read-only badge).
+
+### TEN-04 — mapTenantRow picks the wrong "current" lease (P2)
+`tenant-mappers.ts:179-182`: `primaryLeaseTenant = leaseRows.find((lt) => lt.is_primary) ?? leaseRows[0]` then `activeLease = primaryLeaseTenant?.leases`. The comment claims "prefer active, fallback to first" but the code only prefers `is_primary` — so a tenant with a primary row on a TERMINATED/ENDED lease + a separate ACTIVE lease shows the terminated one as "current."
+**LOCKED:** select the current lease by preferring `leases.lease_status === 'active'` first, then `is_primary`, then a deterministic order (e.g. latest `start_date`) — never just `is_primary`/first. Derive `currentLease` + `activeUnit`/`activeProperty` + `leaseStatus` from that chosen lease. Keep the existing null-safety (`?? null`) and the NOT-NULL-field throws.
+**Verify:** a tenant whose primary lease is terminated but who has an active lease shows the active lease as current + `leaseStatus='active'`.
+
+### TEN-05 — tenant-edit emergency-contact fields effectively mandatory (P2)
+`src/app/(owner)/tenants/components/tenant-edit-form.client.tsx:30-36`: `emergencyContactSchema = tenantInputSchema.pick({emergency_contact_name, emergency_contact_phone, emergency_contact_relationship: true}).required()` used as `validators: { onChange: emergencyContactSchema }` (line 64). `.required()` makes all 3 emergency-contact fields mandatory, so an owner cannot clear them or do a name-only edit — `canSubmit` stays false.
+**LOCKED:** make the emergency-contact fields OPTIONAL — drop `.required()` (or use `.partial()`) so empty/cleared values validate and a partial edit can submit. Keep any real format validation (e.g. phone shape when NON-empty) but do not require presence. The `onSubmit` already sends the three fields; ensure empty strings persist as empty/null per the column nullability.
+**Verify:** editing a tenant and clearing the emergency-contact phone (or leaving all three empty) still submits and saves.
+
+### TEN-06 — moved-out optimistic update targets the wrong key + shape (P2)
+`use-tenant-mutations.ts` `useMarkTenantAsMovedOutMutation` optimistic block: `apply` calls `qc.setQueryData<TenantWithLeaseInfo[]>(tenantQueries.lists(), (old) => old ? old.filter(...) : old)`. Two bugs: (1) KEY — `tenantQueries.lists()` = `['tenants','list']`, but the list is cached under the exact key `[...lists(), filters ?? {}]` = `['tenants','list',{}]` (`tenant-keys.ts:50-52`), and `setQueryData`/`getQueryData` require the EXACT key → no-op. (2) SHAPE — the list data is `PaginatedResponse<TenantWithLeaseInfo>` (an object with `.data[]`, `tenant-keys.ts:53`), NOT a bare array, so `old.filter(...)` would throw if the key matched. The snapshot has the same key+shape mismatch.
+**LOCKED:** fix the optimistic list update to target the real cached key(s) (use `qc.setQueriesData` with the `['tenants','list']` PREFIX filter to hit all filter variants, OR the exact `[...lists(), {}]`) AND the real `PaginatedResponse` shape (map/filter `old.data`, adjust `count`). OR — simpler and safe — DROP the optimistic list mutation and rely on the existing `invalidate: [...lists()...]` (the mutation already invalidates). Keep the detail/withLease optimistic only if their key+shape are correct. Whichever: no silent no-op / no throw.
+**Verify:** marking a tenant moved-out updates the list immediately (or cleanly after invalidation) with no console error.
+
+### Claude's Discretion
+- TEN-01 confirm-dialog UX (single AlertDialog reused vs per-control); bulk delete sequential vs Promise.all.
+- TEN-03 direction (wire-to-persist vs remove) — pick per the status-field semantics.
+- TEN-06 approach (fix key+shape via setQueriesData vs drop the optimistic list step) — prefer the simplest that is correct.
+- TEN-04 tie-break ordering among multiple active leases (latest start_date is reasonable).
+</decisions>
+
+<canonical_refs>
+## Canonical References
+- `src/components/tenants/tenants.tsx` — TEN-01 (row/grid/bulk onDelete wiring).
+- `src/components/tenants/tenant-table-row.tsx` — TEN-02 (line 92 view-lease id) + TEN-03 (line 79 status onChange).
+- `src/components/tenants/tenant-grid.tsx` — TEN-01 (grid delete) + TEN-03 (line 134 status onChange).
+- `src/hooks/api/query-keys/tenant-mappers.ts` — TEN-04 (line 179-182 current-lease selection).
+- `src/app/(owner)/tenants/components/tenant-edit-form.client.tsx` — TEN-05 (emergencyContactSchema.required()).
+- `src/hooks/api/use-tenant-mutations.ts` — TEN-01 (`useDeleteTenantMutation`), TEN-03 (`useUpdateTenantMutation`), TEN-06 (`useMarkTenantAsMovedOutMutation` optimistic).
+- `src/hooks/api/query-keys/tenant-keys.ts` — the list key shape (`lists()` vs `[...lists(), filters]`, `PaginatedResponse`).
+- CLAUDE.md — mutations invalidate related keys + `ownerDashboardKeys.all`; `PaginatedResponse` uses `count` not `data.length`; no string-literal query keys; tenants are records not users.
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+- TEN-01 + TEN-06 both touch `use-tenant-mutations.ts` — coordinate (delete wiring vs moved-out optimistic) so they don't conflict.
+- TEN-04's chosen lease drives `currentLease`, `leaseStatus`, and TEN-02's `onViewLease(currentLease.id)` — get TEN-04 right first, TEN-02 depends on `currentLease.id` being the active lease.
+- No migrations this phase — pure frontend/mapper. Verify via exercising the flows + unit tests, not DB proofs.
+</specifics>
+
+<deferred>
+## Deferred (tracked elsewhere)
+- Anything not in TEN-01..06.
+- The `@modal` parallel-route edit tree (dead/duplicate) unless TEN-05 must touch it for consistency.
+</deferred>
+
+---
+*Phase: 28-tenant-domain*

--- a/.planning/phases/28-tenant-domain/28-REVIEW.md
+++ b/.planning/phases/28-tenant-domain/28-REVIEW.md
@@ -1,0 +1,26 @@
+# Phase 28 — Perfect-PR Review Log
+
+**Gate:** two consecutive zero-finding review cycles. **Result: MET** (cycles 3 + 4).
+**Method:** a Workflow fanned out 5 requirement dimensions (mapper/TEN-04, delete/TEN-01, viewstatus/TEN-02+03, validator/TEN-05, optimistic/TEN-06), each *reviewed* then independently *adversarially verified* against the source. Reviewed 2026-07-08. 4 cycles total.
+
+## Why this phase was near-clean (1 review finding)
+The plan-check caught two real issues BEFORE execution (a TS closure-narrowing error and a broken a11y test from removing the status dropdown), so execution shipped mostly correct. Review cycle 1 was fully clean, but cycle 2's independent adversarial sweep caught one LOW that cycle 1 missed — validating the two-*consecutive*-cycle discipline.
+
+## Review finding (cycle 2, fixed)
+- **LOW** — `handleBulkDelete` called `clearSelection()` synchronously when *opening* the confirm dialog, so selecting rows → Delete Selected → **Cancel** wiped the selection with nothing deleted. Fixed: `clearSelection` is threaded as an `onConfirmed` callback (stored in a `bulkClearRef`), invoked only in `confirmBulkDelete` after the deletes fire; the cancel path nulls the ref. Cycles 3 + 4 then verified clean.
+
+## Plan-check findings (fixed pre-execution)
+- **BLOCKER** — removing the status `<select>` (TEN-03) would break `tenant-grid.a11y.test.tsx`'s combobox assertion, and the test file wasn't in 28-05's scope → the 28-06 gate couldn't pass. Fixed: added the test to scope + updated it to assert the read-only badge's accessible name (badge given an `aria-label`).
+- **WARNING** — 28-05's plan text claimed `tenant.leaseId` would narrow into the `onClick` closure (TS does not) → extract `const leaseId` first.
+
+## Requirements delivered (all verified clean)
+- **TEN-04** — `mapTenantRow` selects the current lease via `pickCurrentLeaseTenant` (active > is_primary > latest start_date, null-lease-filtered, NaN-safe tie-break). Also fixed a latent bug the old `find(is_primary) ?? [0]` had (a null-lease first row could hide a real active lease). currentLease/leaseStatus/unit/property all derive from the one chosen lease.
+- **TEN-01** — delete wired to the existing `useDeleteTenantMutation` from row/grid/bulk behind destructive confirm dialogs; the Phase-26 active-lease guard surfaces via toast, not swallowed.
+- **TEN-02** — View button passes `tenant.leaseId` (never `tenant.id`), via an extracted local so TS narrows it; routes to the ACTIVE lease.
+- **TEN-03** — log-only status dropdowns removed → shared read-only badge with a preserved accessible name; dead `StatusSelectCell`/`StatusDropdown` deleted, no dangling imports.
+- **TEN-05** — emergency-contact validator empty-safe (`z.union([z.literal(''), phoneSchema])`) so cleared/name-only edits submit while a malformed non-empty phone still fails; persists empty per nullable columns.
+- **TEN-06** — dropped the wrong-key/wrong-shape moved-out list optimistic; kept the correct detail/withLease optimism; relies on the (prefix-matching) invalidate. Regression test seeds the real `['tenants','list',{}]` key and asserts it stays a `PaginatedResponse`.
+
+## Final state
+- **0 migrations** (frontend + mapper only). typecheck 0, lint 0, full unit suite green (new regression + validator + a11y tests added).
+- No Phase-25/26/27 regressions (dollars model, soft-delete filters, `lease_tenants` reads all intact — independently swept).

--- a/src/app/(owner)/tenants/components/tenant-edit-form.client.tsx
+++ b/src/app/(owner)/tenants/components/tenant-edit-form.client.tsx
@@ -13,27 +13,11 @@ import { tenantQueries } from "#hooks/api/query-keys/tenant-keys";
 import { useUpdateTenantMutation } from "#hooks/api/use-tenant-mutations";
 import { useAppForm } from "#lib/forms/form-hook";
 import { handleMutationError } from "#lib/mutation-error-handler";
-import { tenantInputSchema } from "#lib/validation/tenants";
+import { tenantEmergencyContactEditSchema } from "#lib/validation/tenants";
 
 export interface TenantEditFormProps {
 	id: string;
 }
-
-/**
- * Validates the 3 emergency-contact fields on change. Form-level (like the
- * form it replaces) so any change re-validates the whole form's `canSubmit` —
- * matching the prior `tenantUpdateSchema` gate. `.required()` lifts the
- * `tenantInputSchema` `.optional()` fields to the form's always-present string
- * shape; passed directly as a Standard Schema (no safeParse / treeifyError),
- * which — unlike the old treeify path — actually surfaces per-field errors.
- */
-const emergencyContactSchema = tenantInputSchema
-	.pick({
-		emergency_contact_name: true,
-		emergency_contact_phone: true,
-		emergency_contact_relationship: true,
-	})
-	.required();
 
 export function TenantEditForm({ id }: TenantEditFormProps) {
 	const { data: tenant } = useSuspenseQuery(tenantQueries.detail(id));
@@ -61,7 +45,7 @@ export function TenantEditForm({ id }: TenantEditFormProps) {
 				handleMutationError(error, "Update tenant");
 			}
 		},
-		validators: { onChange: emergencyContactSchema },
+		validators: { onChange: tenantEmergencyContactEditSchema },
 	});
 
 	const handleSubmit = (e: FormEvent) => {

--- a/src/app/(owner)/tenants/page.tsx
+++ b/src/app/(owner)/tenants/page.tsx
@@ -26,6 +26,7 @@ export default function TenantsPage() {
 	const router = useRouter();
 	const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
 	const [tenantToDelete, setTenantToDelete] = useState<string | null>(null);
+	const [bulkDeleteIds, setBulkDeleteIds] = useState<string[] | null>(null);
 
 	// Fetch tenants list
 	const {
@@ -65,6 +66,16 @@ export default function TenantsPage() {
 		if (tenantToDelete) {
 			deleteTenant(tenantToDelete);
 			setTenantToDelete(null);
+		}
+	};
+
+	// Bulk delete: fire the mutation per id. Each call invalidates the list on
+	// success and toasts the Phase-26 active-lease block on failure, so blocked
+	// tenants surface an error toast while the rest delete — do NOT swallow.
+	const confirmBulkDelete = () => {
+		if (bulkDeleteIds) {
+			bulkDeleteIds.forEach((id) => deleteTenant(id));
+			setBulkDeleteIds(null);
 		}
 	};
 
@@ -111,6 +122,8 @@ export default function TenantsPage() {
 				onEditTenant={handleEditTenant}
 				onContactTenant={handleContactTenant}
 				onViewLease={handleViewLease}
+				onDeleteTenant={(id) => setTenantToDelete(id)}
+				onBulkDelete={(ids) => setBulkDeleteIds(ids)}
 			/>
 
 			<AlertDialog
@@ -130,6 +143,35 @@ export default function TenantsPage() {
 						<AlertDialogCancel>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={confirmDeleteTenant}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog
+				open={bulkDeleteIds !== null}
+				onOpenChange={(open) => !open && setBulkDeleteIds(null)}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							Delete {bulkDeleteIds?.length ?? 0} tenant
+							{(bulkDeleteIds?.length ?? 0) === 1 ? "" : "s"}
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will mark the selected tenants as inactive and remove them
+							from active listings. Their data will be retained for legal
+							compliance. Any tenant with an active lease will be skipped and
+							show an error. Are you sure you want to continue?
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={confirmBulkDelete}
 							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
 							Delete

--- a/src/app/(owner)/tenants/page.tsx
+++ b/src/app/(owner)/tenants/page.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Tenants } from "#components/tenants/tenants";
 import {
 	AlertDialog,
@@ -27,6 +27,9 @@ export default function TenantsPage() {
 	const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
 	const [tenantToDelete, setTenantToDelete] = useState<string | null>(null);
 	const [bulkDeleteIds, setBulkDeleteIds] = useState<string[] | null>(null);
+	// Clears the tenants-list selection — invoked ONLY when a bulk delete is
+	// confirmed (not on cancel), so a cancelled confirm keeps the selection.
+	const bulkClearRef = useRef<(() => void) | null>(null);
 
 	// Fetch tenants list
 	const {
@@ -75,6 +78,8 @@ export default function TenantsPage() {
 	const confirmBulkDelete = () => {
 		if (bulkDeleteIds) {
 			bulkDeleteIds.forEach((id) => deleteTenant(id));
+			bulkClearRef.current?.();
+			bulkClearRef.current = null;
 			setBulkDeleteIds(null);
 		}
 	};
@@ -123,7 +128,10 @@ export default function TenantsPage() {
 				onContactTenant={handleContactTenant}
 				onViewLease={handleViewLease}
 				onDeleteTenant={(id) => setTenantToDelete(id)}
-				onBulkDelete={(ids) => setBulkDeleteIds(ids)}
+				onBulkDelete={(ids, onConfirmed) => {
+					setBulkDeleteIds(ids);
+					bulkClearRef.current = onConfirmed;
+				}}
 			/>
 
 			<AlertDialog
@@ -153,7 +161,14 @@ export default function TenantsPage() {
 
 			<AlertDialog
 				open={bulkDeleteIds !== null}
-				onOpenChange={(open) => !open && setBulkDeleteIds(null)}
+				onOpenChange={(open) => {
+					if (!open) {
+						// Cancel/dismiss: drop the pending clear callback so the
+						// selection is preserved (nothing was deleted).
+						bulkClearRef.current = null;
+						setBulkDeleteIds(null);
+					}
+				}}
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>

--- a/src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
+++ b/src/components/tenants/__tests__/tenant-grid.a11y.test.tsx
@@ -38,7 +38,7 @@ describe("TenantGrid accessibility (A11Y-02)", () => {
 		expect(checkbox).toHaveAccessibleName("Select Jane Doe");
 	});
 
-	it("exposes an accessible name on the per-row status select", () => {
+	it("exposes an accessible name on the read-only status badge", () => {
 		render(
 			<TenantGrid
 				tenants={[stubTenant]}
@@ -51,10 +51,10 @@ describe("TenantGrid accessibility (A11Y-02)", () => {
 			/>,
 		);
 
-		// Resolves ONLY if the <select> carries aria-label="Lease status for Jane Doe".
-		const statusSelect = screen.getByRole("combobox", {
-			name: /lease status for jane doe/i,
-		});
-		expect(statusSelect).toBeInTheDocument();
+		// Resolves ONLY if the read-only badge carries
+		// aria-label="Lease status for Jane Doe" (accessible name preserved
+		// after the writable <select> was removed in TEN-03).
+		const statusBadge = screen.getByLabelText(/lease status for jane doe/i);
+		expect(statusBadge).toBeInTheDocument();
 	});
 });

--- a/src/components/tenants/tenant-grid.tsx
+++ b/src/components/tenants/tenant-grid.tsx
@@ -1,22 +1,10 @@
 "use client";
 
-import {
-	Check,
-	ChevronDown,
-	Eye,
-	Mail,
-	MapPin,
-	Pencil,
-	Phone,
-	Trash2,
-} from "lucide-react";
+import { Check, Eye, Mail, MapPin, Pencil, Phone, Trash2 } from "lucide-react";
 import { BlurFade } from "#components/ui/blur-fade";
 import { BorderBeam } from "#components/ui/border-beam";
-import { createLogger } from "#lib/frontend-logger";
-import type { LeaseStatus } from "#types/core";
 import type { TenantItem } from "#types/sections/tenants";
-
-const logger = createLogger({ component: "TenantGrid" });
+import { TenantLeaseStatusBadge } from "./tenant-table-helpers";
 
 interface TenantGridProps {
 	tenants: TenantItem[];
@@ -26,40 +14,6 @@ interface TenantGridProps {
 	onEdit: (id: string) => void;
 	onDelete: (id: string) => void;
 	onContact: (id: string, method: "email" | "phone") => void;
-}
-
-interface StatusDropdownProps {
-	value: LeaseStatus | undefined;
-	onChange: (value: LeaseStatus) => void;
-	ariaLabel: string;
-}
-
-function StatusDropdown({ value, onChange, ariaLabel }: StatusDropdownProps) {
-	const statusLabels: Record<LeaseStatus, string> = {
-		draft: "Draft",
-		pending_signature: "Pending",
-		active: "Active",
-		ended: "Ended",
-		terminated: "Terminated",
-	};
-
-	return (
-		<div className="relative">
-			<select
-				value={value || "active"}
-				onChange={(e) => onChange(e.target.value as LeaseStatus)}
-				aria-label={ariaLabel}
-				className="appearance-none w-full px-2 py-1 text-xs bg-muted border border-transparent hover:border-border focus:border-primary rounded text-foreground focus:outline-none focus:ring-1 focus:ring-primary/20 cursor-pointer transition-all"
-			>
-				{Object.entries(statusLabels).map(([key, label]) => (
-					<option key={key} value={key}>
-						{label}
-					</option>
-				))}
-			</select>
-			<ChevronDown className="absolute right-1 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground pointer-events-none" />
-		</div>
-	);
 }
 
 interface TenantCardProps {
@@ -125,17 +79,11 @@ function TenantCard({
 							</span>
 						)}
 					</div>
-					{/* Status Dropdown */}
+					{/* Read-only lease-status badge */}
 					<div className="w-24">
-						<StatusDropdown
-							value={tenant.leaseStatus}
+						<TenantLeaseStatusBadge
+							status={tenant.leaseStatus}
 							ariaLabel={`Lease status for ${tenant.fullName}`}
-							onChange={(value) =>
-								logger.info("Status change", {
-									tenantId: tenant.id,
-									newStatus: value,
-								})
-							}
 						/>
 					</div>
 				</div>

--- a/src/components/tenants/tenant-table-helpers.tsx
+++ b/src/components/tenants/tenant-table-helpers.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { ChevronDown, ChevronsUpDown, ChevronUp } from "lucide-react";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "#components/ui/select";
+import { cn } from "#lib/utils";
 import type { LeaseStatus } from "#types/core";
 
 export type SortDirection = "asc" | "desc" | null;
@@ -18,37 +12,53 @@ export type SortField =
 	| "leaseStatus"
 	| null;
 
-export function StatusSelectCell({
-	value,
-	onChange,
+const STATUS_LABELS: Record<LeaseStatus, string> = {
+	draft: "Draft",
+	pending_signature: "Pending",
+	active: "Active",
+	ended: "Ended",
+	terminated: "Terminated",
+};
+
+const STATUS_CHIP: Record<LeaseStatus, string> = {
+	draft: "status-pending",
+	pending_signature: "status-pending",
+	active: "status-active",
+	ended: "status-inactive",
+	terminated: "status-inactive",
+};
+
+/**
+ * Read-only lease-status badge shared by the tenant table row and grid card.
+ * One chip definition so the two views can never drift apart. Lease status is a
+ * lease-derived value with no tenant-list mutation, so it is displayed, never
+ * edited, here (TEN-03).
+ */
+export function TenantLeaseStatusBadge({
+	status,
+	ariaLabel,
 }: {
-	value: LeaseStatus | undefined;
-	onChange: (value: LeaseStatus) => void;
+	status: LeaseStatus | undefined;
+	ariaLabel?: string;
 }) {
-	const statusLabels: Record<LeaseStatus, string> = {
-		draft: "Draft",
-		pending_signature: "Pending",
-		active: "Active",
-		ended: "Ended",
-		terminated: "Terminated",
-	};
+	if (!status) {
+		return (
+			<span className="text-sm text-muted-foreground" aria-label={ariaLabel}>
+				—
+			</span>
+		);
+	}
 
 	return (
-		<Select
-			value={value || "active"}
-			onValueChange={(v) => onChange(v as LeaseStatus)}
+		<span
+			aria-label={ariaLabel}
+			className={cn(
+				"inline-flex items-center rounded border px-2 py-0.5 font-medium text-xs",
+				STATUS_CHIP[status],
+			)}
 		>
-			<SelectTrigger className="h-8 w-[100px] text-sm">
-				<SelectValue />
-			</SelectTrigger>
-			<SelectContent>
-				{Object.entries(statusLabels).map(([key, label]) => (
-					<SelectItem key={key} value={key}>
-						{label}
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
+			{STATUS_LABELS[status]}
+		</span>
 	);
 }
 

--- a/src/components/tenants/tenant-table-row.tsx
+++ b/src/components/tenants/tenant-table-row.tsx
@@ -3,12 +3,8 @@
 import { FileText, Pencil, Trash2 } from "lucide-react";
 import { Button } from "#components/ui/button";
 import { Checkbox } from "#components/ui/checkbox";
-import { createLogger } from "#lib/frontend-logger";
-import type { LeaseStatus } from "#types/core";
 import type { TenantItem } from "#types/sections/tenants";
-import { StatusSelectCell } from "./tenant-table-helpers";
-
-const logger = createLogger({ component: "TenantTableRow" });
+import { TenantLeaseStatusBadge } from "./tenant-table-helpers";
 
 interface TenantTableRowProps {
 	tenant: TenantItem;
@@ -29,6 +25,10 @@ export function TenantTableRow({
 	onDelete,
 	onViewLease,
 }: TenantTableRowProps) {
+	// Extract to a local const so TypeScript narrows it into the onClick closure
+	// (a `tenant.leaseId` property access is NOT narrowed there → TS2345).
+	const leaseId = tenant.leaseId;
+
 	return (
 		<tr
 			className={`hover:bg-muted/50 transition-colors ${
@@ -73,23 +73,15 @@ export function TenantTableRow({
 				)}
 			</td>
 			<td className="px-4 py-2">
-				<StatusSelectCell
-					value={tenant.leaseStatus}
-					onChange={(value: LeaseStatus) =>
-						logger.info("Status change:", {
-							tenantId: tenant.id,
-							newStatus: value,
-						})
-					}
-				/>
+				<TenantLeaseStatusBadge status={tenant.leaseStatus} />
 			</td>
 			<td className="px-4 py-2">
-				{tenant.leaseStatus === "active" ? (
+				{tenant.leaseStatus === "active" && leaseId ? (
 					<Button
 						variant="ghost"
 						size="sm"
 						className="h-auto p-0 text-primary-text"
-						onClick={() => onViewLease(tenant.id)}
+						onClick={() => onViewLease(leaseId)}
 					>
 						<FileText className="mr-1 h-3.5 w-3.5" />
 						View

--- a/src/components/tenants/tenants.tsx
+++ b/src/components/tenants/tenants.tsx
@@ -25,6 +25,8 @@ export function Tenants({
 	onEditTenant,
 	onContactTenant,
 	onViewLease,
+	onDeleteTenant,
+	onBulkDelete,
 }: TenantsProps) {
 	const router = useRouter();
 
@@ -91,9 +93,7 @@ export function Tenants({
 	};
 
 	const handleBulkDelete = () => {
-		logger.info("Bulk delete initiated", {
-			selectedIds: Array.from(selectedIds),
-		});
+		onBulkDelete(Array.from(selectedIds));
 		clearSelection();
 	};
 
@@ -196,9 +196,7 @@ export function Tenants({
 							onDeselectAll={handleDeselectAll}
 							onView={handleViewTenant}
 							onEdit={onEditTenant}
-							onDelete={(id) =>
-								logger.info("Delete tenant requested", { tenantId: id })
-							}
+							onDelete={onDeleteTenant}
 							onViewLease={onViewLease}
 						/>
 					) : (
@@ -208,9 +206,7 @@ export function Tenants({
 							onSelectChange={handleSelectChange}
 							onView={handleViewTenant}
 							onEdit={onEditTenant}
-							onDelete={(id) =>
-								logger.info("Delete tenant requested", { tenantId: id })
-							}
+							onDelete={onDeleteTenant}
 							onContact={onContactTenant}
 						/>
 					)}

--- a/src/components/tenants/tenants.tsx
+++ b/src/components/tenants/tenants.tsx
@@ -93,8 +93,10 @@ export function Tenants({
 	};
 
 	const handleBulkDelete = () => {
-		onBulkDelete(Array.from(selectedIds));
-		clearSelection();
+		// Clear the selection only after the delete is CONFIRMED (passed as the
+		// onConfirmed callback), not on dialog-open — otherwise cancelling the
+		// confirm dialog would wipe the selection with nothing deleted.
+		onBulkDelete(Array.from(selectedIds), clearSelection);
 	};
 
 	const handleBulkExport = () => {

--- a/src/hooks/api/__tests__/use-tenant.test.tsx
+++ b/src/hooks/api/__tests__/use-tenant.test.tsx
@@ -17,6 +17,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createQueryChain } from "#test/mocks/supabase-query-mock";
+import { tenantQueries } from "../query-keys/tenant-keys";
 import {
 	useAllTenants,
 	usePrefetchTenantDetail,
@@ -28,6 +29,7 @@ import {
 import {
 	useCreateTenantMutation,
 	useDeleteTenantMutation,
+	useMarkTenantAsMovedOutMutation,
 	useUpdateTenantMutation,
 } from "../use-tenant-mutations";
 
@@ -467,6 +469,95 @@ describe("Mutation Hooks", () => {
 					"Cannot delete tenant with active lease",
 				),
 			});
+		});
+	});
+
+	describe("useMarkTenantAsMovedOutMutation (TEN-06)", () => {
+		beforeEach(() => {
+			// markMovedOut updates tenants.status then re-selects the row with the
+			// lease join and returns it — mock both chains so the mutation resolves.
+			supabaseFromMock.mockImplementation((table: string) => {
+				if (table === "tenants") {
+					return {
+						update: vi.fn().mockReturnValue({
+							eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+						}),
+						select: vi.fn().mockReturnValue({
+							eq: vi.fn().mockReturnValue({
+								single: vi.fn().mockResolvedValue({
+									data: { ...mockTenantWithLease, status: "moved_out" },
+									error: null,
+								}),
+							}),
+						}),
+					};
+				}
+				return createQueryChain({ data: null });
+			});
+		});
+
+		it("resolves without throwing and leaves the real list cache key a PaginatedResponse object", async () => {
+			const queryClient = new QueryClient({
+				defaultOptions: {
+					queries: { retry: false },
+					mutations: { retry: false },
+				},
+			});
+
+			// Seed the list cache under the REAL exact key ['tenants','list',{}]
+			// with a PaginatedResponse OBJECT (not a bare array). The pre-fix
+			// optimistic block would have thrown `old.filter is not a function`
+			// had it actually matched this key.
+			const listKey = tenantQueries.list().queryKey;
+			queryClient.setQueryData(listKey, {
+				data: [mockTenantWithLease],
+				total: 1,
+				pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+			});
+
+			// Seed detail cache to prove the detail optimistic write still applies.
+			const detailKey = tenantQueries.detail("tenant-123").queryKey;
+			queryClient.setQueryData(detailKey, {
+				...mockTenant,
+				updated_at: "2024-01-01T00:00:00Z",
+			});
+
+			const wrapper = ({ children }: { children: ReactNode }) => (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			);
+
+			const { result } = renderHook(() => useMarkTenantAsMovedOutMutation(), {
+				wrapper,
+			});
+
+			await expect(
+				result.current.mutateAsync({
+					id: "tenant-123",
+					data: { moveOutDate: "2026-07-07", moveOutReason: "lease ended" },
+				}),
+			).resolves.toBeDefined();
+
+			// The list cache entry stays a PaginatedResponse object — the broken
+			// wrong-key/wrong-shape optimistic write is gone, so it is neither
+			// overwritten into an array nor corrupted; invalidation refreshes it.
+			const listAfter = queryClient.getQueryData(listKey);
+			expect(Array.isArray(listAfter)).toBe(false);
+			expect(listAfter).toMatchObject({
+				total: 1,
+				data: expect.any(Array),
+				pagination: { page: 1 },
+			});
+
+			// The detail optimistic write applied (correct key + single-object
+			// shape): updated_at was bumped off the seeded value.
+			const detailAfter = queryClient.getQueryData<{
+				id: string;
+				updated_at: string;
+			}>(detailKey);
+			expect(detailAfter).toMatchObject({ id: "tenant-123" });
+			expect(detailAfter?.updated_at).not.toBe("2024-01-01T00:00:00Z");
 		});
 	});
 });

--- a/src/hooks/api/query-keys/tenant-mappers.test.ts
+++ b/src/hooks/api/query-keys/tenant-mappers.test.ts
@@ -129,3 +129,132 @@ describe("mapTenantRow", () => {
 		).toThrow(/status/);
 	});
 });
+
+// --- TEN-04: current-lease selection prefers the active lease ---
+
+type LeaseTenantFixture = NonNullable<
+	TenantPostgrestRow["lease_tenants"]
+>[number];
+
+function makeLeaseTenant(opts: {
+	leaseId: string;
+	leaseStatus: string;
+	startDate: string;
+	isPrimary: boolean;
+}): LeaseTenantFixture {
+	return {
+		lease_id: opts.leaseId,
+		is_primary: opts.isPrimary,
+		leases: {
+			id: opts.leaseId,
+			lease_status: opts.leaseStatus,
+			start_date: opts.startDate,
+			end_date: "2027-01-01",
+			rent_amount: 1500,
+			security_deposit: 1500,
+			unit_id: `unit-${opts.leaseId}`,
+			primary_tenant_id: minimalNestedRow.id,
+			owner_user_id: minimalNestedRow.owner_user_id ?? "owner",
+			units: {
+				id: `unit-${opts.leaseId}`,
+				unit_number: `U-${opts.leaseId}`,
+				bedrooms: 2,
+				bathrooms: 1,
+				square_feet: 800,
+				rent_amount: 1500,
+				property_id: `prop-${opts.leaseId}`,
+				properties: {
+					id: `prop-${opts.leaseId}`,
+					name: `Property ${opts.leaseId}`,
+					address_line1: `${opts.leaseId} Main St`,
+					address_line2: null,
+					city: "Dallas",
+					state: "TX",
+					postal_code: "75001",
+				},
+			},
+		},
+	};
+}
+
+describe("mapTenantRow current-lease selection (TEN-04)", () => {
+	it("prefers a separate active lease over a terminated is_primary lease", () => {
+		const row: TenantPostgrestRow = {
+			...minimalNestedRow,
+			lease_tenants: [
+				makeLeaseTenant({
+					leaseId: "terminated-primary",
+					leaseStatus: "terminated",
+					startDate: "2025-01-01",
+					isPrimary: true,
+				}),
+				makeLeaseTenant({
+					leaseId: "active-secondary",
+					leaseStatus: "active",
+					startDate: "2024-06-01",
+					isPrimary: false,
+				}),
+			],
+		};
+		const mapped = mapTenantRow(row);
+		expect(mapped.currentLease?.id).toBe("active-secondary");
+		expect(mapped.currentLease?.status).toBe("active");
+		expect(mapped.lease_status).toBe("active");
+		expect(mapped.unit?.id).toBe("unit-active-secondary");
+		expect(mapped.property?.id).toBe("prop-active-secondary");
+	});
+
+	it("falls back to the is_primary lease when none are active", () => {
+		const row: TenantPostgrestRow = {
+			...minimalNestedRow,
+			lease_tenants: [
+				makeLeaseTenant({
+					leaseId: "terminated-secondary",
+					leaseStatus: "terminated",
+					startDate: "2025-05-01",
+					isPrimary: false,
+				}),
+				makeLeaseTenant({
+					leaseId: "terminated-primary",
+					leaseStatus: "terminated",
+					startDate: "2024-01-01",
+					isPrimary: true,
+				}),
+			],
+		};
+		const mapped = mapTenantRow(row);
+		expect(mapped.currentLease?.id).toBe("terminated-primary");
+		expect(mapped.lease_status).toBe("terminated");
+	});
+
+	it("tie-breaks between two active leases by latest start_date", () => {
+		const row: TenantPostgrestRow = {
+			...minimalNestedRow,
+			lease_tenants: [
+				makeLeaseTenant({
+					leaseId: "active-older",
+					leaseStatus: "active",
+					startDate: "2024-01-01",
+					isPrimary: false,
+				}),
+				makeLeaseTenant({
+					leaseId: "active-newer",
+					leaseStatus: "active",
+					startDate: "2025-11-01",
+					isPrimary: false,
+				}),
+			],
+		};
+		const mapped = mapTenantRow(row);
+		expect(mapped.currentLease?.id).toBe("active-newer");
+		expect(mapped.lease_status).toBe("active");
+	});
+
+	it("returns a null currentLease when there are no lease_tenants", () => {
+		const mapped = mapTenantRow({ ...minimalNestedRow, lease_tenants: [] });
+		expect(mapped.currentLease).toBeNull();
+		expect(mapped.unit).toBeNull();
+		expect(mapped.property).toBeNull();
+		expect(mapped.lease_status).toBeUndefined();
+	});
+});

--- a/src/hooks/api/query-keys/tenant-mappers.ts
+++ b/src/hooks/api/query-keys/tenant-mappers.ts
@@ -154,6 +154,49 @@ export interface TenantPostgrestRow {
 	}>;
 }
 
+type LeaseTenantRow = NonNullable<TenantPostgrestRow["lease_tenants"]>[number];
+
+/**
+ * Pick the "current" lease_tenant for a tenant (TEN-04). Only considers
+ * entries whose joined `leases` is non-null. Prefers, in strict priority:
+ *   1. a lease whose `lease_status === "active"`
+ *   2. the `is_primary` row
+ *   3. the latest `start_date` (deterministic tie-break; parsed for safety)
+ * so a primary row on a terminated lease never wins over a separate active
+ * lease. Returns undefined when no lease_tenant has a non-null lease.
+ */
+function pickCurrentLeaseTenant(
+	leaseRows: readonly LeaseTenantRow[],
+): LeaseTenantRow | undefined {
+	const withLease = leaseRows.filter((lt) => lt.leases !== null);
+	if (withLease.length === 0) {
+		return undefined;
+	}
+	return withLease.reduce((best, candidate) => {
+		const bestActive = best.leases?.lease_status === "active";
+		const candidateActive = candidate.leases?.lease_status === "active";
+		if (candidateActive !== bestActive) {
+			return candidateActive ? candidate : best;
+		}
+		const bestPrimary = best.is_primary === true;
+		const candidatePrimary = candidate.is_primary === true;
+		if (candidatePrimary !== bestPrimary) {
+			return candidatePrimary ? candidate : best;
+		}
+		// Tie-break: latest start_date wins (descending). Parse for safety so a
+		// malformed/absent date sorts last rather than corrupting the order.
+		const bestStart = Date.parse(best.leases?.start_date ?? "");
+		const candidateStart = Date.parse(candidate.leases?.start_date ?? "");
+		if (Number.isNaN(candidateStart)) {
+			return best;
+		}
+		if (Number.isNaN(bestStart)) {
+			return candidate;
+		}
+		return candidateStart > bestStart ? candidate : best;
+	});
+}
+
 export function mapTenantRow(row: TenantPostgrestRow): TenantWithLeaseInfo {
 	// Validate the NOT-NULL id + the persisted status BEFORE shaping, so a
 	// dropped column or an enum drift fails loudly at the boundary instead of
@@ -176,10 +219,11 @@ export function mapTenantRow(row: TenantPostgrestRow): TenantWithLeaseInfo {
 
 	const leaseRows = row.lease_tenants ?? [];
 
-	// Find the primary/active lease (prefer active, fallback to first)
-	const primaryLeaseTenant =
-		leaseRows.find((lt) => lt.is_primary) ?? leaseRows[0];
-	const activeLease = primaryLeaseTenant?.leases ?? null;
+	// Select the "current" lease: prefer an active lease, then the is_primary
+	// row, then the latest start_date (TEN-04). A primary row on a terminated
+	// lease must NOT win over a separate active lease.
+	const chosenLeaseTenant = pickCurrentLeaseTenant(leaseRows);
+	const activeLease = chosenLeaseTenant?.leases ?? null;
 	const activeUnit = activeLease?.units ?? null;
 	const activeProperty = activeUnit?.properties ?? null;
 

--- a/src/hooks/api/use-tenant-mutations.ts
+++ b/src/hooks/api/use-tenant-mutations.ts
@@ -92,7 +92,6 @@ export function useMarkTenantAsMovedOutMutation() {
 			{
 				previousDetail: Tenant | undefined;
 				previousWithLease: TenantWithLeaseInfo | undefined;
-				previousList: TenantWithLeaseInfo[] | undefined;
 				id: string;
 			}
 		>(queryClient, {
@@ -122,9 +121,6 @@ export function useMarkTenantAsMovedOutMutation() {
 					previousWithLease: qc.getQueryData<TenantWithLeaseInfo>(
 						tenantQueries.withLease(id).queryKey,
 					),
-					previousList: qc.getQueryData<TenantWithLeaseInfo[]>(
-						tenantQueries.lists(),
-					),
 					id,
 				}),
 				apply: (qc, { id }) => {
@@ -144,10 +140,6 @@ export function useMarkTenantAsMovedOutMutation() {
 						tenantQueries.withLease(id).queryKey,
 						updateFn,
 					);
-					qc.setQueryData<TenantWithLeaseInfo[]>(
-						tenantQueries.lists(),
-						(old) => (old ? old.filter((tenant) => tenant.id !== id) : old),
-					);
 				},
 				rollback: (qc, context) => {
 					if (context.previousDetail)
@@ -160,8 +152,6 @@ export function useMarkTenantAsMovedOutMutation() {
 							tenantQueries.withLease(context.id).queryKey,
 							context.previousWithLease,
 						);
-					if (context.previousList)
-						qc.setQueryData(tenantQueries.lists(), context.previousList);
 				},
 			},
 		}),

--- a/src/lib/validation/__tests__/tenants.test.ts
+++ b/src/lib/validation/__tests__/tenants.test.ts
@@ -4,6 +4,7 @@ import {
 	addTenantSchema,
 	bulkDeleteTenantsSchema,
 	emergencyContactSchema,
+	tenantEmergencyContactEditSchema,
 	tenantFormSchema,
 	tenantInputSchema,
 	tenantQuerySchema,
@@ -214,6 +215,62 @@ describe("emergencyContactSchema", () => {
 			emergencyContactSchema.safeParse({
 				name: "Jane Doe",
 				relationship: "Spouse",
+			}).success,
+		).toBe(false);
+	});
+});
+describe("tenantEmergencyContactEditSchema (TEN-05)", () => {
+	it("accepts all-empty values (owner clears every field)", () => {
+		expect(
+			tenantEmergencyContactEditSchema.safeParse({
+				emergency_contact_name: "",
+				emergency_contact_phone: "",
+				emergency_contact_relationship: "",
+			}).success,
+		).toBe(true);
+	});
+	it("accepts a name-only edit (phone + relationship empty)", () => {
+		expect(
+			tenantEmergencyContactEditSchema.safeParse({
+				emergency_contact_name: "Jane",
+				emergency_contact_phone: "",
+				emergency_contact_relationship: "",
+			}).success,
+		).toBe(true);
+	});
+	it("accepts a valid non-empty phone", () => {
+		expect(
+			tenantEmergencyContactEditSchema.safeParse({
+				emergency_contact_name: "Jane",
+				emergency_contact_phone: "555-123-4567",
+				emergency_contact_relationship: "Spouse",
+			}).success,
+		).toBe(true);
+	});
+	it("rejects a non-empty phone that is too short", () => {
+		expect(
+			tenantEmergencyContactEditSchema.safeParse({
+				emergency_contact_name: "",
+				emergency_contact_phone: "123",
+				emergency_contact_relationship: "",
+			}).success,
+		).toBe(false);
+	});
+	it("rejects a name over 100 chars", () => {
+		expect(
+			tenantEmergencyContactEditSchema.safeParse({
+				emergency_contact_name: "x".repeat(101),
+				emergency_contact_phone: "",
+				emergency_contact_relationship: "",
+			}).success,
+		).toBe(false);
+	});
+	it("rejects a relationship over 50 chars", () => {
+		expect(
+			tenantEmergencyContactEditSchema.safeParse({
+				emergency_contact_name: "",
+				emergency_contact_phone: "",
+				emergency_contact_relationship: "x".repeat(51),
 			}).success,
 		).toBe(false);
 	});

--- a/src/lib/validation/tenants.ts
+++ b/src/lib/validation/tenants.ts
@@ -129,6 +129,25 @@ export const emergencyContactSchema = z.object({
 		.max(50, "Emergency contact relationship cannot exceed 50 characters"),
 });
 
+// Empty-safe emergency-contact schema for the tenant EDIT form (TEN-05).
+// The form always submits present strings ("" when cleared, never undefined),
+// so the fields must accept the empty string rather than require presence — an
+// owner must be able to clear a field or save a name-only edit. Name and
+// relationship are only max-bounded (empty passes); phone accepts "" OR a
+// valid phone (a bare `.optional()` would NOT work because phoneSchema's
+// `.min(10)` rejects "", and the value is never undefined). Do NOT `.required()`
+// or `.partial()` this. Distinct from `emergencyContactSchema`, which validates
+// a REQUIRED contact elsewhere.
+export const tenantEmergencyContactEditSchema = z.object({
+	emergency_contact_name: z
+		.string()
+		.max(100, "Emergency contact name cannot exceed 100 characters"),
+	emergency_contact_phone: z.union([z.literal(""), phoneSchema]),
+	emergency_contact_relationship: z
+		.string()
+		.max(50, "Emergency contact relationship cannot exceed 50 characters"),
+});
+
 // Tenant verification schema
 export const tenantVerificationSchema = z.object({
 	identity_verified: z.boolean(),

--- a/src/types/sections/tenants.ts
+++ b/src/types/sections/tenants.ts
@@ -11,7 +11,7 @@ export interface TenantsProps {
 	onContactTenant: (tenantId: string, method: "email" | "phone") => void;
 	onViewLease: (leaseId: string) => void;
 	onDeleteTenant: (tenantId: string) => void;
-	onBulkDelete: (tenantIds: string[]) => void;
+	onBulkDelete: (tenantIds: string[], onConfirmed: () => void) => void;
 }
 
 export interface TenantItem {

--- a/src/types/sections/tenants.ts
+++ b/src/types/sections/tenants.ts
@@ -10,6 +10,8 @@ export interface TenantsProps {
 	onEditTenant: (tenantId: string) => void;
 	onContactTenant: (tenantId: string, method: "email" | "phone") => void;
 	onViewLease: (leaseId: string) => void;
+	onDeleteTenant: (tenantId: string) => void;
+	onBulkDelete: (tenantIds: string[]) => void;
 }
 
 export interface TenantItem {


### PR DESCRIPTION
## v8.0 Phase 28: Tenant Domain (TEN-01..06)

Fourth phase of the v8.0 bug-eradication milestone. Fixes all 6 tenant-domain bugs from the 2026-07-02 hunt. **No migrations** — pure frontend + one mapper fix (the delete/update/moved-out mutations already existed; the bugs were wiring + logic).

### Fixes
- **TEN-01** — tenant delete was a `logger.info` no-op from row, grid card, and bulk bar. Wired the existing `useDeleteTenantMutation` behind destructive confirm dialogs; the Phase-26 active-lease guard surfaces via toast (not swallowed).
- **TEN-02** — "View lease" passed `tenant.id` to a `leaseId` handler → wrong route. Now passes the current lease id.
- **TEN-03** — per-tenant status dropdowns only logged onChange (snapped back). Replaced with read-only badges (accessible name preserved).
- **TEN-04** — `mapTenantRow` selected the current lease by `is_primary` despite a comment claiming "prefer active", so a tenant with a terminated primary lease + a separate active lease showed the terminated one. Now selects active > is_primary > latest start_date (also fixed a latent null-lease bug), and this drives TEN-02's `leaseId`.
- **TEN-05** — the edit form's `.required()` made emergency-contact fields mandatory (couldn't clear the phone or do a name-only edit). Now empty-safe (`z.union([z.literal(''), phoneSchema])`) — clearing submits, a malformed non-empty phone still fails.
- **TEN-06** — the moved-out optimistic update targeted the wrong query key *and* wrong shape (array vs `PaginatedResponse`) → silent no-op. Dropped the broken list step (kept the correct detail/withLease optimism); relies on the prefix-matching invalidate.

### Review (perfect-PR gate: 2 consecutive zero-finding cycles)
4 cycles. The plan-check caught two issues pre-execution (a TS closure-narrowing bug, a broken a11y test). Cycle 1 was clean, but **cycle 2's independent sweep caught one LOW** cycle 1 missed — bulk-delete cleared the row selection on dialog-*open* instead of on confirm, so Cancel lost the selection. Fixed; cycles 3 + 4 clean. Log: `.planning/phases/28-tenant-domain/28-REVIEW.md`.

### Verification
- **0 migrations** (frontend + mapper only) · typecheck 0 · lint 0 · full unit suite green
- New regression tests: mapper active-lease selection (4 cases), empty-safe validator (6), moved-out optimistic (seeds the real list key), a11y badge
- No Phase-25/26/27 regressions (dollars, soft-delete, `lease_tenants` reads — independently swept)

[hudsor01]
