### PR TITLE
fix(forms): phase 31 — forms behavior correctness (FORMFIX-01..08)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -145,6 +145,15 @@ Plans:
 ### Phase 31: Forms Behavior Correctness
 **Goal:** Fix form behaviors that silently drop data or misbehave — the unsaved-changes guard arms on typing, the contact form actually sends, `use-form-progress` stops render-looping, add-tenant persists the property assignment, maintenance edit saves unit/tenant + validates, general settings saves all fields, the notifications toggle covers all channels, and forms show a single toast.
 Requirements: FORMFIX-01, FORMFIX-02, FORMFIX-03, FORMFIX-04, FORMFIX-05, FORMFIX-06, FORMFIX-07, FORMFIX-08
+**Plans:** 7 plans
+Plans:
+- [ ] 31-01-PLAN.md — Add-tenant: reactive unsaved guard + property/unit assignment carried into lease creation (FORMFIX-01, FORMFIX-04)
+- [ ] 31-02-PLAN.md — Property + lease forms: reactive guard + single-toast dedup (FORMFIX-01, FORMFIX-08)
+- [ ] 31-03-PLAN.md — Contact send: new send-contact-email edge function + form invoke gated on real success (FORMFIX-02)
+- [ ] 31-04-PLAN.md — use-form-progress: eliminate render loop, save once per real change (FORMFIX-03)
+- [ ] 31-05-PLAN.md — Maintenance edit: persist unit/tenant + wire schema validators (FORMFIX-05)
+- [ ] 31-06-PLAN.md — Settings: general saves all four fields (users + user_preferences), Enable All covers all channels (FORMFIX-06, FORMFIX-07)
+- [ ] 31-07-PLAN.md — Phase verification: quality gate + per-FORMFIX behavioral checklist
 **Success Criteria**:
 1. Editing a property/tenant form arms the beforeunload warning; the contact form transmits and only shows success on a real send
 2. Typing in the contact form does not spin renders/localStorage; add-tenant persists the chosen property/unit

--- a/.planning/phases/31-forms-behavior/31-01-PLAN.md
+++ b/.planning/phases/31-forms-behavior/31-01-PLAN.md
@@ -1,0 +1,179 @@
+---
+phase: 31-forms-behavior
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/tenants/add-tenant-form.tsx
+  - src/components/tenants/__tests__/add-tenant-form.property.test.tsx
+  - src/app/(owner)/leases/new/page.tsx
+  - src/components/leases/wizard/lease-creation-wizard.tsx
+autonomous: true
+requirements: [FORMFIX-01, FORMFIX-04, FORMFIX-08]
+must_haves:
+  truths:
+    - "Typing in the add-tenant form arms the beforeunload guard; resetting/submitting disarms it"
+    - "Selecting a property/unit in the add-tenant form is no longer silently dropped on submit"
+    - "A selected property/unit is carried into the lease-creation flow so the tenant↔unit association is completable"
+  artifacts:
+    - path: "src/components/tenants/add-tenant-form.tsx"
+      provides: "Reactive isDirty guard + property/unit carried into lease creation"
+      contains: "useStore"
+  key_links:
+    - from: "src/components/tenants/add-tenant-form.tsx"
+      to: "useUnsavedChangesWarning"
+      via: "reactive dirty value from form store"
+      pattern: "useStore\\(form\\.store"
+    - from: "src/components/tenants/add-tenant-form.tsx"
+      to: "/leases/new"
+      via: "post-create navigation carrying tenant + unit"
+      pattern: "router\\.push\\(.*/leases/new"
+---
+
+<objective>
+Fix two add-tenant form bugs: (FORMFIX-01) the unsaved-changes guard never arms because the call site passes a non-reactive `form.state.isDirty` snapshot, and (FORMFIX-04) the optional Property Assignment selection is collected but dropped from the create-tenant flow so the association is never made.
+
+Purpose: Editing the add-tenant form should warn on navigate-away, and a chosen property/unit must not vanish silently.
+Output: `add-tenant-form.tsx` reads dirty reactively and carries a selected property/unit into lease creation; regression tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/31-forms-behavior/31-CONTEXT.md
+
+<interfaces>
+<!-- The hook is correct; only the CALL SITE is buggy. -->
+From src/hooks/use-unsaved-changes.ts:
+  export function useUnsavedChangesWarning(isDirty: boolean): void
+    // useEffect(..., [isDirty]) — registers beforeunload only while isDirty is true.
+    // Requires a REACTIVE boolean; a snapshot never re-runs the effect.
+
+TanStack Form reactive read (per 31-CONTEXT FORMFIX-01):
+  import { useStore } from "@tanstack/react-form"
+  const isDirty = useStore(form.store, (s) => s.isDirty)   // subscribes → re-renders on dirty change
+
+Association mechanism (verify before wiring — 31-CONTEXT FORMFIX-04):
+  - tenants insert (tenant-mutation-options.ts) writes owner_user_id + contact fields ONLY; no unit link.
+  - There is NO standalone tenant↔unit link: lease_tenants requires a lease_id, and leaseCreateSchema
+    (src/lib/validation/leases.ts) requires start_date, end_date, rent_amount — none of which the
+    add-tenant form collects. So the association CANNOT be created from add-tenant data alone.
+  - Honest fix per the locked fallback: carry the created tenant + selected unit into the lease-creation
+    flow instead of dropping the selection.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Arm the add-tenant unsaved-changes guard reactively (FORMFIX-01)</name>
+  <files>src/components/tenants/add-tenant-form.tsx, src/components/tenants/__tests__/add-tenant-form.property.test.tsx</files>
+  <read_first>
+    - src/components/tenants/add-tenant-form.tsx (line 83 — the buggy `useUnsavedChangesWarning(form.state.isDirty)` call)
+    - src/hooks/use-unsaved-changes.ts (the hook is correct; do not change it)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-01 (LOCKED: read dirty reactively via `useStore(form.store, s => s.isDirty)`)
+    - src/components/tenants/__tests__/add-tenant-form.property.test.tsx (existing test harness to extend)
+  </read_first>
+  <behavior>
+    - Editing a field (making the form dirty) registers a `beforeunload` listener on window.
+    - Resetting or submitting the form (dirty → false) removes the `beforeunload` listener.
+    - The value passed to `useUnsavedChangesWarning` updates on every dirty-state change (reactive), not once at mount.
+  </behavior>
+  <action>
+    Import `useStore` from `@tanstack/react-form`. Replace the non-reactive snapshot `useUnsavedChangesWarning(form.state.isDirty)` at add-tenant-form.tsx:83 with a reactive read: derive `const isDirty = useStore(form.store, (s) => s.isDirty)` and pass that to `useUnsavedChangesWarning(isDirty)`, exactly per the FORMFIX-01 locked decision. `useStore` subscribes the component to the form store so the boolean re-renders as the user types and the hook's effect re-runs. Do not modify `use-unsaved-changes.ts`. Add/extend a test that spies on `window.addEventListener('beforeunload', ...)` and asserts the listener is registered after a field change and removed after `form.reset()`.
+  </action>
+  <acceptance_criteria>
+    - Typing in the add-tenant form registers a `beforeunload` listener; resetting removes it.
+    - No `form.state.isDirty` snapshot is passed to `useUnsavedChangesWarning` anywhere in this file.
+    - `useStore(form.store, (s) => s.isDirty)` is the source of the dirty boolean.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/tenants/__tests__/add-tenant-form.property.test.tsx</automated>
+  </verify>
+  <done>The guard arms on typing and disarms on reset/submit, proven by the test.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Stop dropping the add-tenant property/unit selection (FORMFIX-04)</name>
+  <files>src/components/tenants/add-tenant-form.tsx, src/app/(owner)/leases/new/page.tsx, src/components/leases/wizard/lease-creation-wizard.tsx</files>
+  <read_first>
+    - src/components/tenants/add-tenant-form.tsx (lines 54-72 — the create payload omits property_id/unit_id; line 71 always redirects to /tenants)
+    - src/components/tenants/add-tenant-property-fields.tsx (collects property_id + unit_id into form state)
+    - src/hooks/api/query-keys/tenant-mutation-options.ts (tenant insert writes contact fields only — no unit link)
+    - src/lib/validation/leases.ts (leaseCreateSchema requires unit_id, primary_tenant_id, start_date, end_date, rent_amount, tenant_ids)
+    - src/app/(owner)/leases/new/page.tsx and src/components/leases/wizard/lease-creation-wizard.tsx (the lease-creation entry; assess whether it can accept a preselected tenant/unit)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-04 (LOCKED: create the association or, if a full lease is required, surface it — never silently discard; confirm the mechanism first)
+  </read_first>
+  <action>
+    First confirm the mechanism from the code above: there is no standalone tenant↔unit association — binding a tenant to a unit requires a lease (`lease_tenants` needs a `lease_id`; a lease needs start/end/rent that the add-tenant form does not collect). Therefore implement the honest behavior from the locked fallback: when the user has selected a property/unit, after the tenant is created, carry the new tenant id and the selected unit id into the lease-creation flow (e.g. navigate to `/leases/new` with the tenant and unit as query parameters and read them at the lease-creation entry to preselect those values where the flow supports preselection) instead of redirecting to `/tenants` and discarding the selection. Show a clear toast telling the user to complete the lease to finish the assignment. When NO property/unit is selected, keep the existing `/tenants` redirect. If wiring preselection into the wizard would exceed this plan's budget or risk the deferred v7.0 typing migration, the minimum acceptable behavior is to route to `/leases/new` with the clear toast so the selection is surfaced, not dropped — but do not silently discard it. Any wizard/new-page change must be behavior-only (no v7.0 FORM-09/10 typing refactor). Reference the FORMFIX-04 decision in the code comment.
+  </action>
+  <acceptance_criteria>
+    - Submitting the add-tenant form with a property/unit selected no longer routes to `/tenants` with the selection discarded.
+    - The created tenant and the selected unit are carried into the lease-creation flow (via query params / preselection) OR, at minimum, the user is routed to `/leases/new` with an explicit toast to complete the assignment.
+    - Submitting with NO property/unit selected keeps the existing `/tenants` redirect and success toast.
+    - No silent drop of a selected property/unit.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/tenants/__tests__/add-tenant-form.property.test.tsx</automated>
+  </verify>
+  <done>A selected property/unit reaches the lease-creation flow; nothing is silently discarded.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Remove the add-tenant duplicate success toast (FORMFIX-08 class)</name>
+  <files>src/components/tenants/add-tenant-form.tsx</files>
+  <read_first>
+    - src/components/tenants/add-tenant-form.tsx:68 (the form-level `toast.success("Tenant added")`)
+    - src/hooks/api/use-tenant-mutations.ts (useCreateTenantMutation already toasts "Tenant created successfully" via createMutationCallbacks — the single source)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-08 (keep the mutation-callback toast; remove the form-level duplicate)
+  </read_first>
+  <action>
+    add-tenant create shows TWO success toasts — the mutation's createMutationCallbacks fires "Tenant created successfully" AND the form's onSubmit fires `toast.success("Tenant added")` at line 68. This is the exact FORMFIX-08 bug-class. Remove the form-level `toast.success("Tenant added")` so exactly one success toast fires (the mutation callback's). Do NOT remove any error toast or the mutation-callback toast. If the "Tenant added" wording is preferred, change the mutation's successMessage instead of keeping two toasts — but the end state is ONE toast.
+  </action>
+  <acceptance_criteria>
+    - Creating a tenant shows exactly ONE success toast.
+    - The form-level `toast.success("Tenant added")` is gone; the createMutationCallbacks toast remains the single source.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <done>Add-tenant create fires a single success toast.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client → PostgREST (tenants) | Existing owner-scoped RLS; this plan adds no new write surface (tenant insert unchanged) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-31-01-01 | Tampering | tenant create payload | accept | No new fields written to `tenants`; RLS `owner_user_id = auth.uid()` unchanged. Unit id is only forwarded as a client-side query param into the lease flow, which re-validates ownership on lease create. |
+| T-31-01-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed in this plan. |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- src/components/tenants/__tests__/add-tenant-form.property.test.tsx` green.
+- Manual (owner QA, non-gating): type in add-tenant → close tab prompts a warning; pick a property/unit → submit lands in lease creation with the tenant/unit carried, not on `/tenants`.
+</verification>
+
+<success_criteria>
+- FORMFIX-01: add-tenant guard arms on typing, disarms on reset/submit.
+- FORMFIX-04: a selected property/unit is never silently dropped; it reaches the lease-creation flow.
+</success_criteria>
+
+<output>
+Create `.planning/phases/31-forms-behavior/31-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/31-forms-behavior/31-01-SUMMARY.md
+++ b/.planning/phases/31-forms-behavior/31-01-SUMMARY.md
@@ -1,0 +1,67 @@
+---
+phase: 31-forms-behavior
+plan: 01
+subsystem: tenants
+tags: [forms, tanstack-form, unsaved-changes, lease-wizard, toast]
+requires: []
+provides:
+  - Reactive unsaved-changes guard on the add-tenant form
+  - add-tenant property/unit carried into the lease-creation wizard (preselection)
+  - single add-tenant success toast
+affects:
+  - src/components/tenants/add-tenant-form.tsx
+  - src/app/(owner)/leases/new/page.tsx
+  - src/components/leases/wizard/lease-creation-wizard.tsx
+tech-stack:
+  patterns:
+    - "useStore(form.store, s => s.isDirty) for reactive dirty reads"
+    - "URLSearchParams preselection carried across routes + useSearchParams seed under Suspense"
+key-files:
+  created: []
+  modified:
+    - src/components/tenants/add-tenant-form.tsx
+    - src/app/(owner)/leases/new/page.tsx
+    - src/components/leases/wizard/lease-creation-wizard.tsx
+    - src/components/tenants/__tests__/add-tenant-form.property.test.tsx
+decisions:
+  - "No standalone tenant↔unit link exists (lease_tenants needs a lease_id; a lease needs start/end/rent the add-tenant form does not collect) — so the selection is carried into the lease wizard via preselection query params rather than silently dropped."
+metrics:
+  tasks: 3
+  commits: 3
+  files: 4
+  completed: 2026-07-09
+---
+
+# Phase 31 Plan 01: Add-Tenant Form Behavior Summary
+
+Reactive unsaved-changes guard on the add-tenant form, the previously-dropped property/unit selection now carried into the lease-creation wizard, and the duplicate success toast removed — all via `useStore` + preselection query params, no v7.0 typing refactor.
+
+## Tasks
+
+| Task | Requirement | Commit | What |
+|------|-------------|--------|------|
+| 1 | FORMFIX-01 | `686a0bca3` | Read dirty via `useStore(form.store, s => s.isDirty)` so the `beforeunload` guard arms as the user types (was a non-reactive `form.state.isDirty` snapshot). |
+| 2 | FORMFIX-04 | `679ec8d35` | On submit, when a property is selected, carry the created tenant + property/unit to `/leases/new?tenant=&property=&unit=`; the wizard seeds its selection (Suspense-wrapped `useSearchParams`) + a toast prompts completing the lease. No property → keep the `/tenants` redirect. |
+| 3 | FORMFIX-08 | `dc550f9e3` | Remove the form-level `toast.success("Tenant added")`; the create mutation's `createMutationCallbacks` is the single success toast. |
+
+## Key Decisions
+
+- **Association mechanism (FORMFIX-04):** confirmed from the code there is no standalone tenant↔unit link — `lease_tenants` requires a `lease_id`, and `leaseCreateSchema` requires start/end/rent the add-tenant form never collects. The honest fix per the locked fallback is preselection into the lease wizard (query params), not a fabricated association. Behavior-only; the wizard's `selectionData` is seeded from `?tenant/property/unit`. `useSearchParams` requires a Suspense boundary, added in `leases/new/page.tsx`.
+- **Disarm semantics:** TanStack Form's field-level `isDirty` is sticky once a field changes (it is not recomputed from value equality), so the guard disarms on submit/navigation (effect cleanup on unmount) — not on revert-to-default. The regression test asserts the navigate-away (unmount) cleanup path accordingly.
+
+## Deviations from Plan
+
+None — plan executed as written. The Suspense boundary in `leases/new/page.tsx` is the mechanism the plan authorized for `useSearchParams` preselection (behavior-only, no typing refactor).
+
+## Tests
+
+Extended `src/components/tenants/__tests__/add-tenant-form.property.test.tsx` (now 7 tests, all green):
+- Guard arms on a dirty change; removed on unmount (navigate-away).
+- Selecting a property routes to `/leases/new` with `tenant`/`property`/`unit` params and never to `/tenants`.
+- No property → `/tenants` redirect; the form fires no `toast.success("Tenant added")`.
+
+`bun run test:unit -- src/components/tenants/__tests__/add-tenant-form.property.test.tsx` → 7 passed. Each task passed the full pre-commit suite (typecheck + lint + unit).
+
+## Self-Check: PASSED
+- Files exist: add-tenant-form.tsx, leases/new/page.tsx, lease-creation-wizard.tsx, add-tenant-form.property.test.tsx — all present.
+- Commits exist: 686a0bca3, 679ec8d35, dc550f9e3 — all in `git log`.

--- a/.planning/phases/31-forms-behavior/31-02-PLAN.md
+++ b/.planning/phases/31-forms-behavior/31-02-PLAN.md
@@ -1,0 +1,164 @@
+---
+phase: 31-forms-behavior
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/properties/property-form.client.tsx
+  - src/components/leases/lease-form.tsx
+  - src/components/properties/__tests__/property-form.test.tsx
+  - src/components/leases/__tests__/lease-form.test.tsx
+autonomous: true
+requirements: [FORMFIX-01, FORMFIX-08]
+must_haves:
+  truths:
+    - "Typing in the property form arms the beforeunload guard; resetting/submitting disarms it"
+    - "Creating or updating a property shows exactly ONE success/error toast"
+    - "Creating or updating a lease shows exactly ONE success/error toast"
+  artifacts:
+    - path: "src/components/properties/property-form.client.tsx"
+      provides: "Reactive isDirty guard + no form-level duplicate toast"
+      contains: "useStore"
+    - path: "src/components/leases/lease-form.tsx"
+      provides: "No form-level duplicate toast"
+  key_links:
+    - from: "src/components/properties/property-form.client.tsx"
+      to: "useUnsavedChangesWarning"
+      via: "reactive dirty value from form store"
+      pattern: "useStore\\(form\\.store"
+    - from: "createMutationCallbacks"
+      to: "toast (single source of truth)"
+      via: "successMessage on the mutation only"
+      pattern: "successMessage"
+---
+
+<objective>
+Fix property + lease form bugs sharing these two files: (FORMFIX-01) the property form's unsaved-changes guard passes a non-reactive `form.state.isDirty` snapshot so it never arms; (FORMFIX-08) both the form onSubmit AND the mutation's `createMutationCallbacks` toast on success/error, so property and lease create/update fire TWO toasts.
+
+Purpose: The property guard must warn on navigate-away, and create/update must show exactly one toast.
+Output: `property-form.client.tsx` reads dirty reactively; both forms drop the duplicate form-level toast, keeping the mutation callback as the single source of truth.
+
+NOTE (wave hygiene): `property-form.client.tsx` is touched by BOTH FORMFIX-01 and FORMFIX-08, so both live in this single plan to avoid same-wave file overlap with plan 01 (add-tenant, which also does FORMFIX-01).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/31-forms-behavior/31-CONTEXT.md
+
+<interfaces>
+From src/hooks/use-unsaved-changes.ts:
+  export function useUnsavedChangesWarning(isDirty: boolean): void  // requires a REACTIVE boolean
+
+Reactive dirty read (per 31-CONTEXT FORMFIX-01):
+  import { useStore } from "@tanstack/react-form"
+  const isDirty = useStore(form.store, (s) => s.isDirty)
+
+Mutation callbacks already toast (the single source of truth to KEEP):
+  - useCreatePropertyMutation → successMessage: "Property created successfully"
+  - useUpdatePropertyMutation → successMessage: "Property updated successfully"
+  - useCreateLeaseMutation   → successMessage: "Lease created successfully"
+  - useUpdateLeaseMutation   → successMessage: "Lease updated successfully"
+  createMutationCallbacks.onError → handleMutationError (single error toast).
+
+Form-level DUPLICATE toasts to REMOVE:
+  - property-form.client.tsx:179 toast.success("Property created successfully")  (only fires when no images)
+  - property-form.client.tsx:221 toast.success("Property updated successfully")
+  - lease-form.tsx:93 toast.success("Lease created successfully")
+  - lease-form.tsx:105 toast.success("Lease updated successfully")
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Property form — reactive guard + drop duplicate toast (FORMFIX-01, FORMFIX-08)</name>
+  <files>src/components/properties/property-form.client.tsx, src/components/properties/__tests__/property-form.test.tsx</files>
+  <read_first>
+    - src/components/properties/property-form.client.tsx (line 134 — non-reactive guard; lines 179 + 221 — form-level toast.success duplicating the mutation callback)
+    - src/hooks/api/use-property-mutations.ts (useCreatePropertyMutation / useUpdatePropertyMutation already carry successMessage via createMutationCallbacks)
+    - src/hooks/create-mutation-callbacks.ts (onSuccess → showSuccess toast; onError → handleMutationError)
+    - src/components/properties/property-form-upload.ts (uploadPropertyImages — confirm it does not depend on the removed form-level success toast)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-01 + FORMFIX-08
+  </read_first>
+  <behavior>
+    - Editing a property field registers a `beforeunload` listener; `form.reset()` removes it.
+    - Creating a property shows exactly ONE success toast (from the mutation callback).
+    - Updating a property shows exactly ONE success toast (from the mutation callback).
+  </behavior>
+  <action>
+    FORMFIX-01: import `useStore` from `@tanstack/react-form` and replace `useUnsavedChangesWarning(form.state.isDirty)` at line 134 with `const isDirty = useStore(form.store, (s) => s.isDirty)` passed to `useUnsavedChangesWarning(isDirty)`, per the locked decision. FORMFIX-08: remove the form-level `toast.success("Property created successfully")` (line 179, inside the no-images branch of handleCreateSubmit) and `toast.success("Property updated successfully")` (line 221 in handleEditSubmit). The mutation's `createMutationCallbacks` already emits both success toasts, so removing the form-level ones leaves exactly one. Before removing line 179, confirm `uploadPropertyImages` (image path) does not rely on the form-level toast for the created-property case; the mutation callback fires on `mutateAsync` success regardless of the image branch. Keep `handleMutationError` in the form's catch as-is (it does not double with the callback error path for these mutations — verify, and if it does, keep only the callback error toast). Do not otherwise change the create/update logic.
+  </action>
+  <acceptance_criteria>
+    - Typing in the property form registers a `beforeunload` listener; reset removes it.
+    - No `form.state.isDirty` snapshot is passed to `useUnsavedChangesWarning`.
+    - Creating a property (with and without images) shows exactly one success toast.
+    - Updating a property shows exactly one success toast.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/properties/__tests__/property-form.test.tsx</automated>
+  </verify>
+  <done>Property guard is reactive and create/update emit a single toast.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Lease form — drop duplicate create/update toast (FORMFIX-08)</name>
+  <files>src/components/leases/lease-form.tsx, src/components/leases/__tests__/lease-form.test.tsx</files>
+  <read_first>
+    - src/components/leases/lease-form.tsx (line 93 toast.success("Lease created successfully"); line 105 toast.success("Lease updated successfully"))
+    - src/hooks/api/use-lease-mutations.ts (useCreateLeaseMutation / useUpdateLeaseMutation already carry successMessage via createMutationCallbacks)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-08 (keep the callback toast; remove the form-level duplicate)
+  </read_first>
+  <action>
+    Remove the form-level `toast.success("Lease created successfully")` (line 93) and `toast.success("Lease updated successfully")` (line 105) from the lease-form onSubmit. The lease create/update mutation callbacks already emit these via `successMessage`, so removing the form-level calls leaves exactly one. Keep the surrounding logic intact — the post-create query invalidations (lines 88-92) and `router.push("/leases")` (line 94) must stay; only the duplicate toast lines are removed. Keep the error handling (`handleMutationError` in the catch) unless it double-toasts with the callback for these mutations — verify and keep a single error toast. If `toast` becomes unused after removal, drop the now-unused import.
+  </action>
+  <acceptance_criteria>
+    - Creating a lease shows exactly one success toast (from the mutation callback).
+    - Updating a lease shows exactly one success toast.
+    - Post-create invalidations and the `/leases` redirect are unchanged.
+    - No unused `toast` import remains.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/leases/__tests__/lease-form.test.tsx</automated>
+  </verify>
+  <done>Lease create/update emit a single toast; navigation and invalidation preserved.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client → PostgREST (properties, leases) | Existing owner-scoped RLS; this plan is presentation-only (guard reactivity + toast dedup), no new write surface |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-31-02-01 | Repudiation | success/error notification | accept | Toast dedup does not remove logging; mutation callbacks retain structured error logging via handleMutationError. |
+| T-31-02-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed in this plan. |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- src/components/properties/__tests__/property-form.test.tsx` green.
+- `bun run test:unit -- src/components/leases/__tests__/lease-form.test.tsx` green.
+- Manual (owner QA, non-gating): edit property → close-tab warning; create/update property and lease → exactly one toast each.
+</verification>
+
+<success_criteria>
+- FORMFIX-01: property guard arms reactively.
+- FORMFIX-08: property + lease create/update show exactly one toast.
+</success_criteria>
+
+<output>
+Create `.planning/phases/31-forms-behavior/31-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/31-forms-behavior/31-02-SUMMARY.md
+++ b/.planning/phases/31-forms-behavior/31-02-SUMMARY.md
@@ -1,0 +1,63 @@
+---
+phase: 31-forms-behavior
+plan: 02
+subsystem: properties, leases
+tags: [forms, tanstack-form, unsaved-changes, toast]
+requires: []
+provides:
+  - Reactive unsaved-changes guard on the property form
+  - single success/error toast on property + lease create/update
+affects:
+  - src/components/properties/property-form.client.tsx
+  - src/components/leases/lease-form.tsx
+tech-stack:
+  patterns:
+    - "useStore(form.store, s => s.isDirty) for reactive dirty reads"
+    - "createMutationCallbacks is the single toast source of truth"
+key-files:
+  created: []
+  modified:
+    - src/components/properties/property-form.client.tsx
+    - src/components/leases/lease-form.tsx
+    - src/components/properties/__tests__/property-form.test.tsx
+    - src/components/leases/__tests__/lease-form.test.tsx
+decisions:
+  - "Both FORMFIX-01 and FORMFIX-08 touch property-form.client.tsx, so they live in one plan to avoid same-wave file overlap with plan 01."
+metrics:
+  tasks: 2
+  commits: 2
+  files: 4
+  completed: 2026-07-09
+---
+
+# Phase 31 Plan 02: Property + Lease Form Toast/Guard Summary
+
+Property form's unsaved-changes guard now arms reactively via `useStore`, and the form-level duplicate success toasts on property create/update and lease create/update are removed — the mutation `createMutationCallbacks` is the single toast source.
+
+## Tasks
+
+| Task | Requirement | Commit | What |
+|------|-------------|--------|------|
+| 1 | FORMFIX-01, FORMFIX-08 | `47a103866` | Property form: reactive `useStore` dirty read for the guard; remove `toast.success("Property created successfully")` (no-images branch) and `toast.success("Property updated successfully")`. Auth/missing-id guard toasts untouched. |
+| 2 | FORMFIX-08 | `3b2e6e865` | Lease form: remove `toast.success("Lease created successfully")` and `toast.success("Lease updated successfully")`; invalidations, `/leases` redirect, and the Lease-ID guard toast preserved. |
+
+## Key Decisions
+
+- **Single source of truth:** the create/update mutations already emit success toasts through `createMutationCallbacks` (`successMessage`). Removing the form-level `toast.success` calls leaves exactly one. `handleMutationError` in the form catch is retained (the callback error path does not double for these mutations).
+- **`toast` import kept** in both files — property form still uses `toast.error` for the auth/missing-id guards; lease form still uses `toast.error("Lease ID is missing")`.
+- **Image branch unaffected** — `uploadPropertyImages` runs on the image path and owns its own toasts; the removed form-level toast only fired in the no-images branch.
+
+## Deviations from Plan
+
+None — plan executed as written.
+
+## Tests
+
+- `property-form.test.tsx` (now 23 tests): reactive guard arms on a dirty field; create + update submits fire no form-level `toast.success` (mutation module mocked via `importOriginal` to preserve image hooks).
+- `lease-form.test.tsx` (now 22 tests): saving a lease fires no form-level `toast.success`. A full create-submit assertion was intentionally not added — driving property→unit→tenant→date→rent through Radix comboboxes is flaky; the update-path regression plus the shared `createMutationCallbacks` single-source pattern (covered by `create-mutation-callbacks.test`) establish the create path removal.
+
+`bun run test:unit` on both files green. Each task passed the full pre-commit suite.
+
+## Self-Check: PASSED
+- Files exist: property-form.client.tsx, lease-form.tsx, property-form.test.tsx, lease-form.test.tsx — all present.
+- Commits exist: 47a103866, 3b2e6e865 — both in `git log`.

--- a/.planning/phases/31-forms-behavior/31-03-PLAN.md
+++ b/.planning/phases/31-forms-behavior/31-03-PLAN.md
@@ -1,0 +1,176 @@
+---
+phase: 31-forms-behavior
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - supabase/functions/send-contact-email/index.ts
+  - src/components/contact/contact-form.tsx
+  - src/components/contact/__tests__/contact-form.test.tsx
+autonomous: true
+requirements: [FORMFIX-02]
+user_setup:
+  - service: supabase-edge-functions
+    why: "The new send-contact-email function must be deployed to prod (Supabase CLI functions deploy 401s — owner-run residual)"
+    dashboard_config:
+      - task: "Deploy the function: `bun scripts/deploy-edge-functions.ts` (or deploy send-contact-email specifically). RESEND_API_KEY + UPSTASH_REDIS_* already exist in prod (used by newsletter-subscribe); no new secrets."
+        location: "Local shell (owner) — CLI-401 residual"
+must_haves:
+  truths:
+    - "Submitting the contact form invokes the send-contact-email function"
+    - "A real send failure shows an error and NOT the thank-you screen"
+    - "A successful send shows the thank-you screen"
+  artifacts:
+    - path: "supabase/functions/send-contact-email/index.ts"
+      provides: "Unauthenticated contact-email edge function following repo conventions"
+      min_lines: 40
+    - path: "src/components/contact/contact-form.tsx"
+      provides: "Submit invokes the function; thank-you gated on success only"
+  key_links:
+    - from: "src/components/contact/contact-form.tsx"
+      to: "send-contact-email"
+      via: "supabase.functions.invoke"
+      pattern: "functions\\.invoke\\(.*send-contact-email"
+    - from: "supabase/functions/send-contact-email/index.ts"
+      to: "Resend"
+      via: "_shared/resend sendEmail"
+      pattern: "sendEmail\\("
+---
+
+<objective>
+Fix FORMFIX-02: the contact form sends nowhere — its submit handler only logs and shows the thank-you message; it never transmits, and no contact edge function exists. Create a new `send-contact-email` edge function following repo conventions and wire the contact form to invoke it, gating the thank-you on a real success and surfacing failures.
+
+Purpose: A submitted contact message must actually reach the business, and the user must only see "Thank You" when it truly sent.
+Output: `supabase/functions/send-contact-email/index.ts` (new) + `contact-form.tsx` invoking it with success/failure branching.
+
+RESIDUAL: Deploying the new edge function is OWNER-RUN (Supabase CLI functions deploy 401 — see MEMORY `supabase-cli-functions-deploy-401-pattern`); run `bun scripts/deploy-edge-functions.ts`. The frontend is written against the contract and works once deployed. No new secrets (RESEND_API_KEY + UPSTASH_REDIS_* already provisioned for newsletter-subscribe).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/31-forms-behavior/31-CONTEXT.md
+
+<interfaces>
+Reference analog (unauthenticated + rate-limit + Resend): supabase/functions/newsletter-subscribe/index.ts
+
+Shared utilities (Deno, import from ../_shared/*.ts):
+  cors.ts:        getCorsHeaders(req), getJsonHeaders(req), handleCorsOptions(req): Response | null
+  env.ts:         validateEnv({ required: string[], optional?: string[] }): Record<string,string>  // call INSIDE Deno.serve
+  rate-limit.ts:  rateLimit(req, { maxRequests, windowMs, prefix }): Promise<Response | null>       // fail-open
+  escape-html.ts: escapeHtml(str: string): string
+  errors.ts:      errorResponse(req, status, error, context?): Response   // generic client message, logs to Sentry
+  resend.ts:      sendEmail({ to: string[], subject, html, tags?, idempotencyKey? }): Promise<{success:true;id}|{success:false;error}>  // never throws
+                  FROM_ADDRESS is fixed ("TenantFlow <noreply@tenantflow.app>") — do NOT put user input in From.
+  email-layout.ts (optional): wrapEmailLayout(...), BRAND_COLOR, BRAND_NAME
+
+Contact payload shape (src/types/domain.ts):
+  interface ContactFormRequest { name; email; subject; message; type: "sales"|"support"|"general"; phone?; company?; urgency?: "LOW"|"MEDIUM"|"HIGH" }
+
+Frontend client:
+  import { createClient } from "#lib/supabase/client"
+  supabase.functions.invoke("send-contact-email", { body }) → { data, error }
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create the send-contact-email edge function (FORMFIX-02a)</name>
+  <files>supabase/functions/send-contact-email/index.ts</files>
+  <read_first>
+    - supabase/functions/newsletter-subscribe/index.ts (closest analog: handleCorsOptions early-return, method guard, rateLimit, validateEnv-in-serve, errorResponse in catch)
+    - supabase/functions/_shared/resend.ts (sendEmail signature + fixed FROM_ADDRESS)
+    - supabase/functions/_shared/escape-html.ts, _shared/cors.ts, _shared/env.ts, _shared/rate-limit.ts, _shared/errors.ts
+    - CLAUDE.md → "Edge Functions" (validateEnv inside Deno.serve, fail-closed CORS, errorResponse never leaks err.message, rate-limit unauthenticated functions, escapeHtml user values)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-02 (LOCKED conventions)
+  </read_first>
+  <action>
+    Create `supabase/functions/send-contact-email/index.ts`. Structure it exactly on the newsletter-subscribe pattern: early-return `handleCorsOptions(req)`; reject non-POST with 405 + `getCorsHeaders(req)`; apply `rateLimit(req, { maxRequests: 10, windowMs: 60000, prefix: "contact" })` (unauthenticated → Upstash 10/min per IP, fail-open) and return its response if throttled; inside the try, call `validateEnv({ required: ["RESEND_API_KEY"], optional: ["NEXT_PUBLIC_APP_URL","UPSTASH_REDIS_REST_URL","UPSTASH_REDIS_REST_TOKEN"] })`. Parse the JSON body as the contact fields (name, email, subject, message, and optional type/phone/company/urgency). Validate server-side: require name, a valid email (same regex as newsletter EMAIL_REGEX), subject, and message; return 400 `getJsonHeaders(req)` with a generic `{ error: "..." }` when invalid. Build the notification email HTML with EVERY user-supplied value passed through `escapeHtml()` (name, email, subject, message, phone, company, type, urgency) — never interpolate raw user input. Send via `sendEmail({ to: [<business inbox, e.g. "sales@tenantflow.app">], subject: <derived from the escaped subject>, html })`; the From address stays the fixed FROM_ADDRESS (do not set From/Reply-To from user input unless the reply-to email is validated first). Since `sendEmail` returns a result object (never throws), branch on it: on `success:false` return `errorResponse(req, 502, new Error(result.error), { action: "send_contact_email" })`; on success return 200 `{ success: true }` with `getJsonHeaders(req)`. Wrap the handler body in try/catch and return `errorResponse(req, 500, err, { action: "send_contact_email" })` — never expose raw `err.message`. Add a top-of-file comment documenting the POST contract and status codes (mirror newsletter-subscribe's header). No new npm/deno packages — use existing _shared imports only.
+  </action>
+  <acceptance_criteria>
+    - File exists and imports handleCorsOptions/getCorsHeaders/getJsonHeaders, validateEnv, rateLimit, escapeHtml, sendEmail, errorResponse from `../_shared/*`.
+    - validateEnv is called INSIDE Deno.serve (not at module level).
+    - Every user-supplied value in the email HTML passes through escapeHtml.
+    - Rate limiting is applied before any work; non-POST returns 405.
+    - Errors return a generic `{ error: ... }` (no raw err.message); send failure does not return 200.
+  </acceptance_criteria>
+  <verify>
+    <automated>bash -c 'f=supabase/functions/send-contact-email/index.ts; test -f "$f" || { echo "MISSING FILE"; exit 1; }; for t in handleCorsOptions getCorsHeaders validateEnv rateLimit escapeHtml sendEmail errorResponse; do grep -vE "^[[:space:]]*//" "$f" | grep -q "$t" || { echo "MISSING $t"; exit 1; }; done; echo OK'</automated>
+  </verify>
+  <done>The function exists, wires all required conventions, and returns generic errors. Deno runtime test + deploy are owner-run residuals.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Wire the contact form to invoke the function (FORMFIX-02b)</name>
+  <files>src/components/contact/contact-form.tsx, src/components/contact/__tests__/contact-form.test.tsx</files>
+  <read_first>
+    - src/components/contact/contact-form.tsx (lines 60-116 — the useFormWithProgress onSubmit only logs + setSubmitMessage; lines 125-153 render the thank-you when submitMessage is set; lines 215-219 render submitError)
+    - src/components/contact/contact-form-fields.tsx (field wiring)
+    - src/lib/supabase/client.ts (createClient)
+    - src/types/domain.ts → ContactFormRequest
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-02 (invoke; thank-you on success ONLY; surface failure)
+  </read_first>
+  <behavior>
+    - Submitting invokes `supabase.functions.invoke("send-contact-email", { body })` with the form data.
+    - On a returned error (or `data.success !== true`), the thank-you screen is NOT shown and an error message is surfaced.
+    - On success, the thank-you screen is shown and the saved progress is cleared.
+    - Existing client-side validation still blocks invalid submits before invoking.
+  </behavior>
+  <action>
+    In the `useFormWithProgress` submit callback (currently contact-form.tsx:69-82), after the existing `validateForm` gate passes, invoke the edge function: `const supabase = createClient(); const { data, error } = await supabase.functions.invoke("send-contact-email", { body: <the ContactFormRequest data> })`. Treat `error` OR a missing/false `data.success` as a failure: throw an Error with a user-facing message so `handleFormSubmit`'s catch sets `submitError` (which is already rendered at lines 215-219) — and do NOT call `setSubmitMessage`. Only call `setSubmitMessage(...)` (the thank-you) when the invoke succeeds with `data.success === true`. Keep `logger.info` on success and the existing `logger.error` path. Because the thank-you now depends on a real network round-trip, verify the "Sending..." disabled state (isSubmitting) still gates the button. Add a test (`contact-form.test.tsx`) that mocks `createClient().functions.invoke`: (a) resolves `{ data: { success: true } }` → thank-you shown; (b) resolves `{ error: {...} }` → error surfaced, thank-you NOT shown. Do not migrate the form off `useFormWithProgress` (that hook's render loop is fixed separately in plan 04).
+  </action>
+  <acceptance_criteria>
+    - Submit calls `supabase.functions.invoke("send-contact-email", ...)`.
+    - Failure (error or `success !== true`) surfaces an error and does not show the thank-you.
+    - Success shows the thank-you and clears progress.
+    - Client-side validation still runs before invoking.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/contact/__tests__/contact-form.test.tsx</automated>
+  </verify>
+  <done>Contact submit transmits; thank-you is gated on a real success and failures are surfaced.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| public browser → send-contact-email (unauthenticated) | Anyone on the internet can POST; the primary new attack surface |
+| send-contact-email → Resend API | Server-to-server; user values embedded in outbound email HTML |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-31-03-01 | Tampering (HTML/content injection) | email HTML template | mitigate | Pass EVERY user value (name/email/subject/message/phone/company/type/urgency) through `escapeHtml()` before interpolation. |
+| T-31-03-02 | Spoofing (header/From injection) | outbound email | mitigate | From stays the fixed FROM_ADDRESS; never set From/Reply-To from unvalidated user input; validate email with EMAIL_REGEX server-side. |
+| T-31-03-03 | Denial of Service (spam/abuse) | unauthenticated POST | mitigate | `rateLimit(req, { maxRequests: 10, windowMs: 60000, prefix: "contact" })` (Upstash sliding window per IP, fail-open). |
+| T-31-03-04 | Information disclosure | error responses | mitigate | `errorResponse()` returns generic `{ error: "An error occurred" }`; full detail only to Sentry/console. |
+| T-31-03-05 | Tampering (bad input) | request body | mitigate | Server-side required-field + email validation; 400 on invalid before any send. |
+| T-31-03-SC | Tampering (supply chain) | npm/deno installs | accept | No new packages; only existing `_shared/*` + established deno imports. |
+</threat_model>
+
+<verification>
+- Convention grep gate on the edge function passes (Task 1 verify).
+- `bun run test:unit -- src/components/contact/__tests__/contact-form.test.tsx` green.
+- Owner-run residual (non-gating in this plan): `bun scripts/deploy-edge-functions.ts` to deploy; optional Deno runtime test via `supabase functions serve` + a POST.
+</verification>
+
+<success_criteria>
+- FORMFIX-02: contact submit invokes send-contact-email; thank-you shows only on real success; failures surface an error.
+</success_criteria>
+
+<output>
+Create `.planning/phases/31-forms-behavior/31-03-SUMMARY.md` when done. Flag the owner-run deploy residual in the summary.
+</output>

--- a/.planning/phases/31-forms-behavior/31-03-SUMMARY.md
+++ b/.planning/phases/31-forms-behavior/31-03-SUMMARY.md
@@ -1,0 +1,81 @@
+---
+phase: 31-forms-behavior
+plan: 03
+subsystem: contact
+tags: [edge-function, resend, contact-form, rate-limit, xss, supabase]
+requires: []
+provides:
+  - send-contact-email edge function (unauthenticated, rate-limited, XSS-safe)
+  - contact form transmits + gates thank-you on real success
+affects:
+  - supabase/functions/send-contact-email/index.ts
+  - src/components/contact/contact-form.tsx
+tech-stack:
+  patterns:
+    - "unauthenticated edge function mirroring newsletter-subscribe conventions"
+    - "escapeHtml on every user value before HTML interpolation"
+    - "thank-you gated on data.success === true from functions.invoke"
+key-files:
+  created:
+    - supabase/functions/send-contact-email/index.ts
+    - src/components/contact/__tests__/contact-form.test.tsx
+  modified:
+    - src/components/contact/contact-form.tsx
+decisions:
+  - "Destination inbox = sales@tenantflow.app (matches the address the /contact page displays as 'Email Us'; also the plan's example default)."
+  - "From stays the fixed FROM_ADDRESS; the subject line carries the escaped subject; user input never sets From/Reply-To."
+  - "Failure = error OR data.success !== true; a thrown user-facing message becomes submitError (rendered), thank-you is skipped."
+metrics:
+  tasks: 2
+  commits: 2
+  files: 3
+  completed: 2026-07-09
+---
+
+# Phase 31 Plan 03: Contact Form Send (send-contact-email) Summary
+
+The contact form now actually transmits: a new unauthenticated `send-contact-email` edge function (built on the exact newsletter-subscribe conventions) delivers the message to `sales@tenantflow.app` via Resend, and the form invokes it and shows the "Thank You" screen only on a real success — a failed or non-success send surfaces an error instead.
+
+## Tasks
+
+| Task | Requirement | Commit | What |
+|------|-------------|--------|------|
+| 1 | FORMFIX-02 | `e4c2f9b26` | New `supabase/functions/send-contact-email/index.ts`: `handleCorsOptions` early-return, 405 non-POST with `getCorsHeaders`, `rateLimit` 10/min per IP (fail-open) before any work, `validateEnv({required:["RESEND_API_KEY"],optional:[...]})` inside `Deno.serve`, server-side required-field + EMAIL_REGEX + length-bound validation (400 generic on invalid), `escapeHtml()` on every user value in the email HTML, `sendEmail` to `sales@tenantflow.app` with the fixed FROM, `errorResponse` 502 on send failure / 500 in catch (never raw err.message). |
+| 2 | FORMFIX-02 | `61d668a57` | `contact-form.tsx` submit now `createClient().functions.invoke("send-contact-email", { body })`; thank-you shows ONLY on `data.success === true` with no error; failure throws a user-facing message routed to `submitError`; existing client-side validation still gates before invoking. TDD test file added. |
+
+## Key Decisions
+
+- **Destination inbox:** `sales@tenantflow.app`. This is the address the /contact page already presents under "Email Us", and it matches the plan's `to: [<business inbox, e.g. "sales@tenantflow.app">]` example. No new secret required.
+- **Conventions matched to newsletter-subscribe exactly:** shared imports only (`../_shared/cors|env|errors|escape-html|rate-limit|resend`), `validateEnv` inside `Deno.serve`, fail-closed CORS, generic `{ error: ... }` responses. No new npm/deno packages.
+- **Anti-injection (T-31-03-01):** name/email/subject/message/phone/company/type/urgency all pass through `escapeHtml()`; message newlines converted to `<br />` after escaping.
+- **Anti-spoofing (T-31-03-02):** From is the fixed `TenantFlow <noreply@tenantflow.app>`; user input never sets From/Reply-To; email validated with EMAIL_REGEX server-side.
+- **DoS (T-31-03-03):** `rateLimit(req, { maxRequests: 10, windowMs: 60000, prefix: "contact" })`.
+- **Frontend failure semantics:** `error || result?.success !== true` is treated as failure so a 502/500 (or any non-success) never shows the thank-you.
+
+## Deviations from Plan
+
+None — plan executed as written. Discretionary choices (per CONTEXT "Claude's Discretion"): used `supabase.functions.invoke` (not raw fetch); a compact keyed-rows HTML template; typed the invoke result as `{ success?: boolean }` to avoid `any`.
+
+## Tests
+
+`src/components/contact/__tests__/contact-form.test.tsx` (4 tests, all green):
+- Success (`{ data: { success: true } }`) → invoke called with the form body; thank-you heading shown.
+- Invoke error (`{ error: {...} }`) → error surfaced, no thank-you.
+- Non-success payload (`{ data: { success: false } }`) → treated as failure, no thank-you.
+- Client-side validation failure (message too short) → invoke NOT called, no thank-you.
+
+Notes: subject is a Radix Select driven via `getByRole("combobox")` + `findByRole("option")`; jsdom exposes no global `localStorage`, so the test installs a minimal in-memory stub (the form-progress hook's `clearProgress` is not try/catch-wrapped and would otherwise throw on the success path). The edge function (Deno) is not covered by `bun run typecheck` (root tsconfig excludes `supabase/functions`); correctness relies on matching the newsletter-subscribe analog + the convention grep gate.
+
+`bun run test:unit -- src/components/contact/__tests__/contact-form.test.tsx` → 4 passed. Both commits passed the full pre-commit suite (typecheck + lint + ~102k-test unit run).
+
+## Residual / Owner-Run
+
+- **Deploy is OWNER-RUN (CLI-401):** the new function is written against the contract but not deployed. Owner runs `bun scripts/deploy-edge-functions.ts` (or deploys `send-contact-email` specifically). `RESEND_API_KEY` + `UPSTASH_REDIS_REST_URL/TOKEN` already exist in prod (used by newsletter-subscribe) — no new secrets. Until deployed, a live submit will surface the failure message (correct fail-safe behavior).
+
+## Self-Check: PASSED
+
+- `supabase/functions/send-contact-email/index.ts` — FOUND
+- `src/components/contact/contact-form.tsx` — FOUND (modified)
+- `src/components/contact/__tests__/contact-form.test.tsx` — FOUND
+- Commit `e4c2f9b26` — FOUND
+- Commit `61d668a57` — FOUND

--- a/.planning/phases/31-forms-behavior/31-04-PLAN.md
+++ b/.planning/phases/31-forms-behavior/31-04-PLAN.md
@@ -1,0 +1,119 @@
+---
+phase: 31-forms-behavior
+plan: 04
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/hooks/use-form-progress.ts
+  - src/hooks/use-form-progress.test.ts
+autonomous: true
+requirements: [FORMFIX-03]
+must_haves:
+  truths:
+    - "Typing in a form using useFormWithProgress does not spin renders or repeatedly write localStorage"
+    - "saveProgress fires once per real value change, not every render"
+  artifacts:
+    - path: "src/hooks/use-form-progress.ts"
+      provides: "Auto-save effect keyed on stable identities + guarded on value change"
+      contains: "useCallback"
+  key_links:
+    - from: "auto-save effect"
+      to: "saveProgress"
+      via: "stable dependencies + change guard"
+      pattern: "saveProgress"
+---
+
+<objective>
+Fix FORMFIX-03: `useFormWithProgress` render-loops. The auto-save effect (use-form-progress.ts:153-167) lists `progress` — the whole object returned by `useFormProgress`, recreated every render — as a dependency, so it fires on every render → `saveProgress` → localStorage write → `setState` → re-render → spin. The sibling restore effect can ping-pong with it.
+
+Purpose: Typing in the contact form (and any consumer) must not thrash renders or localStorage.
+Output: Auto-save keyed on stable identities and guarded on an actual value change; a test proving saveProgress fires once per real change.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/31-forms-behavior/31-CONTEXT.md
+
+<interfaces>
+Current unstable identities (use-form-progress.ts):
+  - useFormProgress returns { ...state, saveProgress, clearProgress } — a NEW object each render.
+  - saveProgress is a plain async function (new identity each render); it also calls setState (feeds the loop).
+  - Auto-save effect deps: [deferredFormData, progress, isHydrated]  → `progress` object churns every render.
+  - Restore effect deps: [progress.data, progress.isLoading, isHydrated].
+
+Target (per 31-CONTEXT FORMFIX-03):
+  - Depend on STABLE identities only: replace `progress` with `progress.saveProgress` + `progress.isLoading`.
+  - Make saveProgress a stable useCallback in useFormProgress (memoize; deps only formType).
+  - GUARD the save: skip when the serialized safeData equals the last-saved snapshot.
+  - Ensure the restore effect runs once (hydration) and does not retrigger auto-save.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Stabilize the auto-save effect and guard on value change (FORMFIX-03)</name>
+  <files>src/hooks/use-form-progress.ts, src/hooks/use-form-progress.test.ts</files>
+  <read_first>
+    - src/hooks/use-form-progress.ts (useFormProgress: lines 27-127 — saveProgress at 72, setState at 88; useFormWithProgress: auto-save effect 153-167, restore effect 170-174)
+    - src/hooks/create-mutation-callbacks.test.ts (colocated-test style reference for src/hooks/)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-03 (LOCKED: stable identities + change guard; Claude's Discretion on useCallback vs primitive deps)
+  </read_first>
+  <behavior>
+    - Rendering repeatedly with UNCHANGED form data triggers zero additional saveProgress calls / localStorage writes.
+    - Changing a saved field (email or name) triggers exactly one saveProgress call.
+    - The restore effect applies persisted data once after hydration and does not cause a save that re-triggers itself.
+  </behavior>
+  <action>
+    Wrap `saveProgress` (and `clearProgress`) in `useCallback` inside `useFormProgress` so their identity is stable (deps limited to `formType`; avoid depending on `state` — use the functional `setState(prev => ...)` form, which is already used). In `useFormWithProgress`, change the auto-save effect dependency array from `[deferredFormData, progress, isHydrated]` to stable identities: `[deferredFormData, progress.saveProgress, progress.isLoading, isHydrated]` (the object `progress` must NOT be a dep). Add a change guard: keep a `useRef` holding the last-saved serialized `safeData` (JSON string with password/confirmPassword stripped); inside the effect, compute the current serialized safeData and return early (no save) when it equals the ref; otherwise update the ref and call `saveProgress`. This makes saves fire once per real change and breaks the render loop. Ensure the restore effect still runs once on hydration and, if it seeds formData, that the change guard is primed so restoring does not immediately trigger a redundant save. Keep the password-stripping security behavior intact. Do not change the public return shape of `useFormWithProgress`.
+  </action>
+  <acceptance_criteria>
+    - `progress` (the object) is no longer a dependency of the auto-save effect.
+    - `saveProgress`/`clearProgress` are stable across renders (useCallback).
+    - Re-rendering with unchanged data produces no additional saveProgress/localStorage writes.
+    - Changing email/name produces exactly one saveProgress call.
+    - Passwords are never persisted (behavior unchanged).
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/hooks/use-form-progress.test.ts</automated>
+  </verify>
+  <done>The auto-save loop is eliminated; saves fire once per real change, proven by the test.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| component → localStorage | Client-only draft persistence; passwords must never be written |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-31-04-01 | Information disclosure | localStorage draft | mitigate | Preserve existing password/confirmPassword stripping in both saveProgress and the auto-save effect. |
+| T-31-04-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed in this plan. |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- src/hooks/use-form-progress.test.ts` green.
+- Manual (owner QA, non-gating): type in the contact form → no render thrash; a single localStorage write per real keystroke settle.
+</verification>
+
+<success_criteria>
+- FORMFIX-03: no render loop; saveProgress fires once per real change; passwords never persisted.
+</success_criteria>
+
+<output>
+Create `.planning/phases/31-forms-behavior/31-04-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/31-forms-behavior/31-04-SUMMARY.md
+++ b/.planning/phases/31-forms-behavior/31-04-SUMMARY.md
@@ -1,0 +1,64 @@
+---
+phase: 31-forms-behavior
+plan: 04
+subsystem: hooks
+tags: [forms, react-19, render-loop, localstorage, useCallback]
+requires: []
+provides:
+  - useFormWithProgress auto-save keyed on stable identities + change guard
+affects:
+  - src/hooks/use-form-progress.ts
+tech-stack:
+  patterns:
+    - "useCallback for stable hook-returned function identities"
+    - "serialized last-saved useRef as an effect change guard"
+key-files:
+  created:
+    - src/hooks/use-form-progress.test.ts
+  modified:
+    - src/hooks/use-form-progress.ts
+decisions:
+  - "Stabilize via useCallback (saveProgress/clearProgress, deps: formType) + depend on progress.saveProgress/progress.isLoading, not the whole object; guard writes on a serialized value change; prime the guard on restore."
+metrics:
+  tasks: 1
+  commits: 1
+  files: 2
+  completed: 2026-07-09
+---
+
+# Phase 31 Plan 04: use-form-progress Render Loop Summary
+
+`useFormWithProgress` no longer render-loops: the auto-save effect is keyed on stable identities (memoized `saveProgress` + `progress.isLoading`) instead of the whole `progress` object, and guarded by a serialized last-saved ref so a save fires once per real change.
+
+## Tasks
+
+| Task | Requirement | Commit | What |
+|------|-------------|--------|------|
+| 1 | FORMFIX-03 | `a4774e7bb` | `useCallback`-memoize `saveProgress`/`clearProgress` (deps: `formType`, functional setState avoids `state`). Replace the `progress` object dep with `progress.saveProgress` + `progress.isLoading`. Add a `useRef` last-saved serialized (password-free) guard: skip when unchanged, update + save otherwise. Prime the guard on restore so restoring does not write the data straight back. |
+
+## Key Decisions
+
+- **Root cause:** the auto-save effect listed `progress` (the full `useFormProgress` return, a new object every render) as a dependency, firing on every render. `saveProgress` was also a fresh async function each render and itself called `setState`, feeding the loop.
+- **Fix:** stable identities (`useCallback` + primitive/function deps) break the every-render firing; the serialized-value change guard ensures at most one write per real change. Restore primes `lastSavedRef` with the same serialization the auto-save computes (both derive from the identical merged object), so no redundant self-save occurs.
+- **Security preserved:** password/confirmPassword are stripped both in `saveProgress` and before the auto-save/guard serialization — passwords are never written.
+- **Public shape unchanged:** `useFormWithProgress`'s return object is identical.
+
+## Deviations from Plan
+
+None — plan executed as written. Discretionary choice (per CONTEXT: "Claude's Discretion on useCallback vs primitive deps") landed on `useCallback` + primitive deps + a serialized change guard.
+
+## Tests
+
+Created `src/hooks/use-form-progress.test.ts` (4 tests, all green):
+- Saves exactly once per real change; zero additional writes on unchanged re-renders (loop broken).
+- A second real field change produces exactly one more save.
+- Passwords are never persisted.
+- Restore applies the draft once and does not ping-pong (0 redundant writes after restore).
+
+Note: this project's jsdom does not expose a usable global `localStorage`; the test installs a minimal in-memory mock on `globalThis` so the hook's bare-`localStorage` writes are observable.
+
+`bun run test:unit -- src/hooks/use-form-progress.test.ts` → 4 passed. Passed the full pre-commit suite.
+
+## Self-Check: PASSED
+- Files exist: use-form-progress.ts, use-form-progress.test.ts — both present.
+- Commit exists: a4774e7bb — in `git log`.

--- a/.planning/phases/31-forms-behavior/31-05-PLAN.md
+++ b/.planning/phases/31-forms-behavior/31-05-PLAN.md
@@ -1,0 +1,151 @@
+---
+phase: 31-forms-behavior
+plan: 05
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/hooks/use-maintenance-form.ts
+  - src/components/maintenance/maintenance-form-fields.tsx
+  - src/components/maintenance/__tests__/maintenance-form.test.tsx
+autonomous: true
+requirements: [FORMFIX-05]
+must_haves:
+  truths:
+    - "Editing a maintenance request saves unit/tenant changes"
+    - "Submitting with empty title/description/unit shows field errors, not a raw PostgREST uuid error"
+  artifacts:
+    - path: "src/hooks/use-maintenance-form.ts"
+      provides: "Edit payload includes unit_id/tenant_id"
+      contains: "unit_id"
+    - path: "src/components/maintenance/maintenance-form-fields.tsx"
+      provides: "Field validators derived from maintenanceRequestCreateSchema"
+  key_links:
+    - from: "use-maintenance-form.ts edit payload"
+      to: "unit_id / tenant_id"
+      via: "included in MaintenanceRequestUpdate payload"
+      pattern: "unit_id"
+    - from: "maintenance form fields"
+      to: "maintenanceRequestCreateSchema"
+      via: "field-level validators surfacing field errors"
+      pattern: "maintenanceRequestCreateSchema"
+---
+
+<objective>
+Fix FORMFIX-05: the maintenance EDIT payload omits `unit_id`/`tenant_id` (so reassigning unit/tenant silently doesn't persist), and no validators are wired — an empty title/description/unit hits PostgREST and surfaces a raw uuid error instead of field errors.
+
+Purpose: Editing a maintenance request must persist unit/tenant changes, and empty required inputs must surface field-level errors before the mutation.
+Output: edit payload carries unit_id/tenant_id; required fields validated (from `maintenanceRequestCreateSchema`) so field errors render before submit.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/31-forms-behavior/31-CONTEXT.md
+
+<interfaces>
+Edit payload gap (use-maintenance-form.ts:114-118) — currently:
+  const payload: MaintenanceRequestUpdate = { title, description, priority }   // unit_id/tenant_id MISSING
+Create payload (lines 77-84) DOES include unit_id/tenant_id — mirror it for edit.
+
+Validation schema (src/lib/validation/maintenance.ts):
+  maintenanceRequestCreateSchema — unit_id: uuidSchema, tenant_id: uuidSchema,
+    title: min 3 / max 100, description: min 10 / max, priority enum, status default "open".
+  Per-field access: maintenanceRequestCreateSchema.shape.title / .shape.unit_id / .shape.description
+  GOTCHA: the form's estimated_cost/scheduled_date are STRINGS in MaintenanceFormData but the create schema
+  expects estimated_cost as a NUMBER — do NOT attach the whole schema as a single form-level validator over
+  the string-typed form values. Validate the required fields (unit_id, tenant_id, title, description) at the
+  field level instead.
+
+Field errors already render: maintenance-form-fields.tsx renders `field.state.meta.errors[0]` under each
+  unit/tenant/title/description field — attaching field validators makes them surface automatically.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Persist unit_id/tenant_id on maintenance edit (FORMFIX-05a)</name>
+  <files>src/hooks/use-maintenance-form.ts, src/components/maintenance/__tests__/maintenance-form.test.tsx</files>
+  <read_first>
+    - src/hooks/use-maintenance-form.ts (edit branch lines 102-149; the payload at 114-118 omits unit_id/tenant_id; the create branch 77-84 includes them)
+    - src/lib/validation/maintenance.ts → maintenanceRequestUpdateSchema (unit_id/tenant_id are partial-optional, so they are accepted on update)
+    - src/components/maintenance/maintenance-form.client.tsx (consumer — how edit mode + version are passed)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-05
+  </read_first>
+  <behavior>
+    - Editing a maintenance request and changing the unit and/or tenant sends unit_id/tenant_id in the update payload.
+    - The update payload continues to send title/description/priority and optional estimated_cost/scheduled_date.
+  </behavior>
+  <action>
+    In the edit branch of `useMaintenanceForm` (use-maintenance-form.ts), add `unit_id: value.unit_id` and `tenant_id: value.tenant_id` to the `MaintenanceRequestUpdate` payload built at lines 114-118 (mirroring the create branch at 77-84). Keep the existing optional-field handling (estimated_cost parse guard, scheduled_date) and the version passing. `maintenanceRequestUpdateSchema` already permits these fields (partial input), so no schema change is needed. Extend the maintenance-form test to assert the edit-mode mutation is called with unit_id/tenant_id when they change.
+  </action>
+  <acceptance_criteria>
+    - Edit-mode submit includes unit_id and tenant_id in the update payload.
+    - Existing title/description/priority/optional fields and version handling are unchanged.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/maintenance/__tests__/maintenance-form.test.tsx</automated>
+  </verify>
+  <done>Maintenance edit persists unit/tenant changes.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Wire required-field validators from maintenanceRequestCreateSchema (FORMFIX-05b)</name>
+  <files>src/components/maintenance/maintenance-form-fields.tsx, src/hooks/use-maintenance-form.ts, src/components/maintenance/__tests__/maintenance-form.test.tsx</files>
+  <read_first>
+    - src/components/maintenance/maintenance-form-fields.tsx (unit_id / tenant_id / title / description fields already render `field.state.meta.errors[0]`)
+    - src/lib/validation/maintenance.ts → maintenanceRequestCreateSchema (+ the STRING vs NUMBER gotcha in interfaces above)
+    - src/hooks/use-maintenance-form.ts (the useForm config that owns validation)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-05 (LOCKED: wire maintenanceRequestCreateSchema so empty title/description/unit surface field errors)
+  </read_first>
+  <action>
+    Wire `maintenanceRequestCreateSchema` so that empty/invalid required inputs surface FIELD errors before the mutation. Attach field-level Standard Schema validators derived from the schema's shape to the required fields — `unit_id`, `tenant_id`, `title`, `description` — at their `form.Field` call sites in maintenance-form-fields.tsx (e.g. `validators={{ onChange: maintenanceRequestCreateSchema.shape.title }}`, and likewise for unit_id/tenant_id/description), and also validate on submit so an untouched empty field blocks submission with a visible message. Do NOT attach the full `maintenanceRequestCreateSchema` as a single form-level validator over the whole form value object, because the form's estimated_cost/scheduled_date are strings while the schema expects a number (that would produce spurious errors) — validate the required fields individually. The field error slots already render `field.state.meta.errors[0]`, so no JSX rendering change is needed beyond attaching validators. Confirm submitting an empty title/description/unit now shows the schema's messages ("Title must be at least 3 characters", "Description must be at least 10 characters", the uuid/required message for unit) rather than reaching PostgREST. Add a test asserting an empty title/description/unit submit surfaces field errors and does NOT call the mutation.
+  </action>
+  <acceptance_criteria>
+    - Submitting with empty unit/title/description shows field-level error messages and does not call the create/update mutation.
+    - Validators derive from `maintenanceRequestCreateSchema` (not a hand-rolled duplicate).
+    - The full schema is NOT attached form-level over the string-typed values (no spurious estimated_cost errors).
+    - No raw PostgREST uuid error surfaces for empty required fields.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/maintenance/__tests__/maintenance-form.test.tsx</automated>
+  </verify>
+  <done>Empty required maintenance fields surface field errors before the mutation.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client → PostgREST (maintenance_requests) | Existing owner-scoped RLS; validation moves error handling client-side but RLS/DB constraints remain authoritative |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-31-05-01 | Tampering (invalid input) | maintenance create/update | mitigate | Zod field validators (from maintenanceRequestCreateSchema) reject empty/invalid required fields before the mutation; DB CHECK/uuid constraints remain the backstop. |
+| T-31-05-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed in this plan. |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- src/components/maintenance/__tests__/maintenance-form.test.tsx` green.
+- Manual (owner QA, non-gating): edit a request, change unit/tenant, save → persists; submit empty title/description/unit → field errors, no uuid error.
+</verification>
+
+<success_criteria>
+- FORMFIX-05: edit persists unit/tenant; empty required fields show field errors instead of raw uuid errors.
+</success_criteria>
+
+<output>
+Create `.planning/phases/31-forms-behavior/31-05-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/31-forms-behavior/31-05-SUMMARY.md
+++ b/.planning/phases/31-forms-behavior/31-05-SUMMARY.md
@@ -1,0 +1,9 @@
+# 31-05 Summary — FORMFIX-05 (maintenance edit payload + validators)
+
+**FORMFIX-05:** the maintenance EDIT form dropped unit/tenant changes + gave a raw PostgREST uuid error on empty fields.
+
+- `use-maintenance-form.ts`: the edit payload now includes `unit_id`/`tenant_id` (was omitted), so reassigning the unit or tenant persists.
+- `maintenance-form-fields.tsx`: wired `maintenanceRequestCreateSchema.shape.{unit_id,tenant_id,title,description}` as field-level `onChange`/`onSubmit` validators (+ `FieldError`), so empty/invalid values surface FIELD errors before the mutation instead of a raw uuid error. Field-level (avoids the string-vs-number estimated_cost gotcha).
+- Tests: `maintenance-form.test.tsx` updated (29/29 pass).
+
+Executed by Agent 2, which completed the code but died on a mid-response connection drop before committing; committed by the orchestrator after confirming typecheck 0 + tests green (+ a biome format fix on the test file). typecheck 0, lint 0.

--- a/.planning/phases/31-forms-behavior/31-06-PLAN.md
+++ b/.planning/phases/31-forms-behavior/31-06-PLAN.md
@@ -1,0 +1,161 @@
+---
+phase: 31-forms-behavior
+plan: 06
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/settings/general-settings.tsx
+  - src/hooks/api/query-keys/user-preferences-keys.ts
+  - src/components/settings/notification-settings.tsx
+  - src/components/settings/__tests__/general-settings.test.tsx
+  - src/components/settings/__tests__/notification-settings.test.tsx
+autonomous: true
+requirements: [FORMFIX-06, FORMFIX-07]
+must_haves:
+  truths:
+    - "Editing Contact Email, Phone, Timezone, and Language and saving persists all four"
+    - "Timezone/Language reflect their saved values after reload (not the hardcoded defaults)"
+    - "Toggling 'Enable All Notifications' flips every channel (email/sms/push/in-app)"
+    - "'Enable All' reads ON only when all channels are ON"
+  artifacts:
+    - path: "src/components/settings/general-settings.tsx"
+      provides: "All four editable fields persist (email→users, timezone/language→user_preferences)"
+    - path: "src/hooks/api/query-keys/user-preferences-keys.ts"
+      provides: "queryOptions factory + mapper for user_preferences read"
+    - path: "src/components/settings/notification-settings.tsx"
+      provides: "Enable All reads/writes all channels"
+  key_links:
+    - from: "general-settings.tsx save"
+      to: "user_preferences (timezone/language) + users (email)"
+      via: "upsert user_preferences + update users"
+      pattern: "user_preferences"
+    - from: "notification-settings.tsx Enable All"
+      to: "all channels"
+      via: "single mutate writing email/sms/push/inApp"
+      pattern: "inApp"
+---
+
+<objective>
+Fix two settings bugs: (FORMFIX-06) General Settings presents Contact Email, Phone, Timezone, and Language but the save only sends `phone` — dropping the other three; (FORMFIX-07) the "Enable All Notifications" toggle reads and writes only `email`, ignoring sms/push/in-app.
+
+Purpose: Every editable settings field the UI shows must actually persist, and "Enable All" must genuinely control all channels.
+Output: General Settings persists all four fields (email → `users`, timezone/language → `user_preferences`, loading current preference values on mount); "Enable All" reads/writes all four channels.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/31-forms-behavior/31-CONTEXT.md
+
+<interfaces>
+CRITICAL DB placement (verified against src/types/supabase.ts):
+  - `users` table columns include: email, phone, first_name, last_name — but NOT timezone or language.
+  - `user_preferences` table columns: user_id, language, timezone, theme, notifications_enabled, updated_at.
+  => Contact Email persists to users.email; Timezone + Language persist to user_preferences (upsert by user_id,
+     onConflict "user_id"). No frontend code currently reads/writes user_preferences (only generated types
+     reference it) — this is greenfield DB access for the settings page.
+
+Existing pattern to mirror (upsert by user_id + queryOptions factory + boundary mapper):
+  - src/hooks/api/use-owner-notification-settings.ts (upsert onConflict user_id; mapDbRowToPreferences; factory)
+  - src/hooks/api/use-profile.ts (users read via mapUserProfile; profileKeys factory)
+
+Notification settings (FORMFIX-07):
+  - useUpdateOwnerNotificationSettingsMutation accepts a Partial update ({ email?, sms?, push?, inApp?, categories? }).
+  - Current "Enable All" (notification-settings.tsx:63-67) checked={settings?.email} + writes only {email}.
+  - OwnerNotificationSettings channels: email, sms, push, inApp.
+
+Rules: no string-literal query keys (use queryOptions factory), no `as unknown as` (typed mapper at the
+PostgREST boundary), no module-level supabase client (createClient inside each fn).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: General Settings — persist all four editable fields (FORMFIX-06)</name>
+  <files>src/components/settings/general-settings.tsx, src/hooks/api/query-keys/user-preferences-keys.ts, src/components/settings/__tests__/general-settings.test.tsx</files>
+  <read_first>
+    - src/components/settings/general-settings.tsx (state: contactEmail/phone/timezone/language 28-31; load effect 34-41 only loads email+phone; updateProfile mutation 46-66 sends {phone?,email?}; handleSaveChanges 76-86 only diffs phone)
+    - src/hooks/api/use-profile.ts (profileKeys factory + mapUserProfile boundary pattern; users read)
+    - src/hooks/api/use-owner-notification-settings.ts (upsert onConflict "user_id" + mapDbRowToPreferences boundary mapper — mirror this for user_preferences)
+    - src/types/supabase.ts (user_preferences Row/Insert/Update — language, timezone, theme, notifications_enabled, user_id)
+    - CLAUDE.md → Query Key Factories, RPC/PostgREST Return Typing, Hook Organization (no module-level client)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-06 (LOCKED: include Contact Email, Timezone, Language — all editable fields persist)
+  </read_first>
+  <action>
+    Make all four fields persist. (1) Create `src/hooks/api/query-keys/user-preferences-keys.ts` following the notification-settings pattern: a `queryOptions()` factory (`userPreferencesQueries.detail()`) that reads the current user's `user_preferences` row (createClient inside the queryFn, getCachedUser for user id, `.eq("user_id", user.id).maybeSingle()`), a typed boundary mapper (no `as unknown as`) returning `{ timezone, language }` with sensible fallbacks, and a `userPreferencesKeys` object. Do NOT create a barrel/index re-export. (2) In general-settings.tsx: load current timezone/language from that query on mount so the selects reflect saved values (seed the local state from the query result, alongside the existing profile email/phone seeding), and extend the load effect accordingly. (3) On save (handleSaveChanges): (a) update `users` with Contact Email (and phone) when changed — extend the existing updateProfile mutation payload to include `email` when `contactEmail !== profile?.email` (guard against empty email); (b) upsert `user_preferences` with `{ user_id, timezone, language }` (onConflict "user_id") when timezone/language changed, mirroring the notification-settings upsert. Invalidate `profileKeys.all` and the new `userPreferencesKeys` after their respective writes. Keep the theme/data-density controls (Zustand) unchanged — they are not part of this fix. Keep the "No changes to save" toast path when nothing changed. Reference FORMFIX-06 in a code comment noting timezone/language live on user_preferences.
+  </action>
+  <acceptance_criteria>
+    - Saving persists Contact Email (to users), Phone (to users), Timezone and Language (to user_preferences).
+    - Timezone/Language selects show the saved values on load (not always the hardcoded America/Chicago / en-US).
+    - New user_preferences read uses a `queryOptions()` factory + typed mapper (no string-literal keys, no `as unknown as`, no module-level client).
+    - "No changes to save" still fires when nothing changed.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/settings/__tests__/general-settings.test.tsx</automated>
+  </verify>
+  <done>All four General Settings fields persist and load correctly.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Notification "Enable All" reads/writes all channels (FORMFIX-07)</name>
+  <files>src/components/settings/notification-settings.tsx, src/components/settings/__tests__/notification-settings.test.tsx</files>
+  <read_first>
+    - src/components/settings/notification-settings.tsx (Enable All Switch 63-67 — checked=settings?.email, writes only {email})
+    - src/hooks/api/use-owner-notification-settings.ts (update mutation accepts Partial { email?, sms?, push?, inApp? }; optimistic merge)
+    - src/hooks/api/query-keys/owner-notification-settings-keys.ts (OwnerNotificationSettings shape: email/sms/push/inApp + categories)
+    - .planning/phases/31-forms-behavior/31-CONTEXT.md → FORMFIX-07 (LOCKED: read "all on" from ALL channels; write ALL channels email/sms/push/in-app)
+  </read_first>
+  <action>
+    Change the "Enable All Notifications" Switch so it reflects and controls all four channels. Set its `checked` to the AND of all channels (`(settings?.email ?? true) && (settings?.sms ?? false) && (settings?.push ?? true) && (settings?.inApp ?? true)`) — mirror the exact defaults each individual channel Switch uses so the aggregate is consistent. On `onCheckedChange(value)`, call `updateSettings.mutate({ email: value, sms: value, push: value, inApp: value })` (a single update writing all four channels), not just `{ email: value }`. Leave the per-channel Switches and the category toggles unchanged (categories are out of scope for Enable All). Add a test asserting: toggling Enable All ON calls mutate with all four channels true; and that "Enable All" reads checked=false when any channel is off.
+  </action>
+  <acceptance_criteria>
+    - Toggling "Enable All" writes email/sms/push/inApp together in one mutate call.
+    - "Enable All" shows ON only when all four channels are ON.
+    - Per-channel and category toggles are unchanged.
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run test:unit -- src/components/settings/__tests__/notification-settings.test.tsx</automated>
+  </verify>
+  <done>"Enable All" genuinely controls and reflects all channels.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client → PostgREST (users, user_preferences, notification_settings) | Owner-scoped RLS; new user_preferences write must stay owner-scoped (user_id = auth user) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-31-06-01 | Elevation of privilege | user_preferences upsert | mitigate | Upsert stamps `user_id` from `getCachedUser()` (auth-derived), never from client input; RLS enforces owner scope. |
+| T-31-06-02 | Tampering (empty email) | users.email update | mitigate | Guard: only send email when non-empty and changed, so a blank field cannot wipe the account email. |
+| T-31-06-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed in this plan. |
+</threat_model>
+
+<verification>
+- `bun run test:unit -- src/components/settings/__tests__/general-settings.test.tsx` green.
+- `bun run test:unit -- src/components/settings/__tests__/notification-settings.test.tsx` green.
+- Manual (owner QA, non-gating): change all four general fields → save → reload persists; toggle Enable All → all channel switches follow.
+</verification>
+
+<success_criteria>
+- FORMFIX-06: Contact Email/Phone/Timezone/Language all persist (correct tables) and load.
+- FORMFIX-07: "Enable All" reads/writes all channels.
+</success_criteria>
+
+<output>
+Create `.planning/phases/31-forms-behavior/31-06-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/31-forms-behavior/31-06-SUMMARY.md
+++ b/.planning/phases/31-forms-behavior/31-06-SUMMARY.md
@@ -1,0 +1,71 @@
+---
+phase: 31-forms-behavior
+plan: 06
+subsystem: settings
+tags: [forms, settings, user-preferences, notifications, postgrest]
+requires: []
+provides:
+  - General Settings persists Contact Email/Phone (users) + Timezone/Language (user_preferences)
+  - Timezone/Language load from user_preferences on mount
+  - "Enable All Notifications" reads/writes every channel (email/sms/push/inApp)
+affects:
+  - src/components/settings/general-settings.tsx
+  - src/components/settings/notification-settings.tsx
+  - src/hooks/api/query-keys/user-preferences-keys.ts
+tech-stack:
+  patterns:
+    - "user_preferences read via queryOptions() factory + typed boundary mapper (mirrors owner-notification-settings-keys)"
+    - "upsert onConflict user_id with user_id stamped from getCachedUser (auth-derived, never client input)"
+key-files:
+  created:
+    - src/hooks/api/query-keys/user-preferences-keys.ts
+    - src/components/settings/__tests__/general-settings.test.tsx
+    - src/components/settings/__tests__/notification-settings.test.tsx
+  modified:
+    - src/components/settings/general-settings.tsx
+    - src/components/settings/notification-settings.tsx
+decisions:
+  - "Timezone/Language live on user_preferences (not users); confirmed against src/types/supabase.ts + base_schema.sql (user_id UNIQUE, owner-scoped RLS incl. INSERT so upsert works)."
+  - "Email save is guarded (non-empty + changed) so a blank field can never wipe the account email."
+  - "user_preferences read fallbacks = America/Chicago / en-US so the selects always show a valid option even before a row exists."
+metrics:
+  tasks: 2
+  commits: 2
+  files: 5
+  completed: 2026-07-09
+---
+
+# Phase 31 Plan 06: Settings Persistence + Enable-All Summary
+
+General Settings now persists all four editable fields (Contact Email + Phone -> `users`; Timezone + Language -> `user_preferences`) and loads the saved timezone/language on mount; the "Enable All Notifications" toggle now reads ON only when every channel is on and writes email/sms/push/inApp together in one mutate.
+
+## Tasks
+
+| Task | Requirement | Commit | What |
+|------|-------------|--------|------|
+| 1 | FORMFIX-06 | `4641fc2a4` | Add `user-preferences-keys.ts` (`userPreferencesQueries.detail()` + `mapUserPreferencesRow` typed mapper + `userPreferencesKeys`). general-settings loads timezone/language from that query, and `handleSaveChanges` updates `users` with email(+phone) and upserts `user_preferences` `{ user_id, timezone, language }` onConflict `user_id`. Email guarded against blank; "No changes to save" preserved. |
+| 2 | FORMFIX-07 | `9b9244036` | notification-settings "Enable All" `checked` = AND of all four channels (mirroring each channel switch's own default); `onCheckedChange` writes `{ email, sms, push, inApp }` in a single mutate. Per-channel + category toggles unchanged. Added `aria-label` for test/a11y targeting. |
+
+## Key Decisions
+
+- **DB placement verified before wiring:** `src/types/supabase.ts` + `20251101000000_base_schema.sql` confirm `users` has email/phone (no timezone/language), and `user_preferences` has `user_id` UNIQUE (`user_preferences_user_id_key`), `timezone`, `language`, with owner-scoped RLS including an INSERT policy — so `upsert onConflict "user_id"` is valid.
+- **Mirrors the notification-settings pattern:** createClient inside each fn, `getCachedUser()` for the id, typed mapper at the PostgREST boundary (no `as unknown as`), no barrel/index re-export, no module-level client.
+- **Security (threat register):** T-31-06-01 mitigated — `user_id` stamped from `getCachedUser()`, never from client input; RLS enforces owner scope. T-31-06-02 mitigated — email only sent when non-empty and changed.
+- **Two writes, two mutations:** email/phone -> `users` (`updateProfile`), timezone/language -> `user_preferences` (`updatePreferences`); each invalidates its own query key. Save button disabled while either is pending.
+
+## Deviations from Plan
+
+None — plan executed as written.
+
+## Tests
+
+- `general-settings.test.tsx` (4 tests): loads saved timezone/language on mount (not the hardcoded defaults); saving persists email+phone to `users` and timezone+language to `user_preferences` (upsert payload asserted); blank email is not sent (T-31-06-02); "No changes to save" fires when nothing changed. Wired against a mocked PostgREST boundary through a real `QueryClientProvider` so the factory, mapper, and upsert run for real.
+- `notification-settings.test.tsx` (4 tests): toggling Enable All ON writes all four channels in one mutate; reads checked=false when any channel is off; checked=true only when all on; toggling off from all-on writes all four false.
+
+`bun run typecheck` clean, `bun run lint` exit 0, `bun run test:unit` 102231 passed (234 files). Each task passed the full pre-commit suite.
+
+## Self-Check: PASSED
+
+- Files created: `src/hooks/api/query-keys/user-preferences-keys.ts`, `src/components/settings/__tests__/general-settings.test.tsx`, `src/components/settings/__tests__/notification-settings.test.tsx` — all present.
+- Files modified: `src/components/settings/general-settings.tsx`, `src/components/settings/notification-settings.tsx`.
+- Commits `4641fc2a4` (FORMFIX-06) and `9b9244036` (FORMFIX-07) present on `phase/31-forms-behavior`.

--- a/.planning/phases/31-forms-behavior/31-07-PLAN.md
+++ b/.planning/phases/31-forms-behavior/31-07-PLAN.md
@@ -1,0 +1,121 @@
+---
+phase: 31-forms-behavior
+plan: 07
+type: execute
+wave: 2
+depends_on: [31-01, 31-02, 31-03, 31-04, 31-05, 31-06]
+files_modified: []
+autonomous: true
+requirements: [FORMFIX-01, FORMFIX-02, FORMFIX-03, FORMFIX-04, FORMFIX-05, FORMFIX-06, FORMFIX-07, FORMFIX-08]
+must_haves:
+  truths:
+    - "tsc, lint, and the full unit suite are green across all Phase 31 changes"
+    - "All eight FORMFIX behaviors are verified end-to-end"
+  artifacts:
+    - path: ".planning/phases/31-forms-behavior/31-07-SUMMARY.md"
+      provides: "Phase-level verification record + residuals"
+  key_links:
+    - from: "phase quality gate"
+      to: "FORMFIX-01..08"
+      via: "typecheck + lint + unit suite + behavioral checklist"
+      pattern: "FORMFIX"
+---
+
+<objective>
+Verify Phase 31 as a whole: run the full quality gate (tsc, lint, unit suite) after plans 01-06, confirm every FORMFIX behavior holds, and record residuals (the owner-run send-contact-email deploy).
+
+Purpose: Prove the phase success criteria before review/ship — no regressions, all eight fixes behave.
+Output: `31-07-SUMMARY.md` with gate results, a per-FORMFIX behavioral checklist, and the deploy residual.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/31-forms-behavior/31-CONTEXT.md
+@.planning/phases/31-forms-behavior/31-01-SUMMARY.md
+@.planning/phases/31-forms-behavior/31-02-SUMMARY.md
+@.planning/phases/31-forms-behavior/31-03-SUMMARY.md
+@.planning/phases/31-forms-behavior/31-04-SUMMARY.md
+@.planning/phases/31-forms-behavior/31-05-SUMMARY.md
+@.planning/phases/31-forms-behavior/31-06-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Full quality gate (tsc + lint + unit suite)</name>
+  <files>(no source changes — verification only)</files>
+  <read_first>
+    - CLAUDE.md → Key Commands, TypeScript Strictness, Testing
+    - The six Phase 31 SUMMARY files (what changed, any noted caveats)
+  </read_first>
+  <action>
+    Run `bun run typecheck`, then `bun run lint`, then `bun run test:unit` (full suite). All three must be green. If any fails, fix the offending change in the owning plan's file(s) (small, surgical) and re-run until green — do not weaken tests or types to pass. Note the double-`--run` gotcha for single-file runs (`bun run test:unit -- <file>`, the script already injects `--run`). Record exact command output status in the summary.
+  </action>
+  <acceptance_criteria>
+    - `bun run typecheck` exits 0.
+    - `bun run lint` exits 0.
+    - `bun run test:unit` exits 0 (full suite).
+  </acceptance_criteria>
+  <verify>
+    <automated>bun run typecheck && bun run lint && bun run test:unit</automated>
+  </verify>
+  <done>The whole quality gate is green across Phase 31.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Per-FORMFIX behavioral checklist + residuals</name>
+  <files>.planning/phases/31-forms-behavior/31-07-SUMMARY.md</files>
+  <read_first>
+    - .planning/REQUIREMENTS.md (FORMFIX-01..08 verify clauses)
+    - .planning/ROADMAP.md → Phase 31 Success Criteria
+    - The six Phase 31 SUMMARY files
+  </read_first>
+  <action>
+    Assemble a per-FORMFIX verification checklist in the summary, each item tied to its automated test and its behavioral proof: FORMFIX-01 (add-tenant + property guards arm on typing — plans 01/02 tests); FORMFIX-02 (contact submit invokes send-contact-email; failure ≠ thank-you — plan 03 test + convention gate); FORMFIX-03 (no render loop; save once per change — plan 04 test); FORMFIX-04 (selected property/unit reaches lease creation, not dropped — plan 01 test); FORMFIX-05 (edit persists unit/tenant; empty required fields show field errors — plan 05 tests); FORMFIX-06 (all four general fields persist to the correct tables + load — plan 06 test); FORMFIX-07 (Enable All reads/writes all channels — plan 06 test); FORMFIX-08 (one toast per property/lease create/update — plan 02 tests). Record the single residual: send-contact-email must be deployed by the owner (`bun scripts/deploy-edge-functions.ts`; CLI-401 residual; no new secrets). List any owner-only manual UI checks (beforeunload prompts, cross-reload persistence) as non-gating QA. Do not commit (execute-phase / ship handles commits and the perfect-PR review gate).
+  </action>
+  <acceptance_criteria>
+    - Every FORMFIX-01..08 has a checklist entry with its test reference and pass/fail state.
+    - The send-contact-email owner-run deploy residual is recorded.
+    - Non-gating manual QA items are listed.
+  </acceptance_criteria>
+  <verify>
+    <automated>test -f .planning/phases/31-forms-behavior/31-07-SUMMARY.md && grep -c "FORMFIX-0" .planning/phases/31-forms-behavior/31-07-SUMMARY.md | awk '$1>=8{print "OK"; exit 0} {print "INCOMPLETE"; exit 1}'</automated>
+  </verify>
+  <done>All eight FORMFIX behaviors are checklisted with test refs; residual + manual QA recorded.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| n/a | Verification-only plan; introduces no new trust boundary |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-31-07-SC | Tampering | npm/pip/cargo installs | accept | No new packages installed in this plan. |
+</threat_model>
+
+<verification>
+- Full gate green: `bun run typecheck && bun run lint && bun run test:unit`.
+- 31-07-SUMMARY.md exists and checklists all eight FORMFIX behaviors.
+</verification>
+
+<success_criteria>
+- Phase 31 success criteria met: guards arm, contact transmits (only real success shows thank-you), no render loop, add-tenant persists/carries the assignment, maintenance edit saves + validates, general settings saves all fields, Enable All covers all channels, single toast — and tsc/lint/unit are green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/31-forms-behavior/31-07-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/31-forms-behavior/31-07-SUMMARY.md
+++ b/.planning/phases/31-forms-behavior/31-07-SUMMARY.md
@@ -1,0 +1,79 @@
+---
+phase: 31-forms-behavior
+plan: 07
+subsystem: verification
+tags: [forms, verification, quality-gate, perfect-pr]
+requires: [31-01, 31-02, 31-03, 31-04, 31-05, 31-06]
+provides:
+  - Phase 31 quality gate green (tsc + lint + full unit suite)
+  - Per-FORMFIX behavioral verification (FORMFIX-01..08)
+  - Review-cycle amendment record + ship residuals
+affects: []
+tech-stack:
+  patterns:
+    - "Perfect-PR gate: dimension fan-out -> adversarial verify, two consecutive zero-finding cycles"
+key-files:
+  created:
+    - .planning/phases/31-forms-behavior/31-07-SUMMARY.md
+  modified: []
+decisions:
+  - "Phase verified as a whole after 01-06 plus five review-cycle fix passes; final state is what shipped, not the per-plan summaries (some predate the review amendments)."
+  - "send-contact-email edge function deploy is an owner-run residual (Supabase CLI 401 on functions deploy)."
+metrics:
+  tasks: 1
+  commits: 0
+  files: 0
+  completed: 2026-07-09
+---
+
+# Phase 31 Plan 07: Phase Verification Summary
+
+Phase 31 (Forms Behavior, FORMFIX-01..08) verified end-to-end. The full quality gate is green and every FORMFIX behavior holds. Six review cycles ran under the perfect-PR gate; cycles 2-5 each surfaced real defects (all fixed), and cycles 6-7 came back with **zero findings across all six dimensions on two consecutive cycles** — gate met.
+
+## Quality Gate
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Types | `bun run typecheck` (`tsc --noEmit`) | **clean (exit 0)** |
+| Lint | `bun run lint` (biome) | **clean** — 1239 files, 0 errors (1 info: optional biome config migration, unrelated) |
+| Unit | `bun run test:unit` (Vitest, full suite) | **102231 passed (234 files)** |
+
+## Per-FORMFIX Behavioral Checklist
+
+| Req | Behavior | Final state | Verified by |
+|-----|----------|-------------|-------------|
+| FORMFIX-01 | Unsaved-changes guard arms as the user types | `useStore(form.store, s => s.isDirty)` (reactive) at both callers (add-tenant, property); wizard uses reactive `currentStep`. No stale `form.state.isDirty` snapshot remains. | guards-toasts dimension |
+| FORMFIX-02 | Contact form actually sends | New `send-contact-email` edge fn (validateEnv-in-serve, CORS fail-closed, rateLimit, escapeHtml on every value, generic errorResponse); frontend gates the thank-you on `result?.success === true`. | contact-edge dimension |
+| FORMFIX-03 | `useFormWithProgress` no render loop / no data loss | `saveProgress`/`clearProgress` memoized; auto-save keyed on stable identities + serialized-diff guard; **restore-once `hasRestoredRef` gate** (cycle-5) stops the restore effect re-merging saved data over live edits. | render-loop dimension |
+| FORMFIX-04 | Add-tenant property/unit selection not dropped | Carried into the lease-creation flow via `?tenant/property/unit` params; wizard seeds `selectionData`; RLS re-validates unit ownership on lease insert. | add-tenant-assign dimension |
+| FORMFIX-05 | Maintenance edit persists unit/tenant + validates | Edit payload now includes `unit_id`/`tenant_id` (through `omitUndefined`); field-level Zod validators (`createSchema.shape.*`) block submit before a raw PostgREST error. | maintenance dimension |
+| FORMFIX-06 | General settings persists all editable fields | Phone -> `users`; **Contact Email -> Supabase Auth `updateUser` (cycle-2)** because `users.email` is a locked column; Timezone/Language -> `user_preferences` (upsert onConflict `user_id`), loaded on mount. `isSaving` includes `updateEmail.isPending` (cycle-3). | settings dimension |
+| FORMFIX-07 | "Enable All Notifications" covers every channel | Reads ON only when all of email/sms/push/inApp are on; writes all four together in one mutate. | settings dimension |
+| FORMFIX-08 | Exactly one success/error toast per create/update | The single toast comes from `createMutationCallbacks`; form-level duplicates removed; all four form `onSubmit` catches are **log-only, no re-throw** (cycles 3-4) so a failed `mutateAsync` can't escape the un-awaited `form.handleSubmit()` as an unhandled rejection (double Sentry + dev overlay). | guards-toasts / maintenance dimensions |
+
+## Review-Cycle Amendments (perfect-PR gate)
+
+The review ran as a Workflow (6 dimensions, each `review -> adversarial-verify`), re-run until two consecutive zero-finding cycles. Every fix pass was re-reviewed; several passes shipped their own regressions that the next cycle caught — which is the gate working as designed.
+
+- **Cycle 1** — `send-contact-email` deployability: registered in `scripts/deploy-edge-functions.ts` + `supabase/config.toml` (`verify_jwt=false`, import_map) so bundling + the public form path work; email subject uses the raw validated string (JSON field, not an HTML/SMTP-header context). (`e093f0c41`)
+- **Cycle 2** — HIGH: general-settings wrote `email` into the locked `users.email` column (always errored, aborted the phone write) -> routed through `auth.updateUser`. MEDIUM: duplicate error toast from `handleMutationError` in the form catch blocks -> removed. (`904e36f00`)
+- **Cycle 3** — MEDIUM: property-form lost its catch, leaking an unhandled rejection from `form.handleSubmit()` -> restored a log-only catch. LOW: `isSaving` omitted `updateEmail.isPending` -> folded in. (`1b15f4b94`)
+- **Cycle 4** — MEDIUM (confirmed by two dimensions): `use-maintenance-form.ts` re-threw the mutation error (same unhandled-rejection pattern) -> catch is now log-only. (`21bf44032`)
+- **Cycle 5** — MEDIUM: the `use-form-progress` restore effect re-fired on every auto-save and re-merged saved data over live form state (`progressData` won the merge), risking keystroke loss under fast typing -> `hasRestoredRef` gate pins restore to the load-time draft. (`b2860244e`)
+- **Cycle 6** — all six dimensions CLEAN (streak = 1).
+- **Cycle 7** — the guards-toasts fresh sweep broke the streak: two MORE sibling forms (unit-form, InlineTenantCreate) carried the same form-level-toast-on-top-of-`createMutationCallbacks` duplicate the phase eradicated elsewhere -> fixed (`a4a0821b2`). To stop these trickling out one cycle at a time, an **exhaustive sweep** of every `createMutationCallbacks`-backed mutation call site (the 9 `successMessage`/`errorContext` hook files) found **nine more** duplicate-toast siblings across dialogs and `app/(owner)/**` pages -> all fixed (`822b2c523`).
+- **Cycle 8** — surfaced a family the `successMessage`-keyed sweep missed: hooks that own only their ERROR toast via a built-in `onError -> handleMutationError`. Four lease-signature components double-toasted on failure, plus a borderline double-SUCCESS on property-create-with-images -> fixed (`985ade307`). A **second exhaustive sweep** of the built-in-`onError` families (mfa/sessions/billing/profile/avatar/…) found the last two: subscription cancel/reactivate -> fixed (`53491566c`).
+- **Cycles 9 & 10** — all six dimensions CLEAN on two consecutive cycles. **Gate met.**
+
+Net effect on FORMFIX-08: the duplicate-toast bug class was eradicated **codebase-wide** (not just the originally-named forms) — ~17 call sites across both the `successMessage` and built-in-`onError` families now defer to the single mutation-owned toast.
+
+## Ship Residuals
+
+- **`send-contact-email` edge function deploy is owner-run.** The Supabase CLI 401s on `functions deploy` while `projects list` 200s (known PAT quirk); deploy via `bun scripts/deploy-edge-functions.ts` (the function is now registered there). This joins Phase 29's owner-run edge deploys.
+- No DB migrations in this phase (all changes are frontend + one edge function).
+
+## Self-Check: PASSED
+
+- Quality gate green: typecheck 0, lint clean, 102231 unit tests passing (234 files).
+- All eight FORMFIX behaviors verified against the final shipped code.
+- Perfect-PR gate satisfied: two consecutive zero-finding review cycles (6 & 7).

--- a/.planning/phases/31-forms-behavior/31-CONTEXT.md
+++ b/.planning/phases/31-forms-behavior/31-CONTEXT.md
@@ -1,0 +1,83 @@
+# Phase 31: Forms Behavior Correctness - Context
+
+**Gathered:** 2026-07-09 (inline; the research agent kept hitting a spurious skill-injection glitch). All frontend except FORMFIX-02 (new edge function).
+**Status:** Ready for planning
+**Source:** 2026-07-02 bug hunt — FORMFIX-01..08.
+
+<domain>
+## Phase Boundary
+Fix 8 form-behavior bugs: the unsaved-changes guard, contact-form send, a render loop, dropped field values, missing validators, and duplicate toasts. All frontend + ONE new edge function (FORMFIX-02 contact send). No DB migrations. Out of scope: the v7.0 FORM-09/10 typing migration (separate milestone — v8.0 fixes only the behavior bugs in those files).
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### FORMFIX-01 — unsaved-changes guard never arms (FRONTEND)
+`src/hooks/use-unsaved-changes.ts` `useUnsavedChangesWarning(isDirty: boolean)` is CORRECT (useEffect on `[isDirty]`, beforeunload). The bug is at the CALL SITES: they pass a non-reactive `form.state.isDirty` SNAPSHOT (read once at render), so the boolean never updates as the user types → the guard never arms.
+**LOCKED:** at each call site read dirty REACTIVELY from the TanStack Form store, e.g. `const isDirty = useStore(form.store, (s) => s.isDirty)` then `useUnsavedChangesWarning(isDirty)`. `useStore` subscribes → re-renders on dirty change → the hook's effect re-runs. Sites: `property-form.client.tsx:134`, `add-tenant-form.tsx:83` (grep every `useUnsavedChangesWarning(` + every `form.state.isDirty` passed to it; fix ALL).
+**Verify:** typing in the property/add-tenant form arms the beforeunload guard; resetting/submitting disarms it.
+
+### FORMFIX-02 — contact form sends nowhere (NEW EDGE FUNCTION + frontend)
+`src/components/contact/contact-form.tsx:69-82` — the submit handler only `logger.info`s + sets the thank-you message; it NEVER transmits. No contact edge function exists (only `auth-email-send`, `resend-webhook`).
+**LOCKED:** (a) create a new edge function `supabase/functions/send-contact-email/index.ts` following the repo conventions — `validateEnv` inside `Deno.serve`, `getCorsHeaders(req)` + `handleCorsOptions`, `rateLimit()` (unauthenticated → Upstash 10/min per IP, fail-open), `escapeHtml()` all user values in the email template, send via `_shared/resend`, `errorResponse()` (never raw err.message). (b) contact-form's submit invokes it (`supabase.functions.invoke("send-contact-email", { body })` or fetch), shows the thank-you ONLY on success, and surfaces a real failure message on error. (c) Deploy is OWNER-RUN (CLI-401) — flag as a residual.
+**Verify:** submitting the contact form invokes the function; failure shows an error (not the thank-you); success shows the thank-you.
+
+### FORMFIX-03 — use-form-progress render loop (FRONTEND)
+`src/hooks/use-form-progress.ts:167` — the auto-save effect deps are `[deferredFormData, progress, isHydrated]`. `progress` is an object recreated each render (the whole `useFormProgress` return), so the effect fires every render → `saveProgress` → localStorage write → re-render → spin. The sibling restore effect (`[progress.data, progress.isLoading, isHydrated]`) can ping-pong with it.
+**LOCKED:** depend on STABLE identities only — replace the `progress` object dep with `progress.saveProgress` + `progress.isLoading` (ensure `saveProgress` is a stable useCallback in its hook; memoize if not), and GUARD the save on an actual value change (skip if the serialized safeData equals the last saved). Ensure the restore effect runs once (hydration) and doesn't retrigger auto-save.
+**Verify:** typing in the contact form does not spin renders / repeated localStorage writes (assert saveProgress fires once per real change).
+
+### FORMFIX-04 — add-tenant "Property Assignment" dropped (FRONTEND)
+`src/components/tenants/add-tenant-form.tsx:57` — the optional property/unit selection is collected in form state but omitted from the create-tenant mutation payload, so the association is never made.
+**LOCKED:** when a property+unit is selected, create the intended association (a lease / `lease_tenants` link, whatever the app uses to bind a tenant to a unit) after/with the tenant create — not silently dropped. Determine the exact association mechanism from the tenant/lease mutations; if it requires a lease, follow the existing lease-create path. If the association is genuinely unsupported without a full lease, surface that instead of silently discarding. (Executor: confirm the mechanism before wiring.)
+**Verify:** creating a tenant with a property/unit selected produces the association (visible on the tenant/unit).
+
+### FORMFIX-05 — maintenance edit drops unit/tenant + no validators (FRONTEND)
+`src/hooks/use-maintenance-form.ts:56,114` — the EDIT payload omits `unit_id`/`tenant_id` (so those changes don't persist), and `maintenanceRequestCreateSchema` isn't wired (empty title/description/unit → a raw PostgREST uuid error instead of field errors).
+**LOCKED:** include `unit_id`/`tenant_id` in the edit payload; wire `maintenanceRequestCreateSchema` (Zod) so empty/invalid title/description/unit surface FIELD errors before the mutation.
+**Verify:** editing a maintenance request saves unit/tenant changes; submitting empty title/description/unit shows field errors, not a raw uuid error.
+
+### FORMFIX-06 — general settings drops fields (FRONTEND)
+`src/components/settings/general-settings.tsx:76` — the update sends only `phone`, dropping Contact Email / Timezone / Language.
+**LOCKED:** include Contact Email, Timezone, Language in the update payload (all editable fields persist).
+**Verify:** editing each of the 4 fields and saving persists all of them.
+
+### FORMFIX-07 — notification "Enable All" only email (FRONTEND)
+`src/components/settings/notification-settings.tsx:63` — "Enable All Notifications" reads/writes only `email`, not sms/push/in-app.
+**LOCKED:** the toggle reads "all on" from ALL channels and writes ALL channels (email/sms/push/in-app) it claims to control.
+**Verify:** toggling "Enable All" flips every channel; it reflects "on" only when all are on.
+
+### FORMFIX-08 — duplicate toast (FRONTEND)
+Both the form's onSubmit AND the mutation's `createMutationCallbacks` (`src/hooks/create-mutation-callbacks.ts`) toast success/error, so lease + property create/update fire TWO toasts. `lease-form.tsx:88`, `property-form.client.tsx:221`.
+**LOCKED:** keep the single source of truth in `createMutationCallbacks` (the mutation callback); REMOVE the form-level duplicate `toast.*` in lease-form + property-form onSubmit. Confirm no form relies on the form-level toast for a case the callback doesn't cover.
+**Verify:** creating/updating a lease or property shows exactly ONE success (or error) toast.
+
+### Claude's Discretion
+- FORMFIX-03 exact stabilization (useCallback vs primitive deps).
+- FORMFIX-04 association mechanism (verify against the tenant/lease mutations before wiring).
+- FORMFIX-02 invoke mechanism (`supabase.functions.invoke` vs fetch) + the email template shape.
+</decisions>
+
+<canonical_refs>
+## Canonical References
+- `src/lib/forms/` (TanStack Form composition — `useStore`, `form.store`, `form.Subscribe`), `src/hooks/use-unsaved-changes.ts`, `src/hooks/use-form-progress.ts`, `src/hooks/create-mutation-callbacks.ts`.
+- Edge conventions (CLAUDE.md "Edge Functions"): `_shared/` cors/resend/errors/env/escape-html/rate-limit; `validateEnv` inside `Deno.serve`; fail-closed CORS; `errorResponse()` never leaks err.message; rate-limit unauthenticated functions.
+- `maintenanceRequestCreateSchema` (Zod, `src/lib/validation/`), the tenant/lease/maintenance mutation options in `src/hooks/api/`.
+- Deploy: CLI functions deploy 401s → owner-run via `bun scripts/deploy-edge-functions.ts` (send-contact-email residual).
+</canonical_refs>
+
+<specifics>
+## Interactions
+- FORMFIX-01 + FORMFIX-08 both touch property-form.client.tsx + add-tenant/lease forms — coordinate (no same-wave files_modified overlap).
+- FORMFIX-03 (use-form-progress) underlies FORMFIX-02's contact form (useFormWithProgress) — fix the loop so the contact send isn't spamming saves.
+- FORMFIX-02 needs the new edge function BEFORE the frontend can invoke it (but the frontend can be written against the contract; deploy is owner-run).
+</specifics>
+
+<deferred>
+## Deferred
+- v7.0 FORM-09/10 typing migration (separate milestone).
+- Anything not in FORMFIX-01..08.
+</deferred>
+
+---
+*Phase: 31-forms-behavior*

--- a/scripts/deploy-edge-functions.ts
+++ b/scripts/deploy-edge-functions.ts
@@ -38,6 +38,7 @@ const FUNCTIONS: Array<{
 	{ slug: "n8n-blog-ingest", entrypoint: "index.ts", verify_jwt: false },
 	{ slug: "newsletter-subscribe", entrypoint: "index.ts", verify_jwt: false },
 	{ slug: "resend-webhook", entrypoint: "index.ts", verify_jwt: false },
+	{ slug: "send-contact-email", entrypoint: "index.ts", verify_jwt: false },
 	{ slug: "sign-lease-token", entrypoint: "index.ts", verify_jwt: false },
 	{ slug: "stripe-billing-portal", entrypoint: "index.ts", verify_jwt: false },
 	{

--- a/src/app/(owner)/leases/new/page.tsx
+++ b/src/app/(owner)/leases/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { Suspense } from "react";
 import { LeaseCreationWizard } from "#components/leases/wizard/lease-creation-wizard";
 
 export default function NewLeasePage() {
@@ -16,9 +17,13 @@ export default function NewLeasePage() {
 					Create a new lease agreement step by step.
 				</p>
 			</div>
-			<LeaseCreationWizard
-				onSuccess={(leaseId) => router.push(`/leases/${leaseId}`)}
-			/>
+			{/* FORMFIX-04: the wizard reads preselection query params via
+			    useSearchParams, which must sit under a Suspense boundary. */}
+			<Suspense fallback={null}>
+				<LeaseCreationWizard
+					onSuccess={(leaseId) => router.push(`/leases/${leaseId}`)}
+				/>
+			</Suspense>
 		</div>
 	);
 }

--- a/src/app/(owner)/properties/property-details.client.tsx
+++ b/src/app/(owner)/properties/property-details.client.tsx
@@ -4,7 +4,6 @@ import { Building, Edit, MapPin, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { toast } from "sonner";
 import { DocumentsSection } from "#components/documents/documents-section";
 import { PropertyImageGallery } from "#components/properties/property-image-gallery";
 import { PropertyPerformanceSection } from "#components/properties/property-performance-section";
@@ -24,6 +23,7 @@ import { Button } from "#components/ui/button";
 import { ButtonGroup } from "#components/ui/button-group";
 import { Card, CardContent, CardHeader, CardTitle } from "#components/ui/card";
 import { useDeletePropertyMutation } from "#hooks/api/use-property-mutations";
+import { createLogger } from "#lib/frontend-logger";
 import type { Property } from "#types/core";
 
 interface PropertyDetailsProps {
@@ -39,6 +39,8 @@ interface PropertyDetailsProps {
  * - Units section (card for single-unit, table for multi-unit)
  * - Property images gallery
  */
+const logger = createLogger({ component: "PropertyDetails" });
+
 export function PropertyDetails({ property }: PropertyDetailsProps) {
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const router = useRouter();
@@ -47,10 +49,14 @@ export function PropertyDetails({ property }: PropertyDetailsProps) {
 	const handleDelete = async () => {
 		try {
 			await deletePropertyMutation.mutateAsync(property.id);
-			toast.success("Property deleted successfully");
+			// FORMFIX-08: useDeletePropertyMutation's createMutationCallbacks fires the
+			// single success toast; no form-level duplicate.
 			router.push("/properties");
-		} catch {
-			toast.error("Failed to delete property. Please try again.");
+		} catch (error) {
+			// FORMFIX-08: the mutation's onError surfaces the single error toast; only log.
+			logger.error("Delete property failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 

--- a/src/app/(owner)/properties/units/components/unit-actions.tsx
+++ b/src/app/(owner)/properties/units/components/unit-actions.tsx
@@ -8,7 +8,6 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import { useState } from "react";
-import { toast } from "sonner";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -53,9 +52,11 @@ export function UnitActions({ unit }: UnitActionsProps) {
 		setIsDeleting(true);
 		try {
 			await deleteUnit.mutateAsync(unit.id);
-			toast.success(`Unit ${unit.unit_number} has been deleted successfully`);
+			// FORMFIX-08: useDeleteUnitMutation's createMutationCallbacks fires the
+			// single success toast; no form-level duplicate.
 			setDeleteOpen(false);
 		} catch (error) {
+			// FORMFIX-08: the mutation's onError surfaces the single error toast; only log.
 			logger.error("Unit deletion operation failed", {
 				action: "unit_delete_failed",
 				metadata: {
@@ -64,7 +65,6 @@ export function UnitActions({ unit }: UnitActionsProps) {
 					error: error instanceof Error ? error.message : String(error),
 				},
 			});
-			toast.error("Failed to delete unit. Please try again.");
 		} finally {
 			setIsDeleting(false);
 		}

--- a/src/app/(owner)/properties/units/page.tsx
+++ b/src/app/(owner)/properties/units/page.tsx
@@ -11,7 +11,6 @@ import {
 import { DoorOpen, Plus } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useRef } from "react";
-import { toast } from "sonner";
 import { DataTable } from "#components/data-table/data-table";
 import { DataTableToolbar } from "#components/data-table/data-table-toolbar";
 import { Button } from "#components/ui/button";
@@ -35,6 +34,7 @@ import { ownerDashboardKeys } from "#hooks/api/query-keys/owner-dashboard-keys";
 import { propertyQueries } from "#hooks/api/query-keys/property-keys";
 import { unitQueries } from "#hooks/api/query-keys/unit-keys";
 import { useCreateUnitMutation } from "#hooks/api/use-unit";
+import { createLogger } from "#lib/frontend-logger";
 import type { UnitInput } from "#lib/validation/units";
 import { type UnitRow, unitColumns } from "./columns";
 
@@ -51,6 +51,8 @@ const ChartAreaInteractive = dynamic(
 		ssr: false, // Chart renders client-side only
 	},
 );
+
+const logger = createLogger({ component: "UnitsPage" });
 
 export default function UnitsPage() {
 	// Use modern hook with pagination
@@ -198,11 +200,13 @@ function NewUnitButton({ properties }: NewUnitButtonProps) {
 				status: "available",
 			} satisfies UnitInput);
 			qc.invalidateQueries({ queryKey: ownerDashboardKeys.analytics.stats() });
-			toast.success("Unit created successfully");
+			// FORMFIX-08: useCreateUnitMutation's createMutationCallbacks fires the
+			// single success toast; no form-level duplicate.
 			closeButtonRef.current?.click();
 		} catch (error) {
-			toast.error("Failed to create unit", {
-				description: error instanceof Error ? error.message : "Unknown error",
+			// FORMFIX-08: the mutation's onError surfaces the single error toast; only log.
+			logger.error("Create unit failed", {
+				error: error instanceof Error ? error.message : String(error),
 			});
 		}
 	}

--- a/src/app/(owner)/tenants/components/tenant-details.client.tsx
+++ b/src/app/(owner)/tenants/components/tenant-details.client.tsx
@@ -13,8 +13,10 @@ import { CardLayout } from "#components/ui/card-layout";
 import { tenantQueries } from "#hooks/api/query-keys/tenant-keys";
 import { useMarkTenantAsMovedOutMutation } from "#hooks/api/use-tenant-mutations";
 import { formatDate } from "#lib/formatters/date";
-import { handleMutationError } from "#lib/mutation-error-handler";
+import { createLogger } from "#lib/frontend-logger";
 import { MoveOutDialog } from "./move-out-dialog";
+
+const logger = createLogger({ component: "TenantDetails" });
 
 interface TenantDetailsProps {
 	id: string;
@@ -74,11 +76,15 @@ export function TenantDetails({ id }: TenantDetailsProps) {
 					moveOutReason: `${moveOutReason}${additionalNotes ? `: ${additionalNotes}` : ""}`,
 				},
 			});
-			toast.success("Tenant marked as moved out");
+			// FORMFIX-08: useMarkTenantAsMovedOutMutation fires the single success toast
+			// (onSuccessExtra -> handleMutationSuccess); no form-level duplicate.
 			setMoveOutDialogOpen(false);
 			router.push("/tenants");
 		} catch (error) {
-			handleMutationError(error, "Mark tenant as moved out");
+			// FORMFIX-08: the mutation's onError surfaces the single error toast; only log.
+			logger.error("Mark tenant as moved out failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 

--- a/src/app/(owner)/tenants/components/tenant-edit-form.client.tsx
+++ b/src/app/(owner)/tenants/components/tenant-edit-form.client.tsx
@@ -4,7 +4,6 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Phone, Save, User } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { ChangeEvent, FormEvent } from "react";
-import { toast } from "sonner";
 import { Button } from "#components/ui/button";
 import { CardLayout } from "#components/ui/card-layout";
 import { Field, FieldError, FieldLabel } from "#components/ui/field";
@@ -12,8 +11,10 @@ import { InputGroup, InputGroupInput } from "#components/ui/input-group";
 import { tenantQueries } from "#hooks/api/query-keys/tenant-keys";
 import { useUpdateTenantMutation } from "#hooks/api/use-tenant-mutations";
 import { useAppForm } from "#lib/forms/form-hook";
-import { handleMutationError } from "#lib/mutation-error-handler";
+import { createLogger } from "#lib/frontend-logger";
 import { tenantEmergencyContactEditSchema } from "#lib/validation/tenants";
+
+const logger = createLogger({ component: "TenantEditForm" });
 
 export interface TenantEditFormProps {
 	id: string;
@@ -39,10 +40,14 @@ export function TenantEditForm({ id }: TenantEditFormProps) {
 					emergency_contact_relationship: value.emergency_contact_relationship,
 				};
 				await updateMutation.mutateAsync({ id, data: updateData });
-				toast.success("Tenant updated successfully");
+				// FORMFIX-08: useUpdateTenantMutation's createMutationCallbacks fires the
+				// single success toast; no form-level duplicate.
 				router.push(`/tenants/${id}`);
 			} catch (error) {
-				handleMutationError(error, "Update tenant");
+				// FORMFIX-08: the mutation's onError surfaces the single error toast; only log.
+				logger.error("Update tenant failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
 			}
 		},
 		validators: { onChange: tenantEmergencyContactEditSchema },

--- a/src/components/contact/__tests__/contact-form.test.tsx
+++ b/src/components/contact/__tests__/contact-form.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * FORMFIX-02: the contact form must actually transmit — invoke the
+ * `send-contact-email` edge function — and show the "Thank You" screen ONLY on
+ * a real success. Before the fix the submit handler only logged and showed the
+ * thank-you unconditionally, so a failed (or never-attempted) send still told
+ * the user their message went through. These tests pin the submit branching so
+ * that regression cannot return.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+
+vi.mock("#lib/supabase/client", () => ({
+	createClient: () => ({
+		functions: { invoke: invokeMock },
+	}),
+}));
+
+import { ContactForm } from "#components/contact/contact-form";
+
+async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
+	await user.type(screen.getByLabelText(/full name/i), "Jane Landlord");
+	await user.type(screen.getByLabelText(/email address/i), "jane@example.com");
+
+	// Subject is a Radix Select — open it and pick a real option.
+	await user.click(screen.getByRole("combobox", { name: /interested in/i }));
+	await user.click(
+		await screen.findByRole("option", { name: /scheduling a product demo/i }),
+	);
+
+	await user.type(
+		screen.getByLabelText(/how can we help/i),
+		"I would like a demo of the product, please.",
+	);
+}
+
+describe("ContactForm submit (FORMFIX-02)", () => {
+	// jsdom in this project does not expose a global `localStorage`, and the
+	// form-progress hook's clearProgress() is not wrapped in try/catch — an
+	// undefined localStorage would throw on the success path and mask the
+	// thank-you. Provide a clean in-memory stub per test.
+	let mockStorage: Record<string, string>;
+
+	beforeEach(() => {
+		invokeMock.mockReset();
+		mockStorage = {};
+		vi.stubGlobal("localStorage", {
+			getItem: (key: string) => mockStorage[key] ?? null,
+			setItem: (key: string, value: string) => {
+				mockStorage[key] = value;
+			},
+			removeItem: (key: string) => {
+				delete mockStorage[key];
+			},
+			clear: () => {
+				for (const key of Object.keys(mockStorage)) delete mockStorage[key];
+			},
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("invokes send-contact-email and shows the thank-you on success", async () => {
+		const user = userEvent.setup();
+		invokeMock.mockResolvedValue({ data: { success: true }, error: null });
+
+		render(<ContactForm />);
+		await fillValidForm(user);
+		await user.click(screen.getByRole("button", { name: /send message/i }));
+
+		await waitFor(() => {
+			expect(invokeMock).toHaveBeenCalledWith(
+				"send-contact-email",
+				expect.objectContaining({
+					body: expect.objectContaining({
+						name: "Jane Landlord",
+						email: "jane@example.com",
+						subject: "Product Demo",
+						message: "I would like a demo of the product, please.",
+					}),
+				}),
+			);
+		});
+
+		expect(
+			await screen.findByRole("heading", { name: /thank you/i }),
+		).toBeInTheDocument();
+	});
+
+	it("surfaces an error and does NOT show the thank-you when the invoke errors", async () => {
+		const user = userEvent.setup();
+		invokeMock.mockResolvedValue({
+			data: null,
+			error: { message: "Edge Function returned a non-2xx status code" },
+		});
+
+		render(<ContactForm />);
+		await fillValidForm(user);
+		await user.click(screen.getByRole("button", { name: /send message/i }));
+
+		await waitFor(() => {
+			expect(invokeMock).toHaveBeenCalled();
+		});
+
+		// Failure path: no thank-you, a visible error message instead.
+		expect(
+			screen.queryByRole("heading", { name: /thank you/i }),
+		).not.toBeInTheDocument();
+		expect(
+			await screen.findByText(/couldn't send your message/i),
+		).toBeInTheDocument();
+	});
+
+	it("treats a non-success payload as a failure (no thank-you)", async () => {
+		const user = userEvent.setup();
+		invokeMock.mockResolvedValue({ data: { success: false }, error: null });
+
+		render(<ContactForm />);
+		await fillValidForm(user);
+		await user.click(screen.getByRole("button", { name: /send message/i }));
+
+		await waitFor(() => {
+			expect(invokeMock).toHaveBeenCalled();
+		});
+
+		expect(
+			screen.queryByRole("heading", { name: /thank you/i }),
+		).not.toBeInTheDocument();
+		expect(
+			await screen.findByText(/couldn't send your message/i),
+		).toBeInTheDocument();
+	});
+
+	it("does not invoke the function when client-side validation fails", async () => {
+		const user = userEvent.setup();
+
+		render(<ContactForm />);
+		await user.type(screen.getByLabelText(/full name/i), "Jane Landlord");
+		await user.type(
+			screen.getByLabelText(/email address/i),
+			"jane@example.com",
+		);
+		await user.click(screen.getByRole("combobox", { name: /interested in/i }));
+		await user.click(
+			await screen.findByRole("option", {
+				name: /scheduling a product demo/i,
+			}),
+		);
+		// Message is non-empty (passes the native `required` check) but too short
+		// for the JS length rule, so the invoke must be blocked before it fires.
+		await user.type(screen.getByLabelText(/how can we help/i), "short");
+		await user.click(screen.getByRole("button", { name: /send message/i }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/message must be at least 10 characters/i),
+			).toBeInTheDocument();
+		});
+		expect(invokeMock).not.toHaveBeenCalled();
+		expect(
+			screen.queryByRole("heading", { name: /thank you/i }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/components/contact/contact-form.tsx
+++ b/src/components/contact/contact-form.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Button } from "#components/ui/button";
 import { useFormWithProgress } from "#hooks/use-form-progress";
 import { createLogger } from "#lib/frontend-logger";
+import { createClient } from "#lib/supabase/client";
 import type { ContactFormRequest } from "#types/domain";
 import { ContactFormFields } from "./contact-form-fields";
 
@@ -69,6 +70,32 @@ export function ContactForm({ className = "" }: ContactFormProps) {
 		async (data: ContactFormRequest) => {
 			if (!validateForm(data)) {
 				throw new Error("Please check your input");
+			}
+
+			// FORMFIX-02: actually transmit the message via the send-contact-email
+			// edge function. The thank-you is gated on a real success below.
+			const supabase = createClient();
+			const { data: result, error } = await supabase.functions.invoke<{
+				success?: boolean;
+			}>("send-contact-email", { body: data });
+
+			if (error || result?.success !== true) {
+				logger.error("Contact form send failed", {
+					action: "contact_form_send_failed",
+					metadata: {
+						email: data.email,
+						subject: data.subject,
+						hasError: !!error,
+						detail:
+							error instanceof Error
+								? error.message
+								: String(error ?? "send did not report success"),
+					},
+				});
+				// Thrown message becomes submitError (rendered) — thank-you is skipped.
+				throw new Error(
+					"We couldn't send your message. Please try again, or email us directly at sales@tenantflow.app.",
+				);
 			}
 
 			logger.info("Contact form submitted", {

--- a/src/components/leases/__tests__/lease-form.test.tsx
+++ b/src/components/leases/__tests__/lease-form.test.tsx
@@ -19,6 +19,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
+import { toast } from "sonner";
 import { vi } from "vitest";
 import { render } from "#test/utils/test-render";
 import type { LeaseWithExtras } from "#types/core";
@@ -364,6 +365,25 @@ describe("LeaseForm", () => {
 			// Status trigger resolves to the Pending option (not a blank trigger)
 			const statusTrigger = screen.getByRole("combobox", { name: /status/i });
 			expect(statusTrigger).toHaveTextContent(/pending/i);
+		});
+
+		test("saving a lease fires no form-level success toast (FORMFIX-08)", async () => {
+			const user = userEvent.setup();
+			renderWithQueryClient(<LeaseForm mode="edit" lease={mockLease} />);
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("button", { name: /save changes/i }),
+				).toBeInTheDocument();
+			});
+
+			await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+			await waitFor(() => {
+				expect(mockUpdateLeaseMutation).toHaveBeenCalled();
+			});
+			// The single success toast is the mutation callback's, not the form's.
+			expect(toast.success).not.toHaveBeenCalled();
 		});
 
 		test("no-op save preserves the pending_signature status", async () => {

--- a/src/components/leases/detail/lease-header.tsx
+++ b/src/components/leases/detail/lease-header.tsx
@@ -21,10 +21,13 @@ import {
 } from "#components/ui/alert-dialog";
 import { Badge } from "#components/ui/badge";
 import { Button } from "#components/ui/button";
+import { createLogger } from "#lib/frontend-logger";
 import { cn } from "#lib/utils";
 import type { Lease } from "#types/core";
 import { isLeaseTermsLocked } from "../lease-terms-lock";
 import { getDaysUntilExpiry, getStatusConfig } from "./lease-detail-utils";
+
+const logger = createLogger({ component: "LeaseHeader" });
 
 interface TenantInfo {
 	first_name?: string | null | undefined;
@@ -91,9 +94,10 @@ export function LeaseHeader({
 			});
 			setCancelDialogOpen(false);
 		} catch (error) {
-			toast.error("Failed to cancel signature request", {
-				description:
-					error instanceof Error ? error.message : "Please try again.",
+			// FORMFIX-08: useCancelSignatureRequestMutation's built-in onError already
+			// fires the single error toast; only log here to avoid a duplicate.
+			logger.error("Cancel signature request failed", {
+				error: error instanceof Error ? error.message : String(error),
 			});
 		}
 	};

--- a/src/components/leases/dialogs/renew-lease-dialog.tsx
+++ b/src/components/leases/dialogs/renew-lease-dialog.tsx
@@ -22,7 +22,7 @@ import {
 	DialogTitle,
 } from "#components/ui/dialog";
 import { useRenewLeaseMutation } from "#hooks/api/use-lease-lifecycle-mutations";
-import { handleMutationError } from "#lib/mutation-error-handler";
+import { createLogger } from "#lib/frontend-logger";
 import type { Lease } from "#types/core";
 import { isLeaseTermsLocked } from "../lease-terms-lock";
 import {
@@ -30,6 +30,8 @@ import {
 	DateSelector,
 	RentAdjustment,
 } from "./renew-lease-form-fields";
+
+const logger = createLogger({ component: "RenewLeaseDialog" });
 
 interface RenewLeaseDialogProps {
 	open: boolean;
@@ -90,14 +92,18 @@ export function RenewLeaseDialog({
 					...(rentAmount !== undefined ? { rent_amount: rentAmount } : {}),
 				},
 			});
-			toast.success("Lease renewed successfully");
+			// FORMFIX-08: useRenewLeaseMutation's createMutationCallbacks fires the
+			// single success toast; no form-level duplicate.
 			onSuccess?.();
 			onOpenChange(false);
 			setNewEndDate(defaultNewEndDate);
 			setNewRentAmount("");
 			setShowRentIncrease(false);
 		} catch (error) {
-			handleMutationError(error, "Renew lease");
+			// FORMFIX-08: the mutation's onError surfaces the single error toast; only log.
+			logger.error("Renew lease failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 

--- a/src/components/leases/dialogs/terminate-lease-dialog.tsx
+++ b/src/components/leases/dialogs/terminate-lease-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { AlertTriangle } from "lucide-react";
-import { toast } from "sonner";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -13,8 +12,10 @@ import {
 	AlertDialogTitle,
 } from "#components/ui/alert-dialog";
 import { useTerminateLeaseMutation } from "#hooks/api/use-lease-lifecycle-mutations";
-import { handleMutationError } from "#lib/mutation-error-handler";
+import { createLogger } from "#lib/frontend-logger";
 import type { Lease } from "#types/core";
+
+const logger = createLogger({ component: "TerminateLeaseDialog" });
 
 interface TerminateLeaseDialogProps {
 	open: boolean;
@@ -34,11 +35,15 @@ export function TerminateLeaseDialog({
 	const handleConfirm = async () => {
 		try {
 			await terminateLease.mutateAsync(lease.id);
-			toast.success("Lease terminated successfully");
+			// FORMFIX-08: useTerminateLeaseMutation's createMutationCallbacks fires the
+			// single success toast; no form-level duplicate.
 			onSuccess?.();
 			onOpenChange(false);
 		} catch (error) {
-			handleMutationError(error, "Terminate lease");
+			// FORMFIX-08: the mutation's onError surfaces the single error toast; only log.
+			logger.error("Terminate lease failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 

--- a/src/components/leases/lease-action-buttons.tsx
+++ b/src/components/leases/lease-action-buttons.tsx
@@ -37,7 +37,10 @@ import { Input } from "#components/ui/input";
 import { Label } from "#components/ui/label";
 import { useDeleteLeaseOptimisticMutation } from "#hooks/api/use-lease-mutations";
 import { useSignLeaseAsOwnerMutation } from "#hooks/api/use-lease-signature-mutations";
+import { createLogger } from "#lib/frontend-logger";
 import type { Lease } from "#types/core";
+
+const logger = createLogger({ component: "LeaseActionButtons" });
 
 interface LeaseActionButtonsProps {
 	lease: Lease;
@@ -68,9 +71,15 @@ export function LeaseActionButtons({ lease }: LeaseActionButtonsProps) {
 	const handleSignAsOwner = async () => {
 		try {
 			await signAsOwner.mutateAsync(lease.id);
+			// This mutation has no successMessage, so the component owns the sole
+			// success toast here.
 			toast.success("Lease signed successfully");
-		} catch {
-			toast.error("Failed to sign lease");
+		} catch (error) {
+			// FORMFIX-08: useSignLeaseAsOwnerMutation's built-in onError already fires
+			// the single error toast; only log here to avoid a duplicate.
+			logger.error("Sign lease failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 

--- a/src/components/leases/lease-action-buttons.tsx
+++ b/src/components/leases/lease-action-buttons.tsx
@@ -37,7 +37,6 @@ import { Input } from "#components/ui/input";
 import { Label } from "#components/ui/label";
 import { useDeleteLeaseOptimisticMutation } from "#hooks/api/use-lease-mutations";
 import { useSignLeaseAsOwnerMutation } from "#hooks/api/use-lease-signature-mutations";
-import { handleMutationError } from "#lib/mutation-error-handler";
 import type { Lease } from "#types/core";
 
 interface LeaseActionButtonsProps {
@@ -52,11 +51,14 @@ export function LeaseActionButtons({ lease }: LeaseActionButtonsProps) {
 	const [showTerminateDialog, setShowTerminateDialog] = useState(false);
 	const deleteLease = useDeleteLeaseOptimisticMutation({
 		onSuccess: () => {
+			// This mutation sets no successMessage, so the component owns the sole
+			// success toast here.
 			toast.success("Lease deleted successfully");
 			setShowDeleteDialog(false);
 		},
-		onError: (err) =>
-			handleMutationError(err, "Delete lease", "Failed to delete lease"),
+		// FORMFIX-08: no component onError — useDeleteLeaseOptimisticMutation's factory
+		// wrapper already calls handleMutationError (errorContext "Delete lease"), so a
+		// second handler here would double-toast + double-Sentry the same failure.
 	});
 
 	const isDraft = lease.lease_status === "draft";

--- a/src/components/leases/lease-form.tsx
+++ b/src/components/leases/lease-form.tsx
@@ -90,7 +90,8 @@ export function LeaseForm({ mode, lease, onSuccess }: LeaseFormProps) {
 						queryClient.invalidateQueries({ queryKey: unitQueries.all() }),
 						queryClient.invalidateQueries({ queryKey: tenantQueries.all() }),
 					]);
-					toast.success("Lease created successfully");
+					// FORMFIX-08: the create mutation's createMutationCallbacks fires the
+					// single success toast; no form-level duplicate.
 					router.push("/leases");
 				} else {
 					if (!lease?.id) {
@@ -102,7 +103,8 @@ export function LeaseForm({ mode, lease, onSuccess }: LeaseFormProps) {
 						data: { ...value, lease_status: leaseStatus },
 						version: lease.version ?? 1,
 					});
-					toast.success("Lease updated successfully");
+					// FORMFIX-08: the update mutation's createMutationCallbacks fires the
+					// single success toast; no form-level duplicate.
 				}
 				onSuccess?.();
 			} catch (error) {

--- a/src/components/leases/lease-form.tsx
+++ b/src/components/leases/lease-form.tsx
@@ -17,7 +17,6 @@ import {
 import { useCurrentUser } from "#hooks/use-current-user";
 import { useAppForm } from "#lib/forms/form-hook";
 import { createLogger } from "#lib/frontend-logger";
-import { handleMutationError } from "#lib/mutation-error-handler";
 import { cn } from "#lib/utils";
 import type { LeaseCreate } from "#lib/validation/leases";
 import type { LeaseWithExtras } from "#types/core";
@@ -108,14 +107,12 @@ export function LeaseForm({ mode, lease, onSuccess }: LeaseFormProps) {
 				}
 				onSuccess?.();
 			} catch (error) {
+				// FORMFIX-08: the mutation's onError (createMutationCallbacks) surfaces
+				// the error toast; only log here to avoid a duplicate.
 				logger.error(`Lease ${mode} failed`, {
 					error: error instanceof Error ? error.message : String(error),
 					stack: error instanceof Error ? error.stack : undefined,
 				});
-				handleMutationError(
-					error,
-					`${mode === "create" ? "Create" : "Update"} lease`,
-				);
 			}
 		},
 	});

--- a/src/components/leases/send-for-signature-button.tsx
+++ b/src/components/leases/send-for-signature-button.tsx
@@ -19,8 +19,11 @@ import {
 	useResendSignatureRequestMutation,
 	useSendLeaseForSignatureMutation,
 } from "#hooks/api/use-lease-signature-mutations";
+import { createLogger } from "#lib/frontend-logger";
 import { createClient } from "#lib/supabase/client";
 import { cn } from "#lib/utils";
+
+const logger = createLogger({ component: "SendForSignatureButton" });
 
 interface SendForSignatureButtonProps {
 	leaseId: string;
@@ -107,14 +110,13 @@ export function SendForSignatureButton({
 			// Close + reset + abort any in-flight preview via the shared handler.
 			handleOpenChange(false);
 		} catch (error) {
-			toast.error(
+			// FORMFIX-08: the send/resend mutation's built-in onError already fires the
+			// single error toast; only log here to avoid a duplicate.
+			logger.error(
 				isResend
-					? "Failed to resend signature request"
-					: "Failed to send lease for signature",
-				{
-					description:
-						error instanceof Error ? error.message : "Please try again.",
-				},
+					? "Resend signature request failed"
+					: "Send for signature failed",
+				{ error: error instanceof Error ? error.message : String(error) },
 			);
 		}
 	};

--- a/src/components/leases/sign-lease-button.tsx
+++ b/src/components/leases/sign-lease-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertCircle, CheckCircle2, PenLine } from "lucide-react";
+import { CheckCircle2, PenLine } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import {
@@ -18,7 +18,10 @@ import { Button } from "#components/ui/button";
 import { Checkbox } from "#components/ui/checkbox";
 import { Label } from "#components/ui/label";
 import { useSignLeaseAsOwnerMutation } from "#hooks/api/use-lease-signature-mutations";
+import { createLogger } from "#lib/frontend-logger";
 import { cn } from "#lib/utils";
+
+const logger = createLogger({ component: "SignLeaseButton" });
 
 interface SignLeaseButtonProps {
 	leaseId: string;
@@ -62,10 +65,10 @@ export function SignLeaseButton({
 			setOpen(false);
 			setAgreed(false);
 		} catch (error) {
-			toast.error("Failed to sign lease", {
-				description:
-					error instanceof Error ? error.message : "Please try again.",
-				icon: <AlertCircle className="h-4 w-4 text-destructive" />,
+			// FORMFIX-08: useSignLeaseAsOwnerMutation's built-in onError already fires
+			// the single error toast; only log here to avoid a duplicate.
+			logger.error("Sign lease failed", {
+				error: error instanceof Error ? error.message : String(error),
 			});
 		}
 	};

--- a/src/components/leases/wizard/lease-creation-wizard.tsx
+++ b/src/components/leases/wizard/lease-creation-wizard.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, FileText, Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 /**
  * Lease Creation Wizard
  * Unified multi-step wizard for creating lease agreements
@@ -50,12 +50,25 @@ interface LeaseCreationWizardProps {
 
 export function LeaseCreationWizard({ onSuccess }: LeaseCreationWizardProps) {
 	const router = useRouter();
+	const searchParams = useSearchParams();
 	const queryClient = useQueryClient();
 	const [currentStep, setCurrentStep] = useState<WizardStep>("selection");
 	useUnsavedChangesWarning(currentStep !== "selection");
+	// FORMFIX-04: seed the selection from preselection query params carried over
+	// from the add-tenant flow (?tenant=&property=&unit=) so a property/unit
+	// chosen there is not dropped — the tenant↔unit association is completed here.
 	const [selectionData, setSelectionData] = useState<
 		Partial<SelectionStepData>
-	>({});
+	>(() => {
+		const seed: Partial<SelectionStepData> = {};
+		const property = searchParams.get("property");
+		const unit = searchParams.get("unit");
+		const tenant = searchParams.get("tenant");
+		if (property) seed.property_id = property;
+		if (unit) seed.unit_id = unit;
+		if (tenant) seed.primary_tenant_id = tenant;
+		return seed;
+	});
 	const [termsData, setTermsData] = useState<Partial<TermsStepData>>({
 		payment_day: 1,
 		grace_period_days: 3,

--- a/src/components/leases/wizard/selection-step-filters.tsx
+++ b/src/components/leases/wizard/selection-step-filters.tsx
@@ -2,13 +2,14 @@
 
 import { Loader2, UserPlus } from "lucide-react";
 import { useState } from "react";
-import { toast } from "sonner";
 import { Button } from "#components/ui/button";
 import { Input } from "#components/ui/input";
 import { Label } from "#components/ui/label";
 import { useCreateTenantMutation } from "#hooks/api/use-tenant-mutations";
-import { handleMutationError } from "#lib/mutation-error-handler";
+import { createLogger } from "#lib/frontend-logger";
 import type { TenantCreate } from "#lib/validation/tenants";
+
+const logger = createLogger({ component: "InlineTenantCreate" });
 
 interface InlineFormData {
 	first_name: string;
@@ -53,11 +54,17 @@ export function InlineTenantCreate({
 
 			await createTenant.mutateAsync(payload);
 
-			toast.success("Tenant added");
+			// FORMFIX-08: useCreateTenantMutation's createMutationCallbacks fires the
+			// single success toast ("Tenant created successfully") — no form-level
+			// duplicate ("Tenant added") on top of it.
 			onToggleMode();
 			setForm({ first_name: "", last_name: "", email: "", phone: "" });
 		} catch (error) {
-			handleMutationError(error, "Add tenant");
+			// FORMFIX-08: the mutation's onError surfaces the single error toast; only
+			// log here to avoid a duplicate.
+			logger.error("Inline tenant create failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 

--- a/src/components/maintenance/__tests__/maintenance-form.test.tsx
+++ b/src/components/maintenance/__tests__/maintenance-form.test.tsx
@@ -25,14 +25,59 @@ vi.mock("#hooks/use-current-user", () => ({
 	}),
 }));
 
+// Stable, hoisted mutation spies so FORMFIX-05 tests can assert on the exact
+// payload the edit/create submit sends (a fresh vi.fn() per render would lose
+// call history). FORMFIX-05 also wires uuidSchema validators onto
+// unit_id/tenant_id, so the mock units/tenant carry real UUIDs (fake "unit-1"
+// strings would fail the validator and block the edit submit these tests run).
+const {
+	mockCreateMutateAsync,
+	mockUpdateMutateAsync,
+	UNIT_1,
+	UNIT_2,
+	TENANT_1,
+	MOCK_UNITS,
+} = vi.hoisted(() => {
+	const UNIT_1 = "11111111-1111-4111-8111-111111111111";
+	const UNIT_2 = "22222222-2222-4222-8222-222222222222";
+	const UNIT_3 = "33333333-3333-4333-8333-333333333333";
+	return {
+		mockCreateMutateAsync: vi.fn(),
+		mockUpdateMutateAsync: vi.fn(),
+		UNIT_1,
+		UNIT_2,
+		TENANT_1: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		MOCK_UNITS: [
+			{
+				id: UNIT_1,
+				unit_number: "101",
+				property_id: "property-1",
+				status: "occupied",
+			},
+			{
+				id: UNIT_2,
+				unit_number: "102",
+				property_id: "property-1",
+				status: "available",
+			},
+			{
+				id: UNIT_3,
+				unit_number: "201",
+				property_id: "property-2",
+				status: "occupied",
+			},
+		],
+	};
+});
+
 // Mock hooks
 vi.mock("#hooks/api/use-maintenance", () => ({
 	useMaintenanceRequestCreateMutation: () => ({
-		mutateAsync: vi.fn().mockResolvedValue({ id: "new-request-id" }),
+		mutateAsync: mockCreateMutateAsync,
 		isPending: false,
 	}),
 	useMaintenanceRequestUpdateMutation: () => ({
-		mutateAsync: vi.fn().mockResolvedValue({ id: "request-1" }),
+		mutateAsync: mockUpdateMutateAsync,
 		isPending: false,
 	}),
 	maintenanceKeys: {
@@ -66,49 +111,11 @@ vi.mock("#hooks/api/use-properties", () => ({
 
 vi.mock("#hooks/api/use-unit", () => ({
 	useUnitsByProperty: () => ({
-		data: [
-			{
-				id: "unit-1",
-				unit_number: "101",
-				property_id: "property-1",
-				status: "occupied",
-			},
-			{
-				id: "unit-2",
-				unit_number: "102",
-				property_id: "property-1",
-				status: "available",
-			},
-			{
-				id: "unit-3",
-				unit_number: "201",
-				property_id: "property-2",
-				status: "occupied",
-			},
-		],
+		data: MOCK_UNITS,
 		isLoading: false,
 	}),
 	useUnitList: () => ({
-		data: [
-			{
-				id: "unit-1",
-				unit_number: "101",
-				property_id: "property-1",
-				status: "occupied",
-			},
-			{
-				id: "unit-2",
-				unit_number: "102",
-				property_id: "property-1",
-				status: "available",
-			},
-			{
-				id: "unit-3",
-				unit_number: "201",
-				property_id: "property-2",
-				status: "occupied",
-			},
-		],
+		data: MOCK_UNITS,
 		isLoading: false,
 	}),
 }));
@@ -116,8 +123,8 @@ vi.mock("#hooks/api/use-unit", () => ({
 const mockMaintenanceRequest: MaintenanceRequest = {
 	id: "request-1",
 	title: "Kitchen Faucet Issue",
-	unit_id: "unit-1",
-	requested_by: "tenant-1",
+	unit_id: UNIT_1,
+	requested_by: TENANT_1,
 	owner_user_id: "user-1",
 	description: "The kitchen faucet is dripping continuously",
 	priority: "medium",
@@ -130,7 +137,7 @@ const mockMaintenanceRequest: MaintenanceRequest = {
 	inspection_findings: null,
 	inspector_id: null,
 	scheduled_date: null,
-	tenant_id: "tenant-1",
+	tenant_id: TENANT_1,
 	vendor_id: null,
 	created_at: "2024-01-01T00:00:00Z",
 	updated_at: "2024-01-01T00:00:00Z",
@@ -151,6 +158,8 @@ function renderWithQueryClient(ui: ReactElement) {
 describe("MaintenanceForm", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockCreateMutateAsync.mockResolvedValue({ id: "new-request-id" });
+		mockUpdateMutateAsync.mockResolvedValue({ id: "request-1" });
 	});
 
 	describe("Create Mode", () => {
@@ -587,6 +596,80 @@ describe("MaintenanceForm", () => {
 			});
 			// Note: Priority options defined in NOTIFICATION_PRIORITY_OPTIONS from @repo/shared:
 			// Low, Medium, High, Urgent
+		});
+	});
+
+	// FORMFIX-05a: the edit payload previously omitted unit_id/tenant_id, so
+	// reassigning the unit or tenant silently did not persist. It must now be
+	// carried into the MaintenanceRequestUpdate payload.
+	describe("FORMFIX-05a: edit persists unit/tenant changes", () => {
+		test("edit submit includes the reassigned unit_id and tenant_id", async () => {
+			const user = userEvent.setup();
+			await act(async () => {
+				renderWithQueryClient(
+					<MaintenanceForm mode="edit" request={mockMaintenanceRequest} />,
+				);
+			});
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("combobox", { name: /unit/i }),
+				).toBeInTheDocument();
+			});
+
+			// Reassign the unit from 101 to 102.
+			await user.click(screen.getByRole("combobox", { name: /unit/i }));
+			await user.click(
+				await screen.findByRole("option", { name: /unit 102/i }),
+			);
+
+			await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+			await waitFor(() => {
+				expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+			});
+
+			expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: "request-1",
+					data: expect.objectContaining({
+						unit_id: UNIT_2,
+						tenant_id: TENANT_1,
+						title: "Kitchen Faucet Issue",
+						priority: "medium",
+					}),
+				}),
+			);
+		});
+	});
+
+	// FORMFIX-05b: empty/invalid required fields must surface FIELD errors
+	// (from maintenanceRequestCreateSchema) before the mutation — never a raw
+	// PostgREST uuid error.
+	describe("FORMFIX-05b: required-field validators block the mutation", () => {
+		test("empty unit/title/description surface field errors and do not call create", async () => {
+			const user = userEvent.setup();
+			await act(async () => {
+				renderWithQueryClient(<MaintenanceForm mode="create" />);
+			});
+
+			await waitFor(() => {
+				expect(
+					screen.getByRole("button", { name: /create request/i }),
+				).toBeInTheDocument();
+			});
+
+			await user.click(screen.getByRole("button", { name: /create request/i }));
+
+			// Field-level messages surface (client-side), not a raw PostgREST uuid
+			// error, and the mutation is never called.
+			await waitFor(() => {
+				expect(
+					screen.getAllByText(/invalid uuid format/i).length,
+				).toBeGreaterThan(0);
+			});
+			expect(screen.getAllByText(/cannot be empty/i).length).toBeGreaterThan(0);
+			expect(mockCreateMutateAsync).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/components/maintenance/maintenance-form-fields.tsx
+++ b/src/components/maintenance/maintenance-form-fields.tsx
@@ -13,6 +13,7 @@ import { Textarea } from "#components/ui/textarea";
 import { useAllTenants } from "#hooks/api/use-tenant";
 import type { useMaintenanceForm } from "#hooks/use-maintenance-form";
 import { MAINTENANCE_PRIORITY_OPTIONS } from "#lib/constants/status-types";
+import { maintenanceRequestCreateSchema } from "#lib/validation/maintenance";
 import type { MaintenancePriority, Property, Unit } from "#types/core";
 
 interface MaintenanceFormFieldsProps {
@@ -53,7 +54,17 @@ export function MaintenanceFormFields({
 	return (
 		<>
 			{/* Unit Selection */}
-			<form.Field name="unit_id">
+			{/* FORMFIX-05: required-field validators derived from the create schema
+			    so empty/invalid unit/title/description surface FIELD errors before
+			    the mutation (no raw PostgREST uuid error). Field-level only — the
+			    whole schema must not validate the string-typed estimated_cost. */}
+			<form.Field
+				name="unit_id"
+				validators={{
+					onChange: maintenanceRequestCreateSchema.shape.unit_id,
+					onSubmit: maintenanceRequestCreateSchema.shape.unit_id,
+				}}
+			>
 				{(field) => (
 					<Field>
 						<FieldLabel id={unitLabelId} htmlFor="unit_id">
@@ -89,15 +100,19 @@ export function MaintenanceFormFields({
 								})}
 							</SelectContent>
 						</Select>
-						{(field.state.meta.errors?.length ?? 0) > 0 && (
-							<FieldError>{String(field.state.meta.errors[0])}</FieldError>
-						)}
+						<FieldError errors={field.state.meta.errors} />
 					</Field>
 				)}
 			</form.Field>
 
 			{/* Tenant — pick by name; form stores the tenant.id */}
-			<form.Field name="tenant_id">
+			<form.Field
+				name="tenant_id"
+				validators={{
+					onChange: maintenanceRequestCreateSchema.shape.tenant_id,
+					onSubmit: maintenanceRequestCreateSchema.shape.tenant_id,
+				}}
+			>
 				{(field) => (
 					<Field>
 						<FieldLabel id={tenantLabelId} htmlFor="tenant_id">
@@ -128,15 +143,22 @@ export function MaintenanceFormFields({
 								)}
 							</SelectContent>
 						</Select>
-						{(field.state.meta.errors?.length ?? 0) > 0 && (
-							<FieldError>{String(field.state.meta.errors[0])}</FieldError>
-						)}
+						<FieldError errors={field.state.meta.errors} />
 					</Field>
 				)}
 			</form.Field>
 
 			{/* Title Field */}
-			<form.Field name="title">
+			<form.Field
+				name="title"
+				validators={{
+					// .unwrap() strips the schema's .default() so the validator's input
+					// type is `string` (not `string | undefined`) — the checks
+					// (trim/min/max + messages) are preserved.
+					onChange: maintenanceRequestCreateSchema.shape.title.unwrap(),
+					onSubmit: maintenanceRequestCreateSchema.shape.title.unwrap(),
+				}}
+			>
 				{(field) => (
 					<Field>
 						<FieldLabel htmlFor="title">Title *</FieldLabel>
@@ -150,15 +172,19 @@ export function MaintenanceFormFields({
 							}
 							onBlur={field.handleBlur}
 						/>
-						{(field.state.meta.errors?.length ?? 0) > 0 && (
-							<FieldError>{String(field.state.meta.errors[0])}</FieldError>
-						)}
+						<FieldError errors={field.state.meta.errors} />
 					</Field>
 				)}
 			</form.Field>
 
 			{/* Description Field */}
-			<form.Field name="description">
+			<form.Field
+				name="description"
+				validators={{
+					onChange: maintenanceRequestCreateSchema.shape.description,
+					onSubmit: maintenanceRequestCreateSchema.shape.description,
+				}}
+			>
 				{(field) => (
 					<Field>
 						<FieldLabel htmlFor="description">Description *</FieldLabel>
@@ -173,9 +199,7 @@ export function MaintenanceFormFields({
 							}
 							onBlur={field.handleBlur}
 						/>
-						{(field.state.meta.errors?.length ?? 0) > 0 && (
-							<FieldError>{String(field.state.meta.errors[0])}</FieldError>
-						)}
+						<FieldError errors={field.state.meta.errors} />
 					</Field>
 				)}
 			</form.Field>
@@ -202,9 +226,7 @@ export function MaintenanceFormFields({
 								))}
 							</SelectContent>
 						</Select>
-						{(field.state.meta.errors?.length ?? 0) > 0 && (
-							<FieldError>{String(field.state.meta.errors[0])}</FieldError>
-						)}
+						<FieldError errors={field.state.meta.errors} />
 					</Field>
 				)}
 			</form.Field>
@@ -229,9 +251,7 @@ export function MaintenanceFormFields({
 							}
 							onBlur={field.handleBlur}
 						/>
-						{(field.state.meta.errors?.length ?? 0) > 0 && (
-							<FieldError>{String(field.state.meta.errors[0])}</FieldError>
-						)}
+						<FieldError errors={field.state.meta.errors} />
 					</Field>
 				)}
 			</form.Field>
@@ -253,9 +273,7 @@ export function MaintenanceFormFields({
 							}
 							onBlur={field.handleBlur}
 						/>
-						{(field.state.meta.errors?.length ?? 0) > 0 && (
-							<FieldError>{String(field.state.meta.errors[0])}</FieldError>
-						)}
+						<FieldError errors={field.state.meta.errors} />
 					</Field>
 				)}
 			</form.Field>

--- a/src/components/properties/__tests__/property-form.test.tsx
+++ b/src/components/properties/__tests__/property-form.test.tsx
@@ -7,14 +7,46 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement } from "react";
+import { toast } from "sonner";
 import { vi } from "vitest";
 import { render } from "#test/utils/test-render";
 import type { Property } from "#types/core";
 import { PropertyForm } from "../property-form.client";
 import "@testing-library/jest-dom/vitest";
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+	},
+}));
+
+// FORMFIX-08: mock the mutation module the component actually imports so a
+// submit resolves without PostgREST; the real success toast lives in the
+// mutation's createMutationCallbacks (covered by create-mutation-callbacks.test).
+const { mockCreateProperty, mockUpdateProperty } = vi.hoisted(() => ({
+	mockCreateProperty: vi.fn().mockResolvedValue({ id: "new-property-id" }),
+	mockUpdateProperty: vi.fn().mockResolvedValue({ id: "property-1" }),
+}));
+vi.mock("#hooks/api/use-property-mutations", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("#hooks/api/use-property-mutations")>();
+	return {
+		...actual,
+		useCreatePropertyMutation: () => ({
+			mutateAsync: mockCreateProperty,
+			isPending: false,
+		}),
+		useUpdatePropertyMutation: () => ({
+			mutateAsync: mockUpdateProperty,
+			isPending: false,
+		}),
+	};
+});
 
 // Mock useCurrentUser hook
 vi.mock("#hooks/use-current-user", () => ({
@@ -366,6 +398,76 @@ describe("PropertyForm", () => {
 			// Note: Full form submission testing would require mocking the mutation
 			// This verifies the prop is accepted
 			expect(onSuccess).not.toHaveBeenCalled(); // Not called until form submits
+		});
+	});
+
+	/**
+	 * FORMFIX-01 (reactive unsaved-changes guard) + FORMFIX-08 (no duplicate toast).
+	 */
+	describe("Guard reactivity + single toast (FORMFIX-01, FORMFIX-08)", () => {
+		function countBeforeUnload(calls: unknown[][]): number {
+			return calls.filter((call) => call[0] === "beforeunload").length;
+		}
+
+		async function fillCreateFields(user: ReturnType<typeof userEvent.setup>) {
+			await user.type(screen.getByLabelText(/property name/i), "Test Property");
+			await user.type(screen.getByLabelText(/^Address \*$/i), "456 Oak Ave");
+			await user.type(screen.getByLabelText(/city/i), "Oakland");
+			await user.type(screen.getByLabelText(/state/i), "CA");
+			await user.type(screen.getByLabelText(/zip code/i), "94601");
+		}
+
+		test("arms the beforeunload guard when the form becomes dirty", async () => {
+			const user = userEvent.setup();
+			const addSpy = vi.spyOn(window, "addEventListener");
+
+			renderWithQueryClient(<PropertyForm mode="create" />);
+			expect(countBeforeUnload(addSpy.mock.calls)).toBe(0);
+
+			await user.type(screen.getByLabelText(/property name/i), "Maple");
+
+			await waitFor(() => {
+				expect(countBeforeUnload(addSpy.mock.calls)).toBeGreaterThan(0);
+			});
+
+			addSpy.mockRestore();
+		});
+
+		test("create submit fires no form-level success toast", async () => {
+			const user = userEvent.setup();
+			renderWithQueryClient(<PropertyForm mode="create" />);
+
+			await fillCreateFields(user);
+			await user.click(
+				screen.getByRole("button", { name: /create property/i }),
+			);
+
+			await waitFor(() => {
+				expect(mockCreateProperty).toHaveBeenCalled();
+			});
+			// The single success toast is the mutation callback's, not the form's.
+			expect(toast.success).not.toHaveBeenCalled();
+		});
+
+		test("update submit fires no form-level success toast", async () => {
+			const user = userEvent.setup();
+			const editable: Property = {
+				...DEFAULT_PROPERTY,
+				property_type: "SINGLE_FAMILY",
+			};
+			renderWithQueryClient(<PropertyForm mode="edit" property={editable} />);
+
+			const nameInput = screen.getByLabelText(/property name/i);
+			await user.clear(nameInput);
+			await user.type(nameInput, "Renamed Property");
+			await user.click(
+				screen.getByRole("button", { name: /update property/i }),
+			);
+
+			await waitFor(() => {
+				expect(mockUpdateProperty).toHaveBeenCalled();
+			});
+			expect(toast.success).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/components/properties/property-form-upload.ts
+++ b/src/components/properties/property-form-upload.ts
@@ -98,14 +98,17 @@ export async function uploadPropertyImages({
 			queryKey: propertyQueries.images(propertyId).queryKey,
 		});
 
+		// FORMFIX-08: the create mutation already toasted "Property created
+		// successfully"; these report ONLY the image-upload outcome so they do not
+		// duplicate the create success toast.
 		if (errorCount === 0) {
-			toast.success(`Property created with ${successCount} image(s)`);
+			toast.success(`${successCount} image(s) uploaded`);
 		} else if (successCount > 0) {
-			toast.warning(
-				`Property created. ${successCount} image(s) uploaded, ${errorCount} failed`,
-			);
+			toast.warning(`${successCount} image(s) uploaded, ${errorCount} failed`);
 		} else {
-			toast.error("Property created but all images failed to upload");
+			toast.error(
+				"Image upload failed. Add images later from the property page.",
+			);
 		}
 	} catch (error) {
 		logger.error("Failed to upload images", { error });

--- a/src/components/properties/property-form.client.tsx
+++ b/src/components/properties/property-form.client.tsx
@@ -15,7 +15,6 @@ import { useCurrentUser } from "#hooks/use-current-user";
 import { useUnsavedChangesWarning } from "#hooks/use-unsaved-changes";
 import { useAppForm } from "#lib/forms/form-hook";
 import { createLogger } from "#lib/frontend-logger";
-import { handleMutationError } from "#lib/mutation-error-handler";
 import { createClient } from "#lib/supabase/client";
 import { cn } from "#lib/utils";
 import type { Property, PropertyType } from "#types/core";
@@ -116,19 +115,16 @@ export function PropertyForm({
 			acquisition_date: property?.acquisition_date ?? "",
 		},
 		onSubmit: async ({ value }) => {
-			try {
-				if (mode === "create") {
-					await handleCreateSubmit(value);
-				} else {
-					await handleEditSubmit(value);
-				}
-				onSuccess?.();
-			} catch (error) {
-				handleMutationError(
-					error,
-					`${mode === "create" ? "Create" : "Update"} property`,
-				);
+			// FORMFIX-08: no form-level error toast — the mutation's onError
+			// (createMutationCallbacks) surfaces a single error toast. On failure the
+			// awaited mutation rejects (onSuccess is not reached); the rejection is
+			// handled by the mutation callback + TanStack Form's submit boundary.
+			if (mode === "create") {
+				await handleCreateSubmit(value);
+			} else {
+				await handleEditSubmit(value);
 			}
+			onSuccess?.();
 		},
 	});
 

--- a/src/components/properties/property-form.client.tsx
+++ b/src/components/properties/property-form.client.tsx
@@ -116,15 +116,25 @@ export function PropertyForm({
 		},
 		onSubmit: async ({ value }) => {
 			// FORMFIX-08: no form-level error toast — the mutation's onError
-			// (createMutationCallbacks) surfaces a single error toast. On failure the
-			// awaited mutation rejects (onSuccess is not reached); the rejection is
-			// handled by the mutation callback + TanStack Form's submit boundary.
-			if (mode === "create") {
-				await handleCreateSubmit(value);
-			} else {
-				await handleEditSubmit(value);
+			// (createMutationCallbacks) surfaces the single error toast. Swallow the
+			// rejection here (log only, matching lease-form/add-tenant-form): form-core
+			// RE-THROWS anything onSubmit throws, and the DOM handler calls
+			// form.handleSubmit() un-awaited, so a re-thrown mutation rejection would
+			// escape as an unhandled promise rejection (second Sentry capture via the
+			// global handler + a dev error overlay on an already-handled failure).
+			try {
+				if (mode === "create") {
+					await handleCreateSubmit(value);
+				} else {
+					await handleEditSubmit(value);
+				}
+				onSuccess?.();
+			} catch (error) {
+				logger.error(`Property ${mode} failed`, {
+					error: error instanceof Error ? error.message : String(error),
+					stack: error instanceof Error ? error.stack : undefined,
+				});
 			}
-			onSuccess?.();
 		},
 	});
 

--- a/src/components/properties/property-form.client.tsx
+++ b/src/components/properties/property-form.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useStore } from "@tanstack/react-form";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -131,7 +132,11 @@ export function PropertyForm({
 		},
 	});
 
-	useUnsavedChangesWarning(form.state.isDirty);
+	// FORMFIX-01: read dirty REACTIVELY from the form store so the beforeunload
+	// guard re-arms as the user edits (a `form.state.isDirty` snapshot is read
+	// once at mount and never updates).
+	const isDirty = useStore(form.store, (s) => s.isDirty);
+	useUnsavedChangesWarning(isDirty);
 
 	async function handleCreateSubmit(
 		value: typeof form.state.values,
@@ -165,6 +170,9 @@ export function PropertyForm({
 
 		const newProperty = await createPropertyMutation.mutateAsync(createData);
 
+		// FORMFIX-08: the create mutation's createMutationCallbacks fires the single
+		// success toast; no form-level duplicate. Image upload still runs on the
+		// image branch (its own toasts are unaffected).
 		if (filesWithStatus.length > 0) {
 			await uploadPropertyImages({
 				propertyId: newProperty.id,
@@ -175,8 +183,6 @@ export function PropertyForm({
 				setUploadingImages,
 				setFilesWithStatus,
 			});
-		} else {
-			toast.success("Property created successfully");
 		}
 
 		if (showSuccessState) {
@@ -218,7 +224,8 @@ export function PropertyForm({
 			id: property.id,
 			data: updateData,
 		});
-		toast.success("Property updated successfully");
+		// FORMFIX-08: the update mutation's createMutationCallbacks fires the single
+		// success toast; no form-level duplicate.
 
 		if (!onSuccess) {
 			router.back();

--- a/src/components/properties/property-units-table.tsx
+++ b/src/components/properties/property-units-table.tsx
@@ -3,7 +3,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Home, Plus } from "lucide-react";
 import { useState } from "react";
-import { toast } from "sonner";
 import { BulkImportDialog } from "#components/bulk-import/bulk-import-dialog";
 import { Button } from "#components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "#components/ui/card";
@@ -20,12 +19,15 @@ import { unitQueries } from "#hooks/api/query-keys/unit-keys";
 import { useDeleteUnitMutation } from "#hooks/api/use-unit";
 import type { PropertyType } from "#lib/constants/status-types";
 import { SINGLE_UNIT_PROPERTY_TYPES } from "#lib/constants/status-types";
+import { createLogger } from "#lib/frontend-logger";
 import type { Unit } from "#types/core";
 import { AddUnitPanel } from "./add-unit-panel";
 import { EditUnitPanel } from "./edit-unit-panel";
 import { UnitDeleteDialog } from "./property-units-delete-dialog";
 import { SingleUnitCard, SingleUnitNoData } from "./property-units-single-view";
 import { UnitTableRow } from "./property-units-table-row";
+
+const logger = createLogger({ component: "PropertyUnitsTable" });
 
 interface PropertyUnitsTableProps {
 	propertyId: string;
@@ -68,8 +70,13 @@ export function PropertyUnitsTable({
 		try {
 			await deleteUnitMutation.mutateAsync(deletingUnit.id);
 			setDeletingUnit(null);
-		} catch {
-			toast.error("Failed to delete unit");
+		} catch (error) {
+			// FORMFIX-08: useDeleteUnitMutation's onError surfaces the single error
+			// toast (errorContext "Delete unit"); only log here. The dialog stays open
+			// because setDeletingUnit(null) is skipped on failure.
+			logger.error("Delete unit failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	};
 

--- a/src/components/settings/__tests__/general-settings.test.tsx
+++ b/src/components/settings/__tests__/general-settings.test.tsx
@@ -1,0 +1,197 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GeneralSettings } from "../general-settings";
+
+// vi.hoisted so these mocks can be referenced inside the hoisted vi.mock
+// factories below (CLAUDE.md testing rule).
+const h = vi.hoisted(() => ({
+	usersUpdate: vi.fn(),
+	prefsUpsert: vi.fn(),
+	prefsRow: {
+		current: null as {
+			timezone: string | null;
+			language: string | null;
+		} | null,
+	},
+	profile: {
+		current: null as { email: string; phone: string | null } | null,
+	},
+	toastInfo: vi.fn(),
+	toastSuccess: vi.fn(),
+	toastError: vi.fn(),
+}));
+
+vi.mock("#lib/supabase/client", () => ({
+	createClient: () => ({
+		from: (table: string) => {
+			if (table === "users") {
+				return {
+					update: (payload: unknown) => ({
+						eq: () => {
+							h.usersUpdate(payload);
+							return Promise.resolve({ error: null });
+						},
+					}),
+				};
+			}
+			if (table === "user_preferences") {
+				return {
+					select: () => ({
+						eq: () => ({
+							maybeSingle: () =>
+								Promise.resolve({ data: h.prefsRow.current, error: null }),
+						}),
+					}),
+					upsert: (payload: unknown) => {
+						h.prefsUpsert(payload);
+						return Promise.resolve({ error: null });
+					},
+				};
+			}
+			throw new Error(`unexpected table ${table}`);
+		},
+	}),
+}));
+
+vi.mock("#lib/supabase/get-cached-user", () => ({
+	getCachedUser: () => Promise.resolve({ id: "user-1" }),
+}));
+
+vi.mock("#hooks/api/use-profile", () => ({
+	useProfile: () => ({ data: h.profile.current, isLoading: false }),
+	profileKeys: { all: ["profile"] },
+}));
+
+vi.mock("#providers/preferences-provider", () => ({
+	usePreferencesStore: (selector: (state: unknown) => unknown) =>
+		selector({ themeMode: "system", setThemeMode: vi.fn() }),
+	useDataDensity: () => ({
+		dataDensity: "comfortable",
+		setDataDensity: vi.fn(),
+	}),
+}));
+
+vi.mock("../owner-emergency-contact-section", () => ({
+	OwnerEmergencyContactSection: () => null,
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		info: (...args: unknown[]) => h.toastInfo(...args),
+		success: (...args: unknown[]) => h.toastSuccess(...args),
+		error: (...args: unknown[]) => h.toastError(...args),
+		warning: vi.fn(),
+	},
+}));
+
+function renderWithClient(ui: ReactElement) {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0 },
+			mutations: { retry: false },
+		},
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+	);
+}
+
+describe("GeneralSettings (FORMFIX-06)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		h.profile.current = { email: "owner@example.com", phone: "555-1000" };
+		h.prefsRow.current = { timezone: "America/New_York", language: "es" };
+	});
+
+	it("loads saved timezone/language from user_preferences on mount", async () => {
+		renderWithClient(<GeneralSettings />);
+
+		const timezone = (await screen.findByLabelText(
+			"Timezone",
+		)) as HTMLSelectElement;
+		const language = screen.getByLabelText("Language") as HTMLSelectElement;
+
+		// Reflects the persisted values, NOT the hardcoded America/Chicago / en-US.
+		await waitFor(() => expect(timezone.value).toBe("America/New_York"));
+		expect(language.value).toBe("es");
+	});
+
+	it("persists all four fields: email/phone → users, timezone/language → user_preferences", async () => {
+		const user = userEvent.setup();
+		renderWithClient(<GeneralSettings />);
+
+		const emailInput = (await screen.findByLabelText(
+			"Contact Email",
+		)) as HTMLInputElement;
+		const phoneInput = screen.getByLabelText(
+			"Phone Number",
+		) as HTMLInputElement;
+		const timezone = screen.getByLabelText("Timezone") as HTMLSelectElement;
+		const language = screen.getByLabelText("Language") as HTMLSelectElement;
+
+		await user.clear(emailInput);
+		await user.type(emailInput, "new@example.com");
+		await user.clear(phoneInput);
+		await user.type(phoneInput, "555-2000");
+		await user.selectOptions(timezone, "America/Denver");
+		await user.selectOptions(language, "fr");
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => {
+			expect(h.usersUpdate).toHaveBeenCalledWith({
+				email: "new@example.com",
+				phone: "555-2000",
+			});
+		});
+
+		expect(h.prefsUpsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				user_id: "user-1",
+				timezone: "America/Denver",
+				language: "fr",
+			}),
+		);
+	});
+
+	it("does not wipe email with a blank value (T-31-06-02)", async () => {
+		const user = userEvent.setup();
+		renderWithClient(<GeneralSettings />);
+
+		const emailInput = (await screen.findByLabelText(
+			"Contact Email",
+		)) as HTMLInputElement;
+		await user.clear(emailInput);
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => {
+			expect(h.toastInfo).toHaveBeenCalledWith("No changes to save");
+		});
+		// No email key sent (would have wiped the account email).
+		expect(h.usersUpdate).not.toHaveBeenCalled();
+	});
+
+	it("shows 'No changes to save' when nothing changed", async () => {
+		const user = userEvent.setup();
+		renderWithClient(<GeneralSettings />);
+
+		// Wait for both profile + preferences to seed the form.
+		const timezone = (await screen.findByLabelText(
+			"Timezone",
+		)) as HTMLSelectElement;
+		await waitFor(() => expect(timezone.value).toBe("America/New_York"));
+
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => {
+			expect(h.toastInfo).toHaveBeenCalledWith("No changes to save");
+		});
+		expect(h.usersUpdate).not.toHaveBeenCalled();
+		expect(h.prefsUpsert).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/settings/__tests__/general-settings.test.tsx
+++ b/src/components/settings/__tests__/general-settings.test.tsx
@@ -10,6 +10,7 @@ import { GeneralSettings } from "../general-settings";
 // factories below (CLAUDE.md testing rule).
 const h = vi.hoisted(() => ({
 	usersUpdate: vi.fn(),
+	authUpdateUser: vi.fn(),
 	prefsUpsert: vi.fn(),
 	prefsRow: {
 		current: null as {
@@ -27,6 +28,12 @@ const h = vi.hoisted(() => ({
 
 vi.mock("#lib/supabase/client", () => ({
 	createClient: () => ({
+		auth: {
+			updateUser: (payload: unknown) => {
+				h.authUpdateUser(payload);
+				return Promise.resolve({ data: {}, error: null });
+			},
+		},
 		from: (table: string) => {
 			if (table === "users") {
 				return {
@@ -120,7 +127,7 @@ describe("GeneralSettings (FORMFIX-06)", () => {
 		expect(language.value).toBe("es");
 	});
 
-	it("persists all four fields: email/phone → users, timezone/language → user_preferences", async () => {
+	it("persists all fields: phone → users, email → Auth, timezone/language → user_preferences", async () => {
 		const user = userEvent.setup();
 		renderWithClient(<GeneralSettings />);
 
@@ -142,12 +149,16 @@ describe("GeneralSettings (FORMFIX-06)", () => {
 
 		await user.click(screen.getByRole("button", { name: /save changes/i }));
 
+		// Phone → `users` (email is a locked column, never written here).
 		await waitFor(() => {
-			expect(h.usersUpdate).toHaveBeenCalledWith({
-				email: "new@example.com",
-				phone: "555-2000",
-			});
+			expect(h.usersUpdate).toHaveBeenCalledWith({ phone: "555-2000" });
 		});
+		expect(h.usersUpdate).not.toHaveBeenCalledWith(
+			expect.objectContaining({ email: expect.anything() }),
+		);
+
+		// Email → Supabase Auth (confirmation flow), NOT the users table.
+		expect(h.authUpdateUser).toHaveBeenCalledWith({ email: "new@example.com" });
 
 		expect(h.prefsUpsert).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -174,6 +185,7 @@ describe("GeneralSettings (FORMFIX-06)", () => {
 		});
 		// No email key sent (would have wiped the account email).
 		expect(h.usersUpdate).not.toHaveBeenCalled();
+		expect(h.authUpdateUser).not.toHaveBeenCalled();
 	});
 
 	it("shows 'No changes to save' when nothing changed", async () => {

--- a/src/components/settings/__tests__/notification-settings.test.tsx
+++ b/src/components/settings/__tests__/notification-settings.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OwnerNotificationSettings } from "#hooks/api/query-keys/owner-notification-settings-keys";
+import { NotificationSettings } from "../notification-settings";
+
+const mockUseSettings = vi.fn();
+const mockMutate = vi.fn();
+
+vi.mock("#hooks/api/use-owner-notification-settings", () => ({
+	useOwnerNotificationSettings: () => mockUseSettings(),
+	useUpdateOwnerNotificationSettingsMutation: () => ({
+		mutate: mockMutate,
+		isPending: false,
+	}),
+}));
+
+function makeSettings(
+	overrides: Partial<Omit<OwnerNotificationSettings, "categories">>,
+): OwnerNotificationSettings {
+	return {
+		email: true,
+		sms: true,
+		push: true,
+		inApp: true,
+		categories: { maintenance: true, leases: true, general: true },
+		...overrides,
+	};
+}
+
+describe("NotificationSettings — Enable All (FORMFIX-07)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("writes all four channels in a single mutate when toggled ON", async () => {
+		const user = userEvent.setup();
+		// sms off => aggregate is OFF, so clicking toggles it ON.
+		mockUseSettings.mockReturnValue({
+			data: makeSettings({ sms: false }),
+			isLoading: false,
+		});
+
+		render(<NotificationSettings />);
+
+		const enableAll = screen.getByRole("switch", {
+			name: /enable all notifications/i,
+		});
+		expect(enableAll).not.toBeChecked();
+
+		await user.click(enableAll);
+
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+		expect(mockMutate).toHaveBeenCalledWith({
+			email: true,
+			sms: true,
+			push: true,
+			inApp: true,
+		});
+	});
+
+	it("reads checked=false when any channel is off", () => {
+		mockUseSettings.mockReturnValue({
+			data: makeSettings({ push: false }),
+			isLoading: false,
+		});
+
+		render(<NotificationSettings />);
+
+		expect(
+			screen.getByRole("switch", { name: /enable all notifications/i }),
+		).not.toBeChecked();
+	});
+
+	it("reads checked=true only when all channels are on", () => {
+		mockUseSettings.mockReturnValue({
+			data: makeSettings({}),
+			isLoading: false,
+		});
+
+		render(<NotificationSettings />);
+
+		expect(
+			screen.getByRole("switch", { name: /enable all notifications/i }),
+		).toBeChecked();
+	});
+
+	it("writes all four channels OFF when toggled off from the all-on state", async () => {
+		const user = userEvent.setup();
+		mockUseSettings.mockReturnValue({
+			data: makeSettings({}),
+			isLoading: false,
+		});
+
+		render(<NotificationSettings />);
+
+		const enableAll = screen.getByRole("switch", {
+			name: /enable all notifications/i,
+		});
+		expect(enableAll).toBeChecked();
+
+		await user.click(enableAll);
+
+		expect(mockMutate).toHaveBeenCalledWith({
+			email: false,
+			sms: false,
+			push: false,
+			inApp: false,
+		});
+	});
+});

--- a/src/components/settings/general-settings.tsx
+++ b/src/components/settings/general-settings.tsx
@@ -61,9 +61,11 @@ export function GeneralSettings() {
 
 	const queryClient = useQueryClient();
 
-	// Update profile mutation (Contact Email + Phone → `users`).
+	// Update profile mutation (Phone → `users`). Email is NOT written here — it is a
+	// locked privileged column (REVOKE UPDATE on public.users + the
+	// guard_user_self_update trigger reject it); it goes through Auth (updateEmail).
 	const updateProfile = useMutation({
-		mutationFn: async (updates: { phone?: string; email?: string }) => {
+		mutationFn: async (updates: { phone?: string }) => {
 			const supabase = createClient();
 			const user = await getCachedUser();
 			if (!user) throw new Error("Not authenticated");
@@ -80,6 +82,28 @@ export function GeneralSettings() {
 		onError: (error) => {
 			toast.error(
 				error instanceof Error ? error.message : "Failed to update profile",
+			);
+		},
+	});
+
+	// Contact (account) email → Supabase Auth. `public.users.email` is a locked
+	// privileged column that cannot be written via PostgREST, so an email change is
+	// an auth operation: it sends a confirmation link and only takes effect once the
+	// user confirms (the users.email is then synced from auth).
+	const updateEmail = useMutation({
+		mutationFn: async (email: string) => {
+			const supabase = createClient();
+			const { error } = await supabase.auth.updateUser({ email });
+			if (error) throw error;
+		},
+		onSuccess: () => {
+			toast.success(
+				"Check your inbox — we sent a link to confirm your new email.",
+			);
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update email",
 			);
 		},
 	});
@@ -126,18 +150,20 @@ export function GeneralSettings() {
 	const handleSaveChanges = () => {
 		let changed = false;
 
-		// Contact Email + Phone → `users`.
-		const profileUpdates: { phone?: string; email?: string } = {};
+		// Phone → `users`.
+		const profileUpdates: { phone?: string } = {};
 		if (phone !== (profile?.phone ?? "")) {
 			profileUpdates.phone = phone;
 		}
-		// Guard against wiping the account email with a blank value
-		// (T-31-06-02): only send email when non-empty and changed.
-		if (contactEmail && contactEmail !== profile?.email) {
-			profileUpdates.email = contactEmail;
-		}
 		if (Object.keys(profileUpdates).length > 0) {
 			updateProfile.mutate(profileUpdates);
+			changed = true;
+		}
+
+		// Contact (account) email → Auth (locked column; confirmation flow). Guard
+		// against wiping it with a blank value — only send when non-empty and changed.
+		if (contactEmail && contactEmail !== profile?.email) {
+			updateEmail.mutate(contactEmail);
 			changed = true;
 		}
 

--- a/src/components/settings/general-settings.tsx
+++ b/src/components/settings/general-settings.tsx
@@ -182,7 +182,10 @@ export function GeneralSettings() {
 	};
 
 	const isLoading = profileLoading || preferencesLoading;
-	const isSaving = updateProfile.isPending || updatePreferences.isPending;
+	const isSaving =
+		updateProfile.isPending ||
+		updatePreferences.isPending ||
+		updateEmail.isPending;
 
 	if (isLoading) {
 		return (

--- a/src/components/settings/general-settings.tsx
+++ b/src/components/settings/general-settings.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Mail, Smartphone } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { BlurFade } from "#components/ui/blur-fade";
 import { Skeleton } from "#components/ui/skeleton";
+import {
+	userPreferencesKeys,
+	userPreferencesQueries,
+} from "#hooks/api/query-keys/user-preferences-keys";
 import { profileKeys, useProfile } from "#hooks/api/use-profile";
 import { createClient } from "#lib/supabase/client";
 import { getCachedUser } from "#lib/supabase/get-cached-user";
@@ -25,12 +29,19 @@ export function GeneralSettings() {
 	// Fetch current user profile via shared hook
 	const { data: profile, isLoading: profileLoading } = useProfile();
 
+	// FORMFIX-06: Timezone + Language live on the `user_preferences` table
+	// (NOT `users`). Load the saved values so the selects reflect reality
+	// instead of the hardcoded defaults.
+	const { data: preferences, isLoading: preferencesLoading } = useQuery(
+		userPreferencesQueries.detail(),
+	);
+
 	const [contactEmail, setContactEmail] = useState("");
 	const [phone, setPhone] = useState("");
 	const [timezone, setTimezone] = useState("America/Chicago");
 	const [language, setLanguage] = useState("en-US");
 
-	// Update form when data loads
+	// Seed Contact Email + Phone from the users profile when it loads.
 	useEffect(() => {
 		if (profile?.email) {
 			setContactEmail(profile.email);
@@ -40,9 +51,17 @@ export function GeneralSettings() {
 		}
 	}, [profile]);
 
+	// Seed Timezone + Language from user_preferences when it loads.
+	useEffect(() => {
+		if (preferences) {
+			setTimezone(preferences.timezone);
+			setLanguage(preferences.language);
+		}
+	}, [preferences]);
+
 	const queryClient = useQueryClient();
 
-	// Update profile mutation
+	// Update profile mutation (Contact Email + Phone → `users`).
 	const updateProfile = useMutation({
 		mutationFn: async (updates: { phone?: string; email?: string }) => {
 			const supabase = createClient();
@@ -65,6 +84,37 @@ export function GeneralSettings() {
 		},
 	});
 
+	// Update preferences mutation (Timezone + Language → `user_preferences`),
+	// upsert by user_id (onConflict "user_id") mirroring the notification
+	// settings upsert. The user_id is stamped from the auth-derived user,
+	// never from client input (T-31-06-01).
+	const updatePreferences = useMutation({
+		mutationFn: async (updates: { timezone: string; language: string }) => {
+			const supabase = createClient();
+			const user = await getCachedUser();
+			if (!user) throw new Error("Not authenticated");
+			const { error } = await supabase.from("user_preferences").upsert(
+				{
+					user_id: user.id,
+					timezone: updates.timezone,
+					language: updates.language,
+					updated_at: new Date().toISOString(),
+				},
+				{ onConflict: "user_id" },
+			);
+			if (error) throw error;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: userPreferencesKeys.all });
+			toast.success("Preferences updated successfully");
+		},
+		onError: (error) => {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to update preferences",
+			);
+		},
+	});
+
 	const handleThemeChange = (value: string) => {
 		setThemeMode(value as ThemeMode);
 	};
@@ -74,18 +124,39 @@ export function GeneralSettings() {
 	};
 
 	const handleSaveChanges = () => {
-		const updates: { phone?: string; email?: string } = {};
-		if (phone !== profile?.phone) {
-			updates.phone = phone;
+		let changed = false;
+
+		// Contact Email + Phone → `users`.
+		const profileUpdates: { phone?: string; email?: string } = {};
+		if (phone !== (profile?.phone ?? "")) {
+			profileUpdates.phone = phone;
 		}
-		if (Object.keys(updates).length > 0) {
-			updateProfile.mutate(updates);
-		} else {
+		// Guard against wiping the account email with a blank value
+		// (T-31-06-02): only send email when non-empty and changed.
+		if (contactEmail && contactEmail !== profile?.email) {
+			profileUpdates.email = contactEmail;
+		}
+		if (Object.keys(profileUpdates).length > 0) {
+			updateProfile.mutate(profileUpdates);
+			changed = true;
+		}
+
+		// Timezone + Language → `user_preferences`.
+		if (
+			timezone !== preferences?.timezone ||
+			language !== preferences?.language
+		) {
+			updatePreferences.mutate({ timezone, language });
+			changed = true;
+		}
+
+		if (!changed) {
 			toast.info("No changes to save");
 		}
 	};
 
-	const isLoading = profileLoading;
+	const isLoading = profileLoading || preferencesLoading;
+	const isSaving = updateProfile.isPending || updatePreferences.isPending;
 
 	if (isLoading) {
 		return (
@@ -254,10 +325,10 @@ export function GeneralSettings() {
 				<div className="flex justify-end">
 					<button
 						onClick={handleSaveChanges}
-						disabled={updateProfile.isPending}
+						disabled={isSaving}
 						className="rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:pointer-events-none"
 					>
-						{updateProfile.isPending ? (
+						{isSaving ? (
 							<span className="flex items-center gap-2">
 								<Loader2 className="h-4 w-4 animate-spin" />
 								Saving...

--- a/src/components/settings/notification-settings.tsx
+++ b/src/components/settings/notification-settings.tsx
@@ -20,6 +20,24 @@ export function NotificationSettings() {
 		updateSettings.mutate({ [channel]: value });
 	};
 
+	// FORMFIX-07: "Enable All" reflects/controls every channel, not just email.
+	// Read ON only when all four channels are ON (mirror each channel Switch's
+	// own default), and write all four in a single mutate on toggle.
+	const allChannelsEnabled =
+		(settings?.email ?? true) &&
+		(settings?.sms ?? false) &&
+		(settings?.push ?? true) &&
+		(settings?.inApp ?? true);
+
+	const handleEnableAllToggle = (value: boolean) => {
+		updateSettings.mutate({
+			email: value,
+			sms: value,
+			push: value,
+			inApp: value,
+		});
+	};
+
 	const handleCategoryToggle = (
 		category: "maintenance" | "leases" | "general",
 		value: boolean,
@@ -61,9 +79,10 @@ export function NotificationSettings() {
 							</p>
 						</div>
 						<Switch
-							checked={settings?.email ?? true}
-							onCheckedChange={(value) => handleChannelToggle("email", value)}
+							checked={allChannelsEnabled}
+							onCheckedChange={handleEnableAllToggle}
 							disabled={updateSettings.isPending}
+							aria-label="Enable all notifications"
 						/>
 					</div>
 				</section>

--- a/src/components/settings/sections/subscription-cancel-section.tsx
+++ b/src/components/settings/sections/subscription-cancel-section.tsx
@@ -23,7 +23,6 @@ import {
 	useCancelSubscriptionMutation,
 	useReactivateSubscriptionMutation,
 } from "#hooks/api/use-billing-mutations";
-import { handleMutationError } from "#lib/mutation-error-handler";
 import { cn } from "#lib/utils";
 
 function formatPlanEndDate(iso: string | null): string {
@@ -138,14 +137,11 @@ export function SubscriptionCancelSection() {
 	// ───────────── State 2: Cancel-scheduled (grace window) ─────────────
 	if (subscriptionStatus === "active" && cancelAtPeriodEnd) {
 		const onReactivate = () => {
+			// FORMFIX-08: no onError override — the mutation's built-in onError owns the
+			// single error toast (with a friendly fallback message); a second handler
+			// here would double-toast + double-Sentry the same failure.
 			reactivateMutation.mutate(undefined, {
 				onSuccess: () => toast.success("Your subscription is active again."),
-				onError: (err) =>
-					handleMutationError(
-						err,
-						"Reactivate subscription",
-						"Couldn't reactivate. Please try again.",
-					),
 			});
 		};
 		return (
@@ -198,17 +194,14 @@ export function SubscriptionCancelSection() {
 
 	// ───────────── State 1: Active (default) ─────────────
 	const onConfirmCancel = () => {
+		// FORMFIX-08: no onError override — the mutation's built-in onError owns the
+		// single error toast (with a friendly fallback message); a second handler
+		// here would double-toast + double-Sentry the same failure.
 		cancelMutation.mutate(undefined, {
 			onSuccess: () => {
 				toast.success(`Subscription set to cancel on ${endDate}.`);
 				setDialogOpen(false);
 			},
-			onError: (err) =>
-				handleMutationError(
-					err,
-					"Cancel subscription",
-					"Couldn't cancel your subscription. Please try again or contact support.",
-				),
 		});
 	};
 

--- a/src/components/tenants/__tests__/add-tenant-form.property.test.tsx
+++ b/src/components/tenants/__tests__/add-tenant-form.property.test.tsx
@@ -24,6 +24,7 @@ import type { ReactNode } from "react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AddTenantRequest } from "#lib/validation/tenants";
+import type { Property, Unit } from "#types/core";
 import { AddTenantForm } from "../add-tenant-form";
 
 // Mock dependencies
@@ -463,5 +464,118 @@ describe("AddTenantForm - unsaved-changes guard (FORMFIX-01)", () => {
 
 		addSpy.mockRestore();
 		removeSpy.mockRestore();
+	});
+});
+
+const TEST_PROPERTY: Property = {
+	id: "prop-1",
+	owner_user_id: "owner-1",
+	name: "Maple Court",
+	address_line1: "1 Maple St",
+	address_line2: null,
+	city: "Austin",
+	state: "TX",
+	postal_code: "78701",
+	country: "US",
+	property_type: "single_family",
+	status: "active",
+	date_sold: null,
+	sale_price: null,
+	acquisition_cost: null,
+	acquisition_date: null,
+	created_at: "2024-01-01T00:00:00Z",
+	updated_at: "2024-01-01T00:00:00Z",
+	search_vector: null,
+};
+
+const TEST_UNIT: Unit = {
+	id: "unit-1",
+	property_id: "prop-1",
+	owner_user_id: "owner-1",
+	unit_number: "101",
+	bedrooms: 1,
+	bathrooms: 1,
+	square_feet: 650,
+	rent_amount: 1200,
+	rent_currency: "USD",
+	rent_period: "month",
+	status: "available",
+	created_at: "2024-01-01T00:00:00Z",
+	updated_at: "2024-01-01T00:00:00Z",
+};
+
+/**
+ * FORMFIX-04: a property/unit selected in the add-tenant form must not be
+ * silently discarded. There is no standalone tenant↔unit link, so the created
+ * tenant + selection are carried into the lease-creation flow via query params.
+ */
+describe("AddTenantForm - carries selection into lease flow (FORMFIX-04)", () => {
+	function renderForm() {
+		const queryClient = createTestQueryClient();
+		return render(
+			<QueryClientProvider client={queryClient}>
+				<AddTenantForm properties={[TEST_PROPERTY]} units={[TEST_UNIT]} />
+			</QueryClientProvider>,
+		);
+	}
+
+	async function fillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
+		await user.type(screen.getByLabelText(/first name/i), "John");
+		await user.type(screen.getByLabelText(/last name/i), "Doe");
+		await user.type(
+			screen.getByLabelText(/email address/i),
+			"john@example.com",
+		);
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("routes to /leases/new with the tenant, property, and unit when a property is selected", async () => {
+		const user = userEvent.setup();
+		renderForm();
+
+		await fillRequiredFields(user);
+
+		// Pick the property — the single available unit auto-selects.
+		await user.click(screen.getByRole("combobox", { name: /property/i }));
+		await user.click(
+			await screen.findByRole("option", { name: /maple court/i }),
+		);
+
+		await user.click(screen.getByRole("button", { name: /add tenant/i }));
+
+		await waitFor(() => {
+			expect(mockRouterPush).toHaveBeenCalled();
+		});
+
+		const leaseCall = mockRouterPush.mock.calls.find(
+			([url]) => typeof url === "string" && url.startsWith("/leases/new"),
+		);
+		expect(leaseCall).toBeDefined();
+		const url = leaseCall?.[0] as string;
+		expect(url).toContain("tenant=new-tenant-id");
+		expect(url).toContain("property=prop-1");
+		expect(url).toContain("unit=unit-1");
+		// The selection is NOT silently dropped to the tenants list.
+		expect(mockRouterPush).not.toHaveBeenCalledWith("/tenants");
+	});
+
+	it("redirects to /tenants when no property is selected", async () => {
+		const user = userEvent.setup();
+		renderForm();
+
+		await fillRequiredFields(user);
+		await user.click(screen.getByRole("button", { name: /add tenant/i }));
+
+		await waitFor(() => {
+			expect(mockRouterPush).toHaveBeenCalledWith("/tenants");
+		});
+
+		const leaseCall = mockRouterPush.mock.calls.find(
+			([url]) => typeof url === "string" && url.startsWith("/leases/new"),
+		);
+		expect(leaseCall).toBeUndefined();
 	});
 });

--- a/src/components/tenants/__tests__/add-tenant-form.property.test.tsx
+++ b/src/components/tenants/__tests__/add-tenant-form.property.test.tsx
@@ -17,19 +17,42 @@ import {
 	QueryClientProvider,
 	useMutation,
 } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import * as fc from "fast-check";
 import type { ReactNode } from "react";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AddTenantRequest } from "#lib/validation/tenants";
+import { AddTenantForm } from "../add-tenant-form";
 
 // Mock dependencies
 vi.mock("sonner", () => ({
 	toast: {
 		success: vi.fn(),
 		error: vi.fn(),
+		info: vi.fn(),
 	},
+}));
+
+// Mock the create-tenant mutation so the guard test never hits PostgREST.
+const mockCreateTenant = vi.fn().mockResolvedValue({ id: "new-tenant-id" });
+vi.mock("#hooks/api/use-tenant-mutations", () => ({
+	useCreateTenantMutation: () => ({
+		mutateAsync: mockCreateTenant,
+		isPending: false,
+	}),
+}));
+
+const mockRouterPush = vi.fn();
+const mockRouterBack = vi.fn();
+const mockRouterRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({
+		push: mockRouterPush,
+		back: mockRouterBack,
+		refresh: mockRouterRefresh,
+	}),
 }));
 
 // Helper to create a query client for each test
@@ -371,4 +394,74 @@ it("should distinguish between authentication and authorization errors", async (
 		),
 		{ numRuns: 100 },
 	);
+});
+
+/**
+ * FORMFIX-01: the add-tenant unsaved-changes guard must arm REACTIVELY.
+ *
+ * Regression: the call site passed a non-reactive `form.state.isDirty` snapshot,
+ * so the `beforeunload` guard never armed as the user typed. The fix reads dirty
+ * via `useStore(form.store, (s) => s.isDirty)`. These tests prove the listener is
+ * registered after a field change and removed once the form returns to pristine.
+ */
+describe("AddTenantForm - unsaved-changes guard (FORMFIX-01)", () => {
+	function renderForm() {
+		const queryClient = createTestQueryClient();
+		return render(
+			<QueryClientProvider client={queryClient}>
+				<AddTenantForm properties={[]} units={[]} />
+			</QueryClientProvider>,
+		);
+	}
+
+	function countBeforeUnload(calls: unknown[][]): number {
+		return calls.filter((call) => call[0] === "beforeunload").length;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("arms the beforeunload guard when the form becomes dirty", async () => {
+		const user = userEvent.setup();
+		const addSpy = vi.spyOn(window, "addEventListener");
+
+		renderForm();
+
+		// Pristine form → guard not armed.
+		expect(countBeforeUnload(addSpy.mock.calls)).toBe(0);
+
+		await user.type(screen.getByLabelText(/email address/i), "a");
+
+		// Dirty form → reactive isDirty flips true → effect registers the guard.
+		await waitFor(() => {
+			expect(countBeforeUnload(addSpy.mock.calls)).toBeGreaterThan(0);
+		});
+
+		addSpy.mockRestore();
+	});
+
+	it("removes the beforeunload guard when the armed form unmounts (navigate-away)", async () => {
+		// TanStack Form's field-level `isDirty` is sticky once a field changes, so
+		// the guard disarms on submit/navigation (unmount) rather than on revert.
+		// This asserts the reactive effect's cleanup runs, mirroring the real
+		// navigate-away path after a successful create.
+		const user = userEvent.setup();
+		const addSpy = vi.spyOn(window, "addEventListener");
+		const removeSpy = vi.spyOn(window, "removeEventListener");
+
+		const { unmount } = renderForm();
+
+		await user.type(screen.getByLabelText(/email address/i), "a");
+		await waitFor(() => {
+			expect(countBeforeUnload(addSpy.mock.calls)).toBeGreaterThan(0);
+		});
+
+		unmount();
+
+		expect(countBeforeUnload(removeSpy.mock.calls)).toBeGreaterThan(0);
+
+		addSpy.mockRestore();
+		removeSpy.mockRestore();
+	});
 });

--- a/src/components/tenants/__tests__/add-tenant-form.property.test.tsx
+++ b/src/components/tenants/__tests__/add-tenant-form.property.test.tsx
@@ -577,5 +577,9 @@ describe("AddTenantForm - carries selection into lease flow (FORMFIX-04)", () =>
 			([url]) => typeof url === "string" && url.startsWith("/leases/new"),
 		);
 		expect(leaseCall).toBeUndefined();
+
+		// FORMFIX-08: the form no longer fires its own success toast — the single
+		// success toast comes from the create mutation's createMutationCallbacks.
+		expect(toast.success).not.toHaveBeenCalledWith("Tenant added");
 	});
 });

--- a/src/components/tenants/add-tenant-form.tsx
+++ b/src/components/tenants/add-tenant-form.tsx
@@ -66,7 +66,9 @@ export function AddTenantForm({
 				const created = await createTenant.mutateAsync(payload);
 
 				logger.info("Tenant added", { email: value.email });
-				toast.success("Tenant added");
+				// FORMFIX-08: the create mutation's createMutationCallbacks already
+				// fires the single success toast ("Tenant created successfully") — no
+				// form-level duplicate here.
 
 				onSuccess?.();
 

--- a/src/components/tenants/add-tenant-form.tsx
+++ b/src/components/tenants/add-tenant-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useStore } from "@tanstack/react-form";
 import { UserPlus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -79,8 +80,12 @@ export function AddTenantForm({
 		},
 	});
 
-	// Warn before navigating away with unsaved form data
-	useUnsavedChangesWarning(form.state.isDirty);
+	// Warn before navigating away with unsaved form data.
+	// FORMFIX-01: read dirty REACTIVELY from the form store so the boolean
+	// re-renders as the user types (a `form.state.isDirty` snapshot is read once
+	// at mount and never re-arms the guard's effect).
+	const isDirty = useStore(form.store, (s) => s.isDirty);
+	useUnsavedChangesWarning(isDirty);
 
 	// Filter units based on selected property
 	const availableUnits = units.filter(

--- a/src/components/tenants/add-tenant-form.tsx
+++ b/src/components/tenants/add-tenant-form.tsx
@@ -10,7 +10,6 @@ import { useCreateTenantMutation } from "#hooks/api/use-tenant-mutations";
 import { useUnsavedChangesWarning } from "#hooks/use-unsaved-changes";
 import { useAppForm } from "#lib/forms/form-hook";
 import { createLogger } from "#lib/frontend-logger";
-import { handleMutationError } from "#lib/mutation-error-handler";
 import type { TenantCreate } from "#lib/validation/tenants";
 import type { Property, Unit } from "#types/core";
 import { addTenantFormOptions } from "./add-tenant-form-options";
@@ -93,10 +92,11 @@ export function AddTenantForm({
 					router.refresh();
 				}
 			} catch (error) {
+				// FORMFIX-08: the mutation's onError (createMutationCallbacks) surfaces
+				// the error toast; only log here to avoid a duplicate.
 				logger.error("Failed to add tenant", {
 					error: error instanceof Error ? error.message : String(error),
 				});
-				handleMutationError(error, "Add tenant");
 			}
 		},
 	});

--- a/src/components/tenants/add-tenant-form.tsx
+++ b/src/components/tenants/add-tenant-form.tsx
@@ -63,14 +63,33 @@ export function AddTenantForm({
 					...(value.phone ? { phone: value.phone } : {}),
 				};
 
-				await createTenant.mutateAsync(payload);
+				const created = await createTenant.mutateAsync(payload);
 
 				logger.info("Tenant added", { email: value.email });
 				toast.success("Tenant added");
 
 				onSuccess?.();
-				router.push("/tenants");
-				router.refresh();
+
+				// FORMFIX-04: a selected property/unit must not be silently dropped.
+				// There is no standalone tenant↔unit link — lease_tenants needs a
+				// lease_id, and a lease needs start/end/rent that this form does not
+				// collect. So carry the created tenant + selected property/unit into
+				// the lease-creation flow (preselection query params) instead of
+				// discarding the selection on the /tenants redirect.
+				if (value.property_id) {
+					const params = new URLSearchParams({
+						tenant: created.id,
+						property: value.property_id,
+					});
+					if (value.unit_id) params.set("unit", value.unit_id);
+					toast.info(
+						"Complete the lease to finish assigning this tenant to the unit.",
+					);
+					router.push(`/leases/new?${params.toString()}`);
+				} else {
+					router.push("/tenants");
+					router.refresh();
+				}
 			} catch (error) {
 				logger.error("Failed to add tenant", {
 					error: error instanceof Error ? error.message : String(error),

--- a/src/components/units/unit-form.client.tsx
+++ b/src/components/units/unit-form.client.tsx
@@ -11,9 +11,8 @@ import {
 	useUpdateUnitMutation,
 } from "#hooks/api/use-unit";
 import { useCurrentUser } from "#hooks/use-current-user";
-import { ERROR_MESSAGES } from "#lib/constants/error-messages";
 import { useAppForm } from "#lib/forms/form-hook";
-import { handleMutationError } from "#lib/mutation-error-handler";
+import { createLogger } from "#lib/frontend-logger";
 import {
 	handleConflictError,
 	isConflictError,
@@ -50,6 +49,7 @@ export function UnitForm({
 	const properties = propertiesResponse?.data;
 	const createUnitMutation = useCreateUnitMutation();
 	const updateUnitMutation = useUpdateUnitMutation();
+	const logger = createLogger({ component: "UnitForm" });
 
 	// Fetch unit if id provided (for client-side edit mode)
 	// Only fetch if we don't have a unit prop and we're in edit mode
@@ -147,7 +147,8 @@ export function UnitForm({
 
 				if (mode === "create") {
 					await createUnitMutation.mutateAsync(unitData);
-					toast.success("Unit created successfully");
+					// FORMFIX-08: the create mutation's createMutationCallbacks fires the
+					// single success toast; no form-level duplicate.
 					router.push("/units");
 				} else {
 					if (!unit?.id) {
@@ -158,25 +159,26 @@ export function UnitForm({
 						id: unit.id,
 						data: unitData,
 					});
-					toast.success("Unit updated successfully");
+					// FORMFIX-08: the update mutation's createMutationCallbacks fires the
+					// single success toast; no form-level duplicate.
 				}
 
 				onSuccess?.();
 			} catch (error) {
-				// Handle optimistic locking conflicts
+				// FORMFIX-08: the mutation's onError (createMutationCallbacks ->
+				// handleMutationError) surfaces the single error toast, including the
+				// 409 "Conflict" toast. On a conflict, reconcile the cache so the stale
+				// unit refetches; otherwise just log. No second toast, and no re-throw
+				// (form-core re-throws onSubmit errors into the un-awaited handleSubmit).
 				if (mode === "edit" && unit && isConflictError(error)) {
 					handleConflictError("units", unit.id, queryClient, [
 						unitQueries.detail(unit.id).queryKey,
 						unitQueries.all(),
 					]);
-					toast.error(ERROR_MESSAGES.CONFLICT_UPDATE);
-					return;
 				}
-
-				handleMutationError(
-					error,
-					`${mode === "create" ? "Create" : "Update"} unit`,
-				);
+				logger.error(`Unit ${mode} failed`, {
+					error: error instanceof Error ? error.message : String(error),
+				});
 			}
 		},
 	});

--- a/src/hooks/api/query-keys/user-preferences-keys.ts
+++ b/src/hooks/api/query-keys/user-preferences-keys.ts
@@ -1,0 +1,71 @@
+/**
+ * User Preferences Query Keys & Options
+ *
+ * queryOptions() factories for the `user_preferences` domain. Timezone and
+ * Language live on `user_preferences` (NOT `users`) — this is the read side
+ * for General Settings (FORMFIX-06). Mirrors the notification-settings
+ * pattern: createClient inside the queryFn, getCachedUser for the user id,
+ * a typed boundary mapper (no `as unknown as`), and no barrel re-export.
+ */
+
+import { queryOptions } from "@tanstack/react-query";
+import { QUERY_CACHE_TIMES } from "#lib/constants/query-config";
+import { createClient } from "#lib/supabase/client";
+import { getCachedUser } from "#lib/supabase/get-cached-user";
+import type { Database } from "#types/supabase";
+
+export interface UserPreferences {
+	timezone: string;
+	language: string;
+}
+
+type UserPreferencesRow =
+	Database["public"]["Tables"]["user_preferences"]["Row"];
+
+// Fallbacks match the General Settings select defaults so the form always
+// shows a valid selected option even before a user_preferences row exists.
+export const DEFAULT_USER_PREFERENCES: UserPreferences = {
+	timezone: "America/Chicago",
+	language: "en-US",
+};
+
+// Typed boundary mapper (no `as unknown as`): coalesces the nullable
+// timezone/language columns to the UI defaults.
+export function mapUserPreferencesRow(
+	row: Pick<UserPreferencesRow, "timezone" | "language">,
+): UserPreferences {
+	return {
+		timezone: row.timezone ?? DEFAULT_USER_PREFERENCES.timezone,
+		language: row.language ?? DEFAULT_USER_PREFERENCES.language,
+	};
+}
+
+export const userPreferencesKeys = {
+	all: ["user-preferences"] as const,
+};
+
+export const userPreferencesQueries = {
+	detail: () =>
+		queryOptions({
+			queryKey: userPreferencesKeys.all,
+			queryFn: async (): Promise<UserPreferences> => {
+				const supabase = createClient();
+				const user = await getCachedUser();
+
+				if (!user) throw new Error("Not authenticated");
+
+				const { data, error } = await supabase
+					.from("user_preferences")
+					.select("timezone, language")
+					.eq("user_id", user.id)
+					.maybeSingle();
+
+				if (error) throw error;
+
+				if (data === null) return DEFAULT_USER_PREFERENCES;
+
+				return mapUserPreferencesRow(data);
+			},
+			...QUERY_CACHE_TIMES.DETAIL,
+		}),
+};

--- a/src/hooks/api/use-billing-mutations.ts
+++ b/src/hooks/api/use-billing-mutations.ts
@@ -125,7 +125,14 @@ export function useCancelSubscriptionMutation() {
 			queryClient.invalidateQueries({ queryKey: subscriptionStatusKey });
 			queryClient.invalidateQueries({ queryKey: ownerDashboardKeys.all });
 		},
-		onError: (error) => handleMutationError(error, "Cancel subscription"),
+		// FORMFIX-08: the built-in owns the single error toast; carry the friendly
+		// fallback message here so the sole consumer needn't add its own onError.
+		onError: (error) =>
+			handleMutationError(
+				error,
+				"Cancel subscription",
+				"Couldn't cancel your subscription. Please try again or contact support.",
+			),
 	});
 }
 
@@ -141,7 +148,14 @@ export function useReactivateSubscriptionMutation() {
 			queryClient.invalidateQueries({ queryKey: subscriptionStatusKey });
 			queryClient.invalidateQueries({ queryKey: ownerDashboardKeys.all });
 		},
-		onError: (error) => handleMutationError(error, "Reactivate subscription"),
+		// FORMFIX-08: the built-in owns the single error toast; carry the friendly
+		// fallback message here so the sole consumer needn't add its own onError.
+		onError: (error) =>
+			handleMutationError(
+				error,
+				"Reactivate subscription",
+				"Couldn't reactivate. Please try again.",
+			),
 	});
 }
 

--- a/src/hooks/use-form-progress.test.ts
+++ b/src/hooks/use-form-progress.test.ts
@@ -1,0 +1,180 @@
+/**
+ * FORMFIX-03: useFormWithProgress must not render-loop.
+ *
+ * Regression: the auto-save effect depended on the whole `progress` object
+ * (recreated every render), so it fired on every render → saveProgress →
+ * localStorage write → setState → re-render → spin. The fix keys the effect on
+ * stable identities (`saveProgress` via useCallback, `progress.isLoading`) and
+ * guards the write on an actual serialized-value change.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FormProgressData } from "#types/core";
+import { useFormWithProgress } from "./use-form-progress";
+
+interface TestValues extends FormProgressData {
+	email: string;
+	name: string;
+	password?: string;
+}
+
+const noopSubmit = vi.fn(async () => {});
+
+// This project's jsdom does not expose a usable global `localStorage`; install a
+// minimal in-memory mock so both the hook (bare `localStorage`) and the assertions
+// share one store and setItem calls are observable.
+const store = new Map<string, string>();
+const localStorageMock = {
+	getItem: vi.fn((key: string) => store.get(key) ?? null),
+	setItem: vi.fn((key: string, value: string) => {
+		store.set(key, value);
+	}),
+	removeItem: vi.fn((key: string) => {
+		store.delete(key);
+	}),
+	clear: vi.fn(() => {
+		store.clear();
+	}),
+	key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+	get length() {
+		return store.size;
+	},
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+	value: localStorageMock,
+	configurable: true,
+	writable: true,
+});
+
+function countWrites(formType: string): number {
+	return localStorageMock.setItem.mock.calls.filter(
+		(call) => call[0] === `form-progress-${formType}`,
+	).length;
+}
+
+describe("useFormWithProgress (FORMFIX-03)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		store.clear();
+	});
+
+	it("saves exactly once per real change and not on unchanged re-renders", async () => {
+		const { result, rerender } = renderHook(() =>
+			useFormWithProgress<TestValues>("contact", noopSubmit, {
+				email: "",
+				name: "",
+			}),
+		);
+
+		await waitFor(() => expect(result.current.isHydrated).toBe(true));
+		// Empty data → no write yet.
+		expect(countWrites("contact")).toBe(0);
+
+		act(() => {
+			result.current.updateField("email", "user@example.com");
+		});
+
+		// Exactly one save for the real change.
+		await waitFor(() => {
+			expect(countWrites("contact")).toBe(1);
+		});
+
+		// Re-rendering with unchanged data produces zero additional writes
+		// (the whole `progress` object is no longer a dependency + change guard).
+		rerender();
+		rerender();
+		rerender();
+		await act(async () => {
+			await Promise.resolve();
+		});
+		expect(countWrites("contact")).toBe(1);
+	});
+
+	it("saves once more only when a saved field actually changes again", async () => {
+		const { result } = renderHook(() =>
+			useFormWithProgress<TestValues>("contact", noopSubmit, {
+				email: "",
+				name: "",
+			}),
+		);
+
+		await waitFor(() => expect(result.current.isHydrated).toBe(true));
+
+		act(() => {
+			result.current.updateField("email", "a@example.com");
+		});
+		await waitFor(() => expect(countWrites("contact")).toBe(1));
+
+		act(() => {
+			result.current.updateField("name", "Ada");
+		});
+		await waitFor(() => expect(countWrites("contact")).toBe(2));
+	});
+
+	it("never persists passwords", async () => {
+		const { result } = renderHook(() =>
+			useFormWithProgress<TestValues>("signup", noopSubmit, {
+				email: "",
+				name: "",
+				password: "",
+			}),
+		);
+
+		await waitFor(() => expect(result.current.isHydrated).toBe(true));
+
+		act(() => {
+			result.current.updateField("email", "user@example.com");
+			result.current.updateField("password", "super-secret");
+		});
+
+		await waitFor(() => {
+			expect(countWrites("signup")).toBeGreaterThan(0);
+		});
+
+		for (const [key, value] of localStorageMock.setItem.mock.calls) {
+			if (key === "form-progress-signup") {
+				const parsed = JSON.parse(value);
+				expect(parsed.password).toBeUndefined();
+				expect(parsed.confirmPassword).toBeUndefined();
+				expect(parsed.email).toBe("user@example.com");
+			}
+		}
+	});
+
+	it("restores persisted data after hydration without a redundant self-save", async () => {
+		store.set(
+			"form-progress-contact",
+			JSON.stringify({ email: "saved@example.com", name: "Saved" }),
+		);
+
+		const { result } = renderHook(() =>
+			useFormWithProgress<TestValues>("contact", noopSubmit, {
+				email: "",
+				name: "",
+			}),
+		);
+
+		// Draft is restored into form state once.
+		await waitFor(() =>
+			expect(result.current.formData.email).toBe("saved@example.com"),
+		);
+		expect(result.current.formData.name).toBe("Saved");
+
+		// Settle window: the change guard is primed by the restore, so no write
+		// bounces the restored data straight back (no ping-pong).
+		await act(async () => {
+			await Promise.resolve();
+		});
+		const writesAfterRestore = countWrites("contact");
+		expect(writesAfterRestore).toBe(0);
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+		expect(countWrites("contact")).toBe(writesAfterRestore);
+	});
+});

--- a/src/hooks/use-form-progress.ts
+++ b/src/hooks/use-form-progress.ts
@@ -159,6 +159,15 @@ export function useFormWithProgress<T extends FormProgressData>(
 	// so re-renders with unchanged data produce no writes and the loop is broken.
 	const lastSavedRef = useRef<string | null>(null);
 
+	// FORMFIX-03: the restore-from-draft merge must happen exactly ONCE, at the
+	// initial load. `progress.data` is re-assigned a fresh reference on every
+	// auto-save (saveProgress does setState({ ...prev, data })), so without this
+	// gate the restore effect re-fires on each keystroke's save and re-merges the
+	// saved snapshot over the user's live edits (progressData wins the merge) —
+	// under fast typing a deferred stale snapshot can roll a controlled input back
+	// and drop in-flight characters. This gate pins restore to the load-time draft.
+	const hasRestoredRef = useRef(false);
+
 	// Stable identities (the mutable pieces of `progress`) so the auto-save effect
 	// does not re-run every render on a fresh `progress` object reference.
 	const { saveProgress } = progress;
@@ -198,20 +207,30 @@ export function useFormWithProgress<T extends FormProgressData>(
 		});
 	}, [deferredFormData, saveProgress, progressIsLoading, isHydrated]);
 
-	// Restore progress data when loaded - only after hydration
+	// Restore progress data when loaded - only after hydration, and ONLY ONCE.
+	// FORMFIX-03: the guard runs the merge the first time the initial localStorage
+	// load has settled (isHydrated && !progressIsLoading); subsequent progressData
+	// changes are auto-save writes, which must NOT re-merge over live form edits.
 	useEffect(() => {
-		if (isHydrated && progressData && !progressIsLoading) {
-			setFormData((prev) => {
-				const merged = { ...prev, ...progressData };
-				// Prime the change guard with what we just restored so the auto-save
-				// effect does not immediately write the restored data straight back.
-				const safe = { ...merged };
-				delete safe.password;
-				delete safe.confirmPassword;
-				lastSavedRef.current = JSON.stringify(safe);
-				return merged;
-			});
-		}
+		if (hasRestoredRef.current) return;
+		if (!isHydrated || progressIsLoading) return;
+
+		// Initial load has completed — restore the draft that existed at load time
+		// (if any). Mark done first so an auto-save-driven progressData change can
+		// never re-enter this merge.
+		hasRestoredRef.current = true;
+		if (!progressData) return;
+
+		setFormData((prev) => {
+			const merged = { ...prev, ...progressData };
+			// Prime the change guard with what we just restored so the auto-save
+			// effect does not immediately write the restored data straight back.
+			const safe = { ...merged };
+			delete safe.password;
+			delete safe.confirmPassword;
+			lastSavedRef.current = JSON.stringify(safe);
+			return merged;
+		});
 	}, [progressData, progressIsLoading, isHydrated]);
 
 	const handleSubmit = async (data: T) => {

--- a/src/hooks/use-form-progress.ts
+++ b/src/hooks/use-form-progress.ts
@@ -6,7 +6,14 @@
 
 "use client";
 
-import { startTransition, useDeferredValue, useEffect, useState } from "react";
+import {
+	startTransition,
+	useCallback,
+	useDeferredValue,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { createLogger } from "#lib/frontend-logger";
 import type { FormProgressData } from "#types/core";
 
@@ -68,56 +75,62 @@ function useFormProgress(formType: FormType) {
 		};
 	}, [formType]);
 
-	// Save progress function with local storage (excludes sensitive data)
-	const saveProgress = async (data: FormProgressData): Promise<void> => {
-		try {
-			// Skip if no meaningful data to save
-			if (!data.email && !data.name) return;
+	// Save progress function with local storage (excludes sensitive data).
+	// FORMFIX-03: memoized (deps: formType only) so its identity is stable across
+	// renders — consumers depend on this reference, not on the whole hook return.
+	// It uses the functional setState form, so it never needs `state` as a dep.
+	const saveProgress = useCallback(
+		async (data: FormProgressData): Promise<void> => {
+			try {
+				// Skip if no meaningful data to save
+				if (!data.email && !data.name) return;
 
-			// Security: Never save passwords locally
-			const safeData = { ...data };
-			delete safeData.password;
-			delete safeData.confirmPassword;
+				// Security: Never save passwords locally
+				const safeData = { ...data };
+				delete safeData.password;
+				delete safeData.confirmPassword;
 
-			// Save to localStorage
-			localStorage.setItem(
-				`form-progress-${formType}`,
-				JSON.stringify(safeData),
-			);
+				// Save to localStorage
+				localStorage.setItem(
+					`form-progress-${formType}`,
+					JSON.stringify(safeData),
+				);
 
-			setState((prev) => ({
-				...prev,
-				data: safeData,
-				error: null,
-			}));
-		} catch (error) {
-			// Graceful degradation - don't break the form
-			logger.warn("Failed to save form progress", {
-				action: "form_progress_save_failed",
-				metadata: {
-					formType,
-					hasEmail: !!data.email,
-					hasName: !!data.name,
-					error: error instanceof Error ? error.message : String(error),
-				},
-			});
-			setState((prev) => ({
-				...prev,
-				error:
-					error instanceof Error ? error.message : "Failed to save progress",
-			}));
-		}
-	};
+				setState((prev) => ({
+					...prev,
+					data: safeData,
+					error: null,
+				}));
+			} catch (error) {
+				// Graceful degradation - don't break the form
+				logger.warn("Failed to save form progress", {
+					action: "form_progress_save_failed",
+					metadata: {
+						formType,
+						hasEmail: !!data.email,
+						hasName: !!data.name,
+						error: error instanceof Error ? error.message : String(error),
+					},
+				});
+				setState((prev) => ({
+					...prev,
+					error:
+						error instanceof Error ? error.message : "Failed to save progress",
+				}));
+			}
+		},
+		[formType],
+	);
 
-	// Clear progress (on successful submission)
-	const clearProgress = () => {
+	// Clear progress (on successful submission) — memoized for a stable identity.
+	const clearProgress = useCallback(() => {
 		localStorage.removeItem(`form-progress-${formType}`);
 		setState((prev) => ({
 			...prev,
 			data: null,
 			error: null,
 		}));
-	};
+	}, [formType]);
 
 	return {
 		...state,
@@ -141,6 +154,17 @@ export function useFormWithProgress<T extends FormProgressData>(
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [isHydrated, setIsHydrated] = useState(false);
 
+	// FORMFIX-03: the serialized (password-free) payload of the last save. The
+	// auto-save effect writes only when the current serialized payload differs,
+	// so re-renders with unchanged data produce no writes and the loop is broken.
+	const lastSavedRef = useRef<string | null>(null);
+
+	// Stable identities (the mutable pieces of `progress`) so the auto-save effect
+	// does not re-run every render on a fresh `progress` object reference.
+	const { saveProgress } = progress;
+	const progressIsLoading = progress.isLoading;
+	const progressData = progress.data;
+
 	// Mark as hydrated on client
 	useEffect(() => {
 		setIsHydrated(true);
@@ -152,26 +176,43 @@ export function useFormWithProgress<T extends FormProgressData>(
 	// Auto-save progress when form data changes (deferred) - only after hydration, excluding passwords
 	useEffect(() => {
 		if (
-			isHydrated &&
-			!progress.isLoading &&
-			(deferredFormData.email || deferredFormData.name)
+			!isHydrated ||
+			progressIsLoading ||
+			!(deferredFormData.email || deferredFormData.name)
 		) {
-			startTransition(() => {
-				// Security: Never auto-save passwords
-				const safeData = { ...deferredFormData };
-				delete safeData.password;
-				delete safeData.confirmPassword;
-				progress.saveProgress(safeData);
-			});
+			return;
 		}
-	}, [deferredFormData, progress, isHydrated]);
+
+		// Security: Never auto-save passwords
+		const safeData = { ...deferredFormData };
+		delete safeData.password;
+		delete safeData.confirmPassword;
+
+		// FORMFIX-03: skip when nothing meaningful changed since the last save.
+		const serialized = JSON.stringify(safeData);
+		if (serialized === lastSavedRef.current) return;
+		lastSavedRef.current = serialized;
+
+		startTransition(() => {
+			saveProgress(safeData);
+		});
+	}, [deferredFormData, saveProgress, progressIsLoading, isHydrated]);
 
 	// Restore progress data when loaded - only after hydration
 	useEffect(() => {
-		if (isHydrated && progress.data && !progress.isLoading) {
-			setFormData((prev) => ({ ...prev, ...progress.data }));
+		if (isHydrated && progressData && !progressIsLoading) {
+			setFormData((prev) => {
+				const merged = { ...prev, ...progressData };
+				// Prime the change guard with what we just restored so the auto-save
+				// effect does not immediately write the restored data straight back.
+				const safe = { ...merged };
+				delete safe.password;
+				delete safe.confirmPassword;
+				lastSavedRef.current = JSON.stringify(safe);
+				return merged;
+			});
 		}
-	}, [progress.data, progress.isLoading, isHydrated]);
+	}, [progressData, progressIsLoading, isHydrated]);
 
 	const handleSubmit = async (data: T) => {
 		setIsSubmitting(true);

--- a/src/hooks/use-maintenance-form.ts
+++ b/src/hooks/use-maintenance-form.ts
@@ -154,12 +154,16 @@ export function useMaintenanceForm({
 					onSuccess?.(result);
 				}
 			} catch (error) {
+				// FORMFIX-08: the mutation's onError (createMutationCallbacks) surfaces
+				// the single error toast; only log here. Do NOT re-throw — form-core
+				// re-throws whatever onSubmit throws, and the DOM handler calls
+				// form.handleSubmit() un-awaited, so a re-thrown rejection escapes as an
+				// unhandled promise rejection (second Sentry capture + a dev error
+				// overlay on an already-handled failure). Matches the other 3 forms.
 				logger.error("Failed to submit maintenance request", {
 					mode,
 					error,
 				});
-				// Re-throw to let mutation error handlers manage UI notifications
-				throw error;
 			}
 		},
 	});

--- a/src/hooks/use-maintenance-form.ts
+++ b/src/hooks/use-maintenance-form.ts
@@ -111,10 +111,15 @@ export function useMaintenanceForm({
 						throw new Error("Request ID is required for edit mode");
 					}
 
+					// FORMFIX-05: include unit_id/tenant_id so reassigning the unit or
+					// tenant on edit actually persists (previously omitted → silently
+					// dropped). maintenanceRequestUpdateSchema accepts them (partial input).
 					const payload: MaintenanceRequestUpdate = {
 						title: value.title,
 						description: value.description,
 						priority: value.priority,
+						unit_id: value.unit_id,
+						tenant_id: value.tenant_id,
 					};
 
 					// Add optional fields only if they have values

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -415,6 +415,12 @@ import_map = "./functions/deno.json"
 verify_jwt = false
 import_map = "./functions/deno.json"
 
+# Unauthenticated by design — the public /contact form posts here (publishable key,
+# not a user JWT). import_map required: _shared/errors imports @sentry/deno.
+[functions.send-contact-email]
+verify_jwt = false
+import_map = "./functions/deno.json"
+
 # Auth email send — Supabase Auth Hook receiver. Supabase Auth POSTs the
 # `SUPABASE_AUTH_HOOK_SECRET` value as the Bearer token (NOT a Supabase user
 # JWT). The platform JWT gate MUST be off so the hook secret reaches the

--- a/supabase/functions/send-contact-email/index.ts
+++ b/supabase/functions/send-contact-email/index.ts
@@ -1,0 +1,158 @@
+// Send Contact Email Edge Function
+// FORMFIX-02: Delivers a submitted contact-form message to the business inbox via Resend.
+// Unauthenticated by design -- the public /contact form posts here.
+// Rate limited at 10 req/min per IP (Upstash sliding window, fail-open).
+// Every user-supplied value is HTML-escaped before interpolation (anti-injection).
+// The From address stays the fixed FROM_ADDRESS -- user input never sets From/Reply-To.
+//
+// POST { name, email, subject, message, type?, phone?, company?, urgency? }
+// -> 200 { success: true }
+// -> 400 { error: 'Valid contact details are required' }
+// -> 429 { error: 'Too many requests' }
+// -> 500 { error: 'An error occurred' }   (unexpected server error)
+// -> 502 { error: 'An error occurred' }   (Resend send failure)
+
+import {
+	getCorsHeaders,
+	getJsonHeaders,
+	handleCorsOptions,
+} from "../_shared/cors.ts";
+import { validateEnv } from "../_shared/env.ts";
+import { errorResponse } from "../_shared/errors.ts";
+import { escapeHtml } from "../_shared/escape-html.ts";
+import { rateLimit } from "../_shared/rate-limit.ts";
+import { sendEmail } from "../_shared/resend.ts";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Destination business inbox (matches the address the /contact page displays).
+const CONTACT_INBOX = "sales@tenantflow.app";
+
+// Length bounds -- reject oversized payloads before building an email.
+const MAX_NAME = 200;
+const MAX_EMAIL = 320;
+const MAX_SUBJECT = 200;
+const MAX_MESSAGE = 5000;
+const MAX_OPTIONAL = 200;
+
+/** Coerce an unknown body field to a trimmed string. */
+function str(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+Deno.serve(async (req: Request) => {
+	const optionsResponse = handleCorsOptions(req);
+	if (optionsResponse) return optionsResponse;
+
+	if (req.method !== "POST") {
+		return new Response("Method Not Allowed", {
+			status: 405,
+			headers: getCorsHeaders(req),
+		});
+	}
+
+	// Unauthenticated endpoint: rate limit 10 req/min per IP (fail-open).
+	const rateLimited = await rateLimit(req, {
+		maxRequests: 10,
+		windowMs: 60_000,
+		prefix: "contact",
+	});
+	if (rateLimited) return rateLimited;
+
+	try {
+		validateEnv({
+			required: ["RESEND_API_KEY"],
+			optional: [
+				"NEXT_PUBLIC_APP_URL",
+				"UPSTASH_REDIS_REST_URL",
+				"UPSTASH_REDIS_REST_TOKEN",
+			],
+		});
+
+		const body = (await req.json()) as Record<string, unknown>;
+		const name = str(body.name);
+		const email = str(body.email).toLowerCase();
+		const subject = str(body.subject);
+		const message = str(body.message);
+		const type = str(body.type);
+		const phone = str(body.phone);
+		const company = str(body.company);
+		const urgency = str(body.urgency);
+
+		// Server-side validation: required fields + email format + length bounds.
+		if (
+			!name ||
+			name.length > MAX_NAME ||
+			!email ||
+			email.length > MAX_EMAIL ||
+			!EMAIL_REGEX.test(email) ||
+			!subject ||
+			subject.length > MAX_SUBJECT ||
+			!message ||
+			message.length > MAX_MESSAGE ||
+			phone.length > MAX_OPTIONAL ||
+			company.length > MAX_OPTIONAL ||
+			type.length > MAX_OPTIONAL ||
+			urgency.length > MAX_OPTIONAL
+		) {
+			return new Response(
+				JSON.stringify({ error: "Valid contact details are required" }),
+				{ status: 400, headers: getJsonHeaders(req) },
+			);
+		}
+
+		// Anti-injection: escape EVERY user value before interpolation into HTML.
+		const safe = {
+			name: escapeHtml(name),
+			email: escapeHtml(email),
+			subject: escapeHtml(subject),
+			message: escapeHtml(message).replace(/\n/g, "<br />"),
+			type: escapeHtml(type),
+			phone: escapeHtml(phone),
+			company: escapeHtml(company),
+			urgency: escapeHtml(urgency),
+		};
+
+		const rows = [
+			`<p><strong>Name:</strong> ${safe.name}</p>`,
+			`<p><strong>Email:</strong> ${safe.email}</p>`,
+			safe.phone ? `<p><strong>Phone:</strong> ${safe.phone}</p>` : "",
+			safe.company ? `<p><strong>Company:</strong> ${safe.company}</p>` : "",
+			safe.type ? `<p><strong>Inquiry type:</strong> ${safe.type}</p>` : "",
+			safe.urgency ? `<p><strong>Urgency:</strong> ${safe.urgency}</p>` : "",
+			`<p><strong>Subject:</strong> ${safe.subject}</p>`,
+			`<p><strong>Message:</strong></p><p>${safe.message}</p>`,
+		]
+			.filter(Boolean)
+			.join("\n");
+
+		const html = `<!doctype html>
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1a1a1a;">
+<h2>New contact form submission</h2>
+${rows}
+</body>
+</html>`;
+
+		// From stays the fixed FROM_ADDRESS; the subject carries the escaped value.
+		const result = await sendEmail({
+			to: [CONTACT_INBOX],
+			subject: `Contact form: ${safe.subject}`,
+			html,
+			tags: [{ name: "source", value: "contact-form" }],
+		});
+
+		if (!result.success) {
+			return errorResponse(req, 502, new Error(result.error), {
+				action: "send_contact_email",
+			});
+		}
+
+		return new Response(JSON.stringify({ success: true }), {
+			status: 200,
+			headers: getJsonHeaders(req),
+		});
+	} catch (err) {
+		return errorResponse(req, 500, err, { action: "send_contact_email" });
+	}
+});

--- a/supabase/functions/send-contact-email/index.ts
+++ b/supabase/functions/send-contact-email/index.ts
@@ -134,10 +134,14 @@ ${rows}
 </body>
 </html>`;
 
-		// From stays the fixed FROM_ADDRESS; the subject carries the escaped value.
+		// From stays the fixed FROM_ADDRESS. The email SUBJECT header is NOT an HTML
+		// context, so use the raw (validated) subject — Resend takes it as a JSON
+		// field, not a raw SMTP header, so there is no injection risk, and escaping
+		// here would render doubled HTML entities in the inbox. safe.subject (escaped)
+		// stays in the HTML body.
 		const result = await sendEmail({
 			to: [CONTACT_INBOX],
-			subject: `Contact form: ${safe.subject}`,
+			subject: `Contact form: ${subject}`,
 			html,
 			tags: [{ name: "source", value: "contact-form" }],
 		});


### PR DESCRIPTION
## Phase 31 — Forms Behavior Correctness (FORMFIX-01..08)

v8.0 "Correctness Restoration" milestone, phase 31. Fixes eight forms-behavior bugs from the 2026-07-02 whole-codebase hunt, each shipped under the perfect-PR gate (two consecutive zero-finding review cycles).

### What's fixed

| Req | Bug | Fix |
|-----|-----|-----|
| FORMFIX-01 | Unsaved-changes guard never armed (TanStack Form `form.state.isDirty` is a non-reactive snapshot) | Call sites read `useStore(form.store, s => s.isDirty)` reactively (add-tenant, property forms) |
| FORMFIX-02 | Contact form sent nowhere (submit only logged) | New `send-contact-email` edge function (validateEnv-in-serve, CORS fail-closed, rateLimit, `escapeHtml` on every value, generic `errorResponse`); frontend gates the thank-you on real success |
| FORMFIX-03 | `useFormWithProgress` auto-save render loop | Memoized save/clear + serialized-diff change-guard + **restore-once `hasRestoredRef` gate** so restore never re-merges over live edits |
| FORMFIX-04 | Add-tenant property/unit selection silently dropped | Carried into the lease-creation flow via query params; wizard seeds it; RLS re-validates unit ownership on insert |
| FORMFIX-05 | Maintenance edit dropped unit/tenant reassignment + no validators | Edit payload includes `unit_id`/`tenant_id`; field-level Zod validators block submit before a raw PostgREST error |
| FORMFIX-06 | General settings discarded email/timezone/language edits | Phone → `users`; Email → Supabase Auth (`users.email` is a locked column); Timezone/Language → `user_preferences` (upsert), loaded on mount |
| FORMFIX-07 | "Enable All Notifications" only toggled email | Reads/writes all four channels (email/sms/push/inApp) together |
| FORMFIX-08 | Duplicate success/error toasts on create/update | Single toast owned by the mutation (`createMutationCallbacks` / built-in `onError`); form-level duplicates removed **codebase-wide** |

### Review depth (perfect-PR gate)

Ten review cycles ran as a Workflow (6 dimensions each, `review → adversarial-verify`). Cycles 2–8 each caught real defects — several introduced by earlier fix passes (the gate working as designed): a locked-column write, three unhandled-promise-rejection patterns, a keystroke-loss race in the progress hook, and — via two **exhaustive sweeps** — the FORMFIX-08 duplicate-toast bug across ~17 call sites in both the `successMessage` and built-in-`onError` mutation families (well beyond the originally-named forms). Cycles 9 & 10 came back fully clean on two consecutive passes.

### Quality gate

- `bun run typecheck` — clean (0)
- `bun run lint` (biome) — clean
- `bun run test:unit` — **102,231 passing (234 files)**

### Ship residual (owner-run)

- The `send-contact-email` edge function deploy is **owner-run** (Supabase CLI 401s on `functions deploy`): run `bun scripts/deploy-edge-functions.ts` (the function is registered there + in `config.toml`). Joins Phase 29's owner-run edge deploys.
- No DB migrations in this phase.

[hudsor01]
