### PR TITLE
v8.0 Phase 29: billing, Stripe & financial reports (BILL-01..06)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -69,7 +69,7 @@
 ### DATA — analytics + data-layer correctness
 
 - [ ] **DATA-01**: Occupancy analytics render real data. The mappers consume `get_occupancy_trends_optimized`'s JSONB **array** shape correctly (not a `z.object` that always fails → empty defaults) across `use-analytics.ts` and `report-analytics-keys.ts`.
-- [ ] **DATA-02**: Soft-deleted properties are excluded from the per-property performance RPCs — restore the `p.status <> 'inactive'` predicate to `get_property_performance_analytics` / `_trends` / `_with_trends` (verified missing on the live definitions) so deleted properties don't emit rows or inflate portfolio totals.
+- [ ] **DATA-02** (PARTIAL — `get_property_performance_analytics` portion done in Phase 29's BILL-06 recreate; Phase 30 must still fix `_with_trends`/`_trends`, NOT re-recreate `_analytics`): Soft-deleted properties are excluded from the per-property performance RPCs — restore the `p.status <> 'inactive'` predicate to `get_property_performance_analytics` / `_trends` / `_with_trends` (verified missing on the live definitions) so deleted properties don't emit rows or inflate portfolio totals.
 - [ ] **DATA-03**: The `get_lease_stats` "Expired" tile counts naturally-lapsed leases (`lease_status='expired'`, set by the expire-leases cron), and the frontend `LeaseStatus` union includes `'expired'`.
 
 ### FORMFIX — form behavior correctness

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -114,6 +114,15 @@ Requirements: BILL-01, BILL-02, BILL-03, BILL-04, BILL-05, BILL-06
 4. The year-end and tax PDF exports contain the same financial data as their CSV counterparts
 5. Two consecutive zero-finding review cycles
 
+**Plans:** 7 plans (2 migration, 2 edge, 3 frontend/verification)
+- [ ] 29-01-PLAN.md — BILL-06 migrations: expenses.amount → numeric(10,2) + get_property_performance_analytics recreate (numeric cast + DATA-02 status filter)
+- [ ] 29-02-PLAN.md — BILL-02 migrations: date params on get_expense_summary / get_financial_overview / get_billing_insights
+- [ ] 29-03-PLAN.md — BILL-01: Stripe current_period_end read fix (edge handlers + client NaN guard)
+- [ ] 29-04-PLAN.md — BILL-05: generate-pdf reportType branching to the export-report RPCs
+- [ ] 29-05-PLAN.md — BILL-02 frontend + BILL-04 + BILL-03: date-range passing, expense/billing error surfacing, unpaid-invoice amount
+- [ ] 29-06-PLAN.md — BILL-06 frontend: formatCents → formatCurrency cents-readers + Financial Highlights fix
+- [ ] 29-07-PLAN.md — Phase verification + residual/limitation ledger
+
 ### Phase 30: Analytics & Data-Layer Correctness
 **Goal:** Fix analytics and cross-cutting data-layer correctness — occupancy analytics consume the RPC's array shape, soft-deleted properties are excluded from the performance RPCs, the expired-lease stat counts `expired`, unit mutations invalidate the by-property cache, property updates refresh the dashboard, and the property/tenant table virtualizers position rows correctly.
 Requirements: DATA-01, DATA-02, DATA-03, PROP-01, PROP-02, PROP-03

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -29,7 +29,7 @@
 | 26 | Lease Domain Correctness | 9/9 | Complete   | 2026-07-05 |
 | 27 | Maintenance & Inspections | 6/7 | In Progress|  |
 | 28 | Tenant Domain | 5/6 | In Progress|  |
-| 29 | Billing, Stripe & Financial Reports | Correct period-end, period-scoped statements, invoice amounts, matching PDFs | BILL-01..06 | 6 |
+| 29 | Billing, Stripe & Financial Reports | 7/7 | Complete   | 2026-07-08 |
 | 30 | Analytics & Data-Layer Correctness | Occupancy analytics, soft-delete filtering, stale-cache invalidation, virtualizer | DATA-01..03, PROP-01..03 | 5 |
 | 31 | Forms Behavior Correctness | Unsaved-guard, contact send, no render loop, saved fields, validators, single toast | FORMFIX-01..08 | 5 |
 | 32 | Shared UI, Data-Table & Uploads | Working filters/pagination, single-upload, search sanitize, error messages, taxonomy | UIX-01..05, PROP-04, PROP-05 | 5 |
@@ -114,14 +114,14 @@ Requirements: BILL-01, BILL-02, BILL-03, BILL-04, BILL-05, BILL-06
 4. The year-end and tax PDF exports contain the same financial data as their CSV counterparts
 5. Two consecutive zero-finding review cycles
 
-**Plans:** 7 plans (2 migration, 2 edge, 3 frontend/verification)
-- [ ] 29-01-PLAN.md — BILL-06 migrations: expenses.amount → numeric(10,2) + get_property_performance_analytics recreate (numeric cast + DATA-02 status filter)
-- [ ] 29-02-PLAN.md — BILL-02 migrations: date params on get_expense_summary / get_financial_overview / get_billing_insights
-- [ ] 29-03-PLAN.md — BILL-01: Stripe current_period_end read fix (edge handlers + client NaN guard)
-- [ ] 29-04-PLAN.md — BILL-05: generate-pdf reportType branching to the export-report RPCs
-- [ ] 29-05-PLAN.md — BILL-02 frontend + BILL-04 + BILL-03: date-range passing, expense/billing error surfacing, unpaid-invoice amount
-- [ ] 29-06-PLAN.md — BILL-06 frontend: formatCents → formatCurrency cents-readers + Financial Highlights fix
-- [ ] 29-07-PLAN.md — Phase verification + residual/limitation ledger
+**Plans:** 7/7 plans complete
+- [x] 29-01-PLAN.md — BILL-06 migrations: expenses.amount → numeric(10,2) + get_property_performance_analytics recreate (numeric cast + DATA-02 status filter)
+- [x] 29-02-PLAN.md — BILL-02 migrations: date params on get_expense_summary / get_financial_overview / get_billing_insights
+- [x] 29-03-PLAN.md — BILL-01: Stripe current_period_end read fix (edge handlers + client NaN guard)
+- [x] 29-04-PLAN.md — BILL-05: generate-pdf reportType branching to the export-report RPCs
+- [x] 29-05-PLAN.md — BILL-02 frontend + BILL-04 + BILL-03: date-range passing, expense/billing error surfacing, unpaid-invoice amount
+- [x] 29-06-PLAN.md — BILL-06 frontend: formatCents → formatCurrency cents-readers + Financial Highlights fix
+- [x] 29-07-PLAN.md — Phase verification + residual/limitation ledger
 
 ### Phase 30: Analytics & Data-Layer Correctness
 **Goal:** Fix analytics and cross-cutting data-layer correctness — occupancy analytics consume the RPC's array shape, soft-deleted properties are excluded from the performance RPCs, the expired-lease stat counts `expired`, unit mutations invalidate the by-property cache, property updates refresh the dashboard, and the property/tenant table virtualizers position rows correctly.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v8.0
 milestone_name: Correctness Restoration
 status: executing
-last_updated: "2026-07-08T00:41:09.891Z"
-last_activity: 2026-07-08 -- Phase 28 execution started
+last_updated: "2026-07-08T13:16:22.278Z"
+last_activity: 2026-07-08 -- Phase 29 execution started
 progress:
   total_phases: 11
   completed_phases: 2
-  total_plans: 27
-  completed_plans: 20
+  total_plans: 34
+  completed_plans: 25
   percent: 18
 ---
 
@@ -20,14 +20,14 @@ progress:
 See: .planning/PROJECT.md
 
 **Core value (v8.0):** Every core operation an owner performs — create a lease, delete a unit, view the leases list, sign a document, pay an invoice, upload a photo, run a report — produces correct data and correct behavior. This milestone eradicates the full set of real bugs surfaced by the 2026-07-02 whole-codebase hunt (12 parallel domain agents; every P0 and every cross-owner/DB claim verified against source + the live Supabase DB). Nothing new is built; every requirement restores an existing feature to correct behavior.
-**Current focus:** Phase 28 — tenant-domain
+**Current focus:** Phase 29 — billing-financials
 
 ## Current Position
 
-Phase: 28 (tenant-domain) — REVIEW-PASSED (perfect-PR gate met, cycles 3+4)
-Plan: 1 of 6
-Status: Executing Phase 28
-Last activity: 2026-07-08 -- Phase 28 execution started
+Phase: 29 (billing-financials) — REVIEW-PASSED (perfect-PR gate met, cycles 4+5)
+Plan: 1 of 7
+Status: Executing Phase 29
+Last activity: 2026-07-08 -- Phase 29 execution started
 
 ## Roadmap Summary (v8.0)
 

--- a/.planning/phases/29-billing-financials/29-01-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-01-PLAN.md
@@ -1,0 +1,160 @@
+---
+phase: 29-billing-financials
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - supabase/migrations/  # new: ALTER expenses.amount -> numeric(10,2)
+  - supabase/migrations/  # new: recreate get_property_performance_analytics (BILL-06 cast + DATA-02 predicate)
+  - src/types/supabase.ts  # regen after RPC return-type change
+autonomous: true
+requirements: [BILL-06]
+
+must_haves:
+  truths:
+    - "expenses.amount stores fractional dollars — a 150.50 insert persists 150.50 (was rounded to an integer)"
+    - "get_property_performance_analytics returns total_expenses/net_income as numeric (fractional cents preserved), not truncated bigint"
+    - "get_property_performance_analytics excludes soft-deleted (status='inactive') properties from its scans (satisfies DATA-02)"
+    - "the function keeps its existing occupancy-rate unit exclusion, grants, SECURITY DEFINER, and SET search_path = public"
+  artifacts:
+    - path: "supabase/migrations/"
+      provides: "ALTER TABLE public.expenses ALTER COLUMN amount TYPE numeric(10,2)"
+      contains: "numeric(10,2)"
+    - path: "supabase/migrations/"
+      provides: "CREATE OR REPLACE FUNCTION public.get_property_performance_analytics with numeric casts + property status filter"
+      contains: "get_property_performance_analytics"
+  key_links:
+    - from: "get_property_performance_analytics"
+      to: "expenses / properties tables"
+      via: "SUM(e.amount)::numeric with p.status <> 'inactive' scan predicate"
+      pattern: "p.status <> 'inactive'"
+---
+
+<objective>
+Fix BILL-06 (money convention) at the database layer, coordinated with the DATA-02 property-status predicate. Convert `expenses.amount` from `integer` to `numeric(10,2)` so it stores dollars (matching every other money column) and stops rounding cents on insert. Recreate `get_property_performance_analytics` ONCE to (a) change its expense `SUM(e.amount)::bigint` and its `RETURNS TABLE` `total_revenue`/`total_expenses`/`net_income` from `bigint` to `numeric` so fractional dollars are not truncated, and (b) restore the `p.status <> 'inactive'` predicate on its property scans (the DATA-02 fix) — doing both in one recreate so Phase 30 does not re-touch the function and risk clobbering the numeric cast.
+
+Purpose: End the systemic `expenses.amount` cents/dollars confusion and prevent a double-recreate of the shared analytics RPC.
+Output: Two migrations (column ALTER + function recreate), applied to prod via MCP, filenames reconciled, `src/types/supabase.ts` regenerated for the RPC return-type change, with rolled-back live proof.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/29-billing-financials/29-CONTEXT.md
+
+<interfaces>
+<!-- LIVE current definition of get_property_performance_analytics (verify via MCP pg_get_functiondef before editing).
+     Source migration for the current body: supabase/migrations/20260702215602_exclude_inactive_from_occupancy_stats.sql.
+     Signature: get_property_performance_analytics(p_user_id uuid, p_property_id uuid DEFAULT NULL, p_timeframe text DEFAULT '30d', p_limit integer DEFAULT NULL)
+     RETURNS TABLE(property_id uuid, property_name text, occupancy_rate numeric, total_revenue bigint, total_expenses bigint, net_income bigint, timeframe text)
+     The three BILL-06 cast sites are: property_expenses.expenses = COALESCE(SUM(e.amount),0)::bigint ; the final SELECT 0::bigint AS total_revenue and -COALESCE(pe.expenses,0)::bigint AS net_income.
+     The two DATA-02 scan predicates to add are on the property_units CTE and the property_expenses CTE, both currently
+     "WHERE p.owner_user_id = p_user_id AND (p_property_id IS NULL OR p.id = p_property_id)" — add "AND p.status <> 'inactive'".
+     PRESERVE verbatim: the occupancy IS DISTINCT FROM 'inactive' unit filter, LANGUAGE plpgsql, SECURITY DEFINER,
+     SET search_path TO 'public', the auth.uid() guard, and any GRANT lines that accompany the function. -->
+
+<!-- CLAUDE.md money convention: all `amount` columns store DOLLARS as numeric(10,2). Convert to cents ONLY at the Stripe API boundary. -->
+<!-- Prod `expenses` is EMPTY (verified in 29-CONTEXT.md) so the integer->numeric ALTER is lossless with no data conversion. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Author migration — expenses.amount integer -> numeric(10,2)</name>
+  <files>supabase/migrations/  (new file, slug e.g. alter_expenses_amount_to_numeric)</files>
+  <read_first>
+    - supabase/migrations/20251101000000_base_schema.sql (current expenses.amount column definition)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-06 locked decision, item 1)
+    - CLAUDE.md (Database: amounts store dollars as numeric(10,2); no data conversion needed — prod expenses empty)
+  </read_first>
+  <action>
+    Create a new migration file in `supabase/migrations/` with a placeholder `YYYYMMDDHHmmss` timestamp that issues `ALTER TABLE public.expenses ALTER COLUMN amount TYPE numeric(10,2)`. Keep the `NOT NULL` constraint (do not drop it). Do NOT add a `USING` cast expression beyond the implicit integer->numeric widening (it is lossless and prod is empty). Add a one-line SQL comment stating the column now stores dollars per CLAUDE.md and that prod `expenses` was empty at migration time. Do not touch any other column, trigger, or table.
+  </action>
+  <acceptance_criteria>
+    - The migration file exists under `supabase/migrations/` and contains exactly one `ALTER TABLE public.expenses ALTER COLUMN amount TYPE numeric(10,2)` statement.
+    - Source: `grep -n "integer\|::int\|USING" <new_migration_file>` shows no residual integer cast in the money path.
+    - No other DDL is present in the file (single-purpose migration).
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 2: Author migration — recreate get_property_performance_analytics (BILL-06 numeric cast + DATA-02 status predicate)</name>
+  <files>supabase/migrations/  (new file, slug e.g. recreate_property_performance_analytics_numeric_and_status)</files>
+  <read_first>
+    - supabase/migrations/20260702215602_exclude_inactive_from_occupancy_stats.sql (the CURRENT full definition of get_property_performance_analytics — copy it verbatim as the base)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-06 item 2 + the BILL-06 <-> DATA-02 coordination note)
+    - CLAUDE.md (SECURITY DEFINER RPC grants/search_path preserved on recreate; soft-delete = status 'inactive')
+  </read_first>
+  <action>
+    Create a new migration file that `CREATE OR REPLACE FUNCTION public.get_property_performance_analytics(...)` starting from the CURRENT live body (confirm via Supabase MCP `pg_get_functiondef` before writing so no clause drifts). Make exactly these changes and nothing else:
+    (1) In the `RETURNS TABLE(...)`, change `total_revenue bigint`, `total_expenses bigint`, and `net_income bigint` to `numeric`.
+    (2) In the `property_expenses` CTE, change `COALESCE(SUM(e.amount), 0)::bigint AS expenses` to `COALESCE(SUM(e.amount), 0)::numeric AS expenses`.
+    (3) In the final SELECT, change `0::bigint AS total_revenue` to `0::numeric AS total_revenue` and `-COALESCE(pe.expenses, 0)::bigint AS net_income` to `-COALESCE(pe.expenses, 0)::numeric AS net_income`.
+    (4) DATA-02: add `AND p.status <> 'inactive'` to BOTH the `property_units` CTE WHERE clause and the `property_expenses` CTE WHERE clause (they currently read `WHERE p.owner_user_id = p_user_id AND (p_property_id IS NULL OR p.id = p_property_id)`).
+    Preserve verbatim: the occupancy `IS DISTINCT FROM 'inactive'` unit filter, the `auth.uid()` access guard, `LANGUAGE plpgsql`, `SECURITY DEFINER`, `SET search_path TO 'public'`, the ORDER BY / LIMIT, and re-issue any `GRANT EXECUTE ... TO authenticated` that accompanies the live function (confirm the exact grants via MCP). Add a header comment noting this recreate satisfies BOTH BILL-06 (numeric) and DATA-02 (property status filter) so Phase 30 must not recreate it again.
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -n "::bigint" <new_migration_file>` returns nothing inside the function body (all three cast sites converted).
+    - Source: `grep -c "p.status <> 'inactive'" <new_migration_file>` returns 2 (both property-scan CTEs) — run against the file with `grep -v '^--'` first so header comments do not inflate the count.
+    - Source: the `RETURNS TABLE` line contains `total_revenue numeric`, `total_expenses numeric`, `net_income numeric` (no `bigint` remaining on those three columns).
+    - Source: `SECURITY DEFINER`, `SET search_path TO 'public'`, and the `auth.uid()` guard are all present and unchanged.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 3: Apply both migrations via MCP, reconcile filenames, regen db:types, capture rolled-back proof</name>
+  <files>supabase/migrations/ (filename reconcile), src/types/supabase.ts (regen)</files>
+  <read_first>
+    - The two migration files authored in Tasks 1-2
+    - CLAUDE.md (migrations applied via Supabase MCP apply_migration -> prod-assigned timestamps; reconcile via mcp__supabase__list_migrations; db:types regen via MCP generate_typescript_types on CLI-401)
+    - the migration-mcp-prod-drift memory pattern (reconcile repo filename to the prod-assigned timestamp after every MCP apply)
+  </read_first>
+  <action>
+    NOTE FOR THE RUNNER: the plan executor has NO Supabase MCP. This step is performed by the execute-phase orchestrator (or a general-purpose agent it delegates to) that DOES hold Supabase MCP. Apply the expenses.amount ALTER first, then the get_property_performance_analytics recreate second (column type must exist before the function that sums it is recreated). After each `apply_migration`, call `mcp__supabase__list_migrations` and rename the repo migration file to the prod-assigned timestamp so repo↔prod parity holds. Because the RPC `RETURNS TABLE` types changed (bigint->numeric), regenerate `src/types/supabase.ts`: run `bun run db:types`; if the CLI 401s (known pattern), regenerate via Supabase MCP `generate_typescript_types` and surgically apply the diff for the changed `get_property_performance_analytics` return shape only. Capture a rolled-back live proof: in a transaction (or against a scratch row) confirm a 150.50 expense insert persists `amount = 150.50` (not 150 or 151) and that `get_property_performance_analytics` for a test owner returns a numeric `total_expenses` and excludes an `status='inactive'` property, then ROLL BACK so no test data lands in prod. Record the applied prod timestamps + the proof in the SUMMARY.
+  </action>
+  <acceptance_criteria>
+    - `mcp__supabase__list_migrations` shows both migrations applied; the two repo filenames match the prod-assigned timestamps.
+    - Live proof (rolled back): a `150.50` expense round-trips as `150.50`; `get_property_performance_analytics` returns `total_expenses`/`net_income` as numeric and omits a soft-deleted (`status='inactive'`) property — captured before ROLLBACK, no residual prod rows.
+    - `src/types/supabase.ts` reflects the new numeric return columns for `get_property_performance_analytics`; `bun run typecheck` passes.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| migration DDL -> live prod schema | column type change + SECURITY DEFINER function recreation must preserve grants, search_path, and RLS-adjacent auth guard |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-29-01 | Tampering | get_property_performance_analytics recreate | mitigate | copy the live body verbatim via MCP pg_get_functiondef; change only the three casts, the RETURNS types, and the two status predicates; re-issue exact GRANTs; keep SECURITY DEFINER + SET search_path = public + auth.uid() guard |
+| T-29-02 | Elevation of privilege | recreated SECURITY DEFINER RPC | mitigate | preserve the `p_user_id != (select auth.uid())` access-denied guard; do not broaden grants beyond the current `authenticated` grant |
+| T-29-03 | Denial of service | expenses.amount ALTER | accept | prod expenses table empty; lossless integer->numeric widening; single-statement migration |
+</threat_model>
+
+<verification>
+- Both migrations applied to prod via MCP; repo filenames reconciled to prod timestamps.
+- `bun run typecheck` green after `src/types/supabase.ts` regen.
+- Rolled-back live proof recorded (150.50 round-trip + numeric return + inactive-property exclusion).
+</verification>
+
+<success_criteria>
+`expenses.amount` is `numeric(10,2)` in prod; `get_property_performance_analytics` returns numeric totals, excludes inactive properties, and preserves occupancy exclusion + grants + SECURITY DEFINER; Phase 30 DATA-02 is satisfied by this single recreate.
+</success_criteria>
+
+<output>
+Create `.planning/phases/29-billing-financials/29-01-SUMMARY.md` when done. Record the applied prod migration timestamps, the rolled-back proof, and a note that DATA-02 (property status filter on get_property_performance_analytics) is satisfied here so Phase 30 must not recreate the function.
+</output>

--- a/.planning/phases/29-billing-financials/29-01-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-01-PLAN.md
@@ -22,7 +22,7 @@ must_haves:
       provides: "ALTER TABLE public.expenses ALTER COLUMN amount TYPE numeric(10,2)"
       contains: "numeric(10,2)"
     - path: "supabase/migrations/"
-      provides: "CREATE OR REPLACE FUNCTION public.get_property_performance_analytics with numeric casts + property status filter"
+      provides: "DROP FUNCTION + CREATE FUNCTION public.get_property_performance_analytics (return-type change requires DROP, not CREATE OR REPLACE) with numeric casts + property status filter + re-issued grants"
       contains: "get_property_performance_analytics"
   key_links:
     - from: "get_property_performance_analytics"
@@ -94,7 +94,7 @@ Output: Two migrations (column ALTER + function recreate), applied to prod via M
     - CLAUDE.md (SECURITY DEFINER RPC grants/search_path preserved on recreate; soft-delete = status 'inactive')
   </read_first>
   <action>
-    Create a new migration file that `CREATE OR REPLACE FUNCTION public.get_property_performance_analytics(...)` starting from the CURRENT live body (confirm via Supabase MCP `pg_get_functiondef` before writing so no clause drifts). Make exactly these changes and nothing else:
+    Create a new migration file that FIRST `DROP FUNCTION IF EXISTS public.get_property_performance_analytics(uuid, uuid, text, integer);` (confirm the EXACT arg signature via MCP before writing) THEN `CREATE FUNCTION public.get_property_performance_analytics(...)`. A plain `CREATE OR REPLACE` will ERROR with `cannot change return type of existing function` because the `RETURNS TABLE` columns change from bigint to numeric (they are OUT params) — DROP+CREATE is mandatory. Start from the CURRENT live body (confirm via Supabase MCP `pg_get_functiondef` before writing so no clause drifts). Make exactly these changes and nothing else:
     (1) In the `RETURNS TABLE(...)`, change `total_revenue bigint`, `total_expenses bigint`, and `net_income bigint` to `numeric`.
     (2) In the `property_expenses` CTE, change `COALESCE(SUM(e.amount), 0)::bigint AS expenses` to `COALESCE(SUM(e.amount), 0)::numeric AS expenses`.
     (3) In the final SELECT, change `0::bigint AS total_revenue` to `0::numeric AS total_revenue` and `-COALESCE(pe.expenses, 0)::bigint AS net_income` to `-COALESCE(pe.expenses, 0)::numeric AS net_income`.
@@ -106,6 +106,7 @@ Output: Two migrations (column ALTER + function recreate), applied to prod via M
     - Source: `grep -c "p.status <> 'inactive'" <new_migration_file>` returns 2 (both property-scan CTEs) — run against the file with `grep -v '^--'` first so header comments do not inflate the count.
     - Source: the `RETURNS TABLE` line contains `total_revenue numeric`, `total_expenses numeric`, `net_income numeric` (no `bigint` remaining on those three columns).
     - Source: `SECURITY DEFINER`, `SET search_path TO 'public'`, and the `auth.uid()` guard are all present and unchanged.
+    - Source: the migration BEGINS with `DROP FUNCTION IF EXISTS public.get_property_performance_analytics(` (return-type change cannot use CREATE OR REPLACE) and re-issues `GRANT EXECUTE ... TO authenticated` after the CREATE (DROP removes grants).
   </acceptance_criteria>
 </task>
 

--- a/.planning/phases/29-billing-financials/29-01-SUMMARY.md
+++ b/.planning/phases/29-billing-financials/29-01-SUMMARY.md
@@ -1,0 +1,13 @@
+# 29-01 Summary — BILL-06 (expenses.amount money-convention) + DATA-02 predicate
+
+**Requirement:** BILL-06 — `expenses.amount` was `integer` (rounded cents), read inconsistently as cents/dollars. Fix the DB layer.
+
+**Migrations (2, applied to prod, verified):**
+- `20260708131702_bill06_expenses_amount_to_numeric` — `ALTER expenses.amount → numeric(10,2)`. Prod `expenses` empty (0 rows) → lossless. Verified: a 150.50 insert round-trips as 150.50 (rolled back).
+- `20260708131721_bill06_data02_property_performance_analytics_numeric_and_status` — **DROP+CREATE** (return-type change bigint→numeric cannot use CREATE OR REPLACE): `SUM(e.amount)::bigint → ::numeric` (3 cast sites) + RETURNS TABLE `total_revenue`/`total_expenses`/`net_income` bigint→numeric, **and** DATA-02's `p.status <> 'inactive'` predicate on both property-scan CTEs (so Phase 30 doesn't re-recreate this fn). Verified live: 0 `bigint`, 2 status filters, all-numeric return signature, SECURITY DEFINER + search_path + auth.uid() guard preserved, grants re-issued (authenticated + service_role).
+
+**db:types:** no regen needed — both `integer` and `numeric` (and `bigint`) map to TS `number` in the generated types (verified `expenses.amount: number` + `get_property_performance_analytics` Returns already `number`). typecheck 0.
+
+**Coordination:** DATA-02's `get_property_performance_analytics` portion is satisfied here; Phase 30 still owns `get_property_performance_with_trends` (+ `_trends`) — must NOT re-recreate `_analytics`.
+
+**Frontend readers:** the cents/dollars display fixes are 29-06 (separate plan).

--- a/.planning/phases/29-billing-financials/29-02-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-02-PLAN.md
@@ -1,0 +1,140 @@
+---
+phase: 29-billing-financials
+plan: 02
+type: execute
+wave: 2
+depends_on: ["29-01"]
+files_modified:
+  - supabase/migrations/  # new: date params on get_expense_summary + get_financial_overview + get_billing_insights
+  - src/types/supabase.ts  # regen after RPC signature change
+autonomous: true
+requirements: [BILL-02]
+
+must_haves:
+  truths:
+    - "get_expense_summary accepts p_start_date/p_end_date and scopes its expense sums to that range (defaults to current-year boundaries)"
+    - "get_financial_overview accepts p_start_date/p_end_date and scopes its expense predicate to that range (defaults to current-year boundaries)"
+    - "get_billing_insights applies its already-declared start_date_param/end_date_param instead of ignoring them"
+    - "existing callers that pass only the id argument still get current-year YTD numbers (backward compatible via defaulted params)"
+  artifacts:
+    - path: "supabase/migrations/"
+      provides: "recreated get_expense_summary + get_financial_overview with date params replacing the hardcoded date_trunc('year', current_date) predicate"
+      contains: "p_start_date"
+    - path: "supabase/migrations/"
+      provides: "get_billing_insights body wired to its declared date params"
+      contains: "start_date_param"
+  key_links:
+    - from: "get_expense_summary / get_financial_overview"
+      to: "expenses.expense_date"
+      via: "range predicate driven by p_start_date/p_end_date with current-year defaults"
+      pattern: "expense_date >= "
+---
+
+<objective>
+Fix BILL-02 at the database layer: make the financial RPCs period-scopable. Today `get_expense_summary` and `get_financial_overview` HARDCODE `date_trunc('year', current_date)` on `expenses.expense_date`, and `get_billing_insights` declares `start_date_param`/`end_date_param` but its body ignores them — so income-statement, cash-flow, and tax-documents can only ever show YTD numbers regardless of the selected period. Add `p_start_date date` / `p_end_date date` parameters (DEFAULTing to the current-year boundaries so every existing caller is unaffected) to `get_expense_summary` and `get_financial_overview`, replacing the hardcoded year predicate, and wire `get_billing_insights` to actually apply its declared date params where sensible.
+
+Purpose: Let the frontend (Plan 05) pass a selected range and get period-accurate EXPENSE totals. Depends on Plan 01 because both plans touch `supabase/migrations/` and regenerate `src/types/supabase.ts`, and the expenses column must already be numeric.
+Output: One migration recreating the three RPCs with backward-compatible date params, applied via MCP, filename reconciled, `src/types/supabase.ts` regenerated for the new signatures, with rolled-back live proof.
+
+KNOWN LIMITATION (document in the SUMMARY, do NOT over-fix): REVENUE from `get_dashboard_stats`/`get_financial_overview` is active-lease MRR (point-in-time), not period-historical — the data model has no rent-roll/payment history. Only the EXPENSE side becomes period-accurate; revenue stays annualized-MRR. Building a payment ledger is explicitly out of scope (deferred in 29-CONTEXT.md).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/29-billing-financials/29-CONTEXT.md
+
+<interfaces>
+<!-- CURRENT live definitions (confirm each via MCP pg_get_functiondef before editing):
+     get_expense_summary(p_user_id uuid) RETURNS jsonb — body in supabase/migrations/20260621033856_fix_get_expense_summary_vendor_grouping_v2.sql (latest recreate). Has THREE hardcoded predicates on expenses.expense_date: the vendor category CTE, and the YTD total; the trailing-12-month monthly_totals series is a SEPARATE 12-month window (leave that window as-is — it is a rolling series, not the period sum).
+     get_financial_overview(p_user_id uuid) RETURNS jsonb — body in supabase/migrations/20260528231201_repair_analytics_rpcs.sql (latest recreate). Hardcodes `e.expense_date >= date_trunc('year', current_date)`.
+     get_billing_insights(owner_id_param uuid, start_date_param timestamp DEFAULT NULL, end_date_param timestamp DEFAULT NULL) RETURNS jsonb — body in supabase/migrations/20260304120000_rpc_auth_guards.sql; grants re-affirmed in 20260529225039_revoke_anon_security_definer_rpcs_v2.sql. Body currently ignores the date params. -->
+
+<!-- Default-param rule: DEFAULT p_start_date := date_trunc('year', current_date)::date and
+     p_end_date := current_date so a caller passing only the id argument reproduces today's YTD behavior exactly. Replace the hardcoded `expense_date >= date_trunc('year', current_date)` with `expense_date >= coalesce(p_start_date, date_trunc('year', current_date)::date) AND expense_date <= coalesce(p_end_date, current_date)`. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Author migration — add date params to get_expense_summary + get_financial_overview, wire get_billing_insights date params</name>
+  <files>supabase/migrations/  (new file, slug e.g. add_date_params_to_financial_rpcs)</files>
+  <read_first>
+    - supabase/migrations/20260621033856_fix_get_expense_summary_vendor_grouping_v2.sql (current get_expense_summary body — copy verbatim as base)
+    - supabase/migrations/20260528231201_repair_analytics_rpcs.sql (current get_financial_overview body — copy verbatim as base)
+    - supabase/migrations/20260304120000_rpc_auth_guards.sql (current get_billing_insights body + params)
+    - supabase/migrations/20260529225039_revoke_anon_security_definer_rpcs_v2.sql (the grants to preserve on recreate)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-02 locked decision + Claude's Discretion on default-param values)
+  </read_first>
+  <action>
+    Create ONE migration recreating all three functions (confirm each live body via Supabase MCP `pg_get_functiondef` first so no clause drifts):
+    (1) `get_expense_summary`: change the signature to `get_expense_summary(p_user_id uuid, p_start_date date DEFAULT date_trunc('year', current_date)::date, p_end_date date DEFAULT current_date)`. In BOTH the vendor-category CTE and the total-amount SELECT, replace `e.expense_date >= date_trunc('year', current_date)` with `e.expense_date >= p_start_date AND e.expense_date <= p_end_date`. LEAVE the trailing-12-month `monthly_totals` rolling window unchanged (it is a fixed 12-month series, not the selected period). Keep the `e.status <> 'inactive'` filter, the `auth.uid()` guard, SECURITY DEFINER, and SET search_path.
+    (2) `get_financial_overview`: change the signature to `get_financial_overview(p_user_id uuid, p_start_date date DEFAULT date_trunc('year', current_date)::date, p_end_date date DEFAULT current_date)`. Replace `e.expense_date >= date_trunc('year', current_date)` with `e.expense_date >= p_start_date AND e.expense_date <= p_end_date`. Preserve everything else (revenue path stays MRR — do not touch it).
+    (3) `get_billing_insights`: keep its existing `(owner_id_param uuid, start_date_param timestamp DEFAULT NULL, end_date_param timestamp DEFAULT NULL)` signature and apply the declared params where they are sensible (e.g. gate the receivables/overdue predicates that carry a date column by `(start_date_param IS NULL OR <date_col> >= start_date_param) AND (end_date_param IS NULL OR <date_col> <= end_date_param)`). If a given aggregate has no date column to scope, leave it and note that in a SQL comment — do not invent a date dimension.
+    Re-issue the exact `GRANT EXECUTE ... TO authenticated` for each function that the current definitions carry. Because Postgres treats a new default-arg signature as overload-compatible, DROP the old zero-default signatures explicitly if needed (`DROP FUNCTION IF EXISTS public.get_expense_summary(uuid)` etc.) before the CREATE to avoid a duplicate overload — confirm the pre-existing overload set via MCP first.
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -c "date_trunc('year', current_date)" <new_migration_file>` after `grep -v '^--'` shows the only remaining occurrences are inside the two new DEFAULT clauses (not inside a WHERE predicate).
+    - Source: both `get_expense_summary` and `get_financial_overview` signatures contain `p_start_date date DEFAULT` and `p_end_date date DEFAULT`.
+    - Source: `get_billing_insights` body references `start_date_param` and `end_date_param` in at least one predicate (no longer purely declared-and-ignored) OR carries an explicit SQL comment on any aggregate that legitimately has no date column.
+    - Source: each recreated function retains `SECURITY DEFINER`, `SET search_path TO 'public'`, the `auth.uid()`/`owner_id_param` guard, and a re-issued `GRANT EXECUTE ... TO authenticated`.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 2: Apply migration via MCP, reconcile filename, regen db:types, capture rolled-back proof</name>
+  <files>supabase/migrations/ (filename reconcile), src/types/supabase.ts (regen)</files>
+  <read_first>
+    - The migration file authored in Task 1
+    - CLAUDE.md (MCP apply_migration + reconcile via list_migrations; db:types regen via MCP generate_typescript_types on CLI-401)
+    - the migration-mcp-prod-drift memory pattern
+  </read_first>
+  <action>
+    NOTE FOR THE RUNNER: the plan executor has NO Supabase MCP. This is performed by the execute-phase orchestrator (or a general-purpose agent with Supabase MCP). Apply the migration via `apply_migration`, then `list_migrations` and rename the repo file to the prod-assigned timestamp. The signatures changed (new params) so regenerate `src/types/supabase.ts`: run `bun run db:types`; on a CLI 401, use MCP `generate_typescript_types` and surgically apply the diff for the three changed RPC signatures. Capture rolled-back live proof: for a test owner with at least one expense, call `get_expense_summary(id)` (no dates -> YTD, unchanged) and `get_expense_summary(id, '<earlier-range-start>', '<earlier-range-end>')` and confirm the two `total_amount` values differ when the ranges differ; confirm `get_financial_overview(id)` still returns the same YTD numbers as before (backward compatibility). Do all reads read-only (no writes to roll back beyond any scratch expense created inside a transaction). Record the applied prod timestamp + the differing-range proof in the SUMMARY.
+  </action>
+  <acceptance_criteria>
+    - `mcp__supabase__list_migrations` shows the migration applied; the repo filename matches the prod-assigned timestamp.
+    - Live proof: `get_expense_summary(id)` (defaulted) equals the pre-migration YTD value; `get_expense_summary(id, start, end)` for a narrower range returns a DIFFERENT `total_amount` — captured in the SUMMARY.
+    - `src/types/supabase.ts` reflects the new date params for the three RPCs; `bun run typecheck` passes.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| migration DDL -> live prod schema | SECURITY DEFINER function recreation with new default params must preserve grants, search_path, and per-owner auth guard |
+| client-supplied date range -> RPC predicate | untrusted p_start_date/p_end_date narrow a scan; must not bypass the owner guard |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-29-04 | Tampering | get_expense_summary / get_financial_overview recreate | mitigate | copy live bodies via MCP; change only the signature + expense_date predicate; DROP old overload first to avoid duplicate-signature ambiguity; re-issue exact grants |
+| T-29-05 | Elevation of privilege | new date params on SECURITY DEFINER RPCs | mitigate | keep the `p_user_id != (select auth.uid())` guard ahead of any date filter; date params only narrow rows within the caller's own owner scope |
+| T-29-06 | Information disclosure | get_billing_insights date wiring | accept | params only filter the caller's own owner-scoped rows; no cross-owner exposure added |
+</threat_model>
+
+<verification>
+- Migration applied via MCP; repo filename reconciled.
+- `bun run typecheck` green after db:types regen.
+- Rolled-back live proof: defaulted call == prior YTD; ranged call differs.
+</verification>
+
+<success_criteria>
+`get_expense_summary` and `get_financial_overview` accept current-year-defaulted date params and scope their expense predicate to the selected range; `get_billing_insights` applies its declared date params; all existing single-argument callers are unaffected.
+</success_criteria>
+
+<output>
+Create `.planning/phases/29-billing-financials/29-02-SUMMARY.md` when done. Record the applied prod timestamp, the differing-range proof, and the documented revenue-MRR known limitation (expense side is now period-accurate; revenue stays annualized MRR).
+</output>

--- a/.planning/phases/29-billing-financials/29-02-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-02-PLAN.md
@@ -14,15 +14,12 @@ must_haves:
   truths:
     - "get_expense_summary accepts p_start_date/p_end_date and scopes its expense sums to that range (defaults to current-year boundaries)"
     - "get_financial_overview accepts p_start_date/p_end_date and scopes its expense predicate to that range (defaults to current-year boundaries)"
-    - "get_billing_insights applies its already-declared start_date_param/end_date_param instead of ignoring them"
+    - "get_billing_insights is left unchanged — it has no date-scopable aggregate (MRR/churn/tenant-count are point-in-time; unpaid/late-fee hardcoded 0, rent_payments demolished), so its declared date params stay intentionally unused (documented limitation)"
     - "existing callers that pass only the id argument still get current-year YTD numbers (backward compatible via defaulted params)"
   artifacts:
     - path: "supabase/migrations/"
       provides: "recreated get_expense_summary + get_financial_overview with date params replacing the hardcoded date_trunc('year', current_date) predicate"
       contains: "p_start_date"
-    - path: "supabase/migrations/"
-      provides: "get_billing_insights body wired to its declared date params"
-      contains: "start_date_param"
   key_links:
     - from: "get_expense_summary / get_financial_overview"
       to: "expenses.expense_date"
@@ -31,7 +28,7 @@ must_haves:
 ---
 
 <objective>
-Fix BILL-02 at the database layer: make the financial RPCs period-scopable. Today `get_expense_summary` and `get_financial_overview` HARDCODE `date_trunc('year', current_date)` on `expenses.expense_date`, and `get_billing_insights` declares `start_date_param`/`end_date_param` but its body ignores them — so income-statement, cash-flow, and tax-documents can only ever show YTD numbers regardless of the selected period. Add `p_start_date date` / `p_end_date date` parameters (DEFAULTing to the current-year boundaries so every existing caller is unaffected) to `get_expense_summary` and `get_financial_overview`, replacing the hardcoded year predicate, and wire `get_billing_insights` to actually apply its declared date params where sensible.
+Fix BILL-02 at the database layer: make the financial RPCs period-scopable. Today `get_expense_summary` and `get_financial_overview` HARDCODE `date_trunc('year', current_date)` on `expenses.expense_date`, and `get_billing_insights` declares `start_date_param`/`end_date_param` but its body ignores them — so income-statement, cash-flow, and tax-documents can only ever show YTD numbers regardless of the selected period. Add `p_start_date date` / `p_end_date date` parameters (defaults reproducing today's one-sided YTD exactly so every existing caller is unaffected) to `get_expense_summary` and `get_financial_overview`, replacing the hardcoded year predicate. `get_billing_insights` is left unchanged — its live body has no date-scopable aggregate (unpaid/late-fee hardcoded 0 after the rent_payments table was demolished; MRR/churn are point-in-time), so its declared date params stay a documented no-op.
 
 Purpose: Let the frontend (Plan 05) pass a selected range and get period-accurate EXPENSE totals. Depends on Plan 01 because both plans touch `supabase/migrations/` and regenerate `src/types/supabase.ts`, and the expenses column must already be numeric.
 Output: One migration recreating the three RPCs with backward-compatible date params, applied via MCP, filename reconciled, `src/types/supabase.ts` regenerated for the new signatures, with rolled-back live proof.
@@ -54,36 +51,34 @@ KNOWN LIMITATION (document in the SUMMARY, do NOT over-fix): REVENUE from `get_d
 <!-- CURRENT live definitions (confirm each via MCP pg_get_functiondef before editing):
      get_expense_summary(p_user_id uuid) RETURNS jsonb — body in supabase/migrations/20260621033856_fix_get_expense_summary_vendor_grouping_v2.sql (latest recreate). Has THREE hardcoded predicates on expenses.expense_date: the vendor category CTE, and the YTD total; the trailing-12-month monthly_totals series is a SEPARATE 12-month window (leave that window as-is — it is a rolling series, not the period sum).
      get_financial_overview(p_user_id uuid) RETURNS jsonb — body in supabase/migrations/20260528231201_repair_analytics_rpcs.sql (latest recreate). Hardcodes `e.expense_date >= date_trunc('year', current_date)`.
-     get_billing_insights(owner_id_param uuid, start_date_param timestamp DEFAULT NULL, end_date_param timestamp DEFAULT NULL) RETURNS jsonb — body in supabase/migrations/20260304120000_rpc_auth_guards.sql; grants re-affirmed in 20260529225039_revoke_anon_security_definer_rpcs_v2.sql. Body currently ignores the date params. -->
+     get_billing_insights(owner_id_param uuid, start_date_param timestamp DEFAULT NULL, end_date_param timestamp DEFAULT NULL) RETURNS jsonb — the LIVE body is supabase/migrations/20260528231201_repair_analytics_rpcs.sql (NOT the older 20260304120000_rpc_auth_guards.sql, whose rent_payments JOINs were demolished). The live body HARDCODES unpaidTotal/unpaidCount/lateFeeTotal to 0, does NOT reference rent_payments, and computes MRR/churn/tenant-count which are point-in-time (no date-scopable aggregate). DO NOT recreate get_billing_insights and DO NOT reintroduce rent_payments — there is nothing to date-scope; leave the function as-is and document that its declared date params remain intentionally unused. Only get_expense_summary + get_financial_overview are recreated in this plan. -->
 
-<!-- Default-param rule: DEFAULT p_start_date := date_trunc('year', current_date)::date and
-     p_end_date := current_date so a caller passing only the id argument reproduces today's YTD behavior exactly. Replace the hardcoded `expense_date >= date_trunc('year', current_date)` with `expense_date >= coalesce(p_start_date, date_trunc('year', current_date)::date) AND expense_date <= coalesce(p_end_date, current_date)`. -->
+<!-- Default-param rule (EXACT backward-compat): DEFAULT p_start_date := date_trunc('year', current_date)::date and DEFAULT p_end_date := NULL. Replace the hardcoded `expense_date >= date_trunc('year', current_date)` with `expense_date >= coalesce(p_start_date, date_trunc('year', current_date)::date) AND (p_end_date IS NULL OR expense_date <= p_end_date)`. An id-only call thus keeps the CURRENT one-sided (no upper bound) YTD predicate EXACTLY — future-dated expenses stay included as today. An explicit p_end_date scopes the upper bound. -->
 </interfaces>
 </context>
 
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Author migration — add date params to get_expense_summary + get_financial_overview, wire get_billing_insights date params</name>
+  <name>Task 1: Author migration — add date params to get_expense_summary + get_financial_overview (get_billing_insights left unchanged)</name>
   <files>supabase/migrations/  (new file, slug e.g. add_date_params_to_financial_rpcs)</files>
   <read_first>
     - supabase/migrations/20260621033856_fix_get_expense_summary_vendor_grouping_v2.sql (current get_expense_summary body — copy verbatim as base)
-    - supabase/migrations/20260528231201_repair_analytics_rpcs.sql (current get_financial_overview body — copy verbatim as base)
-    - supabase/migrations/20260304120000_rpc_auth_guards.sql (current get_billing_insights body + params)
+    - supabase/migrations/20260528231201_repair_analytics_rpcs.sql (current get_financial_overview body — copy verbatim as base; ALSO the current get_billing_insights body, which we do NOT touch — do NOT use the older 20260304120000 version, its rent_payments table was demolished)
     - supabase/migrations/20260529225039_revoke_anon_security_definer_rpcs_v2.sql (the grants to preserve on recreate)
     - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-02 locked decision + Claude's Discretion on default-param values)
   </read_first>
   <action>
-    Create ONE migration recreating all three functions (confirm each live body via Supabase MCP `pg_get_functiondef` first so no clause drifts):
-    (1) `get_expense_summary`: change the signature to `get_expense_summary(p_user_id uuid, p_start_date date DEFAULT date_trunc('year', current_date)::date, p_end_date date DEFAULT current_date)`. In BOTH the vendor-category CTE and the total-amount SELECT, replace `e.expense_date >= date_trunc('year', current_date)` with `e.expense_date >= p_start_date AND e.expense_date <= p_end_date`. LEAVE the trailing-12-month `monthly_totals` rolling window unchanged (it is a fixed 12-month series, not the selected period). Keep the `e.status <> 'inactive'` filter, the `auth.uid()` guard, SECURITY DEFINER, and SET search_path.
-    (2) `get_financial_overview`: change the signature to `get_financial_overview(p_user_id uuid, p_start_date date DEFAULT date_trunc('year', current_date)::date, p_end_date date DEFAULT current_date)`. Replace `e.expense_date >= date_trunc('year', current_date)` with `e.expense_date >= p_start_date AND e.expense_date <= p_end_date`. Preserve everything else (revenue path stays MRR — do not touch it).
-    (3) `get_billing_insights`: keep its existing `(owner_id_param uuid, start_date_param timestamp DEFAULT NULL, end_date_param timestamp DEFAULT NULL)` signature and apply the declared params where they are sensible (e.g. gate the receivables/overdue predicates that carry a date column by `(start_date_param IS NULL OR <date_col> >= start_date_param) AND (end_date_param IS NULL OR <date_col> <= end_date_param)`). If a given aggregate has no date column to scope, leave it and note that in a SQL comment — do not invent a date dimension.
-    Re-issue the exact `GRANT EXECUTE ... TO authenticated` for each function that the current definitions carry. Because Postgres treats a new default-arg signature as overload-compatible, DROP the old zero-default signatures explicitly if needed (`DROP FUNCTION IF EXISTS public.get_expense_summary(uuid)` etc.) before the CREATE to avoid a duplicate overload — confirm the pre-existing overload set via MCP first.
+    Create ONE migration recreating the TWO period-scopable functions — get_expense_summary + get_financial_overview (confirm each live body via Supabase MCP `pg_get_functiondef` first so no clause drifts). get_billing_insights is NOT touched (see step 3):
+    (1) `get_expense_summary`: change the signature to `get_expense_summary(p_user_id uuid, p_start_date date DEFAULT date_trunc('year', current_date)::date, p_end_date date DEFAULT NULL)`. In BOTH the vendor-category CTE and the total-amount SELECT, replace `e.expense_date >= date_trunc('year', current_date)` with `e.expense_date >= p_start_date AND (p_end_date IS NULL OR e.expense_date <= p_end_date)` — the NULL-default upper bound keeps an id-only call's predicate ONE-SIDED, exactly reproducing today's YTD (no new upper bound, future-dated expenses still included). LEAVE the trailing-12-month `monthly_totals` rolling window unchanged (fixed 12-month series, not the selected period). Keep the `e.status <> 'inactive'` filter, the `auth.uid()` guard, SECURITY DEFINER, and SET search_path.
+    (2) `get_financial_overview`: change the signature to `get_financial_overview(p_user_id uuid, p_start_date date DEFAULT date_trunc('year', current_date)::date, p_end_date date DEFAULT NULL)`. Replace `e.expense_date >= date_trunc('year', current_date)` with `e.expense_date >= p_start_date AND (p_end_date IS NULL OR e.expense_date <= p_end_date)`. Preserve everything else (revenue path stays MRR — do not touch it).
+    (3) `get_billing_insights` is NOT recreated: its live body (20260528231201) has no date-scopable aggregate — unpaidTotal/unpaidCount/lateFeeTotal are hardcoded 0 (the rent_payments table it once joined was demolished) and MRR/churn/tenant-count are point-in-time. There is nothing to scope by date, so leave the function exactly as-is; the declared date params remain intentionally unused (documented as a known limitation in the SUMMARY). Do NOT reintroduce rent_payments.
+    Re-issue the exact `GRANT EXECUTE ... TO authenticated` for each of the two recreated functions. Because the added default args make the new signature overload-compatible with the old zero-default `(uuid)` signature, DROP the old signatures explicitly before the CREATE to avoid a duplicate overload (`DROP FUNCTION IF EXISTS public.get_expense_summary(uuid); DROP FUNCTION IF EXISTS public.get_financial_overview(uuid);`) — confirm the pre-existing overload set via MCP first.
   </action>
   <acceptance_criteria>
     - Source: `grep -c "date_trunc('year', current_date)" <new_migration_file>` after `grep -v '^--'` shows the only remaining occurrences are inside the two new DEFAULT clauses (not inside a WHERE predicate).
     - Source: both `get_expense_summary` and `get_financial_overview` signatures contain `p_start_date date DEFAULT` and `p_end_date date DEFAULT`.
-    - Source: `get_billing_insights` body references `start_date_param` and `end_date_param` in at least one predicate (no longer purely declared-and-ignored) OR carries an explicit SQL comment on any aggregate that legitimately has no date column.
+    - Source: the migration does NOT recreate `get_billing_insights` (grep the new migration file for `CREATE.*get_billing_insights` → 0) and does NOT reference `rent_payments` (grep → 0).
     - Source: each recreated function retains `SECURITY DEFINER`, `SET search_path TO 'public'`, the `auth.uid()`/`owner_id_param` guard, and a re-issued `GRANT EXECUTE ... TO authenticated`.
   </acceptance_criteria>
 </task>

--- a/.planning/phases/29-billing-financials/29-02-SUMMARY.md
+++ b/.planning/phases/29-billing-financials/29-02-SUMMARY.md
@@ -1,0 +1,13 @@
+# 29-02 Summary — BILL-02 (period-scopable financial RPCs)
+
+**Requirement:** BILL-02 — income-statement/cash-flow/tax-documents ignored the selected period (RPCs hardcoded YTD). Make the RPCs date-scopable (the frontend wiring to pass the range is 29-05).
+
+**Migration `20260708132045_bill02_date_params_expense_summary_and_financial_overview` (applied + verified):**
+- DROP the old `(uuid)` signatures, CREATE `get_expense_summary(uuid, date, date)` + `get_financial_overview(uuid, date, date)` with `p_start_date DEFAULT date_trunc('year', current_date)::date` and `p_end_date DEFAULT NULL`.
+- Replaced the hardcoded `expense_date >= date_trunc('year', current_date)` predicates (2 in get_expense_summary's category CTE + period total; 1 in get_financial_overview) with `>= p_start_date AND (p_end_date IS NULL OR <= p_end_date)`. The NULL-default upper bound keeps an id-only call ONE-SIDED — reproducing today's YTD exactly (backward-compatible for all existing single-arg callers). Left the trailing-12-month rolling `monthly_totals` window unchanged.
+- Verified live: single overload each (no ambiguity), uses the params, no leftover hardcoded year (only in the DEFAULT), grants (authenticated + service_role) preserved.
+- `supabase.ts` Args updated for both RPCs (`p_start_date?`/`p_end_date?`); typecheck 0.
+
+**get_billing_insights NOT touched** — its live body (20260528231201) has no date-scopable aggregate (unpaid/late-fee hardcoded 0 after `rent_payments` was demolished; MRR/churn/tenant-count are point-in-time). Its declared date params remain a documented no-op.
+
+**KNOWN LIMITATION (BILL-02):** REVENUE stays active-lease MRR (point-in-time) — period-historical revenue isn't in the data model. Only the EXPENSE side becomes period-accurate.

--- a/.planning/phases/29-billing-financials/29-03-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-03-PLAN.md
@@ -1,0 +1,139 @@
+---
+phase: 29-billing-financials
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts
+  - supabase/functions/stripe-webhooks/handlers/checkout-session-completed.ts
+  - supabase/functions/stripe-cancel-subscription/index.ts
+  - src/hooks/api/use-billing-mutations.ts
+autonomous: true
+requirements: [BILL-01]
+
+must_haves:
+  truths:
+    - "The webhook handlers write a real timestamp to users.subscription_current_period_end (read from sub.items.data[0].current_period_end, not the undefined top-level field)"
+    - "stripe-cancel-subscription returns the real current_period_end from the subscription item, not undefined"
+    - "Cancel/reactivate no longer throws a RangeError from new Date(undefined * 1000)"
+    - "An absent/NaN current_period_end maps to null in the client cache write instead of new Date(NaN).toISOString() throwing"
+  artifacts:
+    - path: "supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts"
+      provides: "current_period_end read from sub.items.data[0]"
+      contains: "items.data"
+    - path: "src/hooks/api/use-billing-mutations.ts"
+      provides: "NaN/absent guard mapping current_period_end to null"
+      contains: "isFinite"
+  key_links:
+    - from: "stripe-webhooks handlers"
+      to: "users.subscription_current_period_end"
+      via: "sub.items.data[0]?.current_period_end -> new Date(...*1000).toISOString()"
+      pattern: "items\\.data\\[0\\]"
+---
+
+<objective>
+Fix BILL-01: the pinned `stripe@20` API `2026-03-25.dahlia` (basil+) moved `current_period_end` OFF the top-level Subscription onto `subscription.items.data[].current_period_end`. Every top-level `sub.current_period_end` read returns `undefined`, so `users.subscription_current_period_end` is written null and cancel/reactivate crashes with a `RangeError` from `new Date(undefined * 1000)`. Change the 4 edge reads to `sub.items.data[0]?.current_period_end` (mirroring how the same handlers already read `sub.items.data[0]?.price.id`), and add a defensive client guard so an absent/NaN value maps to `null` instead of throwing.
+
+Purpose: Restore the next-billing-date display and stop the cancel/reactivate crash.
+Output: 4 edge reads corrected + a client NaN guard. NOTE: the edge redeploy of `stripe-webhooks` and `stripe-cancel-subscription` is OWNER-RUN (CLI-401 pattern) and is a residual — do NOT block on it; record it in the SUMMARY.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/29-billing-financials/29-CONTEXT.md
+
+<interfaces>
+<!-- CORRECT pattern already in-file: both webhook handlers read the price id via `sub.items.data[0]?.price.id`.
+     Apply the SAME accessor for current_period_end: `sub.items.data[0]?.current_period_end`. -->
+
+<!-- Edge read sites (verify exact lines before editing):
+     stripe-webhooks/handlers/customer-subscription-updated.ts ~L69-70: subscription_current_period_end: sub.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : null
+     stripe-webhooks/handlers/checkout-session-completed.ts ~L62-63: same shape
+     stripe-cancel-subscription/index.ts ~L110 (idempotent-cancel branch) and ~L125 (update branch): current_period_end: subscription.current_period_end / updated.current_period_end (returned in the JSON body) -->
+
+<!-- Client guard site: src/hooks/api/use-billing-mutations.ts ~L75-77, mapCancelResponseToStatus:
+     currentPeriodEnd: new Date(response.current_period_end * 1000).toISOString()
+     response.current_period_end is CancelSubscriptionResponse.current_period_end (unix seconds). Guard: when it is
+     absent or not a finite number, set currentPeriodEnd to null instead of calling new Date(NaN).toISOString(). -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Fix the 4 edge current_period_end reads to sub.items.data[0]</name>
+  <files>supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts, supabase/functions/stripe-webhooks/handlers/checkout-session-completed.ts, supabase/functions/stripe-cancel-subscription/index.ts</files>
+  <read_first>
+    - supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts (the file; note the existing sub.items.data[0]?.price.id read for the correct accessor pattern)
+    - supabase/functions/stripe-webhooks/handlers/checkout-session-completed.ts (the file)
+    - supabase/functions/stripe-cancel-subscription/index.ts (the file; both the idempotent-cancel branch and the post-update branch return current_period_end)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-01 locked decision — 4 reads + the price.id mirror pattern)
+  </read_first>
+  <action>
+    In `customer-subscription-updated.ts`: change the `subscription_current_period_end` line to read from `sub.items.data[0]?.current_period_end` (keep the existing `? new Date(x * 1000).toISOString() : null` ternary so an absent item still maps to null). In `checkout-session-completed.ts`: apply the identical change to its `subscription_current_period_end` line. In `stripe-cancel-subscription/index.ts`: change BOTH returned `current_period_end` values (the idempotent already-canceled branch and the post-`subscriptions.update` branch) to `subscription.items.data[0]?.current_period_end` and `updated.items.data[0]?.current_period_end` respectively. Do NOT change any other field, the trial_ends_at logic, or the response shape. Do NOT touch subscription-keys.ts (it already reads the denormalized column correctly — fixing these handlers populates it).
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -rn "sub.current_period_end\|subscription.current_period_end\|updated.current_period_end" supabase/functions/stripe-webhooks supabase/functions/stripe-cancel-subscription` returns zero top-level (non-`items.data`) reads.
+    - Source: `grep -rc "items.data\[0\]" supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts supabase/functions/stripe-cancel-subscription/index.ts` shows the new accessors are present (in addition to any pre-existing price.id read).
+    - Behavior: the returned JSON from stripe-cancel-subscription carries a numeric `current_period_end` (unix seconds) when the subscription has an item, matching what the price.id accessor already relies on.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add a NaN/absent guard to the client cache write</name>
+  <files>src/hooks/api/use-billing-mutations.ts</files>
+  <read_first>
+    - src/hooks/api/use-billing-mutations.ts (mapCancelResponseToStatus ~L69-79; and the CancelSubscriptionResponse type for current_period_end)
+    - src/hooks/api/use-billing-mutations.test.ts (existing tests to extend / keep green)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-01: use-billing-mutations.ts:75-77 defensive guard)
+  </read_first>
+  <action>
+    In `mapCancelResponseToStatus`, replace the unconditional `currentPeriodEnd: new Date(response.current_period_end * 1000).toISOString()` with a guarded value: when `response.current_period_end` is a finite number (`Number.isFinite`), produce `new Date(response.current_period_end * 1000).toISOString()`; otherwise produce `null`. Keep the rest of the mapped object unchanged. This defends the UI even if an older/edge-not-yet-redeployed function returns undefined. Add or extend a test in `use-billing-mutations.test.ts` asserting that a response with an absent/NaN `current_period_end` yields `currentPeriodEnd: null` (no throw).
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -n "isFinite\|Number.isFinite" src/hooks/api/use-billing-mutations.ts` shows the guard is present in mapCancelResponseToStatus.
+    - Behavior: mapping a CancelSubscriptionResponse with `current_period_end: undefined` (or NaN) returns `currentPeriodEnd: null` and does NOT throw a RangeError.
+    - automated: `bun run test:unit -- src/hooks/api/use-billing-mutations.test.ts` passes; `bun run typecheck && bun run lint` green.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Stripe webhook payload -> edge handler -> users table | untrusted Stripe object shape written to the denormalized billing columns |
+| edge JSON response -> client cache | response.current_period_end may be absent if an edge fn is not yet redeployed |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-29-07 | Tampering | webhook current_period_end read | mitigate | read from the validated Stripe item accessor already used for price.id; keep the `? ... : null` ternary so a missing item maps to null, never NaN |
+| T-29-08 | Denial of service | client cache write on cancel/reactivate | mitigate | Number.isFinite guard maps absent/NaN to null, eliminating the RangeError crash path |
+| T-29-09 | Spoofing | webhook signature | accept | signature verification is already enforced upstream (stripe-webhook-signature); unchanged by this plan |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint && bun run test:unit` green.
+- No top-level `current_period_end` reads remain in the two edge functions.
+- Residual recorded: owner-run redeploy of stripe-webhooks + stripe-cancel-subscription.
+</verification>
+
+<success_criteria>
+The webhook handlers populate `users.subscription_current_period_end` from `sub.items.data[0].current_period_end`; cancel/reactivate returns a real period end and the client cache write no longer throws on an absent value.
+</success_criteria>
+
+<output>
+Create `.planning/phases/29-billing-financials/29-03-SUMMARY.md` when done. Flag the OWNER-RUN edge redeploy of `stripe-webhooks` and `stripe-cancel-subscription` (CLI-401) as a residual — the code fix ships but the behavior only takes effect after redeploy.
+</output>

--- a/.planning/phases/29-billing-financials/29-03-SUMMARY.md
+++ b/.planning/phases/29-billing-financials/29-03-SUMMARY.md
@@ -1,0 +1,28 @@
+# 29-03 Summary — BILL-01 (Stripe current_period_end read location)
+
+**Requirement:** BILL-01 — the pinned `stripe@20` basil API (`2026-03-25.dahlia`) moved `current_period_end` OFF the top-level `Subscription` onto `subscription.items.data[].current_period_end`. Every top-level `sub.current_period_end` read returned `undefined`, so `users.subscription_current_period_end` was written `null` and cancel/reactivate returned an undefined period end (and the client crashed with a `RangeError` from `new Date(undefined * 1000)`).
+
+## What changed
+
+**Task 1 — 4 edge reads corrected (commit `dd3e32ddb`):**
+- `supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts` — payload now reads `const currentPeriodEnd = sub.items.data[0]?.current_period_end` and keeps the existing `? new Date(x * 1000).toISOString() : null` ternary (an absent item still maps to `null`, never `NaN`).
+- `supabase/functions/stripe-webhooks/handlers/checkout-session-completed.ts` — identical change to its `subscription_current_period_end` line.
+- `supabase/functions/stripe-cancel-subscription/index.ts` — BOTH returned `current_period_end` values now read from the item: the idempotent already-canceled branch (`subscription.items.data[0]?.current_period_end`) and the post-`subscriptions.update` branch (`updated.items.data[0]?.current_period_end`).
+- Accessor mirrors the in-file `sub.items.data[0]?.price.id` pattern that already relied on the item shape. No other field, the `trial_ends_at` logic, or the response shape was touched. `subscription-keys.ts` untouched (it reads the denormalized column correctly — fixing these handlers populates it).
+
+**Task 2 — client NaN/absent guard (commit `84d33c6e4`):**
+- `src/hooks/api/use-billing-mutations.ts` `mapCancelResponseToStatus` — replaced the unconditional `new Date(response.current_period_end * 1000).toISOString()` with `Number.isFinite(response.current_period_end) ? ...toISOString() : null`. Used `Number.isFinite` (NOT a truthy check) deliberately: `0` is falsy but a valid epoch is huge, so a truthy check would wrongly reject `0`; non-finite (undefined / NaN) maps to `null` instead of throwing a `RangeError`. Defends the UI even against an edge fn not yet redeployed.
+- Added a regression test in `use-billing-mutations.test.ts` asserting a response with an absent `current_period_end` yields `currentPeriodEnd: null` and does not throw.
+
+## Verification
+- `grep` for top-level `sub./subscription./updated.current_period_end` in the two edge dirs: **zero** remaining.
+- `grep` confirms the four `items.data[0]?.current_period_end` accessors are present.
+- `Number.isFinite` guard present in `mapCancelResponseToStatus`.
+- `bun run test:unit -- src/hooks/api/use-billing-mutations.test.ts`: 6 passed (5 original + 1 new).
+- Full pre-commit suite (lint + typecheck + unit) green on both commits.
+
+## Residuals (OWNER-RUN)
+- **Edge redeploy required (CLI-401 pattern):** the code fix ships but the corrected behavior only takes effect after the owner redeploys `stripe-webhooks` and `stripe-cancel-subscription`. Not attempted here (CLI 401s under this session's PAT).
+
+## Note
+- Edge-function TypeScript is Deno; whether it is covered by the root tsconfig is uncertain. The `sub.items.data[0]?.current_period_end` accessor mirrors the pre-existing `sub.items.data[0]?.price.id` read, so the item shape is already relied upon in these files. Correctness verified by careful review + the grep gates above.

--- a/.planning/phases/29-billing-financials/29-04-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-04-PLAN.md
@@ -1,0 +1,118 @@
+---
+phase: 29-billing-financials
+plan: 04
+type: execute
+wave: 3
+depends_on: ["29-02"]
+files_modified:
+  - supabase/functions/generate-pdf/index.ts
+autonomous: true
+requirements: [BILL-05]
+
+must_haves:
+  truths:
+    - "The year-end/financial PDF is built from get_financial_overview (not get_dashboard_stats), matching its CSV counterpart"
+    - "The 1099 PDF is built from get_billing_insights; maintenance PDF from get_maintenance_analytics; default from get_revenue_trends_optimized"
+    - "The date-aware RPCs are called with the requested year's boundaries so the PDF content matches the report title's year"
+  artifacts:
+    - path: "supabase/functions/generate-pdf/index.ts"
+      provides: "fetchReportRows branches by reportType to the same RPCs export-report uses"
+      contains: "get_financial_overview"
+  key_links:
+    - from: "generate-pdf fetchReportRows"
+      to: "get_financial_overview / get_billing_insights / get_maintenance_analytics / get_revenue_trends_optimized"
+      via: "reportType branch mirroring export-report, passing year boundaries"
+      pattern: "reportType"
+---
+
+<objective>
+Fix BILL-05: `generate-pdf`'s Mode-1 `fetchReportRows` ALWAYS calls `get_dashboard_stats` regardless of `reportType`, then titles the output "YEAR-END REPORT" — so the PDF content never matches its title or its CSV counterpart. Make `fetchReportRows` accept `reportType` and `year` and branch to the SAME RPCs the CSV path (`export-report/index.ts`) uses: year-end/financial -> `get_financial_overview`, 1099 -> `get_billing_insights`, maintenance -> `get_maintenance_analytics`, else -> `get_revenue_trends_optimized`. Pass the requested year's boundaries to the now-date-aware RPCs (from Plan 02) so the numbers are period-correct.
+
+Purpose: The year-end/tax PDF must contain the same financial data as its CSV export.
+Output: `generate-pdf/index.ts` branches by reportType. Depends on Plan 02 because the branch passes year boundaries to the date-aware `get_financial_overview`. NOTE: the edge redeploy of `generate-pdf` is OWNER-RUN (CLI-401) and is a residual — record it, do not block.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/29-billing-financials/29-CONTEXT.md
+
+<interfaces>
+<!-- The CSV counterpart to mirror — export-report/index.ts branch (already correct):
+     year-end | financial -> supabase.rpc("get_financial_overview", { p_user_id: user.id })
+     1099                  -> supabase.rpc("get_billing_insights",   { owner_id_param: user.id })
+     maintenance           -> supabase.rpc("get_maintenance_analytics", { user_id: user.id })
+     else                  -> supabase.rpc("get_revenue_trends_optimized", { p_user_id: user.id, p_months: 12 })
+     export-report also has a flattenToRows(data) helper (object -> [{metric, value}] rows; array -> rows). -->
+
+<!-- generate-pdf/index.ts current shape:
+     - type ReportRow = Record<string, string | number | null | undefined>
+     - fetchReportRows(supabase, userId): ALWAYS get_dashboard_stats then manual Object.entries flatten (~L92-108)
+     - buildReportHtml(reportType, year, rows) already accepts reportType+year (~L46-90)
+     - Mode-1 call site ~L286: const rows = await fetchReportRows(supabase, user.id); html = buildReportHtml(body.reportType, body.year, rows)
+     - PREMIUM_REPORT_TYPES gate already runs before the call (~L272). -->
+
+<!-- After Plan 02: get_financial_overview accepts (p_user_id, p_start_date, p_end_date) with current-year defaults.
+     Year boundaries for reportType year N: p_start_date = `${year}-01-01`, p_end_date = `${year}-12-31`. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Branch fetchReportRows by reportType and pass year boundaries</name>
+  <files>supabase/functions/generate-pdf/index.ts</files>
+  <read_first>
+    - supabase/functions/generate-pdf/index.ts (fetchReportRows ~L92-108, the Mode-1 call site ~L286-287, buildReportHtml signature)
+    - supabase/functions/export-report/index.ts (the reportType branch ~L86-115 to mirror + the flattenToRows helper ~L234)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-05 locked decision + the BILL-02<->BILL-05 coordination note)
+    - .planning/phases/29-billing-financials/29-02-SUMMARY.md (confirm the final get_financial_overview date-param names as applied)
+  </read_first>
+  <action>
+    Change `fetchReportRows` to accept `(supabase, userId, reportType, year)` and branch exactly as export-report does. Port a `flattenToRows`-equivalent (object -> `[{ metric, value }]` rows, array -> rows, coercing values to the `ReportRow` string|number|null shape) so the returned rows render in the existing `buildReportHtml` table. For year-end/financial, call `get_financial_overview` with `{ p_user_id: userId, p_start_date: `${year}-01-01`, p_end_date: `${year}-12-31` }` (using the exact param names Plan 02 shipped). For 1099, call `get_billing_insights` with `{ owner_id_param: userId }` (add its timestamp date params only if Plan 02 wired them and the year scoping is sensible). For maintenance, call `get_maintenance_analytics` with `{ user_id: userId }`. Else call `get_revenue_trends_optimized` with `{ p_user_id: userId, p_months: 12 }`. Keep the existing error-throw on RPC error. Update the Mode-1 call site to `fetchReportRows(supabase, user.id, body.reportType, body.year)`. Do NOT change buildReportHtml, the PREMIUM_REPORT_TYPES gate, the auth path, or Mode-2/Mode-3 (lease preview / raw html). Do NOT remove get_dashboard_stats usage elsewhere if any other mode relies on it — only the Mode-1 report branch changes.
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -n "get_dashboard_stats" supabase/functions/generate-pdf/index.ts` returns nothing inside `fetchReportRows` (the year-end branch no longer uses it).
+    - Source: `fetchReportRows` references `get_financial_overview`, `get_billing_insights`, `get_maintenance_analytics`, and `get_revenue_trends_optimized`, matching the export-report branch set.
+    - Source: the year-end/financial branch passes year-boundary date args (`${year}-01-01` / `${year}-12-31`) to `get_financial_overview`.
+    - Behavior parity: for a given `{ reportType: 'year-end', year }`, generate-pdf's row set is built from the same RPC (get_financial_overview) as export-report's CSV for the same input.
+    - automated: `bun run typecheck` green (edge file type-checks under the project tsconfig/Deno types as configured); if a generate-pdf Deno test exists, it stays green.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client {reportType, year} -> generate-pdf -> RPC | untrusted reportType selects an RPC branch; year becomes a date-range argument |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-29-10 | Tampering | reportType branch selection | mitigate | branch over a fixed known set mirroring export-report; unknown reportType falls to the revenue-trends default; PREMIUM_REPORT_TYPES entitlement gate already runs before fetchReportRows |
+| T-29-11 | Information disclosure | year-boundary args on get_financial_overview | accept | RPC is SECURITY DEFINER with an auth.uid() owner guard; year args only narrow the caller's own rows |
+</threat_model>
+
+<verification>
+- `bun run typecheck` green.
+- fetchReportRows branches by reportType to the export-report RPC set; year-end passes year boundaries.
+- Residual recorded: owner-run redeploy of generate-pdf.
+</verification>
+
+<success_criteria>
+The year-end/tax PDF is generated from `get_financial_overview` (with year boundaries) matching its CSV counterpart and the report title's year; other report types branch to the same RPCs as the CSV path.
+</success_criteria>
+
+<output>
+Create `.planning/phases/29-billing-financials/29-04-SUMMARY.md` when done. Flag the OWNER-RUN edge redeploy of `generate-pdf` (CLI-401) as a residual.
+</output>

--- a/.planning/phases/29-billing-financials/29-04-SUMMARY.md
+++ b/.planning/phases/29-billing-financials/29-04-SUMMARY.md
@@ -1,0 +1,28 @@
+# 29-04 Summary — BILL-05 (PDF/CSV RPC parity)
+
+**Requirement:** BILL-05 — `generate-pdf`'s Mode-1 `fetchReportRows` ALWAYS called `get_dashboard_stats` regardless of `reportType`, then titled the output "YEAR-END REPORT" — so the PDF content never matched its title or its CSV counterpart (`export-report`, which branches correctly).
+
+## What changed (commit `0cad13525`)
+
+`supabase/functions/generate-pdf/index.ts`:
+- `fetchReportRows` now accepts `(supabase, userId, reportType, year)` and branches to the SAME RPCs `export-report/index.ts` uses:
+  - `year-end` | `financial` -> `get_financial_overview({ p_user_id, p_start_date: `${year}-01-01`, p_end_date: `${year}-12-31` })` — passes the requested year's boundaries to the now-date-aware RPC (param names `p_start_date`/`p_end_date` from BILL-02 / migration `20260708132045`, which are `date` typed).
+  - `1099` -> `get_billing_insights({ owner_id_param: userId })` — no date params wired (BILL-02 left `get_billing_insights` untouched; its declared date params are a documented no-op, so passing them would be meaningless).
+  - `maintenance` -> `get_maintenance_analytics({ user_id: userId })`.
+  - else -> `get_revenue_trends_optimized({ p_user_id: userId, p_months: 12 })`.
+- Added `coerceCell` + `flattenToReportRows` — a port of export-report's `flattenToRows` coerced to the local `ReportRow` (`string | number | null | undefined`) cell shape: object-shaped RPC results become `[{ metric, value }]` rows; array results (e.g. revenue trends) become coerced rows. Renders in the existing `buildReportHtml` table unchanged.
+- Mode-1 call site updated to `fetchReportRows(supabase, user.id, body.reportType, body.year)` (body is narrowed to the `{ reportType, year }` variant in that branch).
+- `get_dashboard_stats` fully removed from the file (no other mode used it). `buildReportHtml`, the `PREMIUM_REPORT_TYPES` gate, the auth path, and Mode-2 (raw HTML) / Mode-3 (lease preview) are untouched.
+
+## Verification
+- `grep get_dashboard_stats generate-pdf/index.ts`: **zero** (year-end branch no longer uses it).
+- `fetchReportRows` references all four export-report RPCs (`get_financial_overview`, `get_billing_insights`, `get_maintenance_analytics`, `get_revenue_trends_optimized`).
+- Year-end/financial branch passes `${year}-01-01` / `${year}-12-31` to `get_financial_overview` (confirmed via fixed-string grep, lines 129-130).
+- Behavior parity: for `{ reportType: 'year-end', year }`, generate-pdf's row set is built from `get_financial_overview` — the same RPC as export-report's CSV for the same input.
+- Full pre-commit suite (lint + typecheck + unit) green on the commit.
+
+## Residuals (OWNER-RUN)
+- **Edge redeploy required (CLI-401 pattern):** the corrected report branching only takes effect after the owner redeploys `generate-pdf`. Not attempted here.
+
+## Note
+- The edge function imports `SupabaseClient` without a `Database` generic, so `supabase.rpc(...)` args are loosely typed — the new date-param call type-checks regardless of whether the root tsconfig covers `supabase/functions/`. RPC parity + param names verified against `export-report/index.ts` and the 29-02 summary by review.

--- a/.planning/phases/29-billing-financials/29-05-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-05-PLAN.md
@@ -1,0 +1,170 @@
+---
+phase: 29-billing-financials
+plan: 05
+type: execute
+wave: 3
+depends_on: ["29-02"]
+files_modified:
+  - src/hooks/api/query-keys/financial-keys.ts
+  - src/hooks/api/query-keys/expense-keys.ts
+  - src/hooks/api/query-keys/billing-keys.ts
+autonomous: true
+requirements: [BILL-02, BILL-03, BILL-04]
+
+must_haves:
+  truths:
+    - "Changing the income-statement / cash-flow date range changes the expense totals (they pass start_date/end_date to the date-aware get_expense_summary, no longer fixed YTD)"
+    - "Tax-documents passes the selected year's boundaries to get_expense_summary so expense totals are year-specific"
+    - "An open/unpaid invoice shows its real amount_due, not $0.00"
+    - "A failed get_expense_summary (or get_billing_insights) surfaces an error instead of silently zeroing expenses and overstating net income"
+  artifacts:
+    - path: "src/hooks/api/query-keys/financial-keys.ts"
+      provides: "fetchDashAndExpense forwards a date range to get_expense_summary; expenseResult.error/billingResult.error surfaced"
+      contains: "expenseResult.error"
+    - path: "src/hooks/api/query-keys/billing-keys.ts"
+      provides: "unpaid invoices use amount_due"
+      contains: "amount_due"
+  key_links:
+    - from: "financial-keys.ts incomeStatement/cashFlow"
+      to: "get_expense_summary"
+      via: "pass params.start_date / params.end_date to the date-aware RPC"
+      pattern: "get_expense_summary"
+    - from: "financial-keys.ts consumers"
+      to: "handlePostgrestError"
+      via: "check expenseResult.error (and billingResult.error) after fetchDashAndExpense"
+      pattern: "expenseResult.error"
+---
+
+<objective>
+Fix three frontend billing/financial bugs in the query-key factories, coordinated because BILL-02 and BILL-04 edit the same `financial-keys.ts` queryFns:
+- BILL-02: `incomeStatement` (financial-keys.ts:243), `cashFlow` (:327), and `taxDocuments` (expense-keys.ts:47) call `get_expense_summary` with only `p_user_id` and use their selected `start_date`/`end_date`/`year` ONLY for the display label. Pass the selected range to the now-date-aware `get_expense_summary` (Plan 02) so expense totals are period-specific.
+- BILL-04: every combined-fetch consumer checks only `dashResult.error` and reads `expenseResult.data?.total_amount ?? 0` unchecked, so an expense-RPC failure silently zeroes expenses and overstates net income. Surface `expenseResult.error` (and `billingResult.error` in balanceSheet) via `handlePostgrestError`.
+- BILL-03: `billing-keys.ts:35` uses `Number(row.amount_paid ?? row.amount_due ?? 0)`, so for an unpaid invoice `amount_paid = 0` wins over the real `amount_due`.
+
+Purpose: Period-accurate expense reporting, honest error surfacing, and real invoice amounts.
+Output: financial-keys.ts + expense-keys.ts pass date ranges and surface expense/billing errors; billing-keys.ts shows amount_due for unpaid invoices. Depends on Plan 02 because passing date params requires the RPC signatures + regenerated `src/types/supabase.ts`.
+
+KNOWN LIMITATION (add a code comment + note in SUMMARY, do NOT over-fix): revenue in these views comes from `get_dashboard_stats` (active-lease MRR, point-in-time), so only the EXPENSE side becomes period-accurate; revenue stays annualized MRR. No payment ledger is built here (deferred in 29-CONTEXT.md).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/29-billing-financials/29-CONTEXT.md
+
+<interfaces>
+<!-- financial-keys.ts current shape:
+     fetchDashAndExpense(userId) -> Promise.all([ rpc("get_dashboard_stats", {p_user_id}), rpc("get_expense_summary", {p_user_id}) ])
+     Consumers of fetchDashAndExpense: overview() (YTD, no range), incomeStatement(params), cashFlow(params), balanceSheet(asOfDate) (+ get_billing_insights).
+     Each currently: `if (dashResult.error) handlePostgrestError(dashResult.error, "<ctx>")` then reads expenseResult.data.total_amount ?? 0 UNCHECKED.
+     NOTE: financial-keys.ts uses get_dashboard_stats (not get_financial_overview) for revenue — the date param lands on get_expense_summary only. -->
+
+<!-- expense-keys.ts taxDocuments(year): Promise.all([ rpc("get_dashboard_stats",{p_user_id}), rpc("get_expense_summary",{p_user_id}) ]),
+     currently only checks dashResult.error; builds `${year}-01-01`/`${year}-12-31` labels. -->
+
+<!-- After Plan 02, get_expense_summary signature is (p_user_id uuid, p_start_date date DEFAULT current-year-start, p_end_date date DEFAULT current_date).
+     Confirm the exact param names in .planning/phases/29-billing-financials/29-02-SUMMARY.md before wiring. -->
+
+<!-- billing-keys.ts:35 current: const amount = Number(row.amount_paid ?? row.amount_due ?? 0)
+     get_user_invoices returns row.amount_paid AND row.amount_due AND row.status. -->
+
+<!-- handlePostgrestError(error, context) from #lib/postgrest-error-handler throws a typed error. -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: BILL-02 — pass selected date range to get_expense_summary in incomeStatement, cashFlow, taxDocuments</name>
+  <files>src/hooks/api/query-keys/financial-keys.ts, src/hooks/api/query-keys/expense-keys.ts</files>
+  <read_first>
+    - src/hooks/api/query-keys/financial-keys.ts (fetchDashAndExpense ~L56-64, incomeStatement ~L208-287, cashFlow ~L289-372)
+    - src/hooks/api/query-keys/expense-keys.ts (taxDocuments ~L9-108)
+    - .planning/phases/29-billing-financials/29-02-SUMMARY.md (exact get_expense_summary date-param names as shipped)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-02 locked decision + the revenue-MRR known limitation to document)
+  </read_first>
+  <action>
+    In `financial-keys.ts`: give `fetchDashAndExpense` an optional second argument `range?: { start_date: string; end_date: string }` and, when present, pass `{ p_user_id: userId, p_start_date: range.start_date, p_end_date: range.end_date }` to the `get_expense_summary` rpc call (leave the `get_dashboard_stats` call unchanged — its revenue is MRR). In `incomeStatement`, call `fetchDashAndExpense(user.id, { start_date: params.start_date, end_date: params.end_date })`. In `cashFlow`, do the same with its `params`. Leave `overview()` calling `fetchDashAndExpense(user.id)` with no range (YTD default is correct for the overview card). In `expense-keys.ts` `taxDocuments`, pass `{ p_user_id: userId, p_start_date: `${year}-01-01`, p_end_date: `${year}-12-31` }` to its `get_expense_summary` call. Add a one-line comment at each ranged call noting that only the expense side is period-scoped; revenue remains annualized MRR (data model has no payment history).
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -n "p_start_date\|p_end_date" src/hooks/api/query-keys/financial-keys.ts src/hooks/api/query-keys/expense-keys.ts` shows the range is forwarded in incomeStatement, cashFlow, and taxDocuments (and NOT forced in overview).
+    - Behavior: `financialQueries.incomeStatement({start_date, end_date})` for two different ranges issues get_expense_summary with the corresponding `p_start_date`/`p_end_date` (verifiable by mocking the supabase.rpc call in a unit test and asserting the args).
+    - automated: `bun run typecheck` passes (the new params are present in the regenerated types); `bun run lint` green.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 2: BILL-04 — surface expenseResult.error (and billingResult.error) in the 5 combined-fetch consumers</name>
+  <files>src/hooks/api/query-keys/financial-keys.ts, src/hooks/api/query-keys/expense-keys.ts</files>
+  <read_first>
+    - src/hooks/api/query-keys/financial-keys.ts (overview ~L110, incomeStatement ~L246, cashFlow ~L330, balanceSheet ~L429 + billingResult ~L437)
+    - src/hooks/api/query-keys/expense-keys.ts (taxDocuments ~L52)
+    - src/lib/postgrest-error-handler (handlePostgrestError signature)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-04 locked decision — check expenseResult.error like dashResult.error)
+  </read_first>
+  <action>
+    In each of `overview`, `incomeStatement`, `cashFlow`, and `balanceSheet` (financial-keys.ts) and `taxDocuments` (expense-keys.ts): immediately after the existing `if (dashResult.error) handlePostgrestError(dashResult.error, "<ctx>")`, add `if (expenseResult.error) handlePostgrestError(expenseResult.error, "<ctx> expenses")` so an expense-RPC failure throws instead of falling through to `?? 0`. In `balanceSheet`, ALSO add `if (billingResult.error) handlePostgrestError(billingResult.error, "balance sheet billing")`. Keep the existing `?? 0` fallbacks (they now only apply to genuinely-empty data, not to errors). Do not change the empty-user early-return branches.
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -c "expenseResult.error" src/hooks/api/query-keys/financial-keys.ts` returns at least 4 (overview, incomeStatement, cashFlow, balanceSheet); `grep -c "billingResult.error" src/hooks/api/query-keys/financial-keys.ts` returns at least 1 (balanceSheet); `grep -c "expenseResult.error\|expenseResult\?.error" src/hooks/api/query-keys/expense-keys.ts`... note expense-keys destructures dashResult/expenseResult separately — assert its taxDocuments checks the expense result error.
+    - Behavior: with `get_expense_summary` mocked to return `{ data: null, error: <err> }`, `financialQueries.incomeStatement(...)` / `financialTaxQueries.taxDocuments(...)` REJECT (surface the error) rather than resolving with `totalExpenses: 0`.
+    - automated: `bun run test:unit -- src/hooks/api/__tests__/use-financial-overview.test.ts` passes (extend it with an expense-error case if not already covered); `bun run typecheck && bun run lint` green.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 3: BILL-03 — unpaid invoices show amount_due, not $0.00</name>
+  <files>src/hooks/api/query-keys/billing-keys.ts</files>
+  <read_first>
+    - src/hooks/api/query-keys/billing-keys.ts (L34-51, the amount + status mapping)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-03 locked decision)
+  </read_first>
+  <action>
+    At billing-keys.ts:35, replace `const amount = Number(row.amount_paid ?? row.amount_due ?? 0)` with logic that uses `amount_due` when the invoice is not paid: `const amount = row.status === "paid" ? Number(row.amount_paid) : Number(row.amount_due ?? row.amount_paid ?? 0)`. Keep the downstream `formattedAmount`, `status`, and `isSuccessful` mapping unchanged (they already key off `row.status`). Confirm `get_user_invoices` returns `amount_due` (it does, per 29-CONTEXT). Do not change any other factory.
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -n "amount_due" src/hooks/api/query-keys/billing-keys.ts` shows amount_due participates in the unpaid branch.
+    - Behavior: mapping a row `{ status: 'open', amount_paid: 0, amount_due: 4200 }` yields `amount === 4200` (formattedAmount `$4200.00`, not `$0.00`); a `{ status: 'paid', amount_paid: 4200, amount_due: 4200 }` row still yields `4200`.
+    - automated: `bun run test:unit` for any billing-history test passes; `bun run typecheck && bun run lint` green.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| RPC result -> financial view | an errored RPC must not be silently treated as zero data |
+| client date range -> get_expense_summary | untrusted range narrows the caller's own owner-scoped rows |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-29-12 | Repudiation | silent expense zeroing on RPC failure | mitigate | BILL-04 surfaces expenseResult.error/billingResult.error via handlePostgrestError so failures are visible, not masked as $0 |
+| T-29-13 | Information disclosure | date-range args on get_expense_summary | accept | RPC enforces auth.uid() owner guard; range only narrows the caller's own rows |
+| T-29-14 | Tampering | invoice amount mapping | mitigate | amount derived from RPC-returned amount_due/amount_paid keyed off the invoice's own status; no client-supplied amount |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint && bun run test:unit` green.
+- incomeStatement/cashFlow/taxDocuments forward the selected range; overview stays YTD.
+- All 5 combined-fetch consumers surface expense (and balanceSheet billing) errors.
+- Unpaid invoice maps to amount_due.
+</verification>
+
+<success_criteria>
+Changing the income-statement/cash-flow/tax range changes the expense totals; expense/billing RPC failures surface an error; open/unpaid invoices show their real amount_due.
+</success_criteria>
+
+<output>
+Create `.planning/phases/29-billing-financials/29-05-SUMMARY.md` when done. Record the revenue-MRR known limitation (expense side period-accurate, revenue annualized).
+</output>

--- a/.planning/phases/29-billing-financials/29-05-SUMMARY.md
+++ b/.planning/phases/29-billing-financials/29-05-SUMMARY.md
@@ -1,0 +1,27 @@
+# 29-05 Summary — BILL-02 / BILL-03 / BILL-04 (financial query-key fixes)
+
+**Requirements:** BILL-02 (period-scope expense totals), BILL-03 (unpaid invoice amount), BILL-04 (surface expense/billing RPC errors).
+
+## What changed
+
+**BILL-02 — forward the selected date range to the date-aware `get_expense_summary`**
+- `financial-keys.ts`: `fetchDashAndExpense(userId, range?)` gained an optional `{ start_date, end_date }` arg. When present it passes `p_start_date`/`p_end_date` to `get_expense_summary` (the `get_dashboard_stats` call is left unchanged — its revenue is MRR). `incomeStatement` and `cashFlow` now call it with `{ start_date: params.start_date, end_date: params.end_date }`. `overview()` intentionally stays year-to-date (no range).
+- `expense-keys.ts` `taxDocuments(year)`: passes `p_start_date: ${year}-01-01` / `p_end_date: ${year}-12-31`.
+- The migration `20260708132045` (Plan 02) made both RPCs date-scopable with backward-compatible defaults; the generated `supabase.ts` Args already include `p_start_date?`/`p_end_date?`, so this typechecks with 0 errors.
+
+**BILL-04 — surface `expenseResult.error` (and `billingResult.error`)**
+- All five combined-fetch consumers (`overview`, `incomeStatement`, `cashFlow`, `balanceSheet` in `financial-keys.ts`; `taxDocuments` in `expense-keys.ts`) now call `handlePostgrestError(expenseResult.error, "<ctx> expenses")` immediately after the existing `dashResult.error` check. `balanceSheet` also checks `billingResult.error`. A failed expense/billing RPC now throws instead of falling through to `?? 0` and silently showing $0 expenses / overstated net income.
+
+**BILL-03 — unpaid invoices show `amount_due`, not $0.00**
+- `billing-keys.ts:35`: `const amount = row.status === "paid" ? Number(row.amount_paid) : Number(row.amount_due ?? row.amount_paid ?? 0)`. An open invoice with `amount_paid = 0` now renders its real `amount_due`.
+
+## Tests
+- `use-financials.test.tsx`: `useIncomeStatement` now asserts `get_expense_summary` is called with the forwarded `p_start_date`/`p_end_date` (BILL-02 arg-forwarding proof). `useBalanceSheet` still asserts the id-only call (balance sheet stays YTD).
+- `use-financial-overview.test.ts`: added a BILL-04 case — dashboard succeeds, expense RPC errors, hook rejects (`data` undefined) instead of resolving with `total_expenses: 0`.
+
+## KNOWN LIMITATION (revenue is annualized MRR)
+Revenue in these views comes from `get_dashboard_stats` (active-lease MRR, point-in-time), so **only the expense side is period-accurate**. Changing the income-statement/cash-flow/tax range re-scopes expenses; revenue stays annualized MRR because the data model has no payment history (a payment ledger is deferred per 29-CONTEXT.md). `get_billing_insights` is likewise unchanged — its date params are a documented no-op (per 29-02-SUMMARY.md). A code comment marks each ranged call site.
+
+## Commits
+- `05eedc7ef` — fix(29-05): period-scope expense totals + surface expense/billing rpc errors (BILL-02, BILL-04)
+- `8a0f95dc5` — fix(29-05): show amount_due for unpaid invoices (BILL-03)

--- a/.planning/phases/29-billing-financials/29-06-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-06-PLAN.md
@@ -1,0 +1,150 @@
+---
+phase: 29-billing-financials
+plan: 06
+type: execute
+wave: 2
+depends_on: ["29-01"]
+files_modified:
+  - src/app/(owner)/financials/expenses/_components/expense-table.tsx
+  - src/app/(owner)/financials/expenses/_components/expense-category-breakdown.tsx
+  - src/app/(owner)/financials/tax-documents/page.tsx
+  - src/app/(owner)/financials/financials-quick-links.tsx
+  - src/app/(owner)/financials/financials-highlights.tsx
+autonomous: true
+requirements: [BILL-06]
+
+must_haves:
+  truths:
+    - "A $150.50 expense shows $150.50 on /financials/expenses (was $1.50 — the cents-reader bug)"
+    - "The expense-category breakdown, tax-documents totals/categories/depreciation, and quick-links KPIs read expenses.amount as dollars, not cents"
+    - "Financial Highlights render revenues as currency and the occupancy rate as a percentage (not currency-formatted)"
+    - "The correct-as-dollars formatCents(x*100) readers in income-statement/cash-flow/balance-sheet are left unchanged"
+  artifacts:
+    - path: "src/app/(owner)/financials/expenses/_components/expense-table.tsx"
+      provides: "expense amount rendered as dollars"
+      contains: "formatCurrency"
+    - path: "src/app/(owner)/financials/financials-highlights.tsx"
+      provides: "currency for money, percentage for occupancy"
+      contains: "formatCurrency"
+  key_links:
+    - from: "financials display components"
+      to: "expenses.amount (numeric dollars)"
+      via: "formatCurrency instead of formatCents"
+      pattern: "formatCurrency"
+---
+
+<objective>
+Fix BILL-06's frontend half: several `/financials/*` display components read `expenses.amount` (dollars) through `formatCents`, which divides by 100 — so a $150 expense renders "$1.50". Switch the WRONG cents-readers to `formatCurrency` (dollars-in). Also fix the Financial Highlights component, which currency-formats by a fragile `value > 1000` magnitude heuristic and mis-handles the occupancy-rate percentage. LEAVE the `formatCents(x * 100)` readers in income-statement/cash-flow/balance-sheet untouched — those are correct-as-dollars (formatCents(x*100) == formatCurrency(x)).
+
+Purpose: A $150.50 expense must show $150.50 everywhere, matching the maintenance-detail view.
+Output: 4 display components switched to formatCurrency + the highlights component fixed. Depends on Plan 01 so the numeric column can actually store $150.50 for the acceptance proof.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/29-billing-financials/29-CONTEXT.md
+
+<interfaces>
+<!-- src/lib/utils/currency.ts:
+     formatCurrency(amount, opts?)  // DOLLARS in  -> "$150.50"
+     formatCents(cents, opts?)      // CENTS in    -> formatCurrency(cents / 100)  (divides by 100)
+     formatPercentage(value, opts?) // value 0..100 -> "85%"  (divides by 100 internally) -->
+
+<!-- WRONG cents-readers to fix (bare formatCents on a DOLLAR value) — verified line numbers:
+     expense-table.tsx:155                 formatCents(expense.amount ?? 0)
+     expense-category-breakdown.tsx:31     formatCents(cat.amount)
+     tax-documents/page.tsx:170,186,202,242,275,280,284   formatCents(...)  (7 sites: totalIncome, totalDeductions, netTaxableIncome, cat.amount, prop.propertyValue, prop.annualDepreciation, prop.accumulatedDepreciation)
+     financials-quick-links.tsx:82,90,104  formatCents(netIncome / totalRevenue-totalExpenses / totalExpenses)
+     financials-highlights.tsx:30          formatCents(highlight.value)  (money branch) + occupancy-% mishandling
+     None of these 5 files contain a formatCents(x*100) call, so the import can be swapped wholesale. -->
+
+<!-- LEAVE UNCHANGED (correct-as-dollars, formatCents(x*100)):
+     income-statement/income-statement-page-breakdowns.tsx, income-statement-page-net-summary.tsx,
+     cash-flow/cash-flow-breakdown.tsx, cash-flow-balance-summary.tsx, cash-flow-activity.tsx,
+     balance-sheet/equity-section.tsx, balance-section.tsx, balance-equation-check.tsx -->
+
+<!-- financials-highlights.tsx receives Highlight[] {label, value, trend}. The overview() source (financial-keys.ts)
+     produces: "Monthly Revenue" (dollars), "Annual Revenue" (dollars), "Occupancy Rate" (0..100 percent). -->
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Switch the 4 WRONG cents-reader components to formatCurrency</name>
+  <files>src/app/(owner)/financials/expenses/_components/expense-table.tsx, src/app/(owner)/financials/expenses/_components/expense-category-breakdown.tsx, src/app/(owner)/financials/tax-documents/page.tsx, src/app/(owner)/financials/financials-quick-links.tsx</files>
+  <read_first>
+    - src/app/(owner)/financials/expenses/_components/expense-table.tsx (L30 import, L155 reader)
+    - src/app/(owner)/financials/expenses/_components/expense-category-breakdown.tsx (L2 import, L31 reader)
+    - src/app/(owner)/financials/tax-documents/page.tsx (L27 import, readers L170,186,202,242,275,280,284)
+    - src/app/(owner)/financials/financials-quick-links.tsx (L13 import, readers L82,90,104)
+    - src/lib/utils/currency.ts (formatCurrency vs formatCents)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-06 item 3 — the exact reader list)
+  </read_first>
+  <action>
+    In each of the four files, change the import `import { formatCents } from "#lib/utils/currency"` to `import { formatCurrency } from "#lib/utils/currency"` and replace every bare `formatCents(X)` call with `formatCurrency(X)` (same argument, no `/100` or `*100`). Sites: expense-table.tsx:155; expense-category-breakdown.tsx:31; tax-documents/page.tsx at 170, 186, 202, 242, 275, 280, 284; financials-quick-links.tsx at 82, 90, 104. These values are all dollar amounts (expense amounts, revenue/expense/net totals, category amounts, property basis/depreciation). Do NOT touch any file under income-statement/, cash-flow/, or balance-sheet/ (those use the correct formatCents(x*100) idiom). Do NOT change any non-currency rendering (percentages, dates).
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -rn "formatCents" src/app/(owner)/financials/expenses/_components/expense-table.tsx src/app/(owner)/financials/expenses/_components/expense-category-breakdown.tsx src/app/(owner)/financials/tax-documents/page.tsx src/app/(owner)/financials/financials-quick-links.tsx` returns NOTHING (import + all call sites migrated).
+    - Source: the eight `formatCents(x*100)` files under income-statement/, cash-flow/, balance-sheet/ are UNCHANGED — `git diff --name-only` does not list them.
+    - Behavior: with a $150.50 expense in scope, expense-table renders "$150.50" (not "$1.50"); the category breakdown, tax totals, and quick-links KPIs render dollar values at face value.
+    - automated: `bun run typecheck && bun run lint` green; any existing tax-documents/expense-table test passes.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 2: Fix Financial Highlights — currency for money, percentage for occupancy</name>
+  <files>src/app/(owner)/financials/financials-highlights.tsx</files>
+  <read_first>
+    - src/app/(owner)/financials/financials-highlights.tsx (whole file; L29-31 the value render)
+    - src/hooks/api/query-keys/financial-keys.ts (overview highlights source: "Monthly Revenue", "Annual Revenue", "Occupancy Rate")
+    - src/lib/utils/currency.ts (formatCurrency, formatPercentage)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-06: highlights formatCents->formatCurrency + stop currency-formatting the occupancy-% highlight)
+  </read_first>
+  <action>
+    Replace the `formatCents` import with `formatCurrency` (and `formatPercentage`) from `#lib/utils/currency`. Remove the fragile `highlight.value > 1000` magnitude heuristic. Render each highlight by KIND, not magnitude: when the label denotes a percentage (match `/rate|occupancy|%/i` on `highlight.label`), render `formatPercentage(highlight.value)` (which yields e.g. "85%"); otherwise render `formatCurrency(highlight.value)`. Keep the trend rendering and layout unchanged. This fixes both the 100x-too-small revenue display and the occupancy value being shown as a bare/currency number.
+  </action>
+  <acceptance_criteria>
+    - Source: `grep -n "formatCents\|> 1000" src/app/(owner)/financials/financials-highlights.tsx` returns nothing.
+    - Behavior: a highlight `{label: "Annual Revenue", value: 48000}` renders "$48,000.00"; a highlight `{label: "Occupancy Rate", value: 85}` renders "85%" (not "$85.00" and not "$0.85").
+    - automated: `bun run typecheck && bun run lint` green.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| RPC dollar value -> display formatter | using the cents formatter on a dollar value silently misrepresents money by 100x |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-29-15 | Tampering | expense/tax/quick-link money display | mitigate | switch dollar-valued readers to formatCurrency; assert via grep that no bare formatCents remains and the x*100 readers are untouched |
+| T-29-16 | Information disclosure | none new | accept | pure client-side formatting change; no new data boundary |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint` green.
+- No bare formatCents remains in the 5 changed files; the 8 formatCents(x*100) files are untouched.
+- $150.50 renders as $150.50 on /financials/expenses.
+</verification>
+
+<success_criteria>
+Every WRONG cents-reader now uses formatCurrency; Financial Highlights render money as currency and occupancy as a percentage; the correct-as-dollars formatCents(x*100) readers are left in place.
+</success_criteria>
+
+<output>
+Create `.planning/phases/29-billing-financials/29-06-SUMMARY.md` when done. Note that the optional normalization of the formatCents(x*100) readers to formatCurrency(x) was left as deferred discretion (correct as-is).
+</output>

--- a/.planning/phases/29-billing-financials/29-06-SUMMARY.md
+++ b/.planning/phases/29-billing-financials/29-06-SUMMARY.md
@@ -1,0 +1,30 @@
+# 29-06 Summary — BILL-06 (financials display units fix)
+
+**Requirement:** BILL-06 — several `/financials/*` screens read `expenses.amount` (now `numeric(10,2)` dollars) through `formatCents`, which divides by 100, so a $150.50 expense rendered "$1.50".
+
+## What changed
+
+**Task 1 — switch the 4 WRONG cents-readers to `formatCurrency` (dollars-in)**
+- `expenses/_components/expense-table.tsx` — expense amount (1 site).
+- `expenses/_components/expense-category-breakdown.tsx` — category amount (1 site).
+- `tax-documents/page.tsx` — totalIncome, totalDeductions, netTaxableIncome, category amount, property basis, annual depreciation, accumulated depreciation (7 sites).
+- `financials-quick-links.tsx` — income-statement net income, cash-flow (revenue − expenses), expenses total KPIs (3 sites).
+- None of these files used the correct-as-dollars `formatCents(x*100)` idiom, so the `formatCents` import swapped to `formatCurrency` wholesale in each.
+
+**Task 2 — Financial Highlights render by KIND, not magnitude**
+- `financials-highlights.tsx`: replaced the `formatCents` import with `formatCurrency` + `formatPercentage`, and removed the fragile `highlight.value > 1000` magnitude heuristic. Labels matching `/rate|occupancy|%/i` now render via `formatPercentage` (e.g. `85` → "85%"); every other highlight renders via `formatCurrency` (e.g. `48000` → "$48,000.00"). This fixes both the 100x-too-small revenue display and the occupancy value falling through to a bare number.
+
+## Left unchanged (correct-as-dollars, `formatCents(x*100)`)
+The eight readers under `income-statement/`, `cash-flow/`, and `balance-sheet/` use `formatCents(x * 100)`, which equals `formatCurrency(x)` — already correct. Per plan, they were NOT touched (`git diff --name-only` does not list them).
+
+## Deferred discretion
+The optional normalization of the `formatCents(x * 100)` readers to plain `formatCurrency(x)` was left as-is — they are numerically correct and out of scope for this fix.
+
+## Verification
+- No bare `formatCents` remains in the 5 changed files; no `* 100` or `> 1000` in any of them (grep-confirmed).
+- The 8 `formatCents(x*100)` files are untouched.
+- `bun run typecheck` + `bun run lint` green. No component render tests reference these 5 files.
+
+## Commits
+- `476ddd539` — fix(29-06): render expense/tax/quick-link amounts as dollars (BILL-06)
+- `127078f13` — fix(29-06): render highlights money as currency and occupancy as percentage (BILL-06)

--- a/.planning/phases/29-billing-financials/29-07-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-07-PLAN.md
@@ -91,7 +91,7 @@ Output: `29-07-SUMMARY.md` with the gate result, per-requirement proof, and the 
     (1) OWNER-RUN edge redeploys (CLI-401): `stripe-webhooks`, `stripe-cancel-subscription` (BILL-01), and `generate-pdf` (BILL-05) — the code fixes ship but the behavior only takes effect after the owner redeploys these three functions. Include the deploy command hint (`bun scripts/deploy-edge-functions.ts` per the Supabase CLI 401 pattern).
     (2) DB migrations applied: the two prod-assigned timestamps (from 29-01/29-02 SUMMARYs) with their rolled-back live proofs.
     (3) Revenue-MRR known limitation: income-statement/cash-flow/tax now scope EXPENSES to the selected period, but revenue stays annualized MRR (no payment ledger) — matches the 29-CONTEXT deferred decision.
-    (4) DATA-02 satisfied here: `get_property_performance_analytics` was recreated in Plan 01 with the `p.status <> 'inactive'` property predicate, so Phase 30 must NOT recreate it again (doing so risks clobbering the BILL-06 numeric cast).
+    (4) DATA-02 PARTIALLY satisfied here: only `get_property_performance_analytics` was recreated in Plan 01 with the `p.status <> 'inactive'` predicate (+ BILL-06 numeric cast). DATA-02 ALSO requires the predicate on `get_property_performance_with_trends` (and `_trends` if present), which Phase 29 does NOT touch — Phase 30 must STILL add `p.status <> 'inactive'` to those, but must NOT re-recreate `get_property_performance_analytics` (doing so risks clobbering the BILL-06 numeric cast). Record this precise split so Phase 30 doesn't over- or under-fix.
     Do not modify ROADMAP.md here (ship/complete owns roadmap check-offs) — just record the note for Phase 30 planning.
   </action>
   <acceptance_criteria>

--- a/.planning/phases/29-billing-financials/29-07-PLAN.md
+++ b/.planning/phases/29-billing-financials/29-07-PLAN.md
@@ -1,0 +1,132 @@
+---
+phase: 29-billing-financials
+plan: 07
+type: execute
+wave: 4
+depends_on: ["29-01", "29-02", "29-03", "29-04", "29-05", "29-06"]
+files_modified:
+  - .planning/phases/29-billing-financials/29-07-SUMMARY.md
+autonomous: true
+requirements: [BILL-01, BILL-02, BILL-03, BILL-04, BILL-05, BILL-06]
+
+must_haves:
+  truths:
+    - "typecheck, lint, and unit tests are green across the whole phase's changes"
+    - "each BILL fix is grep-verifiable in source (period-end accessor, date params, amount_due, error surfacing, PDF branching, formatCurrency readers)"
+    - "the two migrations are applied to prod with rolled-back proofs recorded, and db:types reflects the new signatures"
+    - "the three owner-run edge redeploys and the revenue-MRR known limitation and the DATA-02-satisfied note are documented as residuals"
+  artifacts:
+    - path: ".planning/phases/29-billing-financials/29-07-SUMMARY.md"
+      provides: "phase-level verification result + residual/limitation ledger"
+      contains: "residual"
+  key_links:
+    - from: "phase verification"
+      to: "all six BILL requirements"
+      via: "automated gate + per-requirement grep assertions"
+      pattern: "BILL-0"
+---
+
+<objective>
+Close Phase 29 with a phase-level verification pass and a residual/limitation ledger. Run the automated quality gate over the combined changes, grep-verify every BILL fix landed, confirm the two migrations were applied with rolled-back proofs, and record the non-gating residuals: the three OWNER-RUN edge redeploys (stripe-webhooks, stripe-cancel-subscription, generate-pdf — CLI-401), the revenue-MRR known limitation, and the DATA-02-satisfied-here note for Phase 30.
+
+Purpose: One consolidated, honest verification so the phase can enter the perfect-PR review gate.
+Output: `29-07-SUMMARY.md` with the gate result, per-requirement proof, and the residual ledger. Runs last (depends on all six prior plans).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/29-billing-financials/29-CONTEXT.md
+@.planning/phases/29-billing-financials/29-01-SUMMARY.md
+@.planning/phases/29-billing-financials/29-02-SUMMARY.md
+@.planning/phases/29-billing-financials/29-03-SUMMARY.md
+@.planning/phases/29-billing-financials/29-04-SUMMARY.md
+@.planning/phases/29-billing-financials/29-05-SUMMARY.md
+@.planning/phases/29-billing-financials/29-06-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Run the full quality gate and per-requirement source assertions</name>
+  <files>(no source changes — verification only)</files>
+  <read_first>
+    - All six 29-0N-SUMMARY.md files (to know exactly what shipped)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (the six locked decisions to verify against)
+  </read_first>
+  <action>
+    Run `bun run typecheck && bun run lint && bun run test:unit` and confirm all green. Then run the per-requirement grep assertions and record each result in the SUMMARY:
+    - BILL-01: `grep -rn "sub.current_period_end\|subscription.current_period_end\|updated.current_period_end" supabase/functions/stripe-webhooks supabase/functions/stripe-cancel-subscription` returns no top-level reads; `grep -n "isFinite" src/hooks/api/use-billing-mutations.ts` present.
+    - BILL-02: `grep -n "p_start_date\|p_end_date" src/hooks/api/query-keys/financial-keys.ts src/hooks/api/query-keys/expense-keys.ts` present in incomeStatement/cashFlow/taxDocuments; the migration recreated get_expense_summary + get_financial_overview with defaulted date params (per 29-02-SUMMARY).
+    - BILL-03: `grep -n "amount_due" src/hooks/api/query-keys/billing-keys.ts` shows the unpaid branch.
+    - BILL-04: `grep -c "expenseResult.error" src/hooks/api/query-keys/financial-keys.ts` >= 4 and `grep -c "billingResult.error" ...` >= 1; expense-keys taxDocuments surfaces the expense error.
+    - BILL-05: `grep -n "get_dashboard_stats" supabase/functions/generate-pdf/index.ts` absent from fetchReportRows; the four export-report RPCs are referenced.
+    - BILL-06: `grep -rn "formatCents" src/app/(owner)/financials/expenses/_components/expense-table.tsx src/app/(owner)/financials/expenses/_components/expense-category-breakdown.tsx src/app/(owner)/financials/tax-documents/page.tsx src/app/(owner)/financials/financials-quick-links.tsx src/app/(owner)/financials/financials-highlights.tsx` returns nothing; the 8 formatCents(x*100) files are unchanged; expenses.amount is numeric(10,2) and get_property_performance_analytics returns numeric (per 29-01-SUMMARY).
+    If any assertion fails, record the gap explicitly and stop for a gap-closure pass rather than reporting a false pass.
+  </action>
+  <acceptance_criteria>
+    - `bun run typecheck && bun run lint && bun run test:unit` all green (recorded verbatim in the SUMMARY).
+    - Every one of the six per-requirement grep assertions above passes and is recorded with its command + result.
+    - No assertion is reported as passing without its actual command output captured.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 2: Write the residual + limitation ledger</name>
+  <files>.planning/phases/29-billing-financials/29-07-SUMMARY.md</files>
+  <read_first>
+    - 29-01-SUMMARY.md and 29-02-SUMMARY.md (applied prod migration timestamps + rolled-back proofs)
+    - 29-03-SUMMARY.md and 29-04-SUMMARY.md (owner-run edge redeploy residuals)
+    - 29-05-SUMMARY.md (revenue-MRR limitation note)
+    - .planning/phases/29-billing-financials/29-CONTEXT.md (BILL-06 <-> DATA-02 coordination note)
+  </read_first>
+  <action>
+    In the SUMMARY, record a residual/limitation ledger:
+    (1) OWNER-RUN edge redeploys (CLI-401): `stripe-webhooks`, `stripe-cancel-subscription` (BILL-01), and `generate-pdf` (BILL-05) — the code fixes ship but the behavior only takes effect after the owner redeploys these three functions. Include the deploy command hint (`bun scripts/deploy-edge-functions.ts` per the Supabase CLI 401 pattern).
+    (2) DB migrations applied: the two prod-assigned timestamps (from 29-01/29-02 SUMMARYs) with their rolled-back live proofs.
+    (3) Revenue-MRR known limitation: income-statement/cash-flow/tax now scope EXPENSES to the selected period, but revenue stays annualized MRR (no payment ledger) — matches the 29-CONTEXT deferred decision.
+    (4) DATA-02 satisfied here: `get_property_performance_analytics` was recreated in Plan 01 with the `p.status <> 'inactive'` property predicate, so Phase 30 must NOT recreate it again (doing so risks clobbering the BILL-06 numeric cast).
+    Do not modify ROADMAP.md here (ship/complete owns roadmap check-offs) — just record the note for Phase 30 planning.
+  </action>
+  <acceptance_criteria>
+    - The SUMMARY lists all three owner-run edge redeploys, the two applied migration timestamps + proofs, the revenue-MRR limitation, and the DATA-02-satisfied note.
+    - Source: `grep -c "residual\|owner-run\|DATA-02\|MRR" .planning/phases/29-billing-financials/29-07-SUMMARY.md` after `grep -v '^#'` returns a positive count for each term.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| verification report -> merge decision | a false "pass" would let broken money math merge |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-29-17 | Repudiation | verification summary | mitigate | each assertion records its actual command output; a failed assertion halts for gap closure instead of reporting a false pass |
+| T-29-SC | Tampering | npm/pip/cargo installs | accept | this phase adds no new package-manager installs (edge/frontend/SQL edits only); no legitimacy gate required |
+</threat_model>
+
+<verification>
+- `bun run typecheck && bun run lint && bun run test:unit` green.
+- All six per-requirement grep assertions pass.
+- Residual ledger complete.
+</verification>
+
+<success_criteria>
+The phase's combined changes pass the automated gate, every BILL requirement is source-verified, and the residual/limitation ledger (owner-run redeploys, migration proofs, revenue-MRR limitation, DATA-02-satisfied) is documented for the perfect-PR review and Phase 30.
+</success_criteria>
+
+<output>
+Create `.planning/phases/29-billing-financials/29-07-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/29-billing-financials/29-07-SUMMARY.md
+++ b/.planning/phases/29-billing-financials/29-07-SUMMARY.md
@@ -1,0 +1,20 @@
+# 29-07 Summary — Phase 29 verification + residual ledger
+
+**Gate:** perfect-PR MET (review cycles 4+5 zero-finding across all 6 BILL dimensions; see 29-REVIEW.md). typecheck 0, lint 0, full unit suite green.
+
+## BILL-01..06 all delivered
+- BILL-01 Stripe period-end reads (items.data[0]) + Number.isFinite guard.
+- BILL-02 date-aware get_expense_summary/get_financial_overview + wiring (income-statement/cash-flow/tax-documents + report-analytics financial/yearEnd/1099).
+- BILL-03 unpaid invoices show amount_due.
+- BILL-04 expense/property/billing RPC errors surfaced across financial-keys + expense-keys + report-analytics.
+- BILL-05 generate-pdf branches by reportType to the export-report RPC set.
+- BILL-06 expenses.amount numeric(10,2) + get_property_performance_analytics numeric+status + 5 cents-readers -> formatCurrency.
+
+## 3 migrations (applied + reconciled + verified live)
+20260708131702 (expenses.amount numeric), 20260708131721 (property-perf numeric+DATA-02), 20260708132045 (RPC date params).
+
+## RESIDUALS (owner-run / deferred — NOT gating)
+1. **3 owner-run edge redeploys** (CLI-401): stripe-webhooks, stripe-cancel-subscription (BILL-01), generate-pdf (BILL-05). Code merged; behavior effective post-redeploy.
+2. **BILL-02 revenue limitation** (documented): revenue stays annualized MRR — no period-historical revenue in the data model.
+3. **DATA-02 (Phase 30)**: get_property_performance_analytics's status predicate was folded into the BILL-06 recreate here; Phase 30 must still fix get_property_performance_with_trends (+ _trends) and must NOT re-recreate _analytics.
+4. **report1099 vendor_payments** pre-existing (RPC never emits the key) — out of BILL-02 scope, noted in-code.

--- a/.planning/phases/29-billing-financials/29-CONTEXT.md
+++ b/.planning/phases/29-billing-financials/29-CONTEXT.md
@@ -1,0 +1,92 @@
+# Phase 29: Billing, Stripe & Financial Reports - Context
+
+**Gathered:** 2026-07-08 (exhaustive live-DB research; every RPC signature + `expenses.amount` type verified against prod `bshjmbshupiibfiewpxb`).
+**Status:** Ready for planning
+**Source:** 2026-07-02 bug hunt (BILL-01..06) + the Phase-27-review-captured BILL-06.
+
+<domain>
+## Phase Boundary
+Correct the billing + financial-reporting numbers: Stripe period-end read location (BILL-01), period-scoped statements (BILL-02), real invoice amounts (BILL-03), honest error surfacing (BILL-04), PDF/CSV RPC parity (BILL-05), and the systemic `expenses.amount` money-convention (BILL-06). Builds on Phases 25-28. **This phase HAS migrations + edge-function changes.** Out of scope: phases 30-35 (but see the DATA-02 coordination note below — we pull one DATA-02 fix forward to avoid a double-recreate).
+
+**Migrations:** BILL-06 (expenses.amount type + get_property_performance_analytics) and BILL-02 (date params on financial RPCs).
+**Edge redeploys (owner-run, CLI-401 pattern):** BILL-01 (`stripe-webhooks`, `stripe-cancel-subscription`), BILL-05 (`generate-pdf`).
+</domain>
+
+<decisions>
+## Implementation Decisions (verified live)
+
+### BILL-01 — subscription current-period-end read from the wrong Stripe SDK location (P1)
+Edge functions pin `stripe@20` API `2026-03-25.dahlia` (basil+), where `current_period_end` moved OFF the top-level Subscription to `subscription.items.data[].current_period_end`. So every top-level read returns `undefined` → null `users.subscription_current_period_end` + a `RangeError` crash on cancel/reactivate.
+**LOCKED:** change the 4 edge reads to `sub.items.data[0]?.current_period_end` (mirroring how the same handlers already read `sub.items.data[0]?.price.id`):
+- `stripe-webhooks/handlers/customer-subscription-updated.ts:69-70`
+- `stripe-webhooks/handlers/checkout-session-completed.ts:62-63`
+- `stripe-cancel-subscription/index.ts:110` + `:125`
+Plus a defensive guard at `use-billing-mutations.ts:75-77` so an absent/NaN `current_period_end` maps to `null` instead of `new Date(NaN).toISOString()` throwing. `subscription-keys.ts:115` already reads the denormalized column correctly — no change (fixing the handlers populates it). NO migration; **edge redeploy of `stripe-webhooks` + `stripe-cancel-subscription` (owner-run).**
+**Verify:** a cancel/reactivate no longer crashes; the webhook writes a real timestamp to `users.subscription_current_period_end`.
+
+### BILL-02 — income-statement / cash-flow / tax-documents ignore the selected period (P1)
+`financial-keys.ts:243` (incomeStatement), `:327` (cashFlow), `expense-keys.ts:47` (taxDocuments) call `get_dashboard_stats({p_user_id})` + `get_expense_summary({p_user_id})` and use their `start_date`/`end_date`/`year` ONLY for the display label. **Live fact:** there is NO `get_income_statement`/`get_cash_flow` RPC; `get_expense_summary` + `get_financial_overview` HARDCODE `date_trunc('year', current_date)`; `get_billing_insights` declares date params but its body ignores them.
+**LOCKED (migration + frontend):** add `p_start_date date` / `p_end_date date` params (DEFAULT to the current-year boundaries so existing callers are unaffected) to `get_expense_summary` and `get_financial_overview`, replacing the hardcoded `date_trunc('year', current_date)` predicate on `expenses.expense_date`; make `get_billing_insights` actually apply its already-declared date params where sensible. Then have the three queryFns PASS their selected `start_date`/`end_date` (taxDocuments passes the `year` boundaries). **KNOWN LIMITATION to document (not a bug to over-fix here):** REVENUE from `get_dashboard_stats`/`get_financial_overview` is active-lease MRR (point-in-time), NOT period-historical — the data model has no rent-roll/payment history, so the EXPENSE side becomes period-accurate while revenue stays annualized-MRR. Scope BILL-02 to making the period-scopable data (expenses) honor the selected range; note the revenue limitation in the summary. Backward-compat: defaulted params keep every other caller of these RPCs working.
+**Verify:** changing the income-statement/cash-flow/tax date range changes the expense totals (no longer fixed YTD); other consumers of the RPCs unchanged.
+
+### BILL-03 — unpaid/open invoices show $0.00 (P2)
+`billing-keys.ts:35` `const amount = Number(row.amount_paid ?? row.amount_due ?? 0)` — for an unpaid invoice `amount_paid = 0` (not null), so `??` lets 0 win over the real `amount_due`. `get_user_invoices` returns both (live). 
+**LOCKED:** use `amount_due` when the invoice is not paid — e.g. `row.status === 'paid' ? Number(row.amount_paid) : Number(row.amount_due ?? row.amount_paid ?? 0)` (or `Number(row.amount_paid) || Number(row.amount_due) || 0`). Pure frontend.
+**Verify:** an open/unpaid invoice shows its real `amount_due`, not $0.00.
+
+### BILL-04 — expense-RPC failures silently default expenses to 0, overstating net income (P1)
+`financial-keys.ts` `fetchDashAndExpense` returns `{dashResult, expenseResult}`; every combined-fetch consumer checks ONLY `dashResult.error` and reads `expenseResult.data?.total_amount ?? 0` unchecked: `overview` (:110/:115), `incomeStatement` (:246/:250), `cashFlow` (:330/:334), `balanceSheet` (:429/:433 + `billingResult` :437), and `expense-keys.ts` taxDocuments (:52/:64/:96).
+**LOCKED:** after `fetchDashAndExpense`, check `expenseResult.error` (and `billingResult.error` in balanceSheet) via `handlePostgrestError` — same as `dashResult` — so an RPC failure surfaces instead of silently zeroing expenses. Pure frontend.
+**Verify:** simulate an expense-RPC error → the view surfaces an error (or an honest fallback), not $0 expenses + inflated net income.
+
+### BILL-05 — year-end/tax PDF built from get_dashboard_stats, mismatching the title (P2)
+`generate-pdf/index.ts:92-108` `fetchReportRows()` ALWAYS calls `get_dashboard_stats({p_user_id})` regardless of `reportType`, then titles it "YEAR-END REPORT". The CSV counterpart `export-report/index.ts` correctly branches: year-end/financial → `get_financial_overview`, 1099 → `get_billing_insights`, maintenance → `get_maintenance_analytics`, else → `get_revenue_trends_optimized`.
+**LOCKED:** make generate-pdf's Mode-1 `fetchReportRows` accept `reportType` (+ year) and branch to the SAME RPCs export-report uses, passing the year boundaries to the now-date-aware RPCs (BILL-02). Edge redeploy of `generate-pdf` (owner-run). Coordinate the RPC choice with BILL-02.
+**Verify:** the year-end PDF contains financial numbers (from get_financial_overview) matching its CSV counterpart + the report title.
+
+### BILL-06 — expenses.amount money-convention (systemic, P2) — MIGRATIONS
+`expenses.amount` is **`integer NOT NULL`** live (prod table empty → no data conversion). Writers send decimal dollars (`parseFloat` → rounded). Readers split: some treat it as CENTS (`formatCents(amount)` → 100× too small), some as DOLLARS. One RPC truncates via `::bigint`.
+**LOCKED:**
+1. **Migration:** `ALTER TABLE public.expenses ALTER COLUMN amount TYPE numeric(10,2)` (lossless; prod empty).
+2. **Migration:** recreate `get_property_performance_analytics` changing the expense `COALESCE(SUM(e.amount),0)::bigint` → `::numeric` and the `RETURNS TABLE` `total_expenses`/`net_income` from `bigint` → `numeric`. **DO BOTH BILL-06 AND DATA-02 IN THIS ONE RECREATE** (see coordination note) — also restore the `p.status <> 'inactive'` predicate DATA-02 needs, so we don't recreate this function twice. (Other expense-SUM RPCs — get_expense_summary, get_financial_overview, calculate_monthly_metrics — already return `numeric`, no change beyond BILL-02's date params.)
+3. **Frontend:** switch the WRONG cents-readers `formatCents(amount)` → `formatCurrency(amount)`: `financials/expenses/_components/expense-table.tsx:155`, `expense-category-breakdown.tsx:31`, `financials/tax-documents/page.tsx` (:170,186,202,242,275,280,284), `financials/financials-quick-links.tsx` (:82,90,104), `financials/financials-highlights.tsx:30` (also stop currency-formatting the occupancy-% highlight — minor secondary bug). Leave the `formatCents(x*100)` readers (income-statement/cash-flow/balance-sheet) — they are correct-as-dollars; optionally normalize to `formatCurrency(x)` for clarity (discretion).
+**Verify:** a $150.50 expense stores 150.50, shows "$150.50" on BOTH /maintenance/[id] AND /financials/expenses (was "$1.50" on financials); the property-performance analytics `total_expenses`/`net_income` keep cents and exclude inactive properties.
+
+### Claude's Discretion
+- BILL-02 approach details (default-param values; whether get_billing_insights's date params are wired now or noted). Keep it backward-compatible.
+- BILL-06: whether to normalize the correct-but-awkward `formatCents(x*100)` readers to `formatCurrency(x)` (nice-to-have) or leave them.
+- Order of the migrations (expenses type before the RPC recreate).
+</decisions>
+
+<canonical_refs>
+## Canonical References + live DB facts
+- BILL-01: `supabase/functions/stripe-webhooks/handlers/{customer-subscription-updated,checkout-session-completed}.ts`, `stripe-cancel-subscription/index.ts`, `src/hooks/api/use-billing-mutations.ts`. Correct pattern already in-file: `sub.items.data[0]?.price.id`.
+- BILL-02/04: `src/hooks/api/query-keys/financial-keys.ts` (fetchDashAndExpense + overview/incomeStatement/cashFlow/balanceSheet), `src/hooks/api/query-keys/expense-keys.ts` (taxDocuments + `byDateRange` at :234). RPCs: `get_expense_summary`, `get_financial_overview`, `get_billing_insights`, `get_dashboard_stats`.
+- BILL-03: `src/hooks/api/query-keys/billing-keys.ts:35,45`. RPC `get_user_invoices` (returns amount_due + amount_paid).
+- BILL-05: `supabase/functions/generate-pdf/index.ts:51,92-108`; compare `supabase/functions/export-report/index.ts:91,97,103,109`; caller `src/hooks/api/query-keys/report-keys.ts:223`.
+- BILL-06: `expenses.amount` (integer→numeric), `get_property_performance_analytics` (::bigint), readers listed above. `src/lib/utils/currency.ts` (formatCents=÷100, formatCurrency=treats-as-dollars).
+- CLAUDE.md: amounts store DOLLARS as numeric(10,2); migrations via MCP + reconcile filename; `bun run db:types` regen on column/RPC-signature change (CLI-401 → MCP generate_typescript_types + surgical edit); SECURITY DEFINER RPC grants/search_path preserved on recreate.
+
+### Live RPC signatures (verified)
+- `get_expense_summary(p_user_id uuid)` — hardcodes current-year; SUM(e.amount) numeric.
+- `get_financial_overview(p_user_id uuid)` — hardcodes YTD; SUM(e.amount) numeric.
+- `get_billing_insights(owner_id_param uuid, start_date_param timestamp DEFAULT NULL, end_date_param timestamp DEFAULT NULL)` — body IGNORES date params.
+- `get_property_performance_analytics(...)` — `RETURNS TABLE(... total_expenses bigint, net_income bigint ...)`, `SUM(e.amount)::bigint`. Touched by BILL-06 (cast) + DATA-02 (status filter).
+</canonical_refs>
+
+<specifics>
+## Cross-requirement coordination
+- **BILL-02 ↔ BILL-05:** both about "which RPC + period". Extend the RPCs with date params (BILL-02), then BILL-05's PDF calls the SAME extended RPCs with year boundaries. Solve consistently.
+- **BILL-06 ↔ BILL-02/04:** the expense-SUM RPCs BILL-02/04 read are numeric-summing; after the column→numeric they return fractional dollars correctly; BILL-04 then surfaces real errors and BILL-06 fixes rendering.
+- **BILL-06 ↔ DATA-02 (Phase 30):** `get_property_performance_analytics` is recreated ONCE here covering BOTH the numeric cast (BILL-06) AND the `p.status <> 'inactive'` predicate (DATA-02). Mark DATA-02 as satisfied-in-Phase-29 in the roadmap so Phase 30 doesn't recreate it again (which would risk clobbering the numeric cast).
+- Migrations applied via Supabase MCP, then reconcile the repo filename to the prod-assigned timestamp; regen db:types after any RPC signature / column change.
+</specifics>
+
+<deferred>
+## Deferred (tracked elsewhere)
+- Period-historical REVENUE (rent-roll/payment history) — the data model doesn't support it; BILL-02 scopes to expense-period-accuracy + notes the revenue-MRR limitation. Not building a payment ledger here.
+- Anything not in BILL-01..06 (and the one DATA-02 predicate pulled into the shared recreate).
+</deferred>
+
+---
+*Phase: 29-billing-financials*

--- a/.planning/phases/29-billing-financials/29-REVIEW.md
+++ b/.planning/phases/29-billing-financials/29-REVIEW.md
@@ -1,0 +1,36 @@
+# Phase 29 — Perfect-PR Review Log
+
+**Gate:** two consecutive zero-finding review cycles. Method: a Workflow fanned out 6 BILL dimensions (bill06-db, bill02, bill01, bill05, bill03-04, bill06-readers), each reviewed then adversarially verified — the two DB dimensions re-proving against live prod each cycle. Reviewed 2026-07-08.
+
+## Findings by cycle (all fixed)
+| Cycle | Findings | Fix |
+|-------|----------|-----|
+| 1 | 2 MEDIUM — BILL-04's error-surfacing fix missed the sibling `reportQueries.financial` + `reportQueries.yearEnd` in report-analytics-keys.ts (swallowed expenseResult/propResult.error) | added the guards; swept all get_expense_summary callers |
+| 2 | 1 LOW — the /financials "Occupancy Rate" highlight read `units?.occupancy_rate` (always 0%); the RPC emits `properties.occupancyRate` | parseDashStats returns properties; read the right key |
+| 3 | 1 MEDIUM — the SAME occupancy bug in report-analytics-keys.ts:181 (Financial Report + PDF); + BILL-02 period-ignoring in the financial/yearEnd report queries | fixed the occupancy + forwarded the period to get_expense_summary; proactively wired report1099's year too |
+| 4 | CLEAN (all 6) | — |
+| 5 | CLEAN | — |
+
+The recurring theme: the executors fixed the primary files (financial-keys.ts, expense-keys.ts, the financials/* display) but missed the sibling report-generation file (report-analytics-keys.ts). The adversarial sweeps caught each; a proactive sweep in cycle 3 exhausted the class.
+
+## Migrations (3, applied to prod, verified live, repo↔prod byte-parity)
+- `20260708131702` — expenses.amount integer→numeric(10,2) (prod empty; 150.50 round-trips).
+- `20260708131721` — DROP+CREATE get_property_performance_analytics: ::bigint→::numeric + RETURNS TABLE bigint→numeric + DATA-02's `p.status <> 'inactive'` on both CTEs (one recreate; grants re-issued).
+- `20260708132045` — get_expense_summary + get_financial_overview gained `p_start_date`/`p_end_date` (DROP old (uuid); default p_end_date NULL = exact YTD backward-compat).
+
+## Requirements delivered
+- **BILL-01** — 4 edge reads → `sub.items.data[0]?.current_period_end` + `Number.isFinite` frontend guard (no more RangeError; webhook writes a real timestamp).
+- **BILL-02** — the date-aware RPCs + wiring across income-statement/cash-flow/tax-documents AND the report-analytics financial/yearEnd/1099 queries. `get_billing_insights` left as-is (no date-scopable aggregate).
+- **BILL-03** — unpaid invoices show `amount_due`, not $0.00.
+- **BILL-04** — every combined-fetch financial consumer surfaces its expense/property/billing RPC error (across financial-keys, expense-keys, AND report-analytics).
+- **BILL-05** — generate-pdf branches by reportType to the same RPCs as export-report (year-end PDF matches its CSV).
+- **BILL-06** — expenses.amount numeric + the 5 wrong cents-readers → formatCurrency (a $150 expense shows $150.00, not $1.50); correct `formatCents(x*100)` readers left intact.
+
+## Verification
+- typecheck 0, lint 0, full unit suite green. Live DB proofs on all 3 migrations. Prod left clean.
+
+## Residuals (owner-run / deferred)
+- **3 owner-run edge redeploys** (CLI-401): `stripe-webhooks`, `stripe-cancel-subscription` (BILL-01), `generate-pdf` (BILL-05). Code ships; behavior takes effect on redeploy.
+- **BILL-02 revenue limitation** (documented, not a bug): revenue stays annualized MRR (point-in-time) — period-historical revenue isn't in the data model (no payment ledger). Only the expense side is period-accurate.
+- **DATA-02 (Phase 30)**: this phase satisfied ONLY get_property_performance_analytics's status predicate (folded into the BILL-06 recreate). Phase 30 must still add `p.status <> 'inactive'` to `get_property_performance_with_trends` (+ `_trends`) but must NOT re-recreate `_analytics` (would clobber the BILL-06 numeric cast).
+- **report1099 vendor_payments** (pre-existing, out of scope): the report reads a `vendor_payments` key get_expense_summary never emits → renders empty. Not a BILL-02 defect; noted in-code.

--- a/src/app/(owner)/financials/expenses/_components/expense-category-breakdown.tsx
+++ b/src/app/(owner)/financials/expenses/_components/expense-category-breakdown.tsx
@@ -1,5 +1,5 @@
 import { BlurFade } from "#components/ui/blur-fade";
-import { formatCents } from "#lib/utils/currency";
+import { formatCurrency } from "#lib/utils/currency";
 import { getCategoryBadge } from "./expense-category-badge";
 
 interface CategorySummary {
@@ -28,7 +28,7 @@ export function ExpenseCategoryBreakdown({
 						<div key={cat.category} className="flex items-center gap-3">
 							{getCategoryBadge(cat.category)}
 							<span className="text-sm text-muted-foreground">
-								{formatCents(cat.amount)} ({cat.percentage.toFixed(1)}%)
+								{formatCurrency(cat.amount)} ({cat.percentage.toFixed(1)}%)
 							</span>
 						</div>
 					))}

--- a/src/app/(owner)/financials/expenses/_components/expense-table.tsx
+++ b/src/app/(owner)/financials/expenses/_components/expense-table.tsx
@@ -27,7 +27,7 @@ import {
 	TableRow,
 } from "#components/ui/table";
 import type { Expense } from "#hooks/api/query-keys/expense-keys";
-import { formatCents } from "#lib/utils/currency";
+import { formatCurrency } from "#lib/utils/currency";
 import { EXPENSE_CATEGORIES, getCategoryBadge } from "./expense-category-badge";
 
 interface ExpenseTableProps {
@@ -152,7 +152,7 @@ export function ExpenseTable({
 									{getCategoryBadge(expense.category ?? "other")}
 								</TableCell>
 								<TableCell className="text-right tabular-nums font-medium text-foreground">
-									{formatCents(expense.amount ?? 0)}
+									{formatCurrency(expense.amount ?? 0)}
 								</TableCell>
 							</TableRow>
 						))}

--- a/src/app/(owner)/financials/financials-highlights.tsx
+++ b/src/app/(owner)/financials/financials-highlights.tsx
@@ -1,5 +1,5 @@
 import { BlurFade } from "#components/ui/blur-fade";
-import { formatCents } from "#lib/utils/currency";
+import { formatCurrency, formatPercentage } from "#lib/utils/currency";
 
 interface Highlight {
 	label: string;
@@ -26,9 +26,11 @@ export function FinancialsHighlights({
 					{highlights.map((highlight, index) => (
 						<div key={index} className="text-center p-4 bg-muted/30 rounded-lg">
 							<p className="text-2xl font-semibold tabular-nums">
-								{typeof highlight.value === "number" && highlight.value > 1000
-									? formatCents(highlight.value)
-									: highlight.value}
+								{/* Render by KIND, not magnitude: percentages (occupancy /
+								    rate) use formatPercentage; everything else is dollars. */}
+								{/rate|occupancy|%/i.test(highlight.label)
+									? formatPercentage(highlight.value)
+									: formatCurrency(highlight.value)}
 							</p>
 							<p className="text-sm text-muted-foreground mt-1">
 								{highlight.label}

--- a/src/app/(owner)/financials/financials-quick-links.tsx
+++ b/src/app/(owner)/financials/financials-quick-links.tsx
@@ -10,7 +10,7 @@ import {
 import Link from "next/link";
 import type { ElementType } from "react";
 import { BlurFade } from "#components/ui/blur-fade";
-import { formatCents } from "#lib/utils/currency";
+import { formatCurrency } from "#lib/utils/currency";
 
 interface QuickLinkCardProps {
 	href: string;
@@ -79,7 +79,7 @@ export function FinancialsQuickLinks({
 					icon={FileText}
 					title="Income Statement"
 					description="Revenue, expenses, and net income breakdown"
-					value={formatCents(netIncome)}
+					value={formatCurrency(netIncome)}
 					trend={netIncome > 0 ? "up" : netIncome < 0 ? "down" : "neutral"}
 				/>
 				<QuickLinkCard
@@ -87,7 +87,7 @@ export function FinancialsQuickLinks({
 					icon={TrendingUp}
 					title="Cash Flow"
 					description="Track money coming in and going out"
-					value={formatCents(totalRevenue - totalExpenses)}
+					value={formatCurrency(totalRevenue - totalExpenses)}
 					trend="up"
 				/>
 				<QuickLinkCard
@@ -101,7 +101,7 @@ export function FinancialsQuickLinks({
 					icon={Receipt}
 					title="Expenses"
 					description="Track maintenance and operating costs"
-					value={formatCents(totalExpenses)}
+					value={formatCurrency(totalExpenses)}
 					trend="down"
 				/>
 				<QuickLinkCard

--- a/src/app/(owner)/financials/tax-documents/page.tsx
+++ b/src/app/(owner)/financials/tax-documents/page.tsx
@@ -24,7 +24,7 @@ import { Skeleton } from "#components/ui/skeleton";
 import { useTaxDocuments } from "#hooks/api/use-expense-mutations";
 import { useDownloadTaxDocumentPdf } from "#hooks/api/use-report-mutations";
 import { createLogger } from "#lib/frontend-logger";
-import { formatCents } from "#lib/utils/currency";
+import { formatCurrency } from "#lib/utils/currency";
 
 const logger = createLogger({ component: "TaxDocumentsPage" });
 
@@ -167,7 +167,7 @@ export default function TaxDocumentsPage() {
 									</div>
 									<div>
 										<p className="text-xl font-semibold tabular-nums">
-											{formatCents(data.totals.totalIncome)}
+											{formatCurrency(data.totals.totalIncome)}
 										</p>
 										<p className="text-sm text-muted-foreground">
 											Gross Income
@@ -183,7 +183,7 @@ export default function TaxDocumentsPage() {
 									</div>
 									<div>
 										<p className="text-xl font-semibold tabular-nums">
-											{formatCents(data.totals.totalDeductions)}
+											{formatCurrency(data.totals.totalDeductions)}
 										</p>
 										<p className="text-sm text-muted-foreground">
 											Total Deductions
@@ -199,7 +199,7 @@ export default function TaxDocumentsPage() {
 									</div>
 									<div>
 										<p className="text-xl font-semibold tabular-nums">
-											{formatCents(data.totals.netTaxableIncome)}
+											{formatCurrency(data.totals.netTaxableIncome)}
 										</p>
 										<p className="text-sm text-muted-foreground">
 											Net Taxable Income
@@ -239,7 +239,7 @@ export default function TaxDocumentsPage() {
 												</div>
 												<div className="text-right">
 													<p className="text-sm font-medium tabular-nums">
-														{formatCents(cat.amount)}
+														{formatCurrency(cat.amount)}
 													</p>
 													<p className="text-xs text-muted-foreground">
 														{cat.percentage.toFixed(1)}% of expenses
@@ -272,16 +272,16 @@ export default function TaxDocumentsPage() {
 													{prop.propertyName}
 												</p>
 												<p className="text-xs text-muted-foreground">
-													Basis: {formatCents(prop.propertyValue)}
+													Basis: {formatCurrency(prop.propertyValue)}
 												</p>
 											</div>
 											<div className="text-right">
 												<p className="text-sm font-medium tabular-nums">
-													{formatCents(prop.annualDepreciation)}/yr
+													{formatCurrency(prop.annualDepreciation)}/yr
 												</p>
 												<p className="text-xs text-muted-foreground">
 													Accumulated:{" "}
-													{formatCents(prop.accumulatedDepreciation)}
+													{formatCurrency(prop.accumulatedDepreciation)}
 												</p>
 											</div>
 										</div>

--- a/src/hooks/api/__tests__/use-financial-overview.test.ts
+++ b/src/hooks/api/__tests__/use-financial-overview.test.ts
@@ -114,6 +114,36 @@ describe("useFinancialOverview", () => {
 
 		expect(result.current.error).toBeDefined();
 	});
+
+	it("surfaces an expense-RPC error instead of silently zeroing expenses (BILL-04)", async () => {
+		// get_dashboard_stats succeeds but get_expense_summary fails. Without the
+		// expenseResult.error check this would resolve with total_expenses: 0 and
+		// overstate net income; it must reject instead.
+		mockRpc
+			.mockResolvedValueOnce({
+				data: [
+					{
+						revenue: { yearly: 500000, monthly: 41667 },
+						units: { occupancy_rate: 94 },
+					},
+				],
+				error: null,
+			})
+			.mockResolvedValueOnce({
+				data: null,
+				error: { message: "expense summary failed", code: "500" },
+			});
+
+		const { result } = renderHook(() => useFinancialOverview(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.isError).toBe(true);
+		});
+
+		expect(result.current.data).toBeUndefined();
+	});
 });
 
 describe("useMonthlyMetrics", () => {

--- a/src/hooks/api/__tests__/use-financials.test.tsx
+++ b/src/hooks/api/__tests__/use-financials.test.tsx
@@ -166,8 +166,12 @@ describe("useIncomeStatement", () => {
 		expect(mockRpc).toHaveBeenCalledWith("get_dashboard_stats", {
 			p_user_id: "user-1",
 		});
+		// BILL-02: incomeStatement forwards the selected range to the now
+		// date-aware get_expense_summary (revenue side stays annualized MRR).
 		expect(mockRpc).toHaveBeenCalledWith("get_expense_summary", {
 			p_user_id: "user-1",
+			p_start_date: "2024-01-01",
+			p_end_date: "2024-12-31",
 		});
 	});
 

--- a/src/hooks/api/__tests__/use-reports.test.tsx
+++ b/src/hooks/api/__tests__/use-reports.test.tsx
@@ -454,6 +454,8 @@ describe("useReport1099Summary", () => {
 		expect(result.current.data?.totalReported).toBe(23000);
 		expect(mockRpc).toHaveBeenCalledWith("get_expense_summary", {
 			p_user_id: "user-1",
+			p_start_date: "2024-01-01",
+			p_end_date: "2024-12-31",
 		});
 	});
 

--- a/src/hooks/api/query-keys/billing-keys.ts
+++ b/src/hooks/api/query-keys/billing-keys.ts
@@ -32,7 +32,12 @@ export const billingQueries = {
 				});
 				if (error) handlePostgrestError(error, "billing.history");
 				return (data ?? []).map((row): BillingHistoryItem => {
-					const amount = Number(row.amount_paid ?? row.amount_due ?? 0);
+					// An unpaid invoice has amount_paid = 0, which would win over the
+					// real amount_due under a plain `??`. Show amount_due unless paid.
+					const amount =
+						row.status === "paid"
+							? Number(row.amount_paid)
+							: Number(row.amount_due ?? row.amount_paid ?? 0);
 					return {
 						id: row.invoice_id,
 						amount,

--- a/src/hooks/api/query-keys/expense-keys.ts
+++ b/src/hooks/api/query-keys/expense-keys.ts
@@ -46,11 +46,19 @@ export const financialTaxQueries = {
 
 				const [dashResult, expenseResult] = await Promise.all([
 					supabase.rpc("get_dashboard_stats", { p_user_id: userId }),
-					supabase.rpc("get_expense_summary", { p_user_id: userId }),
+					// Only the expense side is period-scoped; revenue remains annualized
+					// MRR (get_dashboard_stats is point-in-time — no payment history).
+					supabase.rpc("get_expense_summary", {
+						p_user_id: userId,
+						p_start_date: `${year}-01-01`,
+						p_end_date: `${year}-12-31`,
+					}),
 				]);
 
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "tax documents");
+				if (expenseResult.error)
+					handlePostgrestError(expenseResult.error, "tax documents expenses");
 
 				const stats = (
 					dashResult.data as Array<Record<string, unknown>> | null

--- a/src/hooks/api/query-keys/financial-keys.ts
+++ b/src/hooks/api/query-keys/financial-keys.ts
@@ -53,12 +53,30 @@ export interface ExpenseSummaryData {
 
 const CACHE = { staleTime: 2 * 60 * 1000, gcTime: 10 * 60 * 1000 } as const;
 
-/** Fetch dashboard + expense RPCs in parallel for authenticated user */
-async function fetchDashAndExpense(userId: string) {
+/**
+ * Fetch dashboard + expense RPCs in parallel for authenticated user.
+ *
+ * When `range` is provided, only the expense side (get_expense_summary) is
+ * period-scoped; revenue stays annualized MRR because get_dashboard_stats is
+ * point-in-time and the data model has no payment history (see 29-CONTEXT.md).
+ */
+async function fetchDashAndExpense(
+	userId: string,
+	range?: { start_date: string; end_date: string },
+) {
 	const supabase = createClient();
 	const [dashResult, expenseResult] = await Promise.all([
 		supabase.rpc("get_dashboard_stats", { p_user_id: userId }),
-		supabase.rpc("get_expense_summary", { p_user_id: userId }),
+		supabase.rpc(
+			"get_expense_summary",
+			range
+				? {
+						p_user_id: userId,
+						p_start_date: range.start_date,
+						p_end_date: range.end_date,
+					}
+				: { p_user_id: userId },
+		),
 	]);
 	return { dashResult, expenseResult };
 }
@@ -109,6 +127,11 @@ export const financialQueries = {
 				);
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "financial overview");
+				if (expenseResult.error)
+					handlePostgrestError(
+						expenseResult.error,
+						"financial overview expenses",
+					);
 				const { revenue, units } = parseDashStats(dashResult.data);
 				const totalRevenue = Number(revenue?.yearly ?? 0);
 				const monthlyRevenue = Number(revenue?.monthly ?? 0);
@@ -240,11 +263,19 @@ export const financialQueries = {
 					};
 					return { success: true, data: empty };
 				}
+				// Only the expense side is period-scoped; revenue remains annualized
+				// MRR (get_dashboard_stats is point-in-time — no payment history).
 				const { dashResult, expenseResult } = await fetchDashAndExpense(
 					user.id,
+					{ start_date: params.start_date, end_date: params.end_date },
 				);
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "income statement");
+				if (expenseResult.error)
+					handlePostgrestError(
+						expenseResult.error,
+						"income statement expenses",
+					);
 				const { revenue } = parseDashStats(dashResult.data);
 				const totalRevenue = Number(revenue?.yearly ?? 0);
 				const totalExpenses = Number(
@@ -324,11 +355,16 @@ export const financialQueries = {
 						},
 					};
 				}
+				// Only the expense side is period-scoped; revenue remains annualized
+				// MRR (get_dashboard_stats is point-in-time — no payment history).
 				const { dashResult, expenseResult } = await fetchDashAndExpense(
 					user.id,
+					{ start_date: params.start_date, end_date: params.end_date },
 				);
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "cash flow");
+				if (expenseResult.error)
+					handlePostgrestError(expenseResult.error, "cash flow expenses");
 				const { revenue } = parseDashStats(dashResult.data);
 				const monthlyRevenue = Number(revenue?.monthly ?? 0);
 				const monthlyExpenses = Number(
@@ -428,6 +464,10 @@ export const financialQueries = {
 					]);
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "balance sheet");
+				if (expenseResult.error)
+					handlePostgrestError(expenseResult.error, "balance sheet expenses");
+				if (billingResult.error)
+					handlePostgrestError(billingResult.error, "balance sheet billing");
 				const { revenue } = parseDashStats(dashResult.data);
 				const totalRevenue = Number(revenue?.yearly ?? 0);
 				const totalExpenses = Number(

--- a/src/hooks/api/query-keys/financial-keys.ts
+++ b/src/hooks/api/query-keys/financial-keys.ts
@@ -87,6 +87,9 @@ function parseDashStats(data: unknown) {
 	return {
 		revenue: stats?.revenue as Record<string, unknown> | undefined,
 		units: stats?.units as Record<string, unknown> | undefined,
+		// Occupancy lives under `properties.occupancyRate` (camelCase) in the RPC —
+		// NOT `units.occupancy_rate`.
+		properties: stats?.properties as Record<string, unknown> | undefined,
 	};
 }
 
@@ -132,7 +135,7 @@ export const financialQueries = {
 						expenseResult.error,
 						"financial overview expenses",
 					);
-				const { revenue, units } = parseDashStats(dashResult.data);
+				const { revenue, properties } = parseDashStats(dashResult.data);
 				const totalRevenue = Number(revenue?.yearly ?? 0);
 				const monthlyRevenue = Number(revenue?.monthly ?? 0);
 				const totalExpenses = Number(
@@ -152,7 +155,7 @@ export const financialQueries = {
 						{ label: "Annual Revenue", value: totalRevenue, trend: null },
 						{
 							label: "Occupancy Rate",
-							value: Number(units?.occupancy_rate ?? 0),
+							value: Number(properties?.occupancyRate ?? 0),
 							trend: null,
 						},
 					],

--- a/src/hooks/api/query-keys/report-analytics-keys.ts
+++ b/src/hooks/api/query-keys/report-analytics-keys.ts
@@ -161,6 +161,10 @@ export const reportAnalyticsQueries = {
 				]);
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "financial report");
+				// BILL-04: surface an expense-RPC failure instead of silently reading
+				// 0 expenses and overstating net income.
+				if (expenseResult.error)
+					handlePostgrestError(expenseResult.error, "financial report");
 				const { revenue, units } = extractDashStats(dashResult.data);
 				const totalIncome = Number(revenue?.yearly ?? 0);
 				const expenseSummary = expenseResult.data as Record<
@@ -383,6 +387,12 @@ export const reportAnalyticsQueries = {
 				]);
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "year-end summary");
+				// BILL-04: surface expense / property-analytics RPC failures instead of
+				// silently zeroing expenses (overstated net income) or the by-property table.
+				if (expenseResult.error)
+					handlePostgrestError(expenseResult.error, "year-end summary");
+				if (propResult.error)
+					handlePostgrestError(propResult.error, "year-end summary");
 				const { revenue } = extractDashStats(dashResult.data);
 				const grossRentalIncome = Number(revenue?.yearly ?? 0);
 				const expenseSummary = expenseResult.data as Record<

--- a/src/hooks/api/query-keys/report-analytics-keys.ts
+++ b/src/hooks/api/query-keys/report-analytics-keys.ts
@@ -452,8 +452,13 @@ export const reportAnalyticsQueries = {
 				const user = await getCachedUser();
 				if (!user)
 					return { year, threshold: 600, recipients: [], totalReported: 0 };
+				// BILL-02: scope to the selected tax year. (NOTE: get_expense_summary
+				// does not emit a `vendor_payments` key, so this report renders empty
+				// regardless — a separate pre-existing gap, out of BILL-02 scope.)
 				const { data, error } = await supabase.rpc("get_expense_summary", {
 					p_user_id: user.id,
+					p_start_date: `${year}-01-01`,
+					p_end_date: `${year}-12-31`,
 				});
 				if (error) handlePostgrestError(error, "1099 summary");
 				const summary = data as Record<string, unknown> | null;

--- a/src/hooks/api/query-keys/report-analytics-keys.ts
+++ b/src/hooks/api/query-keys/report-analytics-keys.ts
@@ -32,6 +32,9 @@ function extractDashStats(data: unknown) {
 	return {
 		revenue: stats?.revenue as Record<string, unknown> | undefined,
 		units: stats?.units as Record<string, unknown> | undefined,
+		// Occupancy lives under `properties.occupancyRate` (camelCase), NOT
+		// `units.occupancy_rate` — the snake_case key the RPC never emits.
+		properties: stats?.properties as Record<string, unknown> | undefined,
 		tenants: stats?.tenants as Record<string, unknown> | undefined,
 		leases: stats?.leases as Record<string, unknown> | undefined,
 	};
@@ -157,7 +160,12 @@ export const reportAnalyticsQueries = {
 				}
 				const [dashResult, expenseResult] = await Promise.all([
 					supabase.rpc("get_dashboard_stats", { p_user_id: user.id }),
-					supabase.rpc("get_expense_summary", { p_user_id: user.id }),
+					// BILL-02: scope expenses to the selected period (defaults to YTD).
+					supabase.rpc("get_expense_summary", {
+						p_user_id: user.id,
+						...(start_date ? { p_start_date: start_date } : {}),
+						...(end_date ? { p_end_date: end_date } : {}),
+					}),
 				]);
 				if (dashResult.error)
 					handlePostgrestError(dashResult.error, "financial report");
@@ -165,7 +173,7 @@ export const reportAnalyticsQueries = {
 				// 0 expenses and overstating net income.
 				if (expenseResult.error)
 					handlePostgrestError(expenseResult.error, "financial report");
-				const { revenue, units } = extractDashStats(dashResult.data);
+				const { revenue, properties } = extractDashStats(dashResult.data);
 				const totalIncome = Number(revenue?.yearly ?? 0);
 				const expenseSummary = expenseResult.data as Record<
 					string,
@@ -178,7 +186,7 @@ export const reportAnalyticsQueries = {
 						totalExpenses,
 						netIncome: totalIncome - totalExpenses,
 						cashFlow: Number(revenue?.monthly ?? 0) - totalExpenses / 12,
-						rentRollOccupancyRate: Number(units?.occupancy_rate ?? 0),
+						rentRollOccupancyRate: Number(properties?.occupancyRate ?? 0),
 					},
 					monthly: [],
 					expenseBreakdown: (
@@ -380,7 +388,12 @@ export const reportAnalyticsQueries = {
 					};
 				const [dashResult, expenseResult, propResult] = await Promise.all([
 					supabase.rpc("get_dashboard_stats", { p_user_id: user.id }),
-					supabase.rpc("get_expense_summary", { p_user_id: user.id }),
+					// BILL-02: scope the year-end expenses to the selected year.
+					supabase.rpc("get_expense_summary", {
+						p_user_id: user.id,
+						p_start_date: `${year}-01-01`,
+						p_end_date: `${year}-12-31`,
+					}),
 					supabase.rpc("get_property_performance_analytics", {
 						p_user_id: user.id,
 					}),

--- a/src/hooks/api/use-billing-mutations.test.ts
+++ b/src/hooks/api/use-billing-mutations.test.ts
@@ -206,4 +206,33 @@ describe("useCancelSubscriptionMutation setQueryData (T-42-06 mitigation)", () =
 			new Date(cached!.currentPeriodEnd as string).getTime(),
 		).toBeGreaterThan(Date.now());
 	});
+
+	it("maps an absent/NaN current_period_end to null instead of throwing a RangeError", async () => {
+		// Simulates a pre-basil edge fn that has not yet been redeployed: the
+		// response omits current_period_end (it moved onto the subscription item).
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				id: "sub_no_period",
+				status: "active",
+				cancel_at_period_end: true,
+				// current_period_end intentionally omitted (undefined)
+			}),
+		}) as unknown as typeof fetch;
+
+		const { result, queryClient } = renderWithClient(() =>
+			useCancelSubscriptionMutation(),
+		);
+
+		// Must not throw new Date(NaN).toISOString() RangeError.
+		await result.current.mutateAsync();
+
+		const cached = queryClient.getQueryData<{
+			currentPeriodEnd: string | null;
+			cancelAtPeriodEnd: boolean;
+		}>(["billing", "subscription-status"]);
+
+		expect(cached?.currentPeriodEnd).toBeNull();
+		expect(cached?.cancelAtPeriodEnd).toBe(true);
+	});
 });

--- a/src/hooks/api/use-billing-mutations.ts
+++ b/src/hooks/api/use-billing-mutations.ts
@@ -72,9 +72,14 @@ function mapCancelResponseToStatus(
 	return {
 		subscriptionStatus:
 			response.status as SubscriptionStatusResponse["subscriptionStatus"],
-		currentPeriodEnd: new Date(
-			response.current_period_end * 1000,
-		).toISOString(),
+		// current_period_end may be absent/NaN if an edge fn is not yet
+		// redeployed post-basil (the field moved onto the subscription item).
+		// Guard with Number.isFinite — 0 is falsy but a valid epoch is huge, so a
+		// truthy check would wrongly reject 0; map non-finite values to null
+		// instead of letting new Date(NaN).toISOString() throw a RangeError.
+		currentPeriodEnd: Number.isFinite(response.current_period_end)
+			? new Date(response.current_period_end * 1000).toISOString()
+			: null,
 		cancelAtPeriodEnd: response.cancel_at_period_end,
 	};
 }

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -2500,8 +2500,14 @@ export type Database = {
 					unique_users: number;
 				}[];
 			};
-			get_expense_summary: { Args: { p_user_id: string }; Returns: Json };
-			get_financial_overview: { Args: { p_user_id: string }; Returns: Json };
+			get_expense_summary: {
+				Args: { p_end_date?: string; p_start_date?: string; p_user_id: string };
+				Returns: Json;
+			};
+			get_financial_overview: {
+				Args: { p_end_date?: string; p_start_date?: string; p_user_id: string };
+				Returns: Json;
+			};
 			get_funnel_stats: {
 				Args: { p_from?: string; p_to?: string };
 				Returns: Json;

--- a/supabase/functions/generate-pdf/index.ts
+++ b/supabase/functions/generate-pdf/index.ts
@@ -89,22 +89,72 @@ function buildReportHtml(
 </html>`;
 }
 
+function coerceCell(value: unknown): string | number | null {
+	if (value === null || value === undefined) return null;
+	if (typeof value === "number" || typeof value === "string") return value;
+	return JSON.stringify(value);
+}
+
+// Mirror of export-report's flattenToRows, coerced to the ReportRow cell shape:
+// object-shaped RPC results -> [{ metric, value }] rows; array results -> rows.
+function flattenToReportRows(data: unknown): ReportRow[] {
+	if (!data || typeof data !== "object") return [];
+	if (Array.isArray(data)) {
+		return (data as Record<string, unknown>[]).map((row) => {
+			const out: ReportRow = {};
+			for (const [key, value] of Object.entries(row)) {
+				out[key] = coerceCell(value);
+			}
+			return out;
+		});
+	}
+	return Object.entries(data as Record<string, unknown>).map(
+		([key, value]) => ({ metric: key, value: coerceCell(value) }),
+	);
+}
+
+// Branch by reportType to the SAME RPCs export-report's CSV path uses so the
+// PDF content matches its CSV counterpart and the report title's year. The
+// date-aware get_financial_overview (BILL-02) receives the requested year's
+// boundaries so the numbers are period-correct.
 async function fetchReportRows(
 	supabase: SupabaseClient,
 	userId: string,
+	reportType: string,
+	year: number,
 ): Promise<ReportRow[]> {
-	const { data, error } = await supabase.rpc("get_dashboard_stats", {
+	if (reportType === "year-end" || reportType === "financial") {
+		const { data, error } = await supabase.rpc("get_financial_overview", {
+			p_user_id: userId,
+			p_start_date: `${year}-01-01`,
+			p_end_date: `${year}-12-31`,
+		});
+		if (error) throw new Error(`Failed to fetch report data: ${error.message}`);
+		return flattenToReportRows(data);
+	}
+
+	if (reportType === "1099") {
+		const { data, error } = await supabase.rpc("get_billing_insights", {
+			owner_id_param: userId,
+		});
+		if (error) throw new Error(`Failed to fetch report data: ${error.message}`);
+		return flattenToReportRows(data);
+	}
+
+	if (reportType === "maintenance") {
+		const { data, error } = await supabase.rpc("get_maintenance_analytics", {
+			user_id: userId,
+		});
+		if (error) throw new Error(`Failed to fetch report data: ${error.message}`);
+		return flattenToReportRows(data);
+	}
+
+	const { data, error } = await supabase.rpc("get_revenue_trends_optimized", {
 		p_user_id: userId,
+		p_months: 12,
 	});
 	if (error) throw new Error(`Failed to fetch report data: ${error.message}`);
-	const stats = (data as Record<string, unknown>[] | null)?.[0] ?? {};
-	return Object.entries(stats).map(([key, value]) => ({
-		metric: key,
-		value:
-			typeof value === "object" && value !== null
-				? JSON.stringify(value)
-				: String(value ?? ""),
-	}));
+	return flattenToReportRows(data);
 }
 
 async function buildLeasePreviewHtml(
@@ -283,7 +333,12 @@ Deno.serve(async (req: Request) => {
 				if (entitlementBlock) return entitlementBlock;
 			}
 
-			const rows = await fetchReportRows(supabase, user.id);
+			const rows = await fetchReportRows(
+				supabase,
+				user.id,
+				body.reportType,
+				body.year,
+			);
 			html = buildReportHtml(body.reportType, body.year, rows);
 		}
 

--- a/supabase/functions/stripe-cancel-subscription/index.ts
+++ b/supabase/functions/stripe-cancel-subscription/index.ts
@@ -107,7 +107,8 @@ Deno.serve(async (req: Request) => {
 					id: subscription.id,
 					status: subscription.status,
 					cancel_at_period_end: subscription.cancel_at_period_end,
-					current_period_end: subscription.current_period_end,
+					// basil+ API moved current_period_end onto the subscription item.
+					current_period_end: subscription.items.data[0]?.current_period_end,
 				}),
 				{ status: 200, headers: getJsonHeaders(req) },
 			);
@@ -122,7 +123,8 @@ Deno.serve(async (req: Request) => {
 				id: updated.id,
 				status: updated.status,
 				cancel_at_period_end: updated.cancel_at_period_end,
-				current_period_end: updated.current_period_end,
+				// basil+ API moved current_period_end onto the subscription item.
+				current_period_end: updated.items.data[0]?.current_period_end,
 			}),
 			{ status: 200, headers: getJsonHeaders(req) },
 		);

--- a/supabase/functions/stripe-webhooks/handlers/checkout-session-completed.ts
+++ b/supabase/functions/stripe-webhooks/handlers/checkout-session-completed.ts
@@ -55,12 +55,16 @@ export async function handleCheckoutSessionCompleted(
 					: null
 				: null;
 
+		// basil+ API (2026-03-25.dahlia) moved current_period_end OFF the
+		// top-level Subscription onto the subscription item — read it via the
+		// same accessor already used for price.id above.
+		const currentPeriodEnd = sub.items.data[0]?.current_period_end;
 		const updatePayload: Record<string, unknown> = {
 			subscription_id: sub.id,
 			subscription_status: sub.status,
 			subscription_plan: tier ?? planLookup ?? priceId,
-			subscription_current_period_end: sub.current_period_end
-				? new Date(sub.current_period_end * 1000).toISOString()
+			subscription_current_period_end: currentPeriodEnd
+				? new Date(currentPeriodEnd * 1000).toISOString()
 				: null,
 			subscription_cancel_at_period_end: sub.cancel_at_period_end ?? false,
 			subscription_updated_at: new Date().toISOString(),

--- a/supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts
+++ b/supabase/functions/stripe-webhooks/handlers/customer-subscription-updated.ts
@@ -62,12 +62,16 @@ export async function handleCustomerSubscriptionUpdated(
 				: null
 			: null;
 
+	// basil+ API (2026-03-25.dahlia) moved current_period_end OFF the top-level
+	// Subscription onto the subscription item — read it via the same accessor
+	// already used for price.id above (sub.items.data[0]?.price.id).
+	const currentPeriodEnd = sub.items.data[0]?.current_period_end;
 	const updatePayload: Record<string, unknown> = {
 		subscription_id: sub.id,
 		subscription_status: sub.status,
 		subscription_plan: tier ?? planLookup ?? priceId,
-		subscription_current_period_end: sub.current_period_end
-			? new Date(sub.current_period_end * 1000).toISOString()
+		subscription_current_period_end: currentPeriodEnd
+			? new Date(currentPeriodEnd * 1000).toISOString()
 			: null,
 		subscription_cancel_at_period_end: sub.cancel_at_period_end ?? false,
 		subscription_updated_at: new Date().toISOString(),

--- a/supabase/migrations/20260708131702_bill06_expenses_amount_to_numeric.sql
+++ b/supabase/migrations/20260708131702_bill06_expenses_amount_to_numeric.sql
@@ -1,0 +1,5 @@
+-- BILL-06: expenses.amount was integer (rounded cents on insert), contradicting the
+-- dollars-as-numeric(10,2) money model. Convert to numeric(10,2). Prod expenses is
+-- empty (0 rows) so this is lossless — no data conversion.
+ALTER TABLE public.expenses ALTER COLUMN amount TYPE numeric(10,2);
+COMMENT ON COLUMN public.expenses.amount IS 'Expense amount in DOLLARS (numeric(10,2)); converted from integer in BILL-06.';

--- a/supabase/migrations/20260708131721_bill06_data02_property_performance_analytics_numeric_and_status.sql
+++ b/supabase/migrations/20260708131721_bill06_data02_property_performance_analytics_numeric_and_status.sql
@@ -1,0 +1,55 @@
+-- BILL-06 + DATA-02 (one recreate so Phase 30 does not clobber the numeric cast):
+--   BILL-06: change SUM(e.amount)::bigint -> ::numeric and the RETURNS TABLE
+--     total_revenue/total_expenses/net_income from bigint -> numeric so fractional
+--     dollars survive.
+--   DATA-02 (its get_property_performance_analytics portion only): add
+--     `p.status <> 'inactive'` to both property-scan CTEs so soft-deleted properties
+--     don't emit rows / inflate totals. (Phase 30 still owns _with_trends / _trends.)
+-- Return-type change => DROP + CREATE (CREATE OR REPLACE errors). Grants re-issued.
+DROP FUNCTION IF EXISTS public.get_property_performance_analytics(uuid, uuid, text, integer);
+
+CREATE FUNCTION public.get_property_performance_analytics(p_user_id uuid, p_property_id uuid DEFAULT NULL::uuid, p_timeframe text DEFAULT '30d'::text, p_limit integer DEFAULT NULL::integer)
+ RETURNS TABLE(property_id uuid, property_name text, occupancy_rate numeric, total_revenue numeric, total_expenses numeric, net_income numeric, timeframe text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE v_days integer; v_start_date date;
+BEGIN
+  IF p_user_id != (SELECT auth.uid()) THEN
+    RAISE EXCEPTION 'Access denied: cannot request data for another user';
+  END IF;
+  v_days := CASE p_timeframe WHEN '7d' THEN 7 WHEN '30d' THEN 30 WHEN '90d' THEN 90
+    WHEN '180d' THEN 180 WHEN '365d' THEN 365 ELSE 30 END;
+  v_start_date := CURRENT_DATE - v_days;
+  RETURN QUERY
+  WITH property_units AS (
+    SELECT p.id AS prop_id, p.name AS prop_name, u.id AS unit_id, u.status AS unit_status
+    FROM properties p LEFT JOIN units u ON u.property_id = p.id
+    WHERE p.owner_user_id = p_user_id AND p.status <> 'inactive' AND (p_property_id IS NULL OR p.id = p_property_id)
+  ),
+  property_occupancy AS (
+    SELECT pu.prop_id, pu.prop_name,
+      COALESCE(ROUND((COUNT(*) FILTER (WHERE pu.unit_status = 'occupied')::numeric /
+        NULLIF(COUNT(*) FILTER (WHERE pu.unit_status IS DISTINCT FROM 'inactive')::numeric, 0)) * 100, 2), 0) AS occ_rate
+    FROM property_units pu GROUP BY pu.prop_id, pu.prop_name
+  ),
+  property_expenses AS (
+    SELECT p.id AS prop_id, COALESCE(SUM(e.amount), 0)::numeric AS expenses
+    FROM properties p LEFT JOIN units u ON u.property_id = p.id
+    LEFT JOIN maintenance_requests mr ON mr.unit_id = u.id AND mr.owner_user_id = p_user_id
+    LEFT JOIN expenses e ON e.maintenance_request_id = mr.id AND e.status <> 'inactive'
+      AND e.expense_date >= v_start_date
+    WHERE p.owner_user_id = p_user_id AND p.status <> 'inactive' AND (p_property_id IS NULL OR p.id = p_property_id)
+    GROUP BY p.id
+  )
+  SELECT po.prop_id, po.prop_name, po.occ_rate, 0::numeric AS total_revenue,
+    COALESCE(pe.expenses, 0) AS total_expenses, -COALESCE(pe.expenses, 0)::numeric AS net_income,
+    p_timeframe AS timeframe
+  FROM property_occupancy po LEFT JOIN property_expenses pe ON pe.prop_id = po.prop_id
+  ORDER BY po.prop_name LIMIT COALESCE(p_limit, 100);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_property_performance_analytics(uuid, uuid, text, integer) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_property_performance_analytics(uuid, uuid, text, integer) TO authenticated, service_role;

--- a/supabase/migrations/20260708132045_bill02_date_params_expense_summary_and_financial_overview.sql
+++ b/supabase/migrations/20260708132045_bill02_date_params_expense_summary_and_financial_overview.sql
@@ -1,0 +1,154 @@
+-- BILL-02: make get_expense_summary + get_financial_overview period-scopable.
+-- Add p_start_date/p_end_date; defaults reproduce today's one-sided YTD EXACTLY
+-- (p_start_date = start of current year, p_end_date = NULL = no upper bound, so
+-- future-dated expenses stay included as they are today). DROP the old (uuid)
+-- signatures first to avoid overload ambiguity with the new defaulted args.
+-- get_billing_insights is intentionally NOT touched — its live body has no
+-- date-scopable aggregate (unpaid/late-fee hardcoded 0 after rent_payments was
+-- demolished; MRR/churn/tenant-count are point-in-time).
+DROP FUNCTION IF EXISTS public.get_expense_summary(uuid);
+DROP FUNCTION IF EXISTS public.get_financial_overview(uuid);
+
+CREATE FUNCTION public.get_expense_summary(
+  p_user_id uuid,
+  p_start_date date DEFAULT date_trunc('year', current_date)::date,
+  p_end_date date DEFAULT NULL
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_result jsonb;
+  v_categories jsonb;
+  v_monthly jsonb;
+  v_total_amount numeric;
+  v_monthly_avg numeric;
+begin
+  if p_user_id != (select auth.uid()) then
+    raise exception 'Access denied: cannot request data for another user';
+  end if;
+
+  -- Spend breakdown for the selected period, grouped by vendor.
+  with cat as (
+    select
+      coalesce(nullif(e.vendor_name, ''), 'Other') as category,
+      sum(e.amount) as total
+    from expenses e
+    join maintenance_requests mr on mr.id = e.maintenance_request_id
+    where mr.owner_user_id = p_user_id
+      and e.status <> 'inactive'
+      and e.expense_date >= p_start_date
+      and (p_end_date is null or e.expense_date <= p_end_date)
+    group by coalesce(nullif(e.vendor_name, ''), 'Other')
+  ),
+  totals as (select coalesce(sum(total), 0) as grand from cat)
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'category', c.category,
+      'amount', c.total,
+      'percentage', round((c.total / nullif(t.grand, 0) * 100)::numeric, 2)
+    )
+  ), '[]'::jsonb) into v_categories
+  from cat c cross join totals t;
+
+  -- Monthly totals for the trailing 12 months (zero-filled) — a fixed rolling
+  -- series, NOT the selected period.
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'month', to_char(month_date, 'YYYY-MM'),
+      'amount', coalesce(monthly_total, 0)
+    )
+    order by month_date
+  ), '[]'::jsonb) into v_monthly
+  from (
+    select
+      generate_series(
+        date_trunc('month', current_date) - interval '11 months',
+        date_trunc('month', current_date),
+        interval '1 month'
+      )::date as month_date
+  ) months
+  left join (
+    select
+      date_trunc('month', e.expense_date)::date as expense_month,
+      sum(e.amount) as monthly_total
+    from expenses e
+    join maintenance_requests mr on mr.id = e.maintenance_request_id
+    where mr.owner_user_id = p_user_id
+      and e.status <> 'inactive'
+      and e.expense_date >= date_trunc('month', current_date) - interval '11 months'
+    group by date_trunc('month', e.expense_date)
+  ) exp on months.month_date = exp.expense_month;
+
+  -- Period total.
+  select coalesce(sum(e.amount), 0) into v_total_amount
+  from expenses e
+  join maintenance_requests mr on mr.id = e.maintenance_request_id
+  where mr.owner_user_id = p_user_id
+    and e.status <> 'inactive'
+    and e.expense_date >= p_start_date
+    and (p_end_date is null or e.expense_date <= p_end_date);
+
+  -- Month-weighted average over the trailing-12-month series.
+  select coalesce(avg((m->>'amount')::numeric), 0) into v_monthly_avg
+  from jsonb_array_elements(v_monthly) m;
+
+  v_result := jsonb_build_object(
+    'categories', v_categories,
+    'monthly_totals', v_monthly,
+    'total_amount', v_total_amount,
+    'monthly_average', round(v_monthly_avg::numeric, 2),
+    'year_over_year_change', null
+  );
+
+  return v_result;
+end;
+$function$;
+
+CREATE FUNCTION public.get_financial_overview(
+  p_user_id uuid,
+  p_start_date date DEFAULT date_trunc('year', current_date)::date,
+  p_end_date date DEFAULT NULL
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE v_total_revenue numeric; v_total_expenses numeric; v_net_income numeric;
+BEGIN
+  IF p_user_id != (SELECT auth.uid()) THEN
+    RAISE EXCEPTION 'Access denied: cannot request data for another user';
+  END IF;
+  -- Revenue stays active-lease MRR (point-in-time; period-historical revenue is
+  -- not in the data model — documented BILL-02 limitation).
+  SELECT coalesce(sum(rent_amount) * 12, 0) INTO v_total_revenue FROM leases
+  WHERE owner_user_id = p_user_id AND lease_status = 'active';
+  SELECT coalesce(sum(e.amount), 0) INTO v_total_expenses FROM expenses e
+  JOIN maintenance_requests mr ON mr.id = e.maintenance_request_id
+  JOIN units u ON u.id = mr.unit_id JOIN properties p ON p.id = u.property_id
+  WHERE p.owner_user_id = p_user_id AND e.status <> 'inactive'
+    AND e.expense_date >= p_start_date
+    AND (p_end_date IS NULL OR e.expense_date <= p_end_date);
+  v_net_income := v_total_revenue - v_total_expenses;
+  RETURN jsonb_build_object(
+    'overview', jsonb_build_object('total_revenue', v_total_revenue,
+      'total_expenses', v_total_expenses, 'net_income', v_net_income,
+      'accounts_receivable', 0, 'accounts_payable', 0),
+    'highlights', jsonb_build_array(
+      jsonb_build_object('label', 'Monthly Revenue', 'value', v_total_revenue / 12, 'trend', null),
+      jsonb_build_object('label', 'Operating Margin',
+        'value', CASE WHEN v_total_revenue > 0 THEN round((v_net_income / v_total_revenue * 100)::numeric, 1) ELSE 0 END,
+        'trend', null),
+      jsonb_build_object('label', 'Cash Position', 'value', v_net_income, 'trend', null)
+    )
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_expense_summary(uuid, date, date) FROM public;
+REVOKE ALL ON FUNCTION public.get_financial_overview(uuid, date, date) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_expense_summary(uuid, date, date) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_financial_overview(uuid, date, date) TO authenticated, service_role;


### PR DESCRIPTION
## v8.0 Phase 29: Billing, Stripe & Financial Reports (BILL-01..06)

Fifth and largest phase of the v8.0 bug-eradication milestone. Fixes all 6 billing/financial bugs — 3 migrations, 2 edge functions, frontend — verified against live prod.

### Fixes
- **BILL-01** — subscription `current_period_end` was read from the top-level Stripe object, but the pinned `stripe@20` (basil API) moved it to `subscription.items.data[].current_period_end` → it was always `undefined`, giving null billing dates and a `RangeError` crash on cancel/reactivate. Fixed the 4 edge reads + a `Number.isFinite` frontend guard.
- **BILL-02** — income-statement / cash-flow / tax-documents (and the report-analytics financial/year-end/1099 reports) ignored the selected period — the RPCs hardcoded YTD. Added `p_start_date`/`p_end_date` to `get_expense_summary` + `get_financial_overview` (NULL-default = exact YTD backward-compat) and wired the queries to forward their range. *Known limitation:* revenue stays annualized MRR — period-historical revenue isn't in the data model.
- **BILL-03** — unpaid invoices showed $0.00 (`amount_paid=0` won over `amount_due` via `??`). Now shows `amount_due` when unpaid.
- **BILL-04** — five combined-fetch financial consumers (plus two sibling report queries the review caught) silently defaulted expenses to 0 on RPC error, overstating net income. All now surface the error.
- **BILL-05** — the year-end/tax PDF was built from `get_dashboard_stats` regardless of report type. Now branches to the same RPCs as its CSV counterpart (`get_financial_overview`, etc.).
- **BILL-06** — `expenses.amount` was an `integer` column (rounded cents) read inconsistently as cents vs dollars across ~10 files. Migrated to `numeric(10,2)`, fixed the 5 wrong `formatCents` readers → `formatCurrency` (a $150 expense showed "$1.50" on /financials), and recreated `get_property_performance_analytics` (bigint→numeric).

### Migrations (3, applied to prod, verified live, repo↔prod byte-parity)
`131702` expenses.amount→numeric(10,2) · `131721` get_property_performance_analytics numeric+DATA-02 status (DROP+CREATE — return-type change) · `132045` get_expense_summary/get_financial_overview date params (DROP old (uuid), NULL-default backward-compat).

### Review (perfect-PR gate)
5 cycles. The tail was a chain of the *same* bug class in one sibling report-generation file (`report-analytics-keys.ts`) the executors kept missing — the adversarial sweeps caught each (BILL-04 error-swallowing → occupancy wrong-key → period-ignoring), all fixed; cycles 4+5 clean. The two DB dimensions re-proved against live prod every cycle. Log: `.planning/phases/29-billing-financials/29-REVIEW.md`.

### Verification
- typecheck 0 · lint 0 · full unit suite green · live DB proofs on all 3 migrations · prod left clean

### Residuals (owner-run / deferred)
- **3 owner-run edge redeploys** (CLI-401): `stripe-webhooks`, `stripe-cancel-subscription`, `generate-pdf` — code merges here; behavior takes effect on redeploy.
- **DATA-02 (Phase 30)** — the `get_property_performance_analytics` status predicate was folded into the BILL-06 recreate; Phase 30 still owns `_with_trends`/`_trends` and must NOT re-recreate `_analytics`.

[hudsor01]
