### PR TITLE
fix(v8.0 audit): PROP-05 sibling + 100x money-model overstatement (MONEY-01/02)

### DIFF
--- a/src/app/(owner)/properties/components/__tests__/property-transforms.test.ts
+++ b/src/app/(owner)/properties/components/__tests__/property-transforms.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { Property, Unit } from "#types/core";
+import {
+	calculateSummary,
+	transformToPropertyItem,
+} from "../property-transforms";
+
+// Regression: MONEY-01 — monthlyRevenue must be in whole DOLLARS (rendered with
+// formatCurrency/formatCompactCurrency, which expect dollars). A prior `* 100`
+// overstated the properties-list revenue column 100x.
+
+const property: Property = {
+	acquisition_cost: null,
+	acquisition_date: null,
+	address_line1: "1 Main St",
+	address_line2: null,
+	city: "Austin",
+	country: "US",
+	created_at: "2026-01-01T00:00:00Z",
+	date_sold: null,
+	id: "prop-1",
+	name: "Test Property",
+	owner_user_id: "owner-1",
+	postal_code: "78701",
+	property_type: "multi_family",
+	sale_price: null,
+	search_vector: null,
+	state: "TX",
+	status: "active",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+function unit(overrides: Partial<Unit>): Unit {
+	return {
+		id: "unit-x",
+		property_id: "prop-1",
+		owner_user_id: "owner-1",
+		unit_number: "101",
+		bedrooms: 2,
+		bathrooms: 1,
+		square_feet: 850,
+		rent_amount: 1500,
+		rent_currency: "USD",
+		rent_period: "month",
+		status: "occupied",
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("transformToPropertyItem monthlyRevenue", () => {
+	it("sums occupied units' rent in whole dollars (not 100x)", () => {
+		const units = [
+			unit({ id: "u1", rent_amount: 1500, status: "occupied" }),
+			unit({ id: "u2", rent_amount: 2000, status: "occupied" }),
+			unit({ id: "u3", rent_amount: 1100, status: "available" }), // excluded
+		];
+
+		const item = transformToPropertyItem(property, units, undefined);
+
+		// 1500 + 2000 occupied dollars — NOT 350000 (the old cents-conversion bug).
+		expect(item.monthlyRevenue).toBe(3500);
+	});
+
+	it("is 0 when no units are occupied", () => {
+		const item = transformToPropertyItem(
+			property,
+			[unit({ id: "u1", status: "available" })],
+			undefined,
+		);
+		expect(item.monthlyRevenue).toBe(0);
+	});
+});
+
+describe("calculateSummary totalMonthlyRevenue", () => {
+	it("sums per-property dollar revenue without re-scaling", () => {
+		const a = transformToPropertyItem(
+			property,
+			[unit({ id: "a1", rent_amount: 1500, status: "occupied" })],
+			undefined,
+		);
+		const b = transformToPropertyItem(
+			{ ...property, id: "prop-2" },
+			[unit({ id: "b1", rent_amount: 2500, status: "occupied" })],
+			undefined,
+		);
+
+		expect(calculateSummary([a, b]).totalMonthlyRevenue).toBe(4000);
+	});
+});

--- a/src/app/(owner)/properties/components/property-transforms.ts
+++ b/src/app/(owner)/properties/components/property-transforms.ts
@@ -40,9 +40,12 @@ export function transformToPropertyItem(
 		(u) => u.status === "maintenance",
 	).length;
 	const occupancyRate = totalUnits > 0 ? (occupiedUnits / totalUnits) * 100 : 0;
+	// units.rent_amount is stored in whole dollars; monthlyRevenue is rendered
+	// with formatCurrency/formatCompactCurrency (both dollar-valued), so keep it
+	// in dollars — the prior `* 100` overstated the figure 100x.
 	const monthlyRevenue = safeUnits
 		.filter((u) => u.status === "occupied")
-		.reduce((sum, u) => sum + (u.rent_amount ?? 0) * 100, 0); // Convert to cents
+		.reduce((sum, u) => sum + (u.rent_amount ?? 0), 0);
 
 	return {
 		id: property.id,

--- a/src/app/(owner)/tenants/components/__tests__/tenant-transforms.test.ts
+++ b/src/app/(owner)/tenants/components/__tests__/tenant-transforms.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { TenantWithLeaseInfo } from "#types/core";
+import { transformToTenantSectionDetail } from "../tenant-transforms";
+
+// Regression: MONEY-02 — currentLease.rentAmount must be in whole DOLLARS
+// (rendered with formatCurrency on the tenant detail sheet). A prior `* 100`
+// showed rent 100x too high.
+
+function tenant(
+	currentLease: NonNullable<TenantWithLeaseInfo["currentLease"]>,
+): TenantWithLeaseInfo {
+	return {
+		id: "tenant-1",
+		owner_user_id: "owner-1",
+		status: "active",
+		created_at: "2026-01-01T00:00:00Z",
+		date_of_birth: null,
+		emergency_contact_name: null,
+		emergency_contact_phone: null,
+		emergency_contact_relationship: null,
+		identity_verified: false,
+		ssn_last_four: null,
+		updated_at: "2026-01-01T00:00:00Z",
+		name: "Alice Tenant",
+		email: "alice@example.com",
+		phone: null,
+		first_name: "Alice",
+		last_name: "Tenant",
+		currentLease,
+	};
+}
+
+describe("transformToTenantSectionDetail currentLease.rentAmount", () => {
+	it("carries the lease rent through in whole dollars (not 100x)", () => {
+		const detail = transformToTenantSectionDetail(
+			tenant({
+				id: "lease-1",
+				start_date: "2026-01-01",
+				end_date: "2026-12-31",
+				rent_amount: 1500,
+				security_deposit: 1500,
+				status: "active",
+				primary_tenant_id: "tenant-1",
+				unit_id: "unit-1",
+			}),
+		);
+
+		// 1500 dollars — NOT 150000 (the old cents-conversion bug).
+		expect(detail.currentLease?.rentAmount).toBe(1500);
+	});
+});

--- a/src/app/(owner)/tenants/components/tenant-transforms.ts
+++ b/src/app/(owner)/tenants/components/tenant-transforms.ts
@@ -73,7 +73,10 @@ export function transformToTenantSectionDetail(
 						unitNumber: tenant.unit?.unit_number ?? "",
 						startDate: tenant.currentLease.start_date,
 						endDate: tenant.currentLease.end_date,
-						rentAmount: (tenant.currentLease.rent_amount ?? 0) * 100, // Convert to cents
+						// leases.rent_amount is whole dollars and this is rendered with
+						// formatCurrency (dollar-valued); the prior `* 100` showed rent
+						// 100x too high on the tenant detail sheet.
+						rentAmount: tenant.currentLease.rent_amount ?? 0,
 					},
 				}
 			: {}),

--- a/src/components/properties/__tests__/edit-unit-panel.test.tsx
+++ b/src/components/properties/__tests__/edit-unit-panel.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Unit } from "#types/core";
+import { EditUnitPanel } from "../edit-unit-panel";
+
+vi.mock("#hooks/use-current-user", () => ({
+	useCurrentUser: () => ({
+		user: { id: "user-1", email: "test@example.com" },
+		user_id: "user-1",
+		isAuthenticated: true,
+		isLoading: false,
+		session: {},
+	}),
+}));
+
+const mockMutateAsync = vi.fn();
+vi.mock("#hooks/api/use-unit", () => ({
+	useUpdateUnitMutation: () => ({
+		mutateAsync: mockMutateAsync,
+		isPending: false,
+	}),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+}
+
+const unit: Unit = {
+	id: "unit-1",
+	property_id: "prop-1",
+	owner_user_id: "owner-1",
+	unit_number: "101",
+	bedrooms: 2,
+	bathrooms: 1,
+	square_feet: 850,
+	rent_amount: 1500,
+	rent_currency: "USD",
+	rent_period: "month",
+	status: "available",
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+const defaultProps = {
+	unit,
+	propertyName: "Test Property",
+	open: true,
+	onOpenChange: vi.fn(),
+	onSuccess: vi.fn(),
+};
+
+describe("EditUnitPanel — PROP-05 clearing an optional field persists", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockMutateAsync.mockResolvedValue({ id: "unit-1" });
+	});
+
+	it("sends square_feet: null (not undefined) when the field is cleared", async () => {
+		render(<EditUnitPanel {...defaultProps} />, { wrapper: createWrapper() });
+
+		// Field is pre-filled from the unit; clear it.
+		const squareFeet = screen.getByLabelText(/square feet/i);
+		expect(squareFeet).toHaveValue(850);
+		fireEvent.change(squareFeet, { target: { value: "" } });
+
+		fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => {
+			expect(mockMutateAsync).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: "unit-1",
+					data: expect.objectContaining({ square_feet: null }),
+				}),
+			);
+		});
+	});
+
+	it("preserves an edited square_feet value", async () => {
+		render(<EditUnitPanel {...defaultProps} />, { wrapper: createWrapper() });
+
+		fireEvent.change(screen.getByLabelText(/square feet/i), {
+			target: { value: "900" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => {
+			expect(mockMutateAsync).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({ square_feet: 900 }),
+				}),
+			);
+		});
+	});
+});

--- a/src/components/properties/edit-unit-panel.tsx
+++ b/src/components/properties/edit-unit-panel.tsx
@@ -94,7 +94,10 @@ export function EditUnitPanel({
 						unit_number: value.unit_number,
 						bedrooms,
 						bathrooms,
-						square_feet: square_feet ?? undefined,
+						// Send the explicit null (not undefined) so clearing Square Feet
+						// persists — omitUndefined keeps null but strips undefined, which
+						// would silently drop the column and keep the old value (PROP-05).
+						square_feet,
 						rent_amount,
 						status: value.status,
 					},


### PR DESCRIPTION
Remediation from the adversarial v8.0 milestone audit (11 phase-auditors + cross-cutting integration pass). The audit confirmed **71 of 72 requirements genuinely fixed in merged main**; this PR closes the one partial requirement plus two real money-display bugs the integration pass surfaced.

## Fixes

- **PROP-05 (partial → complete):** the v8.0 sweep fixed the canonical unit form but missed `edit-unit-panel.tsx` — it sent `square_feet: value ?? undefined`, and since a cleared field is already `null`, `null ?? undefined === undefined`, which `omitUndefined` strips → clearing Square Feet silently kept the old value. Now sends the raw `null`. (Adversarially confirmed by the audit's verify pass.)
- **MONEY-01:** the properties-list "Monthly Revenue" column multiplied whole-dollar `units.rent_amount` by 100 "to cents" then rendered it with `formatCurrency`/`formatCompactCurrency` (dollar-valued) → **100× overstated** (a $1,500 unit showed $150,000 / $150K). Dropped the cents conversion.
- **MONEY-02:** same class on the tenant detail sheet — `currentLease.rentAmount = rent_amount * 100` rendered with `formatCurrency` → a $1,500 lease showed $150,000/mo. Dropped the conversion.

Both money bugs are pre-existing (Feb–May 2026), not v8.0 regressions, but are exactly the money-model consistency the milestone's dollars normalization (CRIT-01/BILL-06) targeted. `units`/`leases.rent_amount` are integer dollars in prod.

## Verification
- typecheck + biome clean · full unit suite green (**102,460 tests**, +6 new regression tests: 2 pure-function money transforms + 1 edit-panel component test).
- Sort-only consumers of these fields are unaffected (relative comparison).

## Audit result (context)
71/72 requirements PASS; migration drift PASS (zero live functions reference dropped `user_type`/`rent_due`); soft-delete/query-key-invalidation/deferred-items all PASS. DATA-04 is the one intentionally-deferred requirement (documented). No silently-dropped requirement IDs.

[hudsor01]