### PR TITLE
docs(planning): correct v8.0 requirement count (56 → 72)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -151,4 +151,4 @@ None scoped. This milestone is exhaustive over the 2026-07-02 hunt; any bug foun
 | MKT-01..05 | 34 — Marketing, Blog & SEO Surface |
 | MISC-01..04, TZ-01..03 | 35 — Timezone Sweep, Bulk-Import, Scripts & Hygiene |
 
-All 56 requirements mapped to exactly one phase ✓
+All 72 requirements mapped to exactly one phase ✓ (73 IDs defined; DATA-04, discovered in the Phase 30 review, is intentionally deferred and unmapped.)


### PR DESCRIPTION
Trivial planning-doc fix from the v8.0 milestone audit: the REQUIREMENTS.md traceability footer said "All 56 requirements mapped" but the table maps **72** requirements to phases (73 distinct IDs; DATA-04 is intentionally deferred and unmapped). No code change.

[hudsor01]