### PR TITLE
fix(marketing): phase 34 — marketing, blog & SEO surface (MKT-01..05)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -204,6 +204,14 @@ Requirements: MKT-01, MKT-02, MKT-03, MKT-04, MKT-05
 3. The homepage SearchAction and `/search` agree; compare/resource cross-link blocks point at existing posts or degrade cleanly
 4. Two consecutive zero-finding review cycles
 
+**Plans:** 5 plans
+Plans:
+- [ ] 34-01-PLAN.md — MKT-01: OG oklch→hsl + OG-scoped design-token drift guard
+- [ ] 34-02-PLAN.md — MKT-02/MKT-03: blog pagination navigation + category 404/error honesty
+- [ ] 34-03-PLAN.md — MKT-04: /search public blog-search rewrite (name="q")
+- [ ] 34-04-PLAN.md — MKT-05: cross-link slug repoints + prod slug-integrity guard
+- [ ] 34-05-PLAN.md — Phase verification (gate + MKT-01 pixel-verify + per-MKT checklist)
+
 ### Phase 35: TZ Sweep, Bulk-Import, Scripts & Hygiene
 **Goal:** Clean up the cross-cutting remainder — eliminate the whole timezone "one day early" class with local-zone date handling, fix the default-report-range month math and the revenue-vs-expenses chart, preserve import currency/status, and fix the script + repo-migration hygiene issues.
 Requirements: MISC-01, MISC-02, MISC-03, MISC-04, TZ-01, TZ-02, TZ-03

--- a/.planning/phases/34-marketing-seo/34-01-PLAN.md
+++ b/.planning/phases/34-marketing-seo/34-01-PLAN.md
@@ -1,0 +1,191 @@
+---
+phase: 34-marketing-seo
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+requirements: [MKT-01]
+files_modified:
+  - src/app/api/og/pricing/route.tsx
+  - src/app/api/og/features/route.tsx
+  - src/app/api/og/compare/[competitor]/route.tsx
+  - src/app/__tests__/design-token-drift.test.ts
+autonomous: true
+must_haves:
+  truths:
+    - "Each of the 3 OG routes (pricing, features, compare/[competitor]) renders its gradient + text color from hsl() literals, NOT oklch() — so satori produces a real (non-black) card"
+    - "The gradient literal is `linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)` and the text color literal is `hsl(0 0% 100%)` in all three routes"
+    - "The `// Brand colors ... (oklch)` comment is updated to say hsl-only (satori renders oklch black); no reference to a globals.css CSS var is introduced (satori has no CSS-var context)"
+    - "design-token-drift.test.ts gains a modernColor pattern (oklch / lab( / lch( / color-mix() scanned against string-literal content only, scoped to the src/app/api/og/ satori surface, so a quoted oklch color in ANY OG route fails CI permanently"
+    - "The modernColor guard does NOT flag oklch/color-mix in comments (blog OG route) and does NOT flag the ~40 legitimate browser-CSS oklch/color-mix string literals elsewhere in src/app + src/components (recharts colors, MagicUI colorTo, Tailwind bg-[color-mix(in oklch,...)])"
+    - "typecheck + lint clean; the full unit suite stays green (no new red from the added pattern)"
+  artifacts:
+    - path: "src/app/api/og/pricing/route.tsx"
+      provides: "hsl gradient + hsl text OG card"
+      contains: "hsl(205 100% 46%)"
+    - path: "src/app/api/og/features/route.tsx"
+      provides: "hsl gradient + hsl text OG card"
+      contains: "hsl(205 100% 46%)"
+    - path: "src/app/api/og/compare/[competitor]/route.tsx"
+      provides: "hsl gradient + hsl text OG card"
+      contains: "hsl(205 100% 46%)"
+    - path: "src/app/__tests__/design-token-drift.test.ts"
+      provides: "modernColor drift guard (OG-scoped, string-literal-only) + meta-tests"
+      contains: "modernColor"
+  key_links:
+    - from: "OG route satori render"
+      to: "hsl color literals"
+      via: "bgGradient + inline color style"
+      pattern: "hsl\\(205 100% 46%\\)"
+    - from: "design-token-drift guard"
+      to: "OG-route satori surface only"
+      via: "rel.startsWith('src/app/api/og/') scoping"
+      pattern: "app/api/og/"
+---
+
+<objective>
+Fix MKT-01 — the `/pricing`, `/features`, and `/compare/[competitor]` Open Graph routes render the whole 1200x630 PNG via satori using `oklch()` literals for BOTH the gradient (2 stops) and the text color. satori renders oklch as black, so every social-share card is a solid black rectangle. (The `/api/og/blog/[slug]` route is fine — its oklch hits are comments only; leave it.)
+
+Replace the oklch literals with their exact hsl equivalents (satori-valid, space-separated; hsl NOT hex/rgb — the design-token-drift guard bans hex/rgb in `src/app/**`, hsl is allowed), update the explanatory comment, and add a permanent CI guard so an oklch color string can never regress into a satori/OG route again.
+
+Purpose: real social-share cards instead of black rectangles, with a permanent regression gate.
+Output: three OG routes on hsl; a new OG-scoped `modernColor` drift pattern with meta-tests.
+
+Exact values (LOCKED, from 34-CONTEXT.md § MKT-01):
+- gradient: `linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)`
+- text color: `hsl(0 0% 100%)`
+
+NOTE — guard scoping (decision beyond the literal CONTEXT wording, required to avoid a red suite): the CONTEXT says add the oklch pattern "scanned against string-literal content only." Taken globally that would flag ~40 legitimate browser-rendered oklch/color-mix string literals in src/app + src/components (recharts `color: "oklch(...)"`, MagicUI `colorTo="oklch(from ...)"`, Tailwind `bg-[color-mix(in oklch,...)]`) AND contradict the existing `src/app/features/__tests__/page.test.ts` which REQUIRES oklch on the marketing features page. oklch is banned ONLY in the satori context. The faithful realization of the CONTEXT's intent is therefore to scope the modernColor assertion to the `src/app/api/og/` satori surface (covers all 4 OG routes). String-literal-only scanning is still required so the updated OG-route comment (which contains the word "oklch") does not self-trigger.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/34-marketing-seo/34-CONTEXT.md
+@CLAUDE.md
+
+<interfaces>
+CURRENT oklch literals in each of the 3 routes (identical):
+  const bgGradient =
+    "linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)";
+  ...
+  color: "oklch(1 0 0)",
+CURRENT comment (line 16 pricing/features; line 23 compare):
+  // Brand colors derived from globals.css `--color-primary` (oklch).
+
+TARGET (all three routes):
+  const bgGradient =
+    "linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)";
+  ...
+  color: "hsl(0 0% 100%)",
+TARGET comment: state hsl-only, e.g. "Brand colors as hsl() literals — satori
+  renders oklch as black, so OG routes must use hsl (never oklch/hex/rgb).
+  Duplicated inline because satori has no CSS-var context (no --color-primary)."
+
+design-token-drift.test.ts CURRENT (relevant lines):
+  - `type DriftPattern = "hex" | "rgb" | "bgWhite" | "inlineMs";`
+  - `DRIFT_PATTERNS` record (4 entries).
+  - `const scanText = pattern === "hex" ? stringContent : content;` (line ~153) —
+    hex is the ONLY pattern that scans string-literal content via extractStringContent.
+  - meta-test describe block "drift regexes catch known drift".
+  - header docblock says "four design-token drift patterns".
+
+design-token-drift.test.ts satori surfaces already present: `src/app/opengraph-image.tsx`
+  is hex-exempt in DRIFT_EXEMPTIONS and uses NO oklch (verified) — the api/og scope
+  captures all 4 route-based OG surfaces; opengraph-image.tsx is out of scope for MKT-01.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Replace oklch literals with hsl in the 3 OG routes (MKT-01)</name>
+  <files>src/app/api/og/pricing/route.tsx, src/app/api/og/features/route.tsx, src/app/api/og/compare/[competitor]/route.tsx</files>
+  <read_first>
+    - src/app/api/og/pricing/route.tsx (whole file — lines 16, 21, 33)
+    - src/app/api/og/features/route.tsx (whole file — lines 16, 21, 33)
+    - src/app/api/og/compare/[competitor]/route.tsx (whole file — lines 23, 28, 40)
+    - .planning/phases/34-marketing-seo/34-CONTEXT.md § MKT-01 (LOCKED — exact hsl values)
+  </read_first>
+  <action>
+    In all three routes, replace the `bgGradient` string value `linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)` with `linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)`, and replace the inline `color: "oklch(1 0 0)"` with `color: "hsl(0 0% 100%)"`. Update the `// Brand colors derived from globals.css \`--color-primary\` (oklch).` comment to explain hsl-only satori requirement (see the TARGET comment in interfaces) — the comment may contain the word "oklch" in prose (e.g. "satori renders oklch as black") but MUST NOT contain the `oklch(` function form. Do NOT reference a globals.css CSS variable (satori has no CSS-var context). Do not change any other markup, the runtime/revalidate exports, the COMPETITORS lookup in the compare route, or the 404 branch. Do NOT introduce any hex or rgb color.
+  </action>
+  <verify>
+    <automated>for f in src/app/api/og/pricing/route.tsx src/app/api/og/features/route.tsx "src/app/api/og/compare/[competitor]/route.tsx"; do grep -q 'hsl(205 100% 46%)' "$f" && grep -q 'hsl(0 0% 100%)' "$f" && ! grep -q 'oklch(' "$f" || { echo "FAIL $f"; exit 1; }; done && echo ok</automated>
+  </verify>
+  <acceptance_criteria>
+    - All three routes contain `hsl(205 100% 46%)`, `hsl(233 61% 47%)`, and `hsl(0 0% 100%)`.
+    - No route contains the `oklch(` function form (comments may say "oklch" without a paren).
+    - No hex/rgb introduced; runtime/revalidate/COMPETITORS logic untouched.
+  </acceptance_criteria>
+  <done>The three OG routes render hsl gradients + hsl text; satori will produce non-black cards.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add the OG-scoped modernColor drift guard + meta-tests (MKT-01 coverage fix)</name>
+  <files>src/app/__tests__/design-token-drift.test.ts</files>
+  <read_first>
+    - src/app/__tests__/design-token-drift.test.ts (whole file — DriftPattern type, DRIFT_PATTERNS, the scanText selection line, the per-pattern loop, the meta-test describe)
+    - .planning/phases/34-marketing-seo/34-CONTEXT.md § MKT-01 (coverage-fix paragraph)
+    - src/app/api/og/blog/[slug]/route.tsx (confirm its oklch hits are comments only — must NOT false-positive)
+  </read_first>
+  <action>
+    Add a fifth drift pattern `modernColor` that catches the satori-black color functions in string-literal content only, scoped to the OG/satori surface:
+    1. Extend the `DriftPattern` union to include `"modernColor"`.
+    2. Add a `modernColor` entry to `DRIFT_PATTERNS`: a global, case-insensitive regex matching `oklch(`, `oklab(`, `lab(`, `lch(`, and `color-mix(` where the token is not preceded by a word char or hyphen — inline as `/(?<![\w-])(?:oklch|oklab|lab|lch|color-mix)\s*\(/gi`. Add a short comment: satori renders these color spaces as black, so they are forbidden inside a quoted style string in an OG/satori route.
+    3. Make modernColor scan string-literal content only: change `const scanText = pattern === "hex" ? stringContent : content;` so BOTH `hex` and `modernColor` use `stringContent` (e.g. a `STRING_ONLY_PATTERNS` set or an inline `pattern === "hex" || pattern === "modernColor"`).
+    4. Scope the assertion to the satori surface: at the top of the per-pattern body (after the `isExempt` continue), add `if (pattern === "modernColor" && !rel.startsWith("src/app/api/og/")) continue;`. This runs the guard on all 4 OG routes and skips every other file (browser-rendered oklch/color-mix literals are legitimate and stay unflagged).
+    5. Add meta-tests in the "drift regexes catch known drift" describe: modernColor regex matches `oklch(0.62 0.18 250)`, `color-mix(in oklch, ...)`, `lab(...)`, `lch(...)`; and (via extractStringContent) it does NOT match `// satori renders oklch black` (comment, no paren inside a string). Optionally assert the guard would flag a quoted `oklch(` fixture but NOT a bare word "oklch".
+    6. Update the header docblock: "four" -> "five" patterns and note modernColor is scoped to `src/app/api/og/` (satori) and scanned against string-literal content only.
+    Do NOT add any DRIFT_EXEMPTIONS entries (scoping handles the false positives). Do NOT change the hex/rgb/bgWhite/inlineMs logic.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/app/__tests__/design-token-drift.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - design-token-drift.test.ts passes: the 3 fixed OG routes have no oklch string literal; the blog OG route (comments only) is not flagged; no browser-CSS oklch/color-mix literal elsewhere is flagged.
+    - modernColor meta-tests pass (catches the color-function forms in a string; ignores the comment form).
+    - Full unit suite stays green (spot-check via the whole-suite gate in 34-05).
+  </acceptance_criteria>
+  <done>An oklch/lab/lch/color-mix color string in any OG/satori route fails CI permanently, without flagging legitimate browser-CSS usage.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| OG route JSX -> satori renderer | Unsupported color functions silently degrade the rendered PNG to black (availability/brand integrity, not a security exploit) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-34-01-DoS | Denial of Service (brand/availability) | satori OG render | mitigate | Replace oklch with satori-valid hsl so the card renders real content; add an OG-scoped CI guard so an oklch color string can never regress into a satori route. |
+| T-34-01-Info | Information Disclosure | OG routes | accept | OG routes render only static marketing copy + competitor name (already public); no user data or secrets in the image. |
+| T-34-01-SC | Tampering | npm/pip/cargo installs | accept | No packages installed; existing `@vercel/og` dependency only. |
+</threat_model>
+
+<verification>
+- `bun run typecheck` clean; `bun run lint` clean.
+- `bun run test:unit -- --run src/app/__tests__/design-token-drift.test.ts` passes (OG routes clean, blog route unflagged, browser components unflagged).
+- Grep: all three routes contain the hsl gradient + text literals and no `oklch(` function form.
+- Pixel-verify (ORCHESTRATOR-run, NOT an executor task — recorded in 34-05): a local ImageResponse harness renders each of the 3 routes' JSX to a PNG and asserts it is not uniformly black (sample center + corners; the gradient must vary). Per the CLAUDE.md blog-cover "pixel-verify before deploy" rule.
+</verification>
+
+<success_criteria>
+- `/pricing`, `/features`, `/compare/*` OG images render real (non-black) cards from hsl literals.
+- A permanent, OG-scoped drift guard prevents oklch/lab/lch/color-mix color strings from regressing into a satori route, with zero false positives on browser-CSS oklch usage.
+</success_criteria>
+
+<output>
+Create `.planning/phases/34-marketing-seo/34-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/34-marketing-seo/34-02-PLAN.md
+++ b/.planning/phases/34-marketing-seo/34-02-PLAN.md
@@ -1,0 +1,181 @@
+---
+phase: 34-marketing-seo
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+requirements: [MKT-02, MKT-03]
+files_modified:
+  - src/components/blog/blog-pagination.tsx
+  - src/components/blog/blog-pagination.test.tsx
+  - src/app/blog/category/[category]/page.tsx
+  - src/app/blog/category/[category]/page.test.tsx
+autonomous: true
+must_haves:
+  truths:
+    - "Clicking Next/Prev on /blog and /blog/category/* performs real <Link> navigation that re-runs the Server Component, so the rendered post grid actually changes to the requested page"
+    - "The pagination onClick no longer calls setPage/nuqs and no longer preventDefaults an enabled link — it only preventDefaults a disabled boundary link (guard-only)"
+    - "No unused locals remain in blog-pagination.tsx (setPage removed; the reactive label reads from the current page derived without the nuqs setter, honoring noUnusedLocals)"
+    - "An out-of-range ?page on a category page (PGRST103 / 'range not satisfiable') returns notFound() (real 404), not a 200 empty state with a false '0 articles' subtitle"
+    - "Any other category posts-query error throws (hits blog/error.tsx) instead of being silently swallowed into an empty state"
+    - "Count stays {count:'exact'} (unchanged); the invalid-category branch still calls notFound() directly (no try/catch added)"
+  artifacts:
+    - path: "src/components/blog/blog-pagination.tsx"
+      provides: "guard-only anchors that let real navigation run"
+      contains: "usePathname"
+    - path: "src/app/blog/category/[category]/page.tsx"
+      provides: "PGRST103 -> notFound + throw-on-error, mirroring blog/page.tsx"
+      contains: "PGRST103"
+  key_links:
+    - from: "pagination <Link> click"
+      to: "Server Component re-run via real navigation"
+      via: "no setPage hijack; guard-only preventDefault on disabled boundary"
+      pattern: "e\\.preventDefault"
+    - from: "category out-of-range ?page"
+      to: "notFound() 404"
+      via: "PGRST103 / range-not-satisfiable check between query and posts"
+      pattern: "PGRST103"
+---
+
+<objective>
+Fix MKT-02 and MKT-03 — two blog-list-surface bugs. Both touch the blog listing but disjoint files.
+
+MKT-02: `blog-pagination.tsx` renders correct `<Link href={pageHref}>` anchors, but each onClick does `e.preventDefault()` + `setPage()` via nuqs `useQueryState("page")` WITHOUT `shallow:false`. So the URL + "Page X of Y" label change client-side but the Server Component (which paginates by `.range(offset, ...)` from `searchParams.page`) never re-runs — the same posts stay on screen. Stop hijacking the anchors: drop the `setPage` hijack + the enabled-link `preventDefault`, keep a guard-only onClick that preventDefaults ONLY when the boundary is disabled. Real `<Link>` navigation (the hrefs are already correct) re-runs the Server Component and swaps the posts.
+
+MKT-03: the blog INDEX page (`blog/page.tsx:112-137`) already handles out-of-range (`PGRST103` / "range not satisfiable" -> `notFound()`) and throws on query error. The CATEGORY page (`blog/category/[category]/page.tsx`) does NEITHER — an out-of-range `?page` (PGRST103 -> data/count null) renders `BlogEmptyState` at HTTP 200 with a false "0 articles" subtitle, and any query error is silently ignored. Mirror the index page's handling between the query and `const posts = ...`. Count is already `{count:'exact'}` — do NOT change it. The invalid-category branch already calls `notFound()` directly, so no try/catch is needed.
+
+Purpose: pagination that actually paginates; honest 404s + surfaced errors on category pages.
+Output: guard-only pagination anchors; PGRST103->notFound + throw-on-error in the category page; both tests updated to prove the new behavior.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/34-marketing-seo/34-CONTEXT.md
+@CLAUDE.md
+@src/app/blog/page.tsx
+
+<interfaces>
+blog-pagination.tsx CURRENT (the hijack — lines 25, 57-64, 79-86):
+  const [page, setPage] = useQueryState("page", parseAsInteger.withDefault(1));
+  ...prev onClick: if (!hasPrev) { e.preventDefault(); return; } e.preventDefault(); setPage(prevPage === 1 ? null : prevPage);
+  ...next onClick: if (!hasNext) { e.preventDefault(); return; } e.preventDefault(); setPage(nextPage);
+TARGET pagination behavior:
+  - Keep the reactive "Page X of Y" label. Source `currentPage` WITHOUT the nuqs setter:
+    either keep `const [page] = useQueryState("page", parseAsInteger.withDefault(1))`
+    (read-only destructure — no unused `setPage`), or derive the current page from the
+    pathname's `?page` search param / a prop. Do NOT leave an unused `setPage` local
+    (noUnusedLocals). `usePathname` + `pageHref` already build the correct hrefs — keep them.
+  - prev onClick: `(e) => { if (!hasPrev) e.preventDefault(); }`
+  - next onClick: `(e) => { if (!hasNext) e.preventDefault(); }`
+  - No shallow nuqs, no setPage call. Real <Link> navigation runs on an enabled click.
+
+blog/page.tsx REFERENCE handling to mirror (lines 118-132):
+  const rangeCode = (postsResult.error as { code?: string } | null)?.code;
+  if (rangeCode === "PGRST103" || /range not satisfiable/i.test(postsResult.error?.message ?? "")) { notFound(); }
+  if (postsResult.error) { throw new Error(postsResult.error.message ?? "..."); }
+
+category page CURRENT (page.tsx:113-124): query then immediately `const posts = (postsResult.data ?? [])`
+  with NO error/PGRST103 handling. `notFound` is already imported (line 3).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Pagination guard-only anchors — drop the setPage hijack (MKT-02)</name>
+  <files>src/components/blog/blog-pagination.tsx, src/components/blog/blog-pagination.test.tsx</files>
+  <read_first>
+    - src/components/blog/blog-pagination.tsx (whole file)
+    - src/components/blog/blog-pagination.test.tsx (whole file — nuqs/next-link/next-navigation mocks; the setPage assertions to replace)
+    - .planning/phases/34-marketing-seo/34-CONTEXT.md § MKT-02 (LOCKED)
+  </read_first>
+  <behavior>
+    - Next link on page 1 still carries a crawlable `?page=2` href; prev on page 2 points to the bare path.
+    - Clicking an ENABLED next/prev link does NOT call setPage (no nuqs hijack) and does NOT preventDefault (real navigation proceeds).
+    - Clicking a DISABLED boundary link preventDefaults (no navigation) and does NOT call setPage.
+    - aria-disabled + pointer-events gating unchanged; nav landmark + "Page X of Y" label unchanged.
+  </behavior>
+  <action>
+    Rewrite the two onClick handlers to guard-only: prev `(e) => { if (!hasPrev) e.preventDefault(); }`, next `(e) => { if (!hasNext) e.preventDefault(); }`. Remove the `setPage` call and the enabled-link `e.preventDefault()`. Remove the unused `setPage` from the `useQueryState` destructure — keep a read-only `const [page] = useQueryState("page", parseAsInteger.withDefault(1))` so the reactive `currentPage` label still tracks the URL (or derive currentPage another noUnusedLocals-safe way). Keep `usePathname`, `pageHref`, the anchor hrefs, aria-disabled, tabIndex, and the disabled-classes gating exactly as-is. Update the inline comment that claims "the onClick keeps the nuqs instant client-side swap" — it now describes guard-only anchors that let real navigation re-run the Server Component.
+    Update blog-pagination.test.tsx: the nuqs mock can keep `useQueryState` returning `[mockPage.value, mockSetPage]`. REPLACE the two "calls setPage" assertions ("calls setPage with next value on next click", "calls setPage with null when navigating back to page 1") with assertions that clicking an ENABLED link does NOT call setPage and does NOT preventDefault (e.g. dispatch the click and assert `mockSetPage` was not called and the default was not prevented). Keep/adjust "does not call setPage when clicking a disabled boundary link" (still true). Keep the href, aria-disabled, nav-landmark, and null-render tests.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/components/blog/blog-pagination.test.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - blog-pagination.test.tsx passes with the new no-setPage assertions.
+    - No unused `setPage` local; typecheck clean under noUnusedLocals.
+    - Enabled clicks proceed to real navigation; disabled clicks are blocked.
+  </acceptance_criteria>
+  <done>Pagination anchors navigate for real, re-running the Server Component so the post grid changes.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Category page PGRST103 -> notFound + throw-on-error (MKT-03)</name>
+  <files>src/app/blog/category/[category]/page.tsx, src/app/blog/category/[category]/page.test.tsx</files>
+  <read_first>
+    - src/app/blog/category/[category]/page.tsx (whole file — the query at 113-120, the `const posts = ...` at 122)
+    - src/app/blog/page.tsx:118-132 (the exact PGRST103 + throw pattern to mirror)
+    - src/app/blog/category/[category]/page.test.tsx (whole file — makeClient mock, MockBuilderOpts, the notFound mock at lines 16-29)
+    - .planning/phases/34-marketing-seo/34-CONTEXT.md § MKT-03 (LOCKED)
+  </read_first>
+  <behavior>
+    - postsResult.error.code === "PGRST103" (or /range not satisfiable/i on the message) => notFound() (throws NEXT_NOT_FOUND).
+    - Any other postsResult.error => throw new Error(error.message) (reaches blog/error.tsx).
+    - No error => render posts grid + pagination as today. Invalid category still notFound() via getValidCategory.
+    - Count assertion ({count:'exact'}) and the "N articles" subtitle logic unchanged for the happy path.
+  </behavior>
+  <action>
+    In `BlogCategoryPage`, between the `postsResult` query (line ~120) and `const posts = (postsResult.data ?? [])` (line ~122), insert the index-page handling: compute `const rangeCode = (postsResult.error as { code?: string } | null)?.code;` then `if (rangeCode === "PGRST103" || /range not satisfiable/i.test(postsResult.error?.message ?? "")) { notFound(); }` then `if (postsResult.error) { throw new Error(postsResult.error.message); }`. Do NOT add a try/catch (the invalid-category branch already calls notFound() directly at line ~109, and notFound()'s thrown NEXT_NOT_FOUND must propagate). Do NOT change the `{ count: "exact" }` select, the `.eq("category", validCategory.name)` filter, or the subtitle. `notFound` is already imported.
+    Update page.test.tsx: extend `MockBuilderOpts` + `makeClient` so `chain.range` can resolve `{ data, count, error }` with a caller-supplied `error` (add a `postsError?: { code?: string; message: string } | null` option; default null). Add two tests: (a) an out-of-range page (`postsError: { code: "PGRST103", message: "Requested range not satisfiable" }`) rejects with NEXT_NOT_FOUND and calls `mockNotFound`; (b) a generic error (`postsError: { code: "XX000", message: "boom" }`) rejects with a thrown Error whose message contains "boom" and does NOT call notFound. Keep every existing test green.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run "src/app/blog/category/[category]/page.test.tsx"</automated>
+  </verify>
+  <acceptance_criteria>
+    - New tests pass: PGRST103 -> notFound; generic error -> thrown Error("boom"); happy path unchanged.
+    - Category page mirrors blog/page.tsx error handling; count stays {count:'exact'}; no try/catch added.
+  </acceptance_criteria>
+  <done>Out-of-range category pages 404 honestly; category query errors surface instead of a silent empty state.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| crawler/user `?page` param -> category Server Component | An attacker-supplied out-of-range page must produce a real 404, not a soft-200 thin page (SEO/crawl-signal integrity) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-34-02-Info | Information Disclosure | category posts query error | mitigate | A swallowed DB error no longer renders a misleading empty state; errors throw to blog/error.tsx and are observable, matching the index page. |
+| T-34-02-DoS | Denial of Service (crawl budget) | out-of-range `?page` | mitigate | PGRST103 -> notFound() so crawlers drop the URL instead of indexing a soft-200 empty page. |
+| T-34-02-SC | Tampering | npm/pip/cargo installs | accept | No packages installed. |
+</threat_model>
+
+<verification>
+- `bun run typecheck` clean (noUnusedLocals: no orphan setPage).
+- `bun run test:unit -- --run src/components/blog/blog-pagination.test.tsx` passes.
+- `bun run test:unit -- --run "src/app/blog/category/[category]/page.test.tsx"` passes.
+- Behavioral (recorded in 34-05): clicking Next on `/blog` and a category page renders a DIFFERENT post set; visiting `?page=9999` on a category returns 404.
+</verification>
+
+<success_criteria>
+- Clicking Next/Prev on `/blog` and category pages changes the rendered posts (real navigation re-runs the Server Component).
+- Out-of-range category pages return 404 with a correct count; category query errors surface instead of a silent empty state.
+</success_criteria>
+
+<output>
+Create `.planning/phases/34-marketing-seo/34-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/34-marketing-seo/34-03-PLAN.md
+++ b/.planning/phases/34-marketing-seo/34-03-PLAN.md
@@ -1,0 +1,174 @@
+---
+phase: 34-marketing-seo
+plan: 03
+type: execute
+wave: 1
+depends_on: []
+requirements: [MKT-04]
+files_modified:
+  - src/app/search/page.tsx
+  - src/app/search/page.test.tsx
+autonomous: true
+must_haves:
+  truths:
+    - "/search is an async server component that reads `searchParams.q` and runs a public blog search (blogAnonClient, status='published') when q is non-empty"
+    - "The search form is `<form method=\"GET\" action=\"/search\">` with `<input name=\"q\" defaultValue={query}>` — name is `q`, matching the homepage SearchAction target `/search?q={search_term_string}`"
+    - "Results render as a BlogCard grid; the Empty compound renders for the no-query and no-matches states (fake 'Recent Searches' + dead Quick-Search cards + portfolio copy are gone)"
+    - "The search value is quote-wrapped via escapeOrValue inside the PostgREST .or() string, and normalized via normalizeSearchInput — no raw interpolation"
+    - "metadata stays noindex:true; the homepage SearchAction JSON-LD is unchanged (not touched by this plan) and is now truthful"
+  artifacts:
+    - path: "src/app/search/page.tsx"
+      provides: "real public blog search server component"
+      exports: ["default", "metadata"]
+      contains: "escapeOrValue"
+    - path: "src/app/search/page.test.tsx"
+      provides: "tests: q-driven query, empty-state, name='q' form, noindex"
+      contains: "name=\"q\""
+  key_links:
+    - from: "search form GET"
+      to: "/search?q=..."
+      via: "input name='q' matching the SearchAction contract"
+      pattern: "name=\"q\""
+    - from: "search query value"
+      to: "PostgREST .or() literal"
+      via: "escapeOrValue quote-wrapping + normalizeSearchInput"
+      pattern: "escapeOrValue"
+---
+
+<objective>
+Fix MKT-04 — the homepage `WebSite` JSON-LD advertises a `SearchAction` at `/search?q={search_term_string}`, but `src/app/search/page.tsx` is a static stub: no `searchParams`, the input is `name="search"` (not `q`), there is no `<form>`, the "Recent Searches" are hardcoded fakes, and the copy frames it as private-portfolio search (wrong — it's public and noindex). `/search` is referenced ONLY by the SearchAction, so it is safe to repurpose.
+
+Wire a real public blog search (Option A, LOCKED). All infra already exists: `blogAnonClient()`, `escapeOrValue`/`normalizeSearchInput`, `BlogCard`, the `Empty` compound. Rewrite `/search/page.tsx` as an async server component that reads `searchParams.q`, runs a published-blog ilike search, renders a `BlogCard` grid for hits, and the `Empty` compound for the no-query / no-matches states. The homepage SearchAction JSON-LD is NOT modified (it stays as-is and is now truthful).
+
+Purpose: make the SearchAction contract real — a public blog search that actually returns posts.
+Output: a rewritten async `/search` server component + a new test proving the q-driven query, the `name="q"` form, the empty state, and noindex.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/34-marketing-seo/34-CONTEXT.md
+@CLAUDE.md
+@src/app/blog/category/[category]/page.test.tsx
+
+<interfaces>
+blogAnonClient (src/lib/blog/blog-queries.ts):
+  export function blogAnonClient(): SupabaseClient  // cookie-less anon; status='published' is the RLS gate
+sanitize-search (src/lib/sanitize-search.ts):
+  export function normalizeSearchInput(input: string): string   // trim + cap 100 chars
+  export function escapeOrValue(input: string): string          // escape \ and " for a quote-wrapped .or() term
+BlogCard (src/components/blog/blog-card.tsx):
+  export function BlogCard({ post, className }: { post: BlogListItem; className?: string })
+Empty compound (src/components/ui/empty.tsx):
+  export { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle }
+BlogListItem (src/hooks/api/query-keys/blog-keys.ts): Pick of id,title,slug,excerpt,published_at,category,reading_time,featured_image,author_user_id,status,tags
+
+BLOG_LIST_COLUMNS convention (local const, per blog/page.tsx and category page — NOT exported; define the same local const here):
+  "id, title, slug, excerpt, published_at, category, reading_time, featured_image, author_user_id, status, tags"
+
+SearchAction contract (src/app/page.tsx:50-54, DO NOT MODIFY):
+  target: `${siteUrl}/search?q={search_term_string}`, "query-input": "required name=search_term_string"
+  => the search form input MUST be name="q".
+
+PostgREST search shape (LOCKED, 34-CONTEXT § MKT-04):
+  blogAnonClient().from("blogs").select(BLOG_LIST_COLUMNS).eq("status","published")
+    .or(`title.ilike."%${escapeOrValue(query)}%",excerpt.ilike."%${escapeOrValue(query)}%",content.ilike."%${escapeOrValue(query)}%"`)
+    .order("published_at",{ascending:false}).limit(24)
+  (content is filterable even though not selected — RLS gates rows by status, not columns.)
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Rewrite /search as an async public-blog-search server component (MKT-04)</name>
+  <files>src/app/search/page.tsx</files>
+  <read_first>
+    - src/app/search/page.tsx (whole file — the stub to replace)
+    - src/lib/sanitize-search.ts (normalizeSearchInput, escapeOrValue)
+    - src/lib/blog/blog-queries.ts (blogAnonClient)
+    - src/components/blog/blog-card.tsx (BlogCard props)
+    - src/components/ui/empty.tsx (Empty compound parts)
+    - src/app/blog/page.tsx:24-27, 87-137 (BLOG_LIST_COLUMNS + PageLayout + BlogCard grid pattern to mirror)
+    - .planning/phases/34-marketing-seo/34-CONTEXT.md § MKT-04 (LOCKED)
+  </read_first>
+  <action>
+    Replace the entire stub with an async server component `export default async function SearchPage({ searchParams }: { searchParams: Promise<{ q?: string }> })`. Keep the existing `export const metadata = createPageMetadata({ ..., path: "/search", noindex: true })` (public, noindex — keep the title/description generic to blog search; drop the "portfolio" framing). Body:
+    - `const { q } = await searchParams; const query = normalizeSearchInput(q ?? "");`
+    - Define a local `const BLOG_LIST_COLUMNS = "id, title, slug, excerpt, published_at, category, reading_time, featured_image, author_user_id, status, tags";` (same convention as blog/page.tsx — do NOT create a barrel/shared export).
+    - When `query` is non-empty: run the LOCKED PostgREST search (see interfaces) via `blogAnonClient()`, `.limit(24)`; map `data ?? []` to `BlogListItem[]`. When `query` is empty: skip the DB call, `posts = []`.
+    - Render inside `<PageLayout containerClass="max-w-6xl py-8">` (keep the existing layout wrapper): an `<h1>` + short public-blog-search description; a `<form method="GET" action="/search">` containing `<input name="q" defaultValue={query} ...>` (name MUST be `q`) with a submit button (reuse `Input` + `Button`, keep the Search lucide icon). Below the form: if `query` is empty render the `Empty` compound prompting the user to search; else if `posts.length === 0` render the `Empty` compound with a "no results for '{query}'" message; else render a `BlogCard` grid (`grid gap-6 md:grid-cols-2 lg:grid-cols-3`) of results. Delete the fake "Recent Searches" section, the three dead Quick-Search cards, and the "Search Tips" card. Remove now-unused imports (Filter, FolderOpen, Users, Badge, Card family) and add the ones you use (Empty parts, BlogCard, blogAnonClient, sanitize-search, BlogListItem type). No `any`; type the mapped rows as `BlogListItem[]`. No inline styles (Tailwind only). Icon-only controls get an aria-label.
+  </action>
+  <verify>
+    <automated>bun run typecheck 2>&1 | tail -5 && grep -q 'name="q"' src/app/search/page.tsx && grep -q 'escapeOrValue' src/app/search/page.tsx && grep -q 'noindex: true' src/app/search/page.tsx && echo ok</automated>
+  </verify>
+  <acceptance_criteria>
+    - Page is an async server component reading `searchParams.q`; form input is `name="q"`; DB search uses escapeOrValue + normalizeSearchInput + blogAnonClient + status='published' + limit 24.
+    - Empty compound covers no-query and no-matches; fake Recent Searches / Quick-Search / Search Tips removed; metadata noindex:true retained.
+    - typecheck clean; no `any`, no unused imports, no inline styles.
+  </acceptance_criteria>
+  <done>/search returns real published blog posts for `?q=...` and shows an Empty state otherwise.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Test the /search server component (MKT-04)</name>
+  <files>src/app/search/page.test.tsx</files>
+  <read_first>
+    - src/app/blog/category/[category]/page.test.tsx (RSC test + blogAnonClient mock chain pattern to mirror — vi.hoisted, mock #lib/blog/blog-queries, mock BlogCard/PageLayout, async render)
+    - src/app/search/page.tsx (the component under test, after Task 1)
+  </read_first>
+  <action>
+    Create `src/app/search/page.test.tsx` (`@vitest-environment jsdom`). Mock `#lib/blog/blog-queries` `blogAnonClient` with a builder chain whose terminal `.limit(24)` (and any `.order`) resolves `{ data, error }` (model on the category test's `makeClient`, but terminate on `limit` and support an `.or` no-op in the chain). Mock `#components/blog/blog-card` (render a testid with the title), `#components/layout/page-layout`, and any JSON-LD/heavy children as in the category test. Render the async component via `await SearchPage({ searchParams: Promise.resolve({ q }) })`. Tests:
+    1. Empty query (`q` undefined) -> renders the Empty state, renders no BlogCard, and does NOT call the DB `.or()` (assert the `or` spy not called).
+    2. Non-empty query with matching rows -> renders a BlogCard per row; the `.or()` argument contains `title.ilike` and the quote-wrapped escaped value (assert the `or` spy received a string containing `escapeOrValue`'d term); the form input has `name="q"` and `defaultValue` equal to the query.
+    3. Non-empty query with zero rows -> renders the Empty "no results" state.
+    4. `metadata.robots` is `noindex, follow` (search stays noindex). (Import `metadata` from the page.)
+    Use `.rejects.toMatchObject`/`stringContaining` style only if asserting thrown errors (not expected here). No `any`.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/app/search/page.test.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - All four tests pass: q-driven query (with escaped .or term + name="q" form), empty-state (no DB call), no-results Empty state, noindex metadata.
+  </acceptance_criteria>
+  <done>The /search rewrite is proven: it searches published blogs on `q`, escapes the term, uses a name="q" form, and stays noindex.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| user `q` search input -> PostgREST `.or()` logic string | Untrusted text is interpolated into a PostgREST filter expression that IS parsed server-side (unlike a discrete .ilike param) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-34-03-Inj | Tampering / Injection | `.or()` filter built from `q` | mitigate | `escapeOrValue` escapes `\` and `"` and the value is wrapped in double quotes at the call site, so `, . ( ) :` are literal text; `normalizeSearchInput` trims + caps length at 100. No raw interpolation. |
+| T-34-03-Info | Information Disclosure | anon blog read | accept | `blogAnonClient` + `status='published'` RLS gate returns only public posts; no session/PII involved. |
+| T-34-03-SC | Tampering | npm/pip/cargo installs | accept | No packages installed; all imports already exist. |
+</threat_model>
+
+<verification>
+- `bun run typecheck` clean; `bun run lint` clean.
+- `bun run test:unit -- --run src/app/search/page.test.tsx` passes.
+- Grep: page contains `name="q"`, `escapeOrValue`, `noindex: true`; homepage `src/app/page.tsx` SearchAction is unchanged (git diff shows no change to page.tsx).
+- Behavioral (recorded in 34-05): visiting `/search?q=lease` renders matching published posts; `/search` (no q) shows the Empty prompt.
+</verification>
+
+<success_criteria>
+- The homepage SearchAction and `/search` agree: `/search?q=...` runs a real public blog search with a `name="q"` GET form and returns BlogCard results (or an honest Empty state), staying noindex.
+</success_criteria>
+
+<output>
+Create `.planning/phases/34-marketing-seo/34-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/34-marketing-seo/34-04-PLAN.md
+++ b/.planning/phases/34-marketing-seo/34-04-PLAN.md
@@ -1,0 +1,183 @@
+---
+phase: 34-marketing-seo
+plan: 04
+type: execute
+wave: 1
+depends_on: []
+requirements: [MKT-05]
+files_modified:
+  - src/app/compare/[competitor]/compare-data.ts
+  - src/lib/content-links.ts
+  - src/lib/content-links.test.ts
+  - tests/integration/content-links-slugs.test.ts
+  - tests/integration/tsconfig.json
+autonomous: true
+must_haves:
+  truths:
+    - "The 3 compare `blogSlug` values point at real published posts, so the 'Read the Full Comparison' block on every /compare/* page renders (RelatedArticles no longer returns null)"
+    - "RESOURCE_TO_BLOGS points every resource segment at real published posts, so the 'Related Blog Posts' block on the 3 /resources/* pages renders"
+    - "BLOG_TO_COMPETITOR + BLOG_TO_RESOURCE (derived) now key on live slugs, so the reverse direction (blog -> compare/resource) also resolves"
+    - "content-links.test.ts asserts the new live slugs (old dead slugs removed)"
+    - "A new integration test queries prod `blogs` for EVERY slug referenced by compare-data.ts + content-links.ts and asserts each is status='published' — guarding against recurrence in CI"
+  artifacts:
+    - path: "src/app/compare/[competitor]/compare-data.ts"
+      provides: "buildium/appfolio/rentredi blogSlug -> live published slugs"
+      contains: "buildium-vs-doorloop-vs-tenantflow-2026"
+    - path: "src/lib/content-links.ts"
+      provides: "RESOURCE_TO_BLOGS -> live published slugs"
+      contains: "twelve-month-preventive-maintenance-calendar-rentals"
+    - path: "tests/integration/content-links-slugs.test.ts"
+      provides: "prod slug-integrity guard for compare + resource cross-links"
+      contains: "status"
+  key_links:
+    - from: "compare/resource cross-link block"
+      to: "published blog post"
+      via: "RelatedArticles .in('slug', slugs).eq('status','published')"
+      pattern: "buildium-vs-doorloop-vs-tenantflow-2026"
+    - from: "referenced cross-link slugs"
+      to: "prod blogs.published"
+      via: "integration test asserting each slug is published"
+      pattern: "content-links-slugs"
+---
+
+<objective>
+Fix MKT-05 — all 6 cross-link blog slugs are dead (verified against prod: none exist; they were hand-authored guesses, not in blog-redirects.ts). `RelatedArticles` filters `.in('slug', slugs).eq('status','published')` and returns `null` on 0 matches, so the "Read the Full Comparison" block on every `/compare/*` page and the "Related Blog Posts" block on the 3 `/resources/*` pages silently vanish. Both directions are dead (`BLOG_TO_COMPETITOR`/`BLOG_TO_RESOURCE` key on the same slugs).
+
+Repoint all 6 to real published slugs (each re-verified live at planning time — see the LOCKED list below, all confirmed `status='published'` in prod), update the unit test, and add an integration test that queries prod and asserts every referenced slug is published so this can't silently recur.
+
+Purpose: restore the topical-cluster cross-links in both directions and guard against future dead slugs.
+Output: repointed compare-data.ts + content-links.ts; updated content-links.test.ts; a new prod slug-integrity integration test.
+
+LOCKED slug mapping (34-CONTEXT § MKT-05; every target re-verified published in prod at plan time):
+- compare-data.ts `blogSlug`:
+  - buildium -> `buildium-vs-doorloop-vs-tenantflow-2026`
+  - appfolio -> `appfolio-alternatives-under-25-month-for-first-time-landlords`
+  - rentredi -> `rentredi-alternatives-under-30-month-for-budget-conscious-landlords`
+- content-links.ts `RESOURCE_TO_BLOGS`:
+  - `seasonal-maintenance-checklist` -> [`twelve-month-preventive-maintenance-calendar-rentals`, `spring-rental-maintenance-checklist`, `fall-rental-maintenance-checklist`] (the last two are the CONTEXT-listed optional extras — INCLUDED: all verified published, and they fill the 3-col RelatedArticles grid)
+  - `landlord-tax-deduction-tracker` -> [`mortgage-interest-deduction-rental-property-schedule-e`, `repairs-deduction-schedule-e-line-14`, `legal-accounting-fees-landlord-deduction`]
+  - `security-deposit-reference-card` -> [`security-deposit-deadlines-and-caps-all-50-states`]
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/34-marketing-seo/34-CONTEXT.md
+@CLAUDE.md
+@src/components/blog/related-articles.tsx
+
+<interfaces>
+compare-data.ts CURRENT dead blogSlug values (lines 22, 125, 254):
+  buildium.blogSlug = "tenantflow-vs-buildium-comparison"
+  appfolio.blogSlug = "tenantflow-vs-appfolio-comparison"
+  rentredi.blogSlug = "tenantflow-vs-rentredi-comparison"
+
+content-links.ts CURRENT dead RESOURCE_TO_BLOGS (lines 18-24):
+  "seasonal-maintenance-checklist": ["preventive-maintenance-checklist-rental-properties-seasonal-guide"]
+  "landlord-tax-deduction-tracker": ["landlord-tax-deductions-missing-2025"]
+  "security-deposit-reference-card": ["security-deposit-laws-by-state-2025"]
+  BLOG_TO_RESOURCE + BLOG_TO_COMPETITOR are DERIVED (Object.fromEntries) — they update automatically.
+
+content-links.test.ts CURRENT assertions to rewrite:
+  - RESOURCE_TO_BLOGS: "has exactly 3 keys" (STILL 3 — keep), plus per-key `.toContain(<dead slug>)` (REPLACE with live slugs).
+  - BLOG_TO_RESOURCE: "has exactly 3 entries" (NOW more — see note) + `.toBe()` mappings on dead slugs (REPLACE).
+  - BLOG_TO_COMPETITOR: "has exactly 3 entries" (STILL 3 — one blogSlug per competitor) + `.toBe()` on dead slugs (REPLACE with live slugs).
+
+Note: RESOURCE_TO_BLOGS stays 3 KEYS, but the total number of blog slugs grows (seasonal=3, tax=3, security=1 => BLOG_TO_RESOURCE has 7 entries). BLOG_TO_COMPETITOR stays 3 (one blogSlug per competitor).
+
+Integration harness (tests/integration/):
+  - vitest project "integration": environment node, include `tests/integration/**/*.test.ts`, setupFiles env-loader.ts (loads .env.local -> NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY into process.env). Root `resolve.tsconfigPaths:true` resolves `#` aliases in this project too.
+  - Public blog reads need NO auth (status='published' is the anon RLS gate) — use `createClient(URL, PUBLISHABLE_KEY)` directly (do NOT need global-auth-setup sessions).
+  - tests/integration/tsconfig.json include is currently `["rls/**/*","setup/**/*"]` — add the new file so it is type-covered.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Repoint the 6 dead slugs + update the unit test (MKT-05)</name>
+  <files>src/app/compare/[competitor]/compare-data.ts, src/lib/content-links.ts, src/lib/content-links.test.ts</files>
+  <read_first>
+    - src/app/compare/[competitor]/compare-data.ts (lines 22, 125, 254 — the three blogSlug fields)
+    - src/lib/content-links.ts (RESOURCE_TO_BLOGS 18-24; derived reverse maps 29-42)
+    - src/lib/content-links.test.ts (whole file — the assertions to rewrite)
+    - .planning/phases/34-marketing-seo/34-CONTEXT.md § MKT-05 (LOCKED)
+  </read_first>
+  <action>
+    In compare-data.ts, replace the three `blogSlug` values with the LOCKED live slugs: buildium -> `buildium-vs-doorloop-vs-tenantflow-2026`, appfolio -> `appfolio-alternatives-under-25-month-for-first-time-landlords`, rentredi -> `rentredi-alternatives-under-30-month-for-budget-conscious-landlords`. Change nothing else in that file.
+    In content-links.ts, replace the three RESOURCE_TO_BLOGS arrays with the LOCKED live slugs (seasonal gets the 3-slug array incl. spring/fall; tax gets its 3 slugs; security gets its 1 slug). Leave the derived BLOG_TO_RESOURCE / BLOG_TO_COMPETITOR builders untouched (they recompute).
+    In content-links.test.ts, rewrite the assertions to the new live slugs: RESOURCE_TO_BLOGS keeps "exactly 3 keys" but each `.toContain()` now checks the live slug(s); BLOG_TO_RESOURCE update the entry count (now 7) and the `.toBe()` reverse mappings for each live slug -> its resource segment; BLOG_TO_COMPETITOR keeps "exactly 3 entries" and updates the three `.toBe()` mappings to the live blogSlugs. Do not weaken assertions — every live slug must be asserted.
+  </action>
+  <verify>
+    <automated>bun run test:unit -- --run src/lib/content-links.test.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - compare-data.ts + content-links.ts reference only the LOCKED live slugs; no dead slug remains (`grep -R "tenantflow-vs-buildium-comparison\|landlord-tax-deductions-missing-2025\|security-deposit-laws-by-state-2025" src` returns nothing).
+    - content-links.test.ts passes with the new slugs, correct entry counts (RESOURCE_TO_BLOGS=3 keys, BLOG_TO_RESOURCE=7, BLOG_TO_COMPETITOR=3).
+  </acceptance_criteria>
+  <done>Both cross-link directions resolve to real published posts; the unit test locks the new slugs.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add a prod slug-integrity integration test (MKT-05 recurrence guard)</name>
+  <files>tests/integration/content-links-slugs.test.ts, tests/integration/tsconfig.json</files>
+  <read_first>
+    - tests/integration/setup/env-loader.ts (env loading — NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)
+    - tests/integration/rls/anon-rpc-grants.rls.test.ts (an existing integration test's import/shape — for style only)
+    - tests/integration/tsconfig.json (the include array to extend)
+    - src/lib/content-links.ts + src/app/compare/[competitor]/compare-data.ts (the exports to import)
+  </read_first>
+  <action>
+    Create `tests/integration/content-links-slugs.test.ts`. Import `RESOURCE_TO_BLOGS` from `#lib/content-links` and `COMPETITORS` from `#app/compare/[competitor]/compare-data` (the `#` aliases resolve via the root tsconfigPaths). Build the full referenced-slug set: all `RESOURCE_TO_BLOGS` array values plus every `COMPETITORS[k].blogSlug` (filter falsy). Create an anon client with `createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!)` (no auth needed — public published reads). In one query, select `slug` from `blogs` where `.in("slug", [...slugSet]).eq("status","published")`, collect the returned slugs into a Set, then assert (a) no error, and (b) for EACH referenced slug, the Set contains it (use a per-slug `expect(publishedSet.has(slug), \`cross-link slug not published: ${slug}\`).toBe(true)` loop so a failure names the dead slug). Guard the whole suite with a skip when the env vars are missing (matches the harness convention) so it doesn't hard-fail a credential-less local run. No `any` — type the row as `{ slug: string }`.
+    Update tests/integration/tsconfig.json `include` to add `"content-links-slugs.test.ts"` so the new file is type-covered by the integration tsconfig.
+  </action>
+  <verify>
+    <automated>bun run test:integration -- --run tests/integration/content-links-slugs.test.ts 2>&1 | tail -20</automated>
+  </verify>
+  <acceptance_criteria>
+    - The test passes against prod: every slug referenced by compare-data.ts + content-links.ts is published.
+    - A future dead slug fails this test with the offending slug named.
+    - tests/integration/tsconfig.json includes the new file.
+  </acceptance_criteria>
+  <done>CI has a permanent guard that every compare/resource cross-link slug is a published post.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| static cross-link config -> prod blog catalogue | Hand-authored slugs can drift from the live catalogue and silently break cross-link blocks (content-integrity, not a security exploit) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-34-04-Info | Information Disclosure | integration test prod read | accept | Test reads only `slug` of published blogs via the anon publishable key (already public); no auth, no PII. |
+| T-34-04-Tamper | Tampering (content integrity) | dead cross-link slugs | mitigate | Repoint to verified-live slugs + a CI integration guard that fails (naming the slug) if any referenced slug stops being published. |
+| T-34-04-SC | Tampering | npm/pip/cargo installs | accept | No packages installed; `@supabase/supabase-js` already present. |
+</threat_model>
+
+<verification>
+- `bun run typecheck` clean; `bun run lint` clean.
+- `bun run test:unit -- --run src/lib/content-links.test.ts` passes with the new slugs + counts.
+- `bun run test:integration -- --run tests/integration/content-links-slugs.test.ts` passes (all referenced slugs published). Also runs in CI `rls-security`'s integration lane.
+- Grep: no dead slug remains in `src` (`tenantflow-vs-*-comparison`, `landlord-tax-deductions-missing-2025`, `security-deposit-laws-by-state-2025`, `preventive-maintenance-checklist-rental-properties-seasonal-guide`).
+- Behavioral (recorded in 34-05): a `/compare/buildium` page shows the "Read the Full Comparison" block; a `/resources/*` page shows "Related Blog Posts".
+</verification>
+
+<success_criteria>
+- The compare/resource cross-link blocks point at existing published posts (both directions resolve), and a CI integration test prevents silent recurrence.
+</success_criteria>
+
+<output>
+Create `.planning/phases/34-marketing-seo/34-04-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/34-marketing-seo/34-05-PLAN.md
+++ b/.planning/phases/34-marketing-seo/34-05-PLAN.md
@@ -1,0 +1,136 @@
+---
+phase: 34-marketing-seo
+plan: 05
+type: execute
+wave: 2
+depends_on: [34-01, 34-02, 34-03, 34-04]
+requirements: [MKT-01, MKT-02, MKT-03, MKT-04, MKT-05]
+files_modified: []
+autonomous: false
+must_haves:
+  truths:
+    - "typecheck + lint + the full unit suite are green (incl. the new/updated drift, pagination, category, search, and content-links tests)"
+    - "The content-links prod slug-integrity integration test passes (or is recorded as run in CI rls-security)"
+    - "MKT-01 pixel-verify: each of the 3 OG routes' JSX renders to a PNG that is NOT uniformly black (orchestrator-run ImageResponse harness)"
+    - "Each of MKT-01..05 has a confirmed behavioral outcome recorded, plus a residual/limitation ledger"
+    - "All four ROADMAP Phase-34 success criteria are demonstrably met"
+  artifacts:
+    - path: ".planning/phases/34-marketing-seo/34-05-SUMMARY.md"
+      provides: "phase verification record: gate results, per-MKT checklist, pixel-verify result, residual ledger"
+      contains: "Per-Requirement"
+  key_links:
+    - from: "phase gate"
+      to: "perfect-PR merge discipline"
+      via: "two consecutive zero-finding review cycles"
+      pattern: "zero-finding"
+---
+
+<objective>
+Phase 34 verification — prove MKT-01..05 behave and the quality gate is green, with NO source changes. This plan runs the gate, records the MKT-01 pixel-verify (the satori-black guard's real proof), exercises each fix, and ledgers residuals.
+
+Scope of the five fixes to verify:
+- MKT-01 (34-01): 3 OG routes on hsl (non-black cards) + the OG-scoped modernColor drift guard.
+- MKT-02 (34-02): blog/category pagination navigates for real (Server Component re-runs, posts change).
+- MKT-03 (34-02): category out-of-range ?page -> notFound(); category query errors throw.
+- MKT-04 (34-03): /search is a real public blog search with a name="q" GET form; noindex retained; SearchAction now truthful.
+- MKT-05 (34-04): the 6 cross-link slugs repointed to live posts + a prod slug-integrity integration guard.
+
+Purpose: confirm the phase is shippable under the perfect-PR gate (two consecutive zero-finding review cycles).
+Output: 34-05-SUMMARY.md with gate results, a per-requirement checklist, the pixel-verify result, and the residual ledger. No code changes.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/34-marketing-seo/34-CONTEXT.md
+@.planning/phases/34-marketing-seo/34-01-PLAN.md
+@.planning/phases/34-marketing-seo/34-02-PLAN.md
+@.planning/phases/34-marketing-seo/34-03-PLAN.md
+@.planning/phases/34-marketing-seo/34-04-PLAN.md
+@.planning/phases/33-security/33-05-SUMMARY.md
+@CLAUDE.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Quality gate + per-MKT checklist + residual ledger</name>
+  <files>.planning/phases/34-marketing-seo/34-05-SUMMARY.md</files>
+  <read_first>
+    - .planning/phases/34-marketing-seo/34-01-SUMMARY.md, 34-02-SUMMARY.md, 34-03-SUMMARY.md, 34-04-SUMMARY.md (the four executed plans' results)
+    - .planning/phases/34-marketing-seo/34-CONTEXT.md (the locked per-MKT behavior)
+    - .planning/phases/33-security/33-05-SUMMARY.md (the verification-summary shape to mirror)
+  </read_first>
+  <action>
+    Run the full quality gate and record exact results in 34-05-SUMMARY.md:
+      - `bun run typecheck` (tsc --noEmit) -> exit code.
+      - `bun run lint` (biome) -> error count.
+      - `bun run test:unit` (full Vitest suite) -> passed/total + file count. Confirm the new/updated tests are included and green: design-token-drift (modernColor), blog-pagination, blog/category page, search/page, content-links.
+      - Integration: run `bun run test:integration -- --run tests/integration/content-links-slugs.test.ts` if credentials are present (hits prod, anon read; record pass/fail + published-slug count); otherwise cite CI `rls-security`'s integration lane as the live gate.
+    Assemble a per-requirement checklist table (MKT-01..05) mapping each to its verified behavior and the plan/commit that delivered it (mirror 33-05's "Per-SEC Checklist").
+    Residual ledger: note the guard-scope decision for MKT-01 (modernColor scoped to `src/app/api/og/` — global would flag ~40 legit browser-CSS oklch/color-mix literals + contradict src/app/features/__tests__/page.test.ts); the seasonal-maintenance-checklist optional spring/fall slugs were INCLUDED (verified published); and any OG-route CDN cache note (the black PNGs may be edge-cached — flag that a cache purge / `?v=` bump may be needed post-deploy for already-cached cards). Record any other limitation surfaced during the gate.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint && bun run test:unit</automated>
+  </verify>
+  <acceptance_criteria>
+    - typecheck exit 0; lint 0 errors; full unit suite green (all five new/updated test areas included).
+    - 34-05-SUMMARY.md contains the per-MKT checklist, the integration-test result (or CI citation), the pixel-verify result (from Task 2), and the residual ledger.
+  </acceptance_criteria>
+  <done>The gate is green and every requirement's behavior + residual is recorded.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: MKT-01 pixel-verify + behavioral spot-checks (orchestrator-run)</name>
+  <what-built>MKT-01 hsl OG routes; MKT-02 real pagination; MKT-03 category 404/error honesty; MKT-04 real /search; MKT-05 live cross-links. This checkpoint runs the MKT-01 pixel harness (which the executor could not run — it needs a local ImageResponse render) and spot-checks the other four in the browser.</what-built>
+  <how-to-verify>
+    MKT-01 (pixel-verify — the required proof, per CLAUDE.md blog-cover "pixel-verify before deploy"):
+      1. Build/run a local ImageResponse harness that imports each of the 3 OG routes' JSX (or replicates it) and renders `pricing`, `features`, and `compare/[competitor]` (e.g. slug `buildium`) to a PNG at 1200x630.
+      2. For each PNG, sample the center pixel + the four corners. Assert NOT uniformly black — the 135deg gradient must vary across the samples (top-left vs bottom-right differ), i.e. at least one sampled pixel has a meaningfully non-zero, non-equal RGB. Record pass/fail per route.
+      3. (Optional) Also hit the running dev routes `GET /api/og/pricing`, `/api/og/features`, `/api/og/compare/buildium` and eyeball the returned PNG is a blue-gradient card with white text, not black.
+    MKT-02: on `/blog` (and a category with >9 posts) click Next -> the rendered post grid changes to page 2's posts and the URL is `?page=2`; Prev returns to page 1's posts. Confirm the posts ACTUALLY change (not just the label).
+    MKT-03: visit a category page with an out-of-range `?page=9999` -> HTTP 404 (not a 200 "0 articles" empty state).
+    MKT-04: visit `/search?q=lease` -> matching published posts render as cards; `/search` (no q) -> Empty prompt; the form input is `name="q"`; view-source confirms the homepage SearchAction still targets `/search?q={search_term_string}`.
+    MKT-05: `/compare/buildium` shows the "Read the Full Comparison" block; a `/resources/*` page shows "Related Blog Posts".
+  </how-to-verify>
+  <resume-signal>Type "approved" once the 3 OG PNGs are confirmed non-black and MKT-02/03/04/05 behaviors are confirmed, or describe any issue found.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| phase deliverables -> public surface | Verification confirms each public-surface fix (OG render, pagination, 404 honesty, search contract, cross-links) actually holds before merge |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-34-05V-Val | Tampering / Info (content + crawl integrity) | all five MKT fixes | mitigate | Gate + pixel-verify + behavioral checklist confirm MKT-01..05 hold; perfect-PR (two consecutive zero-finding review cycles) is the merge gate. |
+| T-34-05V-SC | Tampering | npm/pip/cargo installs | accept | No packages installed; verification-only plan. |
+</threat_model>
+
+<verification>
+- `bun run typecheck` exit 0; `bun run lint` 0 errors; `bun run test:unit` full suite green.
+- content-links prod slug-integrity integration test passes (local or CI rls-security).
+- MKT-01 pixel-verify: 3 OG PNGs non-black (gradient varies).
+- Human/orchestrator behavioral: MKT-02 posts change on Next/Prev; MKT-03 out-of-range 404; MKT-04 /search returns posts with a name="q" form; MKT-05 cross-link blocks render.
+- 34-05-SUMMARY.md records the gate, per-MKT checklist, pixel-verify, and residual ledger.
+</verification>
+
+<success_criteria>
+- All four ROADMAP Phase-34 success criteria met: (1) `/pricing`,`/features`,`/compare/*` OG images render non-black cards; (2) Next/Prev on `/blog` + category pages changes the posts and out-of-range pages 404 with a correct count; (3) the homepage SearchAction and `/search` agree and cross-link blocks point at existing posts; (4) two consecutive zero-finding review cycles under the perfect-PR gate.
+</success_criteria>
+
+<output>
+Create `.planning/phases/34-marketing-seo/34-05-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/34-marketing-seo/34-05-SUMMARY.md
+++ b/.planning/phases/34-marketing-seo/34-05-SUMMARY.md
@@ -1,0 +1,68 @@
+---
+phase: 34-marketing-seo
+plan: 05
+subsystem: verification
+tags: [marketing, blog, seo, og, verification, perfect-pr]
+requires: [34-01, 34-02, 34-03, 34-04]
+provides:
+  - Phase 34 quality gate green (tsc + lint + full unit suite)
+  - MKT-01 OG pixel-verify (rendered PNGs not black)
+  - Per-MKT behavioral verification (MKT-01..05)
+affects: []
+tech-stack:
+  patterns:
+    - "Perfect-PR gate: 5-dimension fan-out -> adversarial verify, two consecutive zero-finding cycles"
+    - "OG pixel-verify via a local ImageResponse harness (satori renders oklch black)"
+key-files:
+  created:
+    - .planning/phases/34-marketing-seo/34-05-SUMMARY.md
+  modified: []
+decisions:
+  - "MKT-04 = Option A (wire real public blog search at /search), not removing the SearchAction."
+  - "MKT-01 drift-guard scoped to src/app/api/og/ only (a global oklch ban would red ~58 legit browser-CSS literals)."
+metrics:
+  tasks: 1
+  commits: 0
+  files: 0
+  completed: 2026-07-10
+---
+
+# Phase 34 Plan 05: Phase Verification Summary
+
+Phase 34 (Marketing, Blog & SEO Surface; MKT-01..05) verified end-to-end. The full quality gate is green, the OG images are pixel-verified non-black, and every MKT behavior holds. **No DB migrations.**
+
+## Quality Gate
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Types | `bun run typecheck` (`tsc --noEmit`) | **clean (exit 0)** |
+| Lint | `bun run lint` (biome) | **clean** — 0 errors (1 info: optional biome schema bump) |
+| Unit | `bun run test:unit` (Vitest, full suite) | **102425 passed (241 files)** |
+| OG pixel-verify | local ImageResponse harness → sharp stats | **pricing/features/compare all render content** (maxChannel 255, meanSum ~347; a solid-black would be ≤8) |
+| Slug integrity | `tests/integration/content-links-slugs.test.ts` | runs in CI `rls-security` (asserts every cross-link slug is published in prod) |
+
+## Per-MKT Checklist
+
+| Req | Behavior | Final state |
+|-----|----------|-------------|
+| MKT-01 | OG images render real content | `/pricing`, `/features`, `/compare/*` OG routes use hsl (not oklch — satori renders oklch black); pixel-verified non-black. OG-scoped `modernColor` drift guard added. |
+| MKT-02 | Blog/category pagination changes the posts | blog-pagination stopped hijacking its own `<Link>` anchors (dropped shallow-nuqs `setPage` + enabled-link `preventDefault`) → real navigation re-runs the Server Component. |
+| MKT-03 | Out-of-range pages 404 honestly | The category page now mirrors the index: PGRST103/"range not satisfiable" → `notFound()`, other query error → throw (no more silent empty at 200). Count stays `{count:'exact'}`. |
+| MKT-04 | SearchAction ↔ /search agree | `/search` rewritten as an async server component that reads `?q`, runs a sanitized published-blog search via `blogAnonClient`, renders a `BlogCard` grid + `Empty` states, in a `<form method="GET">` with `name="q"`. SearchAction JSON-LD is now truthful. |
+| MKT-05 | Cross-links point at real posts | All 6 dead slugs repointed to verified-published posts (compare + resource, both link directions); the 3 `LEAD_MAGNETS` keys re-keyed; a prod slug-integrity integration test guards recurrence. |
+
+## Ship Residual
+
+- None. No DB migrations, no owner-run edge deploys. `/api/og/*` are edge routes redeployed by Vercel on merge (the blog-cover static art is unaffected — only the on-the-fly OG cards changed).
+
+## Review-Cycle Amendments (perfect-PR gate)
+
+- **Cycle 1** — LOW (MKT-04): the rewritten `/search` typed `searchParams` as `{ q?: string }`, but Next.js returns a `string[]` for a repeated `?q=` param, and `normalizeSearchInput` calls `.trim()` — so `/search?q=a&q=b` threw and 500'd this public route. Coerced to a scalar (`Array.isArray(q) ? q[0] : q`) + a regression test.
+- **Cycles 2 & 3** — all five dimensions CLEAN on two consecutive cycles (cycle 2's verifier ran live `.or()` injection payloads against prod PostgREST — all returned 200 with no draft leak). **Gate met.**
+
+## Self-Check: PASSED
+
+- Quality gate green: typecheck 0, lint clean, 102426 unit tests (241 files).
+- MKT-01 OG images pixel-verified non-black.
+- All 5 MKT behaviors verified against the final shipped code.
+- Perfect-PR gate satisfied: two consecutive zero-finding review cycles.

--- a/.planning/phases/34-marketing-seo/34-CONTEXT.md
+++ b/.planning/phases/34-marketing-seo/34-CONTEXT.md
@@ -1,0 +1,39 @@
+# Phase 34 — Marketing, Blog & SEO Surface — CONTEXT (locked decisions)
+
+Source: 2026-07-02 hunt requirements MKT-01..05, verified against current source (+ live prod `blogs` for MKT-05 slugs) by the phase-34 understand Workflow (2026-07-10). **No DB migrations** — all frontend / edge-route / content changes.
+
+## MKT-01 — OG images render solid black (satori oklch)
+**Confirmed:** the `/pricing`, `/features`, `/compare/[competitor]` OG routes render the whole 1200×630 PNG via satori using `oklch()` literals for the background gradient (2 stops) AND the text color — satori renders oklch as black, so the entire card is black. (The blog OG route is fine — its oklch hits are comments only; leave it.)
+**Decision:** in each of the 3 routes (`src/app/api/og/pricing/route.tsx`, `.../features/route.tsx`, `.../compare/[competitor]/route.tsx`), replace the oklch literals with their exact hsl equivalents (space-separated, satori-valid; **hsl NOT hex/rgb** — the design-token-drift guard bans hex/rgb in `src/app/**`, hsl is allowed):
+- gradient: `linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)` → `linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)`
+- text: `color: "oklch(1 0 0)"` → `color: "hsl(0 0% 100%)"`
+- Update the `// Brand colors ... (oklch)` comment to say hsl-only (satori renders oklch black). Do NOT reference the globals.css `--color-primary` token (satori has no CSS-var context — inline literals required).
+**Coverage fix (this is why it shipped):** add an `oklch` (+ `lab(`/`lch(`/`color-mix(`) pattern to `DRIFT_PATTERNS` in `src/app/__tests__/design-token-drift.test.ts`, scanned against **string-literal content only** (reuse the existing `extractStringContent` path) so oklch-in-comments (blog route) doesn't false-positive but oklch inside a quoted style string fails CI permanently.
+**Verify:** a local `ImageResponse` pixel harness — render each route's JSX, write the PNG, assert it's not uniformly black (sample center+corners, gradient varies). Per the CLAUDE.md blog-cover "pixel-verify before deploy" rule.
+
+## MKT-02 — blog/category pagination doesn't re-render the post grid
+**Confirmed:** `src/components/blog/blog-pagination.tsx` renders correct `<Link href={pageHref}>` anchors, but each onClick does `e.preventDefault()` + `setPage()` via nuqs `useQueryState("page")` WITHOUT `shallow:false` — so the URL + "Page X of Y" label change client-side but the Server Component (which paginates by `.range(offset, ...)` from `searchParams.page`) never re-runs → same posts. Server side (`blog/page.tsx`, `blog/category/[category]/page.tsx`) is already correct.
+**Decision:** stop hijacking the anchors — let the real `<Link>` navigation run (it already has the right hrefs, which re-runs the Server Component). Drop the unused `setPage` (keep `const [page] = useQueryState(...)` for the reactive label, or read from props to avoid `noUnusedLocals`); change each onClick to a guard only: `onClick={(e) => { if (!hasPrev) e.preventDefault() }}` (prev) / `{ if (!hasNext) e.preventDefault() }` (next). No shallow nuqs.
+
+## MKT-03 — out-of-range blog/category page + category error handling
+**Confirmed:** the blog INDEX page (`blog/page.tsx:112-124`) already handles out-of-range (`PGRST103`/"range not satisfiable" → `notFound()`) + throws on query error. The CATEGORY page (`blog/category/[category]/page.tsx`) does NEITHER: an out-of-range `?page` (PGRST103 → data/count null) renders `BlogEmptyState` at HTTP 200 with a false "0 articles" subtitle, and any query error is silently ignored (silent empty, no Sentry/error boundary). Count is already `{count:'exact'}` (NOT a `data.length` bug).
+**Decision:** in the category page, between the query and `const posts = ...`, mirror the index page: if `error.code === 'PGRST103'` (or /range not satisfiable/) → `notFound()`; else if `error` → `throw new Error(error.message)` (hits `blog/error.tsx`). No try/catch needed (the invalid-category branch already calls `notFound()` directly).
+
+## MKT-04 — SearchAction advertises /search but /search is a dead stub
+**Confirmed:** the homepage `WebSite` JSON-LD (`src/app/page.tsx:50-54`) advertises a `SearchAction` at `/search?q={search_term_string}`, but `src/app/search/page.tsx` is a static stub: no `searchParams`, input is `name="search"` (not `q`), no `<form>`, hardcoded fake "Recent Searches", framed as private-portfolio search (wrong — it's public, noindex). `/search` is referenced ONLY by the SearchAction (safe to repurpose).
+**Decision: Option A — wire a real public blog search** (blog content is public + all infra exists: `blogAnonClient()`, `escapeOrValue`/`normalizeSearchInput`, `BlogCard`, `Empty`, `BLOG_LIST_COLUMNS`). Rewrite `/search/page.tsx` as an async server component:
+- `SearchPage({ searchParams }: { searchParams: Promise<{ q?: string }> })`; `const { q } = await searchParams`; `const query = normalizeSearchInput(q ?? "")`.
+- When `query` non-empty: `blogAnonClient().from("blogs").select(BLOG_LIST_COLUMNS).eq("status","published").or(\`title.ilike."%${escapeOrValue(query)}%",excerpt.ilike."%${escapeOrValue(query)}%",content.ilike."%${escapeOrValue(query)}%"\`).order("published_at",{ascending:false}).limit(24)`.
+- Wrap the input in `<form method="GET" action="/search">` with `<input name="q" defaultValue={query}>` (name MUST be `q` to match the SearchAction). Render a `BlogCard` grid for results; the `Empty` compound for no-query / no-matches. Delete the fake "Recent Searches" + dead Quick-Search cards. Replace "your portfolio" copy with public blog-search copy. Keep `noindex: true`.
+- The SearchAction JSON-LD stays as-is (now truthful).
+
+## MKT-05 — six dead cross-link blog slugs
+**Confirmed against prod `blogs`:** all 6 referenced slugs do NOT exist (never did — hand-authored guesses, not in `blog-redirects.ts`). `RelatedArticles` (`related-articles.tsx`) filters `.in('slug', slugs).eq('status','published')` and returns `null` on 0 matches → the "Read the Full Comparison" (every `/compare/*`) + "Related Blog Posts" (3 `/resources/*`) sections silently vanish. Both directions dead (reverse maps `BLOG_TO_COMPETITOR`/`BLOG_TO_RESOURCE` key on the same slugs).
+**Decision: repoint all 6 to real published slugs** (verified live; fixes both directions since the reverse maps derive from these two sources):
+- `compare-data.ts` `blogSlug`: buildium → `buildium-vs-doorloop-vs-tenantflow-2026`; appfolio → `appfolio-alternatives-under-25-month-for-first-time-landlords`; rentredi → `rentredi-alternatives-under-30-month-for-budget-conscious-landlords`.
+- `content-links.ts` `RESOURCE_TO_BLOGS`: `seasonal-maintenance-checklist` → `twelve-month-preventive-maintenance-calendar-rentals` (+ optional `spring-rental-maintenance-checklist`, `fall-rental-maintenance-checklist`); `landlord-tax-deduction-tracker` → `mortgage-interest-deduction-rental-property-schedule-e`, `repairs-deduction-schedule-e-line-14`, `legal-accounting-fees-landlord-deduction`; `security-deposit-reference-card` → `security-deposit-deadlines-and-caps-all-50-states`.
+- Update `content-links.test.ts` slug assertions. **Add a guard against recurrence:** an integration test (`tests/integration/`) that queries prod `blogs` for every slug referenced by `compare-data.ts` + `content-links.ts` and asserts each is `published` (unit tests can't hit the DB; this runs in CI). VERIFY each target slug's existence before finalizing (a slug may have changed) — re-check via MCP at execution.
+
+## Cross-cutting
+- No migrations. No new query-key factories. Follow CLAUDE.md (no `any`, no barrel, hsl-only in satori/OG, `Empty` compound for empty states, `NotFoundPage` semantics for 404s where applicable). Reuse `blogAnonClient` for public blog reads.
+- Gate: perfect-PR (two consecutive zero-finding review cycles), run as a Workflow. MKT-01 needs a pixel-verify (rendered PNG not black) before merge.

--- a/src/app/__tests__/design-token-drift.test.ts
+++ b/src/app/__tests__/design-token-drift.test.ts
@@ -1,10 +1,14 @@
 /**
  * Design-token drift guard (TOKEN-03).
  *
- * Recursively scans `src/components/**` and `src/app/**` for the four design-token
- * drift patterns — hex color literals, `rgb()`/`rgba()`, the `bg-white` class, and
- * non-zero inline `[NNN]ms` durations — and asserts zero matches outside the
- * documented D-03 allowlist (`DRIFT_EXEMPTIONS`).
+ * Recursively scans `src/components/**` and `src/app/**` for five design-token
+ * drift patterns — hex color literals, `rgb()`/`rgba()`, the `bg-white` class,
+ * non-zero inline `[NNN]ms` durations, and modern color functions
+ * (`oklch()`/`oklab()`/`lab()`/`lch()`/`color-mix()`) — and asserts zero matches
+ * outside the documented D-03 allowlist (`DRIFT_EXEMPTIONS`). The `modernColor`
+ * pattern is scoped to the `src/app/api/og/` satori surface (next/og renders
+ * those color spaces as solid black) and scanned against string-literal content
+ * only, so an OG-route comment mentioning oklch does not self-trigger.
  *
  * This is a Vitest unit-project test (it runs in the lefthook pre-commit hook
  * and the CI test gate). The mechanism is documented for maintainers in
@@ -18,9 +22,10 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { describe, expect, it } from "vitest";
 
-type DriftPattern = "hex" | "rgb" | "bgWhite" | "inlineMs";
+type DriftPattern = "hex" | "rgb" | "bgWhite" | "inlineMs" | "modernColor";
 
-// The four design-token drift patterns (D-02 enumerates exactly these four).
+// The five design-token drift patterns (D-02 enumerates the first four; MKT-01
+// adds `modernColor`, scoped to the src/app/api/og/ satori surface — see below).
 const DRIFT_PATTERNS: Record<DriftPattern, RegExp> = {
 	// #RGB / #RGBA / #RRGGBB / #RRGGBBAA at a word boundary
 	hex: /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})\b/g,
@@ -33,6 +38,14 @@ const DRIFT_PATTERNS: Record<DriftPattern, RegExp> = {
 	// literals animationDelay: "200ms". [1-9]\d* excludes the 0ms zero-case
 	// (globals.css has no --duration-0; 0ms is a legitimate no-delay).
 	inlineMs: /\[\s*[a-z-]*:?\s*[1-9]\d*ms\s*\]|["'`]\s*[1-9]\d*ms\s*["'`]/g,
+	// MKT-01: satori (next/og ImageResponse) renders oklch/oklab/lab/lch/
+	// color-mix() as solid black, so these color functions are forbidden inside a
+	// quoted style string in an OG/satori route. Scoped to `src/app/api/og/` (see
+	// the per-pattern loop) and scanned against string-literal content only, so a
+	// browser-CSS oklch/color-mix literal elsewhere — or an OG-route comment
+	// mentioning oklch — never triggers it. (?<![\w-]) blocks `--foo-lab(` /
+	// `scolor-mix(` word/hyphen-prefixed false positives.
+	modernColor: /(?<![\w-])(?:oklch|oklab|lab|lch|color-mix)\s*\(/gi,
 };
 
 // String / template-literal extractor. The hex scan runs against string-literal
@@ -147,10 +160,20 @@ for (const root of ["src/components", "src/app"]) {
 			describe(rel, () => {
 				for (const pattern of Object.keys(DRIFT_PATTERNS) as DriftPattern[]) {
 					if (isExempt(rel, pattern)) continue;
+					// modernColor is scoped to the OG/satori surface only — browser-CSS
+					// oklch/color-mix literals elsewhere in src/app + src/components are
+					// legitimate (React drives them through a real CSS engine, not satori),
+					// and src/app/features/page.test.ts REQUIRES oklch on the marketing page.
+					if (pattern === "modernColor" && !rel.startsWith("src/app/api/og/"))
+						continue;
 					it(`no ${pattern} drift`, () => {
-						// hex scans string-literal content only (Pitfall-4 false-positive
-						// guard); the other three scan the raw file text.
-						const scanText = pattern === "hex" ? stringContent : content;
+						// hex + modernColor scan string-literal content only (Pitfall-4
+						// false-positive guard, and so an OG-route comment mentioning oklch
+						// does not self-trigger); the other patterns scan the raw file text.
+						const scanText =
+							pattern === "hex" || pattern === "modernColor"
+								? stringContent
+								: content;
 						const rawMatches: readonly string[] =
 							scanText.match(DRIFT_PATTERNS[pattern]) ?? [];
 						const matches =
@@ -191,6 +214,44 @@ describe("drift regexes catch known drift (meta-test)", () => {
 		).not.toBeNull());
 	it("inlineMs regex IGNORES the 0ms zero-case", () =>
 		expect('"0ms"'.match(DRIFT_PATTERNS.inlineMs)).toBeNull());
+	it("modernColor regex catches oklch(", () =>
+		expect(
+			"oklch(0.62 0.18 250)".match(DRIFT_PATTERNS.modernColor),
+		).not.toBeNull());
+	it("modernColor regex catches oklab(", () =>
+		expect(
+			"oklab(0.4 0.1 0.1)".match(DRIFT_PATTERNS.modernColor),
+		).not.toBeNull());
+	it("modernColor regex catches color-mix(", () =>
+		expect(
+			"color-mix(in oklch, white 50%, black)".match(DRIFT_PATTERNS.modernColor),
+		).not.toBeNull());
+	it("modernColor regex catches lab( and lch(", () => {
+		expect("lab(50% 40 59.5)".match(DRIFT_PATTERNS.modernColor)).not.toBeNull();
+		expect(
+			"lch(52.2% 72.2 50)".match(DRIFT_PATTERNS.modernColor),
+		).not.toBeNull();
+	});
+	it("modernColor regex IGNORES a bare word oklch with no paren", () =>
+		expect(
+			"renders oklch as black".match(DRIFT_PATTERNS.modernColor),
+		).toBeNull());
+	it("modernColor regex IGNORES word/hyphen-prefixed lab(/color-mix(", () => {
+		expect("--foo-lab(".match(DRIFT_PATTERNS.modernColor)).toBeNull();
+		expect("scolor-mix(".match(DRIFT_PATTERNS.modernColor)).toBeNull();
+	});
+	it("modernColor scan (string-literal only) ignores an oklch mention in a comment", () =>
+		expect(
+			extractStringContent("// satori renders oklch as black; use hsl").match(
+				DRIFT_PATTERNS.modernColor,
+			),
+		).toBeNull());
+	it("modernColor scan flags a quoted oklch color string", () =>
+		expect(
+			extractStringContent('const c = "oklch(1 0 0)";').match(
+				DRIFT_PATTERNS.modernColor,
+			),
+		).not.toBeNull());
 	it("hex scan keeps a hex inside a string literal", () =>
 		expect(
 			extractStringContent('const fill = "#2563eb";').match(DRIFT_PATTERNS.hex),

--- a/src/app/api/og/compare/[competitor]/route.tsx
+++ b/src/app/api/og/compare/[competitor]/route.tsx
@@ -20,12 +20,11 @@ export async function GET(_req: Request, { params }: RouteParams) {
 		return new Response("Not found", { status: 404 });
 	}
 
-	// Brand colors derived from globals.css `--color-primary` (oklch).
-	// `@vercel/og` requires inline CSS values so the canonical token
-	// literals are duplicated here. This is the ONE permitted exception
-	// to the no-hex/no-inline-color rule (Phase 6 CONTEXT.md § Design Token).
+	// Brand colors as hsl() literals. satori renders oklch as black, so OG
+	// routes MUST use hsl (never oklch/hex/rgb). Duplicated inline because
+	// satori has no CSS-var context (no --color-primary token available).
 	const bgGradient =
-		"linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)";
+		"linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)";
 
 	return new ImageResponse(
 		<div
@@ -37,7 +36,7 @@ export async function GET(_req: Request, { params }: RouteParams) {
 				justifyContent: "space-between",
 				padding: "60px",
 				background: bgGradient,
-				color: "oklch(1 0 0)",
+				color: "hsl(0 0% 100%)",
 				fontFamily: "sans-serif",
 			}}
 		>

--- a/src/app/api/og/features/route.tsx
+++ b/src/app/api/og/features/route.tsx
@@ -13,12 +13,11 @@ export const runtime = "edge";
 export const revalidate = 3600;
 
 export function GET() {
-	// Brand colors derived from globals.css `--color-primary` (oklch).
-	// `@vercel/og` requires inline CSS values so the canonical token
-	// literals are duplicated here. This is the ONE permitted exception
-	// to the no-hex/no-inline-color rule (Phase 6 CONTEXT.md § Design Token).
+	// Brand colors as hsl() literals. satori renders oklch as black, so OG
+	// routes MUST use hsl (never oklch/hex/rgb). Duplicated inline because
+	// satori has no CSS-var context (no --color-primary token available).
 	const bgGradient =
-		"linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)";
+		"linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)";
 
 	return new ImageResponse(
 		<div
@@ -30,7 +29,7 @@ export function GET() {
 				justifyContent: "space-between",
 				padding: "60px",
 				background: bgGradient,
-				color: "oklch(1 0 0)",
+				color: "hsl(0 0% 100%)",
 				fontFamily: "sans-serif",
 			}}
 		>

--- a/src/app/api/og/pricing/route.tsx
+++ b/src/app/api/og/pricing/route.tsx
@@ -13,12 +13,11 @@ export const runtime = "edge";
 export const revalidate = 3600;
 
 export function GET() {
-	// Brand colors derived from globals.css `--color-primary` (oklch).
-	// `@vercel/og` requires inline CSS values so the canonical token
-	// literals are duplicated here. This is the ONE permitted exception
-	// to the no-hex/no-inline-color rule (Phase 6 CONTEXT.md § Design Token).
+	// Brand colors as hsl() literals. satori renders oklch as black, so OG
+	// routes MUST use hsl (never oklch/hex/rgb). Duplicated inline because
+	// satori has no CSS-var context (no --color-primary token available).
 	const bgGradient =
-		"linear-gradient(135deg, oklch(0.62 0.18 250) 0%, oklch(0.45 0.20 270) 100%)";
+		"linear-gradient(135deg, hsl(205 100% 46%) 0%, hsl(233 61% 47%) 100%)";
 
 	return new ImageResponse(
 		<div
@@ -30,7 +29,7 @@ export function GET() {
 				justifyContent: "space-between",
 				padding: "60px",
 				background: bgGradient,
-				color: "oklch(1 0 0)",
+				color: "hsl(0 0% 100%)",
 				fontFamily: "sans-serif",
 			}}
 		>

--- a/src/app/blog/[slug]/blog-post-page.tsx
+++ b/src/app/blog/[slug]/blog-post-page.tsx
@@ -49,21 +49,21 @@ const LEAD_MAGNETS: Record<
 		downloadUrl: string;
 	}
 > = {
-	"preventive-maintenance-checklist-rental-properties-seasonal-guide": {
+	"twelve-month-preventive-maintenance-calendar-rentals": {
 		title: "Download the Complete Maintenance Checklist",
 		description:
 			"Get a printable season-by-season maintenance checklist covering HVAC, plumbing, electrical, and exterior inspections for your rental properties.",
 		resourceType: "checklist",
 		downloadUrl: "/resources/seasonal-maintenance-checklist",
 	},
-	"landlord-tax-deductions-missing-2025": {
+	"mortgage-interest-deduction-rental-property-schedule-e": {
 		title: "Free Tax Deduction Tracker Spreadsheet",
 		description:
 			"Track every deductible expense throughout the year with this ready-to-use spreadsheet. Categorized by IRS schedule with auto-calculated totals.",
 		resourceType: "spreadsheet",
 		downloadUrl: "/resources/landlord-tax-deduction-tracker",
 	},
-	"security-deposit-laws-by-state-2025": {
+	"security-deposit-deadlines-and-caps-all-50-states": {
 		title: "Security Deposit Quick Reference Card",
 		description:
 			"A one-page reference with deposit limits, return deadlines, and required documentation for all 50 states. Print it and keep it at your desk.",

--- a/src/app/blog/category/[category]/page.test.tsx
+++ b/src/app/blog/category/[category]/page.test.tsx
@@ -127,12 +127,14 @@ interface MockBuilderOpts {
 	posts?: BlogListItem[];
 	postsCount?: number | null;
 	categories?: typeof mockCategories;
+	postsError?: { code?: string; message: string } | null;
 }
 
 function makeClient({
 	posts = mockPosts,
 	postsCount = 14,
 	categories = mockCategories,
+	postsError = null,
 }: MockBuilderOpts = {}) {
 	const fromMock = vi.fn(() => {
 		const chain: Record<string, unknown> = {};
@@ -140,7 +142,11 @@ function makeClient({
 		chain.eq = vi.fn(() => chain);
 		chain.order = vi.fn(() => chain);
 		chain.range = vi.fn(() =>
-			Promise.resolve({ data: posts, count: postsCount, error: null }),
+			Promise.resolve({
+				data: postsError ? null : posts,
+				count: postsError ? null : postsCount,
+				error: postsError,
+			}),
 		);
 		// Awaiting the builder directly (the HEAD count path used by
 		// getCategoryPublishedCount) resolves to the same {count} shape.
@@ -268,6 +274,43 @@ describe("BlogCategoryPage (server component)", () => {
 	it("renders NewsletterSignup", async () => {
 		render(await renderPage("software-comparisons"));
 		expect(screen.getByTestId("newsletter-signup")).toBeInTheDocument();
+	});
+
+	it("returns notFound() for an out-of-range page (PGRST103)", async () => {
+		mockBlogAnonClient.mockReturnValue(
+			makeClient({
+				postsError: {
+					code: "PGRST103",
+					message: "Requested range not satisfiable",
+				},
+			}),
+		);
+		mockGetBlogCategories.mockResolvedValue(mockCategories);
+		await expect(
+			BlogCategoryPage({
+				params: Promise.resolve({ category: "software-comparisons" }),
+				searchParams: Promise.resolve({ page: "9999" }),
+			}),
+		).rejects.toMatchObject({
+			message: expect.stringContaining("NEXT_NOT_FOUND"),
+		});
+		expect(mockNotFound).toHaveBeenCalled();
+	});
+
+	it("throws (surfaces to error boundary) on a generic posts-query error", async () => {
+		mockBlogAnonClient.mockReturnValue(
+			makeClient({ postsError: { code: "XX000", message: "boom" } }),
+		);
+		mockGetBlogCategories.mockResolvedValue(mockCategories);
+		await expect(
+			BlogCategoryPage({
+				params: Promise.resolve({ category: "software-comparisons" }),
+				searchParams: Promise.resolve({}),
+			}),
+		).rejects.toMatchObject({
+			message: expect.stringContaining("boom"),
+		});
+		expect(mockNotFound).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/app/blog/category/[category]/page.tsx
+++ b/src/app/blog/category/[category]/page.tsx
@@ -119,6 +119,25 @@ export default async function BlogCategoryPage({
 		.order("published_at", { ascending: false })
 		.range(offset, offset + PAGE_LIMIT - 1);
 
+	// An out-of-range ?page=N (offset past the last row) makes PostgREST return
+	// 416 "Requested range not satisfiable" (code PGRST103) — a crawler probing
+	// a page beyond the last, not a server error. Return a real 404 so crawlers
+	// drop the URL instead of soft-rendering a false "0 articles" empty state.
+	// Mirrors blog/page.tsx; notFound() throws NEXT_NOT_FOUND, which propagates.
+	const rangeCode = (postsResult.error as { code?: string } | null)?.code;
+	if (
+		rangeCode === "PGRST103" ||
+		/range not satisfiable/i.test(postsResult.error?.message ?? "")
+	) {
+		notFound();
+	}
+
+	// Any other query error surfaces to blog/error.tsx instead of being silently
+	// swallowed into an empty state.
+	if (postsResult.error) {
+		throw new Error(postsResult.error.message);
+	}
+
 	const posts = (postsResult.data ?? []) as BlogListItem[];
 	const total = postsResult.count ?? 0;
 	const totalPages = Math.max(1, Math.ceil(total / PAGE_LIMIT));

--- a/src/app/compare/[competitor]/compare-data.ts
+++ b/src/app/compare/[competitor]/compare-data.ts
@@ -19,7 +19,7 @@ export const COMPETITORS: Record<string, CompetitorData> = {
 	buildium: {
 		name: "Buildium",
 		slug: "buildium",
-		blogSlug: "tenantflow-vs-buildium-comparison",
+		blogSlug: "buildium-vs-doorloop-vs-tenantflow-2026",
 		tagline: "The Modern Buildium Alternative",
 		description:
 			"See why landlords are switching from Buildium to TenantFlow for lower costs, modern features, and a better tenant experience.",
@@ -122,7 +122,7 @@ export const COMPETITORS: Record<string, CompetitorData> = {
 	appfolio: {
 		name: "AppFolio",
 		slug: "appfolio",
-		blogSlug: "tenantflow-vs-appfolio-comparison",
+		blogSlug: "appfolio-alternatives-under-25-month-for-first-time-landlords",
 		tagline: "The AppFolio Alternative for Landlords",
 		description:
 			"AppFolio requires 50+ units and $298/month minimum. TenantFlow starts at $19/month with no minimums. Compare features and pricing.",
@@ -251,7 +251,8 @@ export const COMPETITORS: Record<string, CompetitorData> = {
 	rentredi: {
 		name: "RentRedi",
 		slug: "rentredi",
-		blogSlug: "tenantflow-vs-rentredi-comparison",
+		blogSlug:
+			"rentredi-alternatives-under-30-month-for-budget-conscious-landlords",
 		tagline: "TenantFlow vs RentRedi: More Features, Fair Price",
 		description:
 			"RentRedi is cheap but basic. TenantFlow adds advanced reporting, visual workflows, and lease management for just $10 more per month.",

--- a/src/app/features/__tests__/page.test.ts
+++ b/src/app/features/__tests__/page.test.ts
@@ -97,16 +97,18 @@ describe("/api/og/features/route.tsx — SEO-02 OG route contract", () => {
 		expect(source).toMatch(/height:\s*630/);
 	});
 
-	it("uses only oklch() color literals, no hex", async () => {
+	it("uses only hsl() color literals — no oklch (satori renders it black), no hex", async () => {
 		const { readFileSync } = await import("node:fs");
 		const { resolve } = await import("node:path");
 		const source = readFileSync(
 			resolve(__dirname, "../../api/og/features/route.tsx"),
 			"utf8",
 		);
-		// oklch present
-		expect(source).toMatch(/oklch\(/);
-		// no hex colors (any length)
+		// MKT-01: satori does not support oklch (renders it as solid black), so the
+		// OG route must use hsl() literals only.
+		expect(source).toMatch(/hsl\(/);
+		// no oklch in a style string (comments may mention it) + no hex colors
+		expect(source).not.toMatch(/["'`][^"'`]*oklch\(/);
 		expect(source).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
 	});
 });

--- a/src/app/search/page.test.tsx
+++ b/src/app/search/page.test.tsx
@@ -141,6 +141,25 @@ describe("SearchPage (server component)", () => {
 		expect(orArg).toContain(`title.ilike."%${escapeOrValue(q)}%"`);
 	});
 
+	it("coerces a repeated ?q= (string[]) to its first value instead of 500ing", async () => {
+		// Next.js returns a string[] for a repeated param; normalizeSearchInput
+		// calls .trim(), so an array would throw a 500 on this public route.
+		mockBlogAnonClient.mockReturnValue(
+			makeClient({ data: mockPosts, error: null }),
+		);
+		const { container } = render(
+			await SearchPage({
+				searchParams: Promise.resolve({ q: ["lease", "ignored"] }),
+			}),
+		);
+		// It ran (no throw) and used the first value.
+		expect(screen.getAllByTestId("blog-card")).toHaveLength(2);
+		const input = container.querySelector("input[name='q']");
+		expect(input).toHaveValue("lease");
+		const orArg = orSpy.mock.calls[0]?.[0] as string;
+		expect(orArg).toContain('title.ilike."%lease%"');
+	});
+
 	it("renders the no-results Empty state when a query matches zero rows", async () => {
 		mockBlogAnonClient.mockReturnValue(makeClient({ data: [], error: null }));
 

--- a/src/app/search/page.test.tsx
+++ b/src/app/search/page.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Public Blog Search Page Tests (Server Component / RSC pattern)
+ *
+ * Tests the MKT-04 rewrite: /search reads searchParams.q, runs a published-blog
+ * ilike search via blogAnonClient (escaped .or() term), renders a BlogCard grid
+ * for hits, the Empty compound for the no-query / no-matches states, uses a
+ * name="q" GET form matching the homepage SearchAction, and stays noindex.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockBlogAnonClient = vi.hoisted(() => vi.fn());
+const orSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("#lib/blog/blog-queries", () => ({
+	blogAnonClient: mockBlogAnonClient,
+}));
+
+vi.mock("#components/blog/blog-card", () => ({
+	BlogCard: ({ post }: { post: { id: string; title: string } }) => (
+		<div data-testid="blog-card" data-post-id={post.id}>
+			{post.title}
+		</div>
+	),
+}));
+
+vi.mock("#components/layout/page-layout", () => ({
+	PageLayout: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="page-layout">{children}</div>
+	),
+}));
+
+import type { BlogListItem } from "#hooks/api/query-keys/blog-keys";
+import { escapeOrValue } from "#lib/sanitize-search";
+import SearchPage, { metadata } from "./page";
+
+const mockPosts: BlogListItem[] = [
+	{
+		id: "post-1",
+		title: "How to Write a Solid Residential Lease",
+		slug: "solid-residential-lease",
+		excerpt: "The clauses every landlord lease needs.",
+		published_at: "2026-02-15T10:00:00Z",
+		category: "lease-law",
+		reading_time: 8,
+		featured_image: null,
+		author_user_id: "user-1",
+		status: "published",
+		tags: ["leases"],
+	},
+	{
+		id: "post-2",
+		title: "Lease Renewal Checklist",
+		slug: "lease-renewal-checklist",
+		excerpt: "Renew without the headaches.",
+		published_at: "2026-02-10T10:00:00Z",
+		category: "lease-law",
+		reading_time: 5,
+		featured_image: null,
+		author_user_id: "user-1",
+		status: "published",
+		tags: ["leases"],
+	},
+];
+
+interface QueryResult {
+	data: BlogListItem[] | null;
+	error: { message: string } | null;
+}
+
+/**
+ * Builder chain mirroring the search query:
+ *   from(...).select(...).eq(...).or(...).order(...).limit(24)
+ * Terminates (resolves the result) on `.limit`. `.or` records its argument via
+ * the shared orSpy so tests can assert the escaped filter string.
+ */
+function makeClient(result: QueryResult) {
+	const from = vi.fn(() => {
+		const chain: Record<string, unknown> = {};
+		chain.select = vi.fn(() => chain);
+		chain.eq = vi.fn(() => chain);
+		chain.or = vi.fn((arg: string) => {
+			orSpy(arg);
+			return chain;
+		});
+		chain.order = vi.fn(() => chain);
+		chain.limit = vi.fn(() => Promise.resolve(result));
+		return chain;
+	});
+	return { from };
+}
+
+describe("SearchPage (server component)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the Empty prompt and skips the DB call when q is absent", async () => {
+		render(await SearchPage({ searchParams: Promise.resolve({}) }));
+
+		expect(screen.getByText("Start searching")).toBeInTheDocument();
+		expect(screen.queryByTestId("blog-card")).not.toBeInTheDocument();
+		// No query -> no PostgREST round-trip at all.
+		expect(mockBlogAnonClient).not.toHaveBeenCalled();
+		expect(orSpy).not.toHaveBeenCalled();
+	});
+
+	it("renders a BlogCard per matching row with a name='q' GET form and escaped .or() term", async () => {
+		mockBlogAnonClient.mockReturnValue(
+			makeClient({ data: mockPosts, error: null }),
+		);
+		// A quote makes the escaping non-trivial: the raw value stays in the input
+		// but the .or() term is backslash-escaped.
+		const q = 'lease"guide';
+
+		const { container } = render(
+			await SearchPage({ searchParams: Promise.resolve({ q }) }),
+		);
+
+		const cards = screen.getAllByTestId("blog-card");
+		expect(cards).toHaveLength(2);
+		expect(cards[0]).toHaveTextContent(
+			"How to Write a Solid Residential Lease",
+		);
+
+		// Form is a GET to /search with the name="q" input the SearchAction targets.
+		const form = container.querySelector("form");
+		expect(form?.method).toBe("get");
+		expect(form?.getAttribute("action")).toBe("/search");
+		const input = screen.getByRole("searchbox");
+		expect(input).toHaveAttribute("name", "q");
+		expect(input).toHaveValue(q);
+
+		// The .or() argument is the escaped, quote-wrapped filter string.
+		const orArg = orSpy.mock.calls[0]?.[0] as string;
+		expect(orArg).toContain("title.ilike.");
+		expect(orArg).toContain(escapeOrValue(q));
+		expect(orArg).toContain(`title.ilike."%${escapeOrValue(q)}%"`);
+	});
+
+	it("renders the no-results Empty state when a query matches zero rows", async () => {
+		mockBlogAnonClient.mockReturnValue(makeClient({ data: [], error: null }));
+
+		render(await SearchPage({ searchParams: Promise.resolve({ q: "zzzzz" }) }));
+
+		expect(screen.getByText(/No results for/)).toBeInTheDocument();
+		expect(screen.queryByTestId("blog-card")).not.toBeInTheDocument();
+	});
+
+	it("throws when the search query errors", async () => {
+		mockBlogAnonClient.mockReturnValue(
+			makeClient({ data: null, error: { message: "boom" } }),
+		);
+
+		await expect(
+			SearchPage({ searchParams: Promise.resolve({ q: "lease" }) }),
+		).rejects.toMatchObject({
+			message: expect.stringContaining("boom"),
+		});
+	});
+
+	it("stays noindex (SearchAction results page is not indexable)", () => {
+		expect(metadata.robots).toBe("noindex, follow");
+	});
+});

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,173 +1,135 @@
-import { FileText, Filter, FolderOpen, Search, Users } from "lucide-react";
+import { Search } from "lucide-react";
+import { BlogCard } from "#components/blog/blog-card";
 import { PageLayout } from "#components/layout/page-layout";
-import { Badge } from "#components/ui/badge";
 import { Button } from "#components/ui/button";
 import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "#components/ui/card";
+	Empty,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "#components/ui/empty";
 import { Input } from "#components/ui/input";
+import type { BlogListItem } from "#hooks/api/query-keys/blog-keys";
+import { blogAnonClient } from "#lib/blog/blog-queries";
+import { escapeOrValue, normalizeSearchInput } from "#lib/sanitize-search";
 import { createPageMetadata } from "#lib/seo/page-metadata";
 
+// Same column convention as blog/page.tsx + the category page. Defined locally
+// per CLAUDE.md (no barrel/shared re-export).
+const BLOG_LIST_COLUMNS =
+	"id, title, slug, excerpt, published_at, category, reading_time, featured_image, author_user_id, status, tags";
+
 export const metadata = createPageMetadata({
-	title: "Search",
+	title: "Search the Blog",
 	description:
-		"Search properties, tenants, leases, and documents across your TenantFlow portfolio.",
+		"Search TenantFlow's property management guides for independent landlords — leases, maintenance, tax season, and the document vault.",
 	path: "/search",
+	// Public search surface, but a thin query-driven results page has no
+	// standalone content value — keep it out of the index while still serving
+	// the homepage WebSite SearchAction contract.
 	noindex: true,
 });
 
-export default function SearchPage() {
+export default async function SearchPage({
+	searchParams,
+}: {
+	searchParams: Promise<{ q?: string }>;
+}) {
+	const { q } = await searchParams;
+	const query = normalizeSearchInput(q ?? "");
+
+	let posts: BlogListItem[] = [];
+
+	if (query) {
+		// The `.or()` string is parsed by PostgREST, so the value MUST be
+		// double-quoted at the call site and escaped via escapeOrValue (see
+		// sanitize-search.ts). `content` is filterable even though it is not
+		// selected — RLS gates rows by status, not columns.
+		const escaped = escapeOrValue(query);
+		const { data, error } = await blogAnonClient()
+			.from("blogs")
+			.select(BLOG_LIST_COLUMNS)
+			.eq("status", "published")
+			.or(
+				`title.ilike."%${escaped}%",excerpt.ilike."%${escaped}%",content.ilike."%${escaped}%"`,
+			)
+			.order("published_at", { ascending: false })
+			.limit(24);
+
+		if (error) {
+			throw new Error(error.message);
+		}
+
+		posts = (data ?? []) as BlogListItem[];
+	}
+
 	return (
 		<PageLayout containerClass="max-w-6xl py-8">
 			<div className="flex flex-col gap-6">
-				{/* Search Header */}
-				<div className="flex flex-col gap-4">
-					<div className="flex flex-col gap-2">
-						<h1 className="typography-h2">Search TenantFlow</h1>
-						<p className="text-muted-foreground">
-							Find properties, tenants, leases, and documents across your
-							portfolio
-						</p>
-					</div>
-
-					{/* Search Bar */}
-					<div className="flex gap-2">
-						<div className="relative flex-1">
-							<Search className="absolute left-3 top-1/2 transform translate-y-[-50%] text-muted-foreground size-4" />
-							<Input
-								id="global-search"
-								name="search"
-								placeholder="Search properties, tenants, leases..."
-								className="pl-10 pr-4 py-3 text-base"
-								aria-label="Global search"
-							/>
-						</div>
-						<Button variant="outline" size="lg" className="px-6">
-							<Filter className="size-4 mr-2" />
-							Filters
-						</Button>
-						<Button size="lg" className="px-6">
-							<Search className="size-4 mr-2" />
-							Search
-						</Button>
-					</div>
+				<div className="flex flex-col gap-2">
+					<h1 className="typography-h2">Search the blog</h1>
+					<p className="text-muted-foreground">
+						Find guides for independent landlords — leases, maintenance, tax
+						season, and the document vault.
+					</p>
 				</div>
 
-				{/* Quick Searches */}
-				<div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-					<Card className="cursor-pointer hover:bg-muted/50 transition-colors">
-						<CardHeader className="pb-3">
-							<div className="flex items-center gap-2">
-								<FolderOpen className="size-5 text-primary" />
-								<CardTitle className="text-base">Search Properties</CardTitle>
-							</div>
-							<CardDescription>
-								Find properties by name, address, or type
-							</CardDescription>
-						</CardHeader>
-					</Card>
-
-					<Card className="cursor-pointer hover:bg-muted/50 transition-colors">
-						<CardHeader className="pb-3">
-							<div className="flex items-center gap-2">
-								<Users className="size-5 text-primary" />
-								<CardTitle className="text-base">Search Tenants</CardTitle>
-							</div>
-							<CardDescription>
-								Look up tenants by name, email, or phone
-							</CardDescription>
-						</CardHeader>
-					</Card>
-
-					<Card className="cursor-pointer hover:bg-muted/50 transition-colors">
-						<CardHeader className="pb-3">
-							<div className="flex items-center gap-2">
-								<FileText className="size-5 text-primary" />
-								<CardTitle className="text-base">Search Leases</CardTitle>
-							</div>
-							<CardDescription>
-								Find leases by status, dates, or terms
-							</CardDescription>
-						</CardHeader>
-					</Card>
-				</div>
-
-				{/* Recent Searches */}
-				<div className="flex flex-col gap-4">
-					<h2 className="typography-h4">Recent Searches</h2>
-					<div className="flex flex-wrap gap-2">
-						<Badge
-							variant="secondary"
-							className="cursor-pointer hover:bg-secondary/80"
-						>
-							&quot;Sunset Gardens&quot;
-						</Badge>
-						<Badge
-							variant="secondary"
-							className="cursor-pointer hover:bg-secondary/80"
-						>
-							&quot;Active Leases&quot;
-						</Badge>
-						<Badge
-							variant="secondary"
-							className="cursor-pointer hover:bg-secondary/80"
-						>
-							&quot;Downtown Loft&quot;
-						</Badge>
-						<Badge
-							variant="secondary"
-							className="cursor-pointer hover:bg-secondary/80"
-						>
-							&quot;Maintenance Requests&quot;
-						</Badge>
+				<form method="GET" action="/search" className="flex gap-2">
+					<div className="relative flex-1">
+						<Search
+							aria-hidden="true"
+							className="absolute left-3 top-1/2 size-4 translate-y-[-50%] text-muted-foreground"
+						/>
+						<Input
+							id="blog-search"
+							name="q"
+							type="search"
+							defaultValue={query}
+							placeholder="Search articles..."
+							className="pl-10"
+							aria-label="Search the blog"
+						/>
 					</div>
-				</div>
+					<Button type="submit" size="lg" className="px-6">
+						<Search className="size-4" />
+						Search
+					</Button>
+				</form>
 
-				{/* Search Tips */}
-				<Card>
-					<CardHeader>
-						<CardTitle>Search Tips</CardTitle>
-						<CardDescription>
-							Get better results with these search techniques
-						</CardDescription>
-					</CardHeader>
-					<CardContent>
-						<div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-							<div>
-								<strong>Property Search:</strong>
-								<p className="text-muted-foreground mt-1">
-									Try searching by property name, address, or type (e.g.,
-									&quot;apartment&quot;, &quot;commercial&quot;)
-								</p>
-							</div>
-							<div>
-								<strong>Tenant Search:</strong>
-								<p className="text-muted-foreground mt-1">
-									Search by full name, email address, or phone number for best
-									results
-								</p>
-							</div>
-							<div>
-								<strong>Lease Search:</strong>
-								<p className="text-muted-foreground mt-1">
-									Use status filters like &quot;active&quot;,
-									&quot;expired&quot;, or search by date ranges
-								</p>
-							</div>
-							<div>
-								<strong>Advanced Search:</strong>
-								<p className="text-muted-foreground mt-1">
-									Use quotes for exact phrases and filters to narrow down
-									results
-								</p>
-							</div>
-						</div>
-					</CardContent>
-				</Card>
+				{query === "" ? (
+					<Empty>
+						<EmptyHeader>
+							<EmptyMedia variant="icon">
+								<Search />
+							</EmptyMedia>
+							<EmptyTitle>Start searching</EmptyTitle>
+							<EmptyDescription>
+								Enter a keyword above to search our property management
+								articles.
+							</EmptyDescription>
+						</EmptyHeader>
+					</Empty>
+				) : posts.length === 0 ? (
+					<Empty>
+						<EmptyHeader>
+							<EmptyMedia variant="icon">
+								<Search />
+							</EmptyMedia>
+							<EmptyTitle>No results for &ldquo;{query}&rdquo;</EmptyTitle>
+							<EmptyDescription>
+								We couldn&rsquo;t find any articles matching your search. Try a
+								different keyword.
+							</EmptyDescription>
+						</EmptyHeader>
+					</Empty>
+				) : (
+					<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+						{posts.map((post) => (
+							<BlogCard key={post.id} post={post} />
+						))}
+					</div>
+				)}
 			</div>
 		</PageLayout>
 	);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -34,10 +34,14 @@ export const metadata = createPageMetadata({
 export default async function SearchPage({
 	searchParams,
 }: {
-	searchParams: Promise<{ q?: string }>;
+	searchParams: Promise<{ q?: string | string[] }>;
 }) {
 	const { q } = await searchParams;
-	const query = normalizeSearchInput(q ?? "");
+	// Next.js returns a string[] for a repeated ?q= param; coerce to a scalar so
+	// normalizeSearchInput (which calls .trim()) never receives an array — a
+	// crawler hitting /search?q=a&q=b must not 500 this public route.
+	const raw = Array.isArray(q) ? q[0] : q;
+	const query = normalizeSearchInput(raw ?? "");
 
 	let posts: BlogListItem[] = [];
 

--- a/src/components/blog/blog-pagination.test.tsx
+++ b/src/components/blog/blog-pagination.test.tsx
@@ -4,13 +4,14 @@
  * The pagination controls are REAL `<Link>` anchors carrying `?page=N`
  * hrefs so the paginated URLs exist in the SSR HTML and are crawlable
  * (page 2+ posts were crawl orphans when these were hrefless `<button>`s).
- * The onClick still drives the instant nuqs client-side swap.
+ * An enabled click performs real navigation (no nuqs hijack) so the Server
+ * Component re-runs and the post grid changes; the onClick is a guard that
+ * only preventDefaults a disabled boundary link.
  *
  * @vitest-environment jsdom
  */
 
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSetPage = vi.hoisted(() => vi.fn());
@@ -115,29 +116,33 @@ describe("BlogPagination", () => {
 		expect(nav).toBeInTheDocument();
 	});
 
-	it("calls setPage with next value on next click", async () => {
-		const user = userEvent.setup();
+	it("lets an enabled next click navigate (no setPage hijack, default not prevented)", () => {
+		mockPage.value = 3;
 		render(<BlogPagination totalPages={5} />);
 		const next = screen.getByRole("link", { name: "Next page" });
-		await user.click(next);
-		expect(mockSetPage).toHaveBeenCalledWith(2);
-	});
-
-	it("calls setPage with null when navigating back to page 1", async () => {
-		mockPage.value = 2;
-		const user = userEvent.setup();
-		render(<BlogPagination totalPages={5} />);
-		const prev = screen.getByRole("link", { name: "Previous page" });
-		await user.click(prev);
-		expect(mockSetPage).toHaveBeenCalledWith(null);
-	});
-
-	it("does not call setPage when clicking a disabled boundary link", async () => {
-		const user = userEvent.setup();
-		render(<BlogPagination totalPages={5} />);
-		const prev = screen.getByRole("link", { name: "Previous page" });
-		await user.click(prev);
+		const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+		next.dispatchEvent(event);
 		expect(mockSetPage).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("lets an enabled prev click navigate (no setPage hijack, default not prevented)", () => {
+		mockPage.value = 2;
+		render(<BlogPagination totalPages={5} />);
+		const prev = screen.getByRole("link", { name: "Previous page" });
+		const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+		prev.dispatchEvent(event);
+		expect(mockSetPage).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("preventDefaults a disabled boundary link and never calls setPage", () => {
+		render(<BlogPagination totalPages={5} />);
+		const prev = screen.getByRole("link", { name: "Previous page" });
+		const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+		prev.dispatchEvent(event);
+		expect(mockSetPage).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(true);
 	});
 
 	it("applies custom className", () => {

--- a/src/components/blog/blog-pagination.tsx
+++ b/src/components/blog/blog-pagination.tsx
@@ -13,8 +13,7 @@ interface BlogPaginationProps {
 
 /**
  * Build a `?page=N` href for the current pathname. Page 1 drops the param
- * entirely so the canonical first page stays at the bare path (mirrors the
- * nuqs `null` default the click handler sets).
+ * entirely so the canonical first page stays at the bare path.
  */
 function pageHref(pathname: string, page: number): string {
 	return page <= 1 ? pathname : `${pathname}?page=${page}`;
@@ -22,7 +21,9 @@ function pageHref(pathname: string, page: number): string {
 
 export function BlogPagination({ totalPages, className }: BlogPaginationProps) {
 	const pathname = usePathname();
-	const [page, setPage] = useQueryState("page", parseAsInteger.withDefault(1));
+	// Read-only: the reactive "Page X of Y" label tracks the URL `?page` after a
+	// real navigation. No setter — navigation is driven by the <Link> hrefs.
+	const [page] = useQueryState("page", parseAsInteger.withDefault(1));
 
 	const currentPage = Math.max(1, Math.min(page, totalPages));
 
@@ -45,9 +46,12 @@ export function BlogPagination({ totalPages, className }: BlogPaginationProps) {
 			className={cn("flex items-center justify-center gap-4", className)}
 		>
 			{/* Real anchors so the page>1 URLs exist in the SSR HTML and are
-			    crawlable — the onClick keeps the nuqs instant client-side swap.
-			    aria-disabled (not the `disabled` attribute, invalid on <a>)
-			    plus pointer-events-none gate the boundary pages. */}
+			    crawlable — a click performs real <Link> navigation, which
+			    re-runs the Server Component so the post grid actually changes.
+			    The onClick is a guard only: it preventDefaults nothing but a
+			    disabled boundary link. aria-disabled (not the `disabled`
+			    attribute, invalid on <a>) plus pointer-events-none gate the
+			    boundary pages. */}
 			<Link
 				href={pageHref(pathname, prevPage)}
 				className={cn(linkClasses, !hasPrev && disabledClasses)}
@@ -55,12 +59,7 @@ export function BlogPagination({ totalPages, className }: BlogPaginationProps) {
 				aria-disabled={!hasPrev}
 				tabIndex={hasPrev ? undefined : -1}
 				onClick={(e) => {
-					if (!hasPrev) {
-						e.preventDefault();
-						return;
-					}
-					e.preventDefault();
-					setPage(prevPage === 1 ? null : prevPage);
+					if (!hasPrev) e.preventDefault();
 				}}
 			>
 				<ChevronLeft className="size-4" />
@@ -77,12 +76,7 @@ export function BlogPagination({ totalPages, className }: BlogPaginationProps) {
 				aria-disabled={!hasNext}
 				tabIndex={hasNext ? undefined : -1}
 				onClick={(e) => {
-					if (!hasNext) {
-						e.preventDefault();
-						return;
-					}
-					e.preventDefault();
-					setPage(nextPage);
+					if (!hasNext) e.preventDefault();
 				}}
 			>
 				<ChevronRight className="size-4" />

--- a/src/components/blog/related-articles.test.tsx
+++ b/src/components/blog/related-articles.test.tsx
@@ -48,7 +48,7 @@ function setupSupabaseChain(returnData: BlogListItem[] | null) {
 const mockPost1: BlogListItem = {
 	id: "post-1",
 	title: "Seasonal Maintenance Guide",
-	slug: "preventive-maintenance-checklist-rental-properties-seasonal-guide",
+	slug: "twelve-month-preventive-maintenance-calendar-rentals",
 	excerpt: "Keep your rental property in top shape.",
 	published_at: "2026-01-01T00:00:00Z",
 	category: "Maintenance",
@@ -62,7 +62,7 @@ const mockPost1: BlogListItem = {
 const mockPost2: BlogListItem = {
 	id: "post-2",
 	title: "Tax Deductions for Landlords",
-	slug: "landlord-tax-deductions-missing-2025",
+	slug: "mortgage-interest-deduction-rental-property-schedule-e",
 	excerpt: "Stop leaving money on the table.",
 	published_at: "2026-02-01T00:00:00Z",
 	category: "Finance",

--- a/src/lib/content-links.test.ts
+++ b/src/lib/content-links.test.ts
@@ -37,48 +37,66 @@ describe("content-links", () => {
 			);
 		});
 
-		it("seasonal-maintenance-checklist contains 'preventive-maintenance-checklist-rental-properties-seasonal-guide'", () => {
-			expect(RESOURCE_TO_BLOGS["seasonal-maintenance-checklist"]).toContain(
-				"preventive-maintenance-checklist-rental-properties-seasonal-guide",
-			);
+		it("seasonal-maintenance-checklist maps to its 3 live maintenance slugs", () => {
+			expect(RESOURCE_TO_BLOGS["seasonal-maintenance-checklist"]).toEqual([
+				"twelve-month-preventive-maintenance-calendar-rentals",
+				"spring-rental-maintenance-checklist",
+				"fall-rental-maintenance-checklist",
+			]);
 		});
 
-		it("landlord-tax-deduction-tracker contains 'landlord-tax-deductions-missing-2025'", () => {
-			expect(RESOURCE_TO_BLOGS["landlord-tax-deduction-tracker"]).toContain(
-				"landlord-tax-deductions-missing-2025",
-			);
+		it("landlord-tax-deduction-tracker maps to its 3 live tax-deduction slugs", () => {
+			expect(RESOURCE_TO_BLOGS["landlord-tax-deduction-tracker"]).toEqual([
+				"mortgage-interest-deduction-rental-property-schedule-e",
+				"repairs-deduction-schedule-e-line-14",
+				"legal-accounting-fees-landlord-deduction",
+			]);
 		});
 
-		it("security-deposit-reference-card contains 'security-deposit-laws-by-state-2025'", () => {
-			expect(RESOURCE_TO_BLOGS["security-deposit-reference-card"]).toContain(
-				"security-deposit-laws-by-state-2025",
-			);
+		it("security-deposit-reference-card maps to its live security-deposit slug", () => {
+			expect(RESOURCE_TO_BLOGS["security-deposit-reference-card"]).toEqual([
+				"security-deposit-deadlines-and-caps-all-50-states",
+			]);
 		});
 	});
 
 	describe("BLOG_TO_RESOURCE", () => {
-		it("has exactly 3 entries", () => {
-			expect(Object.keys(BLOG_TO_RESOURCE)).toHaveLength(3);
+		it("has exactly 7 entries", () => {
+			expect(Object.keys(BLOG_TO_RESOURCE)).toHaveLength(7);
 		});
 
-		it("maps 'preventive-maintenance-checklist-rental-properties-seasonal-guide' to 'seasonal-maintenance-checklist'", () => {
+		it("maps every seasonal-maintenance slug to 'seasonal-maintenance-checklist'", () => {
 			expect(
 				BLOG_TO_RESOURCE[
-					"preventive-maintenance-checklist-rental-properties-seasonal-guide"
+					"twelve-month-preventive-maintenance-calendar-rentals"
 				],
 			).toBe("seasonal-maintenance-checklist");
+			expect(BLOG_TO_RESOURCE["spring-rental-maintenance-checklist"]).toBe(
+				"seasonal-maintenance-checklist",
+			);
+			expect(BLOG_TO_RESOURCE["fall-rental-maintenance-checklist"]).toBe(
+				"seasonal-maintenance-checklist",
+			);
 		});
 
-		it("maps 'landlord-tax-deductions-missing-2025' to 'landlord-tax-deduction-tracker'", () => {
-			expect(BLOG_TO_RESOURCE["landlord-tax-deductions-missing-2025"]).toBe(
+		it("maps every tax-deduction slug to 'landlord-tax-deduction-tracker'", () => {
+			expect(
+				BLOG_TO_RESOURCE[
+					"mortgage-interest-deduction-rental-property-schedule-e"
+				],
+			).toBe("landlord-tax-deduction-tracker");
+			expect(BLOG_TO_RESOURCE["repairs-deduction-schedule-e-line-14"]).toBe(
+				"landlord-tax-deduction-tracker",
+			);
+			expect(BLOG_TO_RESOURCE["legal-accounting-fees-landlord-deduction"]).toBe(
 				"landlord-tax-deduction-tracker",
 			);
 		});
 
-		it("maps 'security-deposit-laws-by-state-2025' to 'security-deposit-reference-card'", () => {
-			expect(BLOG_TO_RESOURCE["security-deposit-laws-by-state-2025"]).toBe(
-				"security-deposit-reference-card",
-			);
+		it("maps the security-deposit slug to 'security-deposit-reference-card'", () => {
+			expect(
+				BLOG_TO_RESOURCE["security-deposit-deadlines-and-caps-all-50-states"],
+			).toBe("security-deposit-reference-card");
 		});
 	});
 
@@ -87,22 +105,26 @@ describe("content-links", () => {
 			expect(Object.keys(BLOG_TO_COMPETITOR)).toHaveLength(3);
 		});
 
-		it("maps 'tenantflow-vs-buildium-comparison' to 'buildium'", () => {
-			expect(BLOG_TO_COMPETITOR["tenantflow-vs-buildium-comparison"]).toBe(
-				"buildium",
-			);
+		it("maps 'buildium-vs-doorloop-vs-tenantflow-2026' to 'buildium'", () => {
+			expect(
+				BLOG_TO_COMPETITOR["buildium-vs-doorloop-vs-tenantflow-2026"],
+			).toBe("buildium");
 		});
 
-		it("maps 'tenantflow-vs-appfolio-comparison' to 'appfolio'", () => {
-			expect(BLOG_TO_COMPETITOR["tenantflow-vs-appfolio-comparison"]).toBe(
-				"appfolio",
-			);
+		it("maps the appfolio-alternatives slug to 'appfolio'", () => {
+			expect(
+				BLOG_TO_COMPETITOR[
+					"appfolio-alternatives-under-25-month-for-first-time-landlords"
+				],
+			).toBe("appfolio");
 		});
 
-		it("maps 'tenantflow-vs-rentredi-comparison' to 'rentredi'", () => {
-			expect(BLOG_TO_COMPETITOR["tenantflow-vs-rentredi-comparison"]).toBe(
-				"rentredi",
-			);
+		it("maps the rentredi-alternatives slug to 'rentredi'", () => {
+			expect(
+				BLOG_TO_COMPETITOR[
+					"rentredi-alternatives-under-30-month-for-budget-conscious-landlords"
+				],
+			).toBe("rentredi");
 		});
 	});
 });

--- a/src/lib/content-links.ts
+++ b/src/lib/content-links.ts
@@ -17,10 +17,18 @@ import { COMPETITORS } from "#app/compare/[competitor]/compare-data";
  */
 export const RESOURCE_TO_BLOGS: Record<string, string[]> = {
 	"seasonal-maintenance-checklist": [
-		"preventive-maintenance-checklist-rental-properties-seasonal-guide",
+		"twelve-month-preventive-maintenance-calendar-rentals",
+		"spring-rental-maintenance-checklist",
+		"fall-rental-maintenance-checklist",
 	],
-	"landlord-tax-deduction-tracker": ["landlord-tax-deductions-missing-2025"],
-	"security-deposit-reference-card": ["security-deposit-laws-by-state-2025"],
+	"landlord-tax-deduction-tracker": [
+		"mortgage-interest-deduction-rental-property-schedule-e",
+		"repairs-deduction-schedule-e-line-14",
+		"legal-accounting-fees-landlord-deduction",
+	],
+	"security-deposit-reference-card": [
+		"security-deposit-deadlines-and-caps-all-50-states",
+	],
 };
 
 /**

--- a/tests/integration/content-links-slugs.test.ts
+++ b/tests/integration/content-links-slugs.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Cross-link slug-integrity guard (MKT-05, phase 34-04).
+ *
+ * The compare pages (`/compare/*`) and resource pages (`/resources/*`) surface
+ * "Read the Full Comparison" / "Related Blog Posts" blocks whose targets are
+ * hand-authored blog slugs living in two static config files:
+ *   - `compare-data.ts`  -> `COMPETITORS[k].blogSlug`
+ *   - `content-links.ts` -> `RESOURCE_TO_BLOGS` array values
+ *
+ * `RelatedArticles` filters `.in('slug', slugs).eq('status','published')` and
+ * returns null on zero matches, so a stale slug silently deletes the whole
+ * block (both directions — the reverse maps derive from these two sources).
+ * Unit tests can't hit the DB, so this integration test queries prod `blogs`
+ * and asserts EVERY referenced slug is `published`, naming the offender on
+ * failure. Reads only `slug` of published rows via the public anon key — no
+ * auth, no PII.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { beforeAll, describe, expect, it } from "vitest";
+import { COMPETITORS } from "#app/compare/[competitor]/compare-data";
+import { RESOURCE_TO_BLOGS } from "#lib/content-links";
+
+const SUPABASE_URL = process.env["NEXT_PUBLIC_SUPABASE_URL"];
+const SUPABASE_PUBLISHABLE_KEY =
+	process.env["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"];
+
+const hasEnv = Boolean(SUPABASE_URL && SUPABASE_PUBLISHABLE_KEY);
+
+/** Every blog slug referenced by the compare + resource cross-link config. */
+const REFERENCED_SLUGS: string[] = [
+	...Object.values(RESOURCE_TO_BLOGS).flat(),
+	...Object.values(COMPETITORS)
+		.map((c) => c.blogSlug)
+		.filter((slug): slug is string => Boolean(slug)),
+];
+
+describe.skipIf(!hasEnv)("content-links cross-link slug integrity", () => {
+	const publishedSet = new Set<string>();
+	let queryError: string | null = null;
+
+	beforeAll(async () => {
+		const supabase = createClient(SUPABASE_URL!, SUPABASE_PUBLISHABLE_KEY!);
+		const { data, error } = await supabase
+			.from("blogs")
+			.select("slug")
+			.in("slug", REFERENCED_SLUGS)
+			.eq("status", "published");
+		if (error) {
+			queryError = error.message;
+			return;
+		}
+		for (const row of (data ?? []) as { slug: string }[]) {
+			publishedSet.add(row.slug);
+		}
+	});
+
+	it("queries prod blogs without error", () => {
+		expect(queryError).toBeNull();
+	});
+
+	for (const slug of REFERENCED_SLUGS) {
+		it(`cross-link slug is published: ${slug}`, () => {
+			expect(
+				publishedSet.has(slug),
+				`cross-link slug not published: ${slug}`,
+			).toBe(true);
+		});
+	}
+});

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -13,6 +13,6 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true
 	},
-	"include": ["rls/**/*", "setup/**/*"],
+	"include": ["rls/**/*", "setup/**/*", "content-links-slugs.test.ts"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Phase 34 — Marketing, Blog & SEO Surface (MKT-01..05)

v8.0 "Correctness Restoration" milestone, phase 34. Fixes five public-surface bugs from the 2026-07-02 hunt, under the perfect-PR gate. **No DB migrations** — all frontend/edge/content.

### What's fixed

| Req | Bug | Fix |
|-----|-----|-----|
| MKT-01 | `/pricing`, `/features`, `/compare/*` OG images rendered solid black | satori doesn't support `oklch()` (renders it black) — converted the gradient + text color to the exact `hsl()` equivalents in all 3 routes; **pixel-verified** the PNGs now render the brand gradient. Added an OG-scoped drift guard so a future oklch in an OG route fails CI |
| MKT-02 | Blog/category Next/Prev changed the URL + label but not the posts | blog-pagination hijacked its own `<Link>` anchors (`preventDefault` + shallow-nuqs `setPage`) — dropped the hijack so real navigation re-runs the Server Component |
| MKT-03 | Out-of-range category pages soft-rendered "0 articles" at 200; query errors silently empty | The category page now mirrors the index: `PGRST103` → `notFound()`, other error → throw. Count stays `{count:'exact'}` |
| MKT-04 | Homepage `SearchAction` advertised `/search?q=` but `/search` was a dead stub | Rewrote `/search` as an async server component doing a real sanitized public blog search (`blogAnonClient`, `escapeOrValue`), `<form method="GET">` with `name="q"`, `Empty` states, `noindex` kept — the SearchAction is now truthful |
| MKT-05 | Six cross-link blog slugs were dead → compare/resource sections silently vanished | Repointed all 6 to verified-published posts (both link directions) + re-keyed the 3 `LEAD_MAGNETS` entries; added a prod slug-integrity integration test to guard recurrence |

### Review depth (perfect-PR gate)

5 dimensions (one per MKT), each `review → adversarial-verify`, with an injection check on the new `/search` `.or()` filter (reusing the Phase-32 UIX-03 escaping) and a scope check on the drift guard. [cycles summarized on merge]

### Quality gate

- `bun run typecheck` — clean (0)
- `bun run lint` (biome) — clean
- `bun run test:unit` — **102,425 passing (241 files)**
- OG pixel-verify — pricing/features/compare all render content (not black)
- `content-links-slugs` integration test asserts every cross-link slug is published (CI `rls-security`)

[hudsor01]
