### PR TITLE
fix(v9.0 phase 39): data layer & cache integrity (DATA-01..18)

### DIFF
--- a/src/app/(admin)/admin/blog/page.tsx
+++ b/src/app/(admin)/admin/blog/page.tsx
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import type { Metadata } from "next";
 import {
 	BLOG_REVIEW_COLUMNS,
+	BLOG_REVIEW_QUEUE_LIMIT,
 	type BlogReviewItem,
 	mapBlogReviewRow,
 } from "#hooks/api/query-keys/blog-keys";
@@ -21,7 +22,8 @@ export default async function AdminBlogReviewPage() {
 		.from("blogs")
 		.select(BLOG_REVIEW_COLUMNS)
 		.eq("status", "in-review")
-		.order("created_at", { ascending: false });
+		.order("created_at", { ascending: false })
+		.limit(BLOG_REVIEW_QUEUE_LIMIT);
 
 	if (error) {
 		Sentry.captureException(error, { tags: { page: "admin-blog-review" } });

--- a/src/hooks/api/__tests__/property-mutations.test.tsx
+++ b/src/hooks/api/__tests__/property-mutations.test.tsx
@@ -397,16 +397,18 @@ describe("usePropertyImages", () => {
 
 		const mockSelect = vi.fn().mockReturnValue({
 			eq: vi.fn().mockReturnValue({
-				order: vi.fn().mockResolvedValue({
-					data: [
-						{
-							id: "img-1",
-							property_id: "prop-123",
-							image_url: "http://example.com/img.jpg",
-							display_order: 0,
-						},
-					],
-					error: null,
+				order: vi.fn().mockReturnValue({
+					limit: vi.fn().mockResolvedValue({
+						data: [
+							{
+								id: "img-1",
+								property_id: "prop-123",
+								image_url: "http://example.com/img.jpg",
+								display_order: 0,
+							},
+						],
+						error: null,
+					}),
 				}),
 			}),
 		});

--- a/src/hooks/api/__tests__/use-inspection-mutations.test.tsx
+++ b/src/hooks/api/__tests__/use-inspection-mutations.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Inspection Mutation Hooks Tests
+ *
+ * DATA-01: useUpdateInspection must INVALIDATE the enriched detail cache
+ * (rooms + signed photo URLs) rather than overwrite it with the bare updated
+ * row via updateDetail. This asserts the detail key is invalidated so a
+ * regression re-adding updateDetail (collapsing the Rooms section) fails here.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryChain } from "#test/mocks/supabase-query-mock";
+import { inspectionQueries } from "../query-keys/inspection-keys";
+import { useUpdateInspection } from "../use-inspection-mutations";
+
+vi.mock("#lib/frontend-logger", () => ({
+	logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+	createLogger: () => ({
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	}),
+}));
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@sentry/nextjs", () => ({
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
+	addBreadcrumb: vi.fn(),
+}));
+
+const supabaseFromMock = vi.fn();
+vi.mock("#lib/supabase/client", () => ({
+	createClient: () => ({ from: supabaseFromMock }),
+}));
+
+const mockInspection = {
+	id: "insp-123",
+	inspection_type: "move_in",
+	status: "completed",
+	property_id: "prop-1",
+	scheduled_date: "2026-01-01",
+};
+
+function createSpyWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+	function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	}
+	return { Wrapper, invalidateSpy };
+}
+
+describe("useUpdateInspection", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		supabaseFromMock.mockImplementation(() =>
+			createQueryChain({ data: mockInspection }),
+		);
+	});
+
+	it("invalidates the enriched detail key on update (DATA-01)", async () => {
+		const { Wrapper, invalidateSpy } = createSpyWrapper();
+		const { result } = renderHook(() => useUpdateInspection("insp-123"), {
+			wrapper: Wrapper,
+		});
+
+		await result.current.mutateAsync({ status: "completed" });
+
+		const invalidatedKeys = invalidateSpy.mock.calls.map((c) =>
+			JSON.stringify((c[0] as { queryKey?: unknown })?.queryKey),
+		);
+		expect(invalidatedKeys).toContain(
+			JSON.stringify(inspectionQueries.detailQuery("insp-123").queryKey),
+		);
+	});
+});

--- a/src/hooks/api/__tests__/use-lease.test.tsx
+++ b/src/hooks/api/__tests__/use-lease.test.tsx
@@ -29,6 +29,8 @@ import { createQueryChain } from "#test/mocks/supabase-query-mock";
 import type { Lease, Property } from "#types/core";
 import { leaseQueries } from "../query-keys/lease-keys";
 import { ownerDashboardKeys } from "../query-keys/owner-dashboard-keys";
+import { tenantQueries } from "../query-keys/tenant-keys";
+import { unitQueries } from "../query-keys/unit-keys";
 import {
 	useExpiringLeases,
 	useLease,
@@ -135,6 +137,32 @@ function createWrapper() {
 			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 		);
 	};
+}
+
+// Exposes a spy on the client's invalidateQueries so a mutation's cache-key
+// targeting can be asserted (DATA-02/06/18).
+function createSpyWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+	function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	}
+	return { Wrapper, invalidateSpy };
+}
+
+function invalidatedKeys(spy: {
+	mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };
+}): string[] {
+	return spy.mock.calls.map((c) =>
+		JSON.stringify((c[0] as { queryKey?: unknown })?.queryKey),
+	);
 }
 
 // Set up global fetch mock before tests
@@ -618,6 +646,29 @@ describe("Mutation Hooks", () => {
 
 			expect(supabaseFromMock).toHaveBeenCalledWith("leases");
 		});
+
+		it("invalidates the lease detail key on update (DATA-06)", async () => {
+			supabaseFromMock.mockImplementation((table: string) =>
+				createQueryChain({
+					data: table === "leases" ? { ...mockLease, rent_amount: 1600 } : null,
+				}),
+			);
+			const { Wrapper, invalidateSpy } = createSpyWrapper();
+			const { result } = renderHook(() => useUpdateLeaseMutation(), {
+				wrapper: Wrapper,
+			});
+
+			await result.current.mutateAsync({
+				id: "lease-123",
+				data: { rent_amount: 1600 },
+			});
+
+			// The detail page reads the embed-carrying leaseQueries.detail(id); it
+			// must be invalidated so the units/properties embeds refetch.
+			expect(invalidatedKeys(invalidateSpy)).toContain(
+				JSON.stringify(leaseQueries.detail("lease-123").queryKey),
+			);
+		});
 	});
 
 	describe("useDeleteLeaseMutation", () => {
@@ -672,6 +723,36 @@ describe("Mutation Hooks", () => {
 			});
 
 			expect(supabaseFromMock).toHaveBeenCalledWith("leases");
+		});
+
+		it("invalidates detail + tenant/unit views on renew (DATA-02/18)", async () => {
+			supabaseFromMock.mockImplementation((table: string) =>
+				createQueryChain({
+					data:
+						table === "leases"
+							? { ...mockLease, end_date: "2026-01-01" }
+							: null,
+				}),
+			);
+			const { Wrapper, invalidateSpy } = createSpyWrapper();
+			const { result } = renderHook(() => useRenewLeaseMutation(), {
+				wrapper: Wrapper,
+			});
+
+			await result.current.mutateAsync({
+				id: "lease-123",
+				data: { end_date: "2026-01-01" },
+			});
+
+			// Renew flips lease_status→active (unit may flip occupied via trigger)
+			// and changes end_date/rent embedded in tenant list rows: detail, tenant
+			// lists, and unit queries must all be invalidated.
+			const keys = invalidatedKeys(invalidateSpy);
+			expect(keys).toContain(
+				JSON.stringify(leaseQueries.detail("lease-123").queryKey),
+			);
+			expect(keys).toContain(JSON.stringify(tenantQueries.lists()));
+			expect(keys).toContain(JSON.stringify(unitQueries.all()));
 		});
 	});
 

--- a/src/hooks/api/__tests__/use-properties.test.tsx
+++ b/src/hooks/api/__tests__/use-properties.test.tsx
@@ -16,7 +16,6 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createQueryChain } from "#test/mocks/supabase-query-mock";
 import {
-	usePropertiesWithUnits,
 	useProperty,
 	usePropertyImages,
 	usePropertyList,
@@ -63,11 +62,10 @@ const {
 	mockFrom,
 	mockSelect,
 	mockEq,
-	mockNeq,
 	mockOrder,
+	mockLimit,
 	mockSingle,
 	mockUpdate,
-	mockHead,
 	mockGetUser,
 	mockRpc,
 	mockStorageFrom,
@@ -76,11 +74,10 @@ const {
 	mockFrom: vi.fn(),
 	mockSelect: vi.fn(),
 	mockEq: vi.fn(),
-	mockNeq: vi.fn(),
 	mockOrder: vi.fn(),
+	mockLimit: vi.fn(),
 	mockSingle: vi.fn(),
 	mockUpdate: vi.fn(),
-	mockHead: vi.fn(),
 	mockGetUser: vi.fn(),
 	mockRpc: vi.fn(),
 	mockStorageFrom: vi.fn(),
@@ -211,41 +208,15 @@ describe("Query Hooks", () => {
 		});
 	});
 
-	describe("usePropertiesWithUnits", () => {
-		it("should query properties with units using supabase.from", async () => {
-			const propertyWithUnits = { ...mockProperty, units: [] };
-			mockFrom.mockReturnValue(
-				createQueryChain({ data: [propertyWithUnits], error: null }),
-			);
-
-			const { result } = renderHook(() => usePropertiesWithUnits(), {
-				wrapper: createWrapper(),
-			});
-
-			await waitFor(() => {
-				expect(result.current.isSuccess || result.current.isError).toBe(true);
-			});
-
-			expect(mockFrom).toHaveBeenCalledWith("properties");
-		});
-	});
-
 	describe("usePropertyStats", () => {
-		it("should aggregate stats from multiple PostgREST queries", async () => {
-			// Stats uses three parallel queries to: properties (active), properties (total), units (occupied)
-			const headResult = { data: null, error: null, count: 5 };
-			mockHead.mockResolvedValue(headResult);
-
-			const chain: Record<string, ReturnType<typeof vi.fn>> = {};
-			chain.select = mockSelect;
-			chain.eq = mockEq;
-			chain.neq = mockNeq;
-
-			mockSelect.mockReturnValue(chain);
-			mockEq.mockResolvedValue(headResult);
-			mockNeq.mockResolvedValue(headResult);
-
-			mockFrom.mockReturnValue({ select: mockSelect });
+		it("should aggregate stats from two property-denominated PostgREST queries", async () => {
+			// Stats now runs TWO parallel property-denominated HEAD counts, both on
+			// `properties`:
+			//   total    = .neq('status','inactive')
+			//   occupied = .neq('status','inactive').eq('units.status','occupied')
+			//              via the units!inner join (parent-row count)
+			const chain = createQueryChain({ data: null, error: null, count: 5 });
+			mockFrom.mockReturnValue(chain);
 
 			const { result } = renderHook(() => usePropertyStats(), {
 				wrapper: createWrapper(),
@@ -256,6 +227,8 @@ describe("Query Hooks", () => {
 			});
 
 			expect(mockFrom).toHaveBeenCalledWith("properties");
+			expect(chain.neq).toHaveBeenCalledWith("status", "inactive");
+			expect(chain.eq).toHaveBeenCalledWith("units.status", "occupied");
 		});
 	});
 });
@@ -340,10 +313,12 @@ describe("Utility Hooks", () => {
 			const imageChain: Record<string, ReturnType<typeof vi.fn>> = {};
 			imageChain.eq = mockEq;
 			imageChain.order = mockOrder;
+			imageChain.limit = mockLimit;
 
 			mockSelect.mockReturnValue(imageChain);
 			mockEq.mockReturnValue({ order: mockOrder });
-			mockOrder.mockResolvedValue({
+			mockOrder.mockReturnValue({ limit: mockLimit });
+			mockLimit.mockResolvedValue({
 				data: [
 					{
 						id: "img-1",

--- a/src/hooks/api/__tests__/use-tenant.test.tsx
+++ b/src/hooks/api/__tests__/use-tenant.test.tsx
@@ -109,6 +109,33 @@ function createWrapper() {
 	};
 }
 
+// Like createWrapper but exposes spies on the client's invalidate/remove so a
+// mutation's cache-key targeting can be asserted (DATA-03).
+function createSpyWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false },
+			mutations: { retry: false },
+		},
+	});
+	const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+	const removeSpy = vi.spyOn(queryClient, "removeQueries");
+	function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	}
+	return { Wrapper, invalidateSpy, removeSpy };
+}
+
+function invalidatedKeys(spy: {
+	mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };
+}): string[] {
+	return spy.mock.calls.map((c) =>
+		JSON.stringify((c[0] as { queryKey?: unknown })?.queryKey),
+	);
+}
+
 // Sample tenant data matching DB schema. `status` is NOT NULL on the
 // tenants row and is now field-validated at the create/update boundary by
 // mapTenantBaseRow (TYPE-02), so the fixture must carry a valid status.
@@ -395,6 +422,28 @@ describe("Mutation Hooks", () => {
 				expect.objectContaining({ identity_verified: true }),
 			);
 		});
+
+		it("invalidates the withLease detail key on update (DATA-03)", async () => {
+			const { Wrapper, invalidateSpy } = createSpyWrapper();
+			const { result } = renderHook(() => useUpdateTenantMutation(), {
+				wrapper: Wrapper,
+			});
+
+			await result.current.mutateAsync({
+				id: "tenant-123",
+				data: { identity_verified: true },
+			});
+
+			// The tenant detail page reads tenantQueries.withLease(id); it must be
+			// invalidated (alongside detail(id)) or edits stay stale for 5 minutes.
+			const keys = invalidatedKeys(invalidateSpy);
+			expect(keys).toContain(
+				JSON.stringify(tenantQueries.withLease("tenant-123").queryKey),
+			);
+			expect(keys).toContain(
+				JSON.stringify(tenantQueries.detail("tenant-123").queryKey),
+			);
+		});
 	});
 
 	describe("useDeleteTenantMutation", () => {
@@ -432,6 +481,46 @@ describe("Mutation Hooks", () => {
 			expect(supabaseFromMock).toHaveBeenCalledWith("tenants");
 			expect(tenantsUpdateMock).toHaveBeenCalledWith(
 				expect.objectContaining({ status: "inactive" }),
+			);
+		});
+
+		it("removes the detail and withLease keys on delete (DATA-03)", async () => {
+			supabaseFromMock.mockImplementation((table: string) => {
+				if (table === "tenants") {
+					return {
+						update: vi.fn().mockReturnValue({
+							eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+						}),
+					};
+				}
+				if (table === "lease_tenants") {
+					return {
+						select: vi.fn().mockReturnValue({
+							eq: vi.fn().mockReturnValue({
+								eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+							}),
+						}),
+					};
+				}
+				return createQueryChain({ data: null });
+			});
+
+			const { Wrapper, removeSpy } = createSpyWrapper();
+			const { result } = renderHook(() => useDeleteTenantMutation(), {
+				wrapper: Wrapper,
+			});
+
+			await result.current.mutateAsync("tenant-123");
+
+			// Soft-delete: the withLease queryFn fetches by id with no status
+			// filter, so the entries must be REMOVED (not invalidated) or the
+			// deleted tenant re-populates its detail caches.
+			const keys = invalidatedKeys(removeSpy);
+			expect(keys).toContain(
+				JSON.stringify(tenantQueries.detail("tenant-123").queryKey),
+			);
+			expect(keys).toContain(
+				JSON.stringify(tenantQueries.withLease("tenant-123").queryKey),
 			);
 		});
 

--- a/src/hooks/api/query-keys/blog-keys.ts
+++ b/src/hooks/api/query-keys/blog-keys.ts
@@ -86,6 +86,11 @@ const BLOG_DETAIL_COLUMNS =
 export const BLOG_REVIEW_COLUMNS =
 	"id, title, slug, content, excerpt, category, word_count, reading_time, created_at";
 
+// Bounds the admin review-queue fetch. Shared by reviewQueue() and the
+// /admin/blog server-side fetch so both paths render the same window and can
+// never silently truncate at PostgREST's max-rows ceiling.
+export const BLOG_REVIEW_QUEUE_LIMIT = 50;
+
 /**
  * Typed mapper at the PostgREST boundary for review-queue rows (CLAUDE.md: no
  * raw `as` casts). NOT NULL fields throw; nullable columns normalize to null.
@@ -174,7 +179,8 @@ export const blogQueries = {
 					.from("blogs")
 					.select(BLOG_REVIEW_COLUMNS)
 					.eq("status", "in-review")
-					.order("created_at", { ascending: false });
+					.order("created_at", { ascending: false })
+					.limit(BLOG_REVIEW_QUEUE_LIMIT);
 
 				if (error) handlePostgrestError(error, "blog review queue");
 

--- a/src/hooks/api/query-keys/document-category-keys.ts
+++ b/src/hooks/api/query-keys/document-category-keys.ts
@@ -21,6 +21,8 @@ import { mutationKeys } from "../mutation-keys";
 
 const LIST_STALE_TIME_MS = 5 * 60 * 1000; // 5 min — categories change rarely
 const LIST_GC_TIME_MS = 30 * 60 * 1000;
+// Generous cap: per-owner category counts are tiny (7 seeded defaults + customs).
+const CATEGORY_LIST_LIMIT = 100;
 
 export interface DocumentCategoryRow {
 	id: string;
@@ -110,7 +112,8 @@ export const documentCategoryQueries = {
 						"id, slug, label, sort_order, is_default, owner_user_id, created_at, updated_at",
 					)
 					.order("sort_order", { ascending: true })
-					.order("label", { ascending: true });
+					.order("label", { ascending: true })
+					.limit(CATEGORY_LIST_LIMIT);
 				if (error) handlePostgrestError(error, "document categories list");
 				return ((data ?? []) as Record<string, unknown>[]).map(
 					mapDocumentCategoryRow,

--- a/src/hooks/api/query-keys/expense-keys.ts
+++ b/src/hooks/api/query-keys/expense-keys.ts
@@ -156,15 +156,13 @@ export const expenseQueries = {
 			] as const,
 			queryFn: async (): Promise<PaginatedExpenses> => {
 				const supabase = createClient();
-				const isPaginated =
-					options?.limit !== undefined && options?.offset !== undefined;
 
-				// `count: 'exact'` runs a separate COUNT(*) on every fetch — only
-				// pay for it when the caller actually consumes `total` (paginated
-				// mode). Legacy useExpenses() discards `total` via select(); no count.
+				// Always request the exact count so `total` is the true row count on
+				// every path (CLAUDE.md: use `count`, never `data.length`). This is
+				// the same unconditional COUNT(*) every other list factory pays.
 				let q = supabase
 					.from("expenses")
-					.select(EXPENSE_SELECT, isPaginated ? { count: "exact" } : undefined)
+					.select(EXPENSE_SELECT, { count: "exact" })
 					.neq("status", "inactive")
 					.order("expense_date", { ascending: false });
 
@@ -190,7 +188,7 @@ export const expenseQueries = {
 				if (error) handlePostgrestError(error, "expenses");
 				return {
 					data: (data ?? []) as Expense[],
-					total: count ?? data?.length ?? 0,
+					total: count ?? 0,
 				};
 			},
 			staleTime: 2 * 60 * 1000,

--- a/src/hooks/api/query-keys/inspection-keys.ts
+++ b/src/hooks/api/query-keys/inspection-keys.ts
@@ -22,6 +22,9 @@ import {
 const INSPECTION_SELECT_COLUMNS =
 	"id, lease_id, property_id, unit_id, owner_user_id, inspection_type, status, scheduled_date, completed_at, tenant_reviewed_at, tenant_signature_data, overall_condition, owner_notes, tenant_notes, created_at, updated_at";
 
+// Display cap for the live inspections list (mirrors document-keys' LIST_DISPLAY_LIMIT).
+const INSPECTION_LIST_LIMIT = 100;
+
 const INSPECTION_DETAIL_SELECT =
 	"id, lease_id, property_id, unit_id, owner_user_id, inspection_type, status, scheduled_date, completed_at, tenant_reviewed_at, tenant_signature_data, overall_condition, owner_notes, tenant_notes, created_at, updated_at, inspection_rooms(id, inspection_id, room_name, room_type, condition_rating, notes, created_at, updated_at, inspection_photos(id, inspection_room_id, inspection_id, storage_path, file_name, file_size, mime_type, caption, uploaded_by, created_at))";
 
@@ -45,9 +48,9 @@ export const inspectionQueries = {
 					.from("inspections")
 					.select(
 						`${INSPECTION_SELECT_COLUMNS}, properties(name, address_line1), units(unit_number), inspection_rooms(id)`,
-						{ count: "exact" },
 					)
-					.order("created_at", { ascending: false });
+					.order("created_at", { ascending: false })
+					.limit(INSPECTION_LIST_LIMIT);
 
 				if (error) handlePostgrestError(error, "inspections");
 
@@ -91,7 +94,8 @@ export const inspectionQueries = {
 					.from("inspections")
 					.select(INSPECTION_SELECT_COLUMNS)
 					.eq("lease_id", leaseId)
-					.order("created_at", { ascending: true });
+					.order("created_at", { ascending: true })
+					.limit(50);
 
 				if (error) handlePostgrestError(error, "inspections");
 

--- a/src/hooks/api/query-keys/lease-keys.ts
+++ b/src/hooks/api/query-keys/lease-keys.ts
@@ -13,11 +13,9 @@ import type { Lease, LeaseStatsResponse } from "#types/core";
 import { revenueTrendsQuery } from "./analytics-keys";
 
 export interface LeaseFilters {
-	property_id?: string;
 	unit_id?: string;
 	tenant_id?: string;
 	status?: string;
-	search?: string;
 	limit?: number;
 	offset?: number;
 }

--- a/src/hooks/api/query-keys/maintenance-keys.ts
+++ b/src/hooks/api/query-keys/maintenance-keys.ts
@@ -63,70 +63,45 @@ export const maintenanceQueries = {
 				const limit = filters?.limit ?? 50;
 				const offset = filters?.offset ?? 0;
 
-				let data: MaintenanceRequest[] | null;
-				let error: {
-					message: string;
-					code: string;
-					details: string;
-					hint: string;
-				} | null;
-				let count: number | null;
+				// Single builder so EVERY filter applies on EVERY path. When
+				// filtering by property_id we join through units (`units!inner`);
+				// mapMaintenanceRow reads only the maintenance_requests columns, so
+				// the embed is ignored and each row is field-validated at the boundary.
+				// The select string is widened to `string` (runtime-conditional) so the
+				// client returns a generic row shape mapped at the boundary.
+				const selectColumns: string = filters?.property_id
+					? `${MAINTENANCE_SELECT_COLUMNS}, units!inner(property_id)`
+					: MAINTENANCE_SELECT_COLUMNS;
 
-				if (filters?.property_id) {
-					// Join through units when filtering by property_id.
-					// PostgREST `units!inner(property_id)` filter adds a `units`
-					// embed to each row -- mapMaintenanceRow reads only the
-					// maintenance_requests columns, so the embed is ignored and
-					// each row is field-validated at the boundary.
-					const result = await supabase
-						.from("maintenance_requests")
-						.select(
-							"id, owner_user_id, unit_id, tenant_id, title, description, priority, status, vendor_id, requested_by, assigned_to, estimated_cost, actual_cost, scheduled_date, completed_at, inspection_date, inspection_findings, inspector_id, created_at, updated_at, units!inner(property_id)",
-							{ count: "exact" },
-						)
-						.eq("units.property_id", filters.property_id)
-						.order("created_at", { ascending: false })
-						.range(offset, offset + limit - 1);
-					data = (result.data ?? []).map(mapMaintenanceRow);
-					error = result.error;
-					count = result.count;
-				} else {
-					let q = supabase
-						.from("maintenance_requests")
-						.select(MAINTENANCE_SELECT_COLUMNS, { count: "exact" })
-						.order("created_at", { ascending: false });
+				let q = supabase
+					.from("maintenance_requests")
+					.select(selectColumns, { count: "exact" })
+					.order("created_at", { ascending: false });
 
-					if (filters?.unit_id) {
-						q = q.eq("unit_id", filters.unit_id);
-					}
-					if (filters?.priority) {
-						q = q.eq("priority", filters.priority);
-					}
-					if (filters?.status) {
-						q = q.eq("status", filters.status);
-					}
+				if (filters?.property_id)
+					q = q.eq("units.property_id", filters.property_id);
+				if (filters?.unit_id) q = q.eq("unit_id", filters.unit_id);
+				if (filters?.priority) q = q.eq("priority", filters.priority);
+				if (filters?.status) q = q.eq("status", filters.status);
 
-					q = q.range(offset, offset + limit - 1);
+				q = q.range(offset, offset + limit - 1);
 
-					const result = await q;
-					data = ((result.data ?? []) as Record<string, unknown>[]).map(
-						mapMaintenanceRow,
-					);
-					error = result.error;
-					count = result.count;
-				}
+				const { data: rows, error, count } = await q;
 
-				if (error)
-					handlePostgrestError(
-						error as Parameters<typeof handlePostgrestError>[0],
-						"maintenance_requests",
-					);
+				if (error) handlePostgrestError(error, "maintenance_requests");
+
+				// The widened `string` select yields an opaque row type; each row is
+				// validated field-by-field at the mapMaintenanceRow boundary.
+				const rawRows: unknown[] = rows ?? [];
+				const data = rawRows.map((row) =>
+					mapMaintenanceRow(row as Record<string, unknown>),
+				);
 
 				const total = count ?? 0;
 				const totalPages = Math.ceil(total / limit);
 
 				return {
-					data: data ?? [],
+					data,
 					total,
 					pagination: {
 						page: Math.floor(offset / limit) + 1,
@@ -290,7 +265,8 @@ export const maintenanceQueries = {
 					.select(MAINTENANCE_SELECT_COLUMNS)
 					.lt("scheduled_date", new Date().toISOString())
 					.not("status", "in", '("completed","cancelled")')
-					.order("scheduled_date", { ascending: true });
+					.order("scheduled_date", { ascending: true })
+					.limit(50);
 
 				if (error) handlePostgrestError(error, "maintenance_requests");
 

--- a/src/hooks/api/query-keys/property-keys.ts
+++ b/src/hooks/api/query-keys/property-keys.ts
@@ -86,24 +86,6 @@ export const propertyQueries = {
 			...QUERY_CACHE_TIMES.DETAIL,
 		}),
 
-	withUnits: () =>
-		queryOptions({
-			queryKey: [...propertyQueries.all(), "with-units"] as const,
-			queryFn: async (): Promise<Property[]> => {
-				const supabase = createClient();
-				const { data, error } = await supabase
-					.from("properties")
-					.select("*, units(*)")
-					.neq("status", "inactive")
-					.order("created_at", { ascending: false });
-
-				if (error) handlePostgrestError(error, "properties");
-
-				return (data as Property[]) ?? [];
-			},
-			...QUERY_CACHE_TIMES.DETAIL,
-		}),
-
 	details: () => [...propertyQueries.all(), "detail"] as const,
 
 	detail: (id: string) =>
@@ -169,9 +151,10 @@ export const propertyQueries = {
 				const supabase = createClient();
 				const { data, error } = await supabase
 					.from("property_images")
-					.select("*")
+					.select("id, property_id, image_url, display_order, created_at")
 					.eq("property_id", property_id)
-					.order("display_order", { ascending: true });
+					.order("display_order", { ascending: true })
+					.limit(50);
 
 				if (error) throw new Error(error.message);
 

--- a/src/hooks/api/query-keys/property-stats-keys.ts
+++ b/src/hooks/api/query-keys/property-stats-keys.ts
@@ -15,6 +15,10 @@ import type { Database } from "#types/supabase";
 import { occupancyTrendsQuery } from "./analytics-keys";
 import { propertyQueries } from "./property-keys";
 
+// Bounds the property performance list fetch (bounded-lists rule). Matches the
+// paired get_property_performance_with_trends RPC's p_limit of 100.
+const PROPERTY_PERFORMANCE_LIMIT = 100;
+
 /**
  * Extract RPC return type from generated Database types
  */
@@ -175,7 +179,8 @@ export const propertyStatsQueries = {
 						.from("properties")
 						.select(`id, name, address_line1, property_type, units(id, status)`)
 						.eq("owner_user_id", user.id)
-						.neq("status", "inactive"),
+						.neq("status", "inactive")
+						.limit(PROPERTY_PERFORMANCE_LIMIT),
 				]);
 
 				if (trendsResult.error)

--- a/src/hooks/api/query-keys/property-stats-keys.ts
+++ b/src/hooks/api/query-keys/property-stats-keys.ts
@@ -105,31 +105,30 @@ function getTimeframeDays(timeframe: string): number {
 
 export const propertyStatsQueries = {
 	/**
-	 * Property statistics
-	 * Aggregates active, total counts directly via PostgREST
+	 * Property statistics — all counts are PROPERTY-denominated so the derived
+	 * fields stay consistent (vacant = total - occupied ≥ 0, occupancyRate ≤ 100%):
+	 *  - total    = non-inactive properties
+	 *  - occupied = non-inactive properties with ≥1 occupied unit (the `units!inner`
+	 *    join counts parent rows; joining through already-status-filtered properties
+	 *    also excludes soft-deleted properties' units).
 	 */
 	stats: () =>
 		queryOptions({
 			queryKey: [...propertyQueries.all(), "stats"],
 			queryFn: async (): Promise<PropertyStats> => {
 				const supabase = createClient();
-				const [activeResult, totalResult, occupiedResult] = await Promise.all([
-					supabase
-						.from("properties")
-						.select("id", { count: "exact", head: true })
-						.eq("status", "active"),
+				const [totalResult, occupiedResult] = await Promise.all([
 					supabase
 						.from("properties")
 						.select("id", { count: "exact", head: true })
 						.neq("status", "inactive"),
 					supabase
-						.from("units")
-						.select("id", { count: "exact", head: true })
-						.eq("status", "occupied"),
+						.from("properties")
+						.select("id, units!inner(id)", { count: "exact", head: true })
+						.neq("status", "inactive")
+						.eq("units.status", "occupied"),
 				]);
 
-				if (activeResult.error)
-					handlePostgrestError(activeResult.error, "properties");
 				if (totalResult.error)
 					handlePostgrestError(totalResult.error, "properties");
 				if (occupiedResult.error)

--- a/src/hooks/api/query-keys/report-keys.ts
+++ b/src/hooks/api/query-keys/report-keys.ts
@@ -100,9 +100,12 @@ export const reportQueries = {
 				const supabase = createClient();
 				const { data, error } = await supabase
 					.from("report_runs")
-					.select("*")
+					.select(
+						"id, report_id, execution_status, file_path, file_size, execution_time_ms, error_message, started_at, completed_at, created_at",
+					)
 					.eq("report_id", reportId)
-					.order("created_at", { ascending: false });
+					.order("created_at", { ascending: false })
+					.limit(50);
 
 				if (error) handlePostgrestError(error, "report runs");
 				return data ?? [];

--- a/src/hooks/api/query-keys/unit-keys.ts
+++ b/src/hooks/api/query-keys/unit-keys.ts
@@ -38,6 +38,10 @@ export interface UnitFilters {
 const UNIT_SELECT_COLUMNS =
 	"id, property_id, owner_user_id, unit_number, bedrooms, bathrooms, square_feet, rent_amount, rent_currency, rent_period, status, created_at, updated_at";
 
+// Per-property unit bound: comfortably exceeds any realistic single-property
+// unit count while staying under the PostgREST 1000-row ceiling.
+const UNITS_BY_PROPERTY_LIMIT = 500;
+
 /**
  * Unit query factory
  */
@@ -114,7 +118,8 @@ export const unitQueries = {
 					.select(UNIT_SELECT_COLUMNS)
 					.eq("property_id", property_id)
 					.neq("status", "inactive")
-					.order("unit_number", { ascending: true });
+					.order("unit_number", { ascending: true })
+					.limit(UNITS_BY_PROPERTY_LIMIT);
 
 				if (error) handlePostgrestError(error, "units");
 
@@ -162,7 +167,8 @@ export const unitQueries = {
 					.select(UNIT_SELECT_COLUMNS)
 					.eq("property_id", property_id)
 					.neq("status", "inactive")
-					.order("unit_number", { ascending: true });
+					.order("unit_number", { ascending: true })
+					.limit(UNITS_BY_PROPERTY_LIMIT);
 
 				if (error) handlePostgrestError(error, "units");
 

--- a/src/hooks/api/use-inspection-mutations.ts
+++ b/src/hooks/api/use-inspection-mutations.ts
@@ -39,11 +39,14 @@ export function useUpdateInspection(id: string) {
 	return useMutation({
 		...inspectionMutations.update(id),
 		...createMutationCallbacks(queryClient, {
-			invalidate: [inspectionQueries.lists()],
-			updateDetail: (updated) => ({
-				queryKey: inspectionQueries.detailQuery(id).queryKey,
-				data: updated,
-			}),
+			// The update mutationFn returns a bare row (no enriched `rooms`), so it
+			// must NOT be written into the detail cache via updateDetail (superset
+			// rule). Invalidate the detail key so detailQuery refetches the enriched
+			// shape (rooms + signed photo URLs) instead — matches complete/submit.
+			invalidate: [
+				inspectionQueries.detailQuery(id).queryKey,
+				inspectionQueries.lists(),
+			],
 			successMessage: "Inspection updated",
 			errorContext: "Update inspection",
 			broadcastSuccess: true,

--- a/src/hooks/api/use-lease-lifecycle-mutations.ts
+++ b/src/hooks/api/use-lease-lifecycle-mutations.ts
@@ -47,12 +47,22 @@ export function useRenewLeaseMutation() {
 
 	return useMutation({
 		...leaseMutations.renew(),
-		...createMutationCallbacks<Lease>(queryClient, {
-			invalidate: [leaseQueries.lists(), ownerDashboardKeys.all],
-			updateDetail: (lease) => ({
-				queryKey: leaseQueries.detail(lease.id).queryKey,
-				data: lease,
-			}),
+		...createMutationCallbacks<
+			Lease,
+			{ id: string; data: { end_date: string; rent_amount?: number } }
+		>(queryClient, {
+			// renew() returns a bare row (no units/tenants embeds), so it must NOT
+			// be written into the detail cache (superset rule). Invalidate the detail
+			// key so it refetches the embed-carrying shape. Renewing also flips
+			// lease_status to 'active' (unit status via trigger) and changes
+			// end_date/rent_amount embedded in tenant list rows — invalidate those too.
+			invalidate: ({ id }) => [
+				leaseQueries.lists(),
+				leaseQueries.detail(id).queryKey,
+				tenantQueries.lists(),
+				unitQueries.all(),
+				ownerDashboardKeys.all,
+			],
 			successMessage: "Lease renewed successfully",
 			errorContext: "Renew lease",
 		}),

--- a/src/hooks/api/use-lease-mutations.ts
+++ b/src/hooks/api/use-lease-mutations.ts
@@ -12,6 +12,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createMutationCallbacks } from "#hooks/create-mutation-callbacks";
 import { logger } from "#lib/frontend-logger";
+import type { LeaseUpdate } from "#lib/validation/leases";
 import type { Lease } from "#types/core";
 import { leaseQueries } from "./query-keys/lease-keys";
 import { leaseMutations } from "./query-keys/lease-mutation-options";
@@ -149,20 +150,23 @@ export function useUpdateLeaseMutation() {
 
 	return useMutation({
 		...leaseMutations.update(),
-		...createMutationCallbacks<Lease>(queryClient, {
-			invalidate: [
-				leaseQueries.lists(),
-				tenantQueries.lists(),
-				unitQueries.all(),
-				ownerDashboardKeys.all,
-			],
-			updateDetail: (lease) => ({
-				queryKey: leaseQueries.detail(lease.id).queryKey,
-				data: lease,
-			}),
-			successMessage: "Lease updated successfully",
-			errorContext: "Update lease",
-		}),
+		...createMutationCallbacks<Lease, { id: string; data: LeaseUpdate }>(
+			queryClient,
+			{
+				// update() returns a bare row (no units/tenants embeds), so it must
+				// NOT be written into the detail cache (superset rule). Invalidate the
+				// detail key so it refetches the embed-carrying shape.
+				invalidate: ({ id }) => [
+					leaseQueries.lists(),
+					leaseQueries.detail(id).queryKey,
+					tenantQueries.lists(),
+					unitQueries.all(),
+					ownerDashboardKeys.all,
+				],
+				successMessage: "Lease updated successfully",
+				errorContext: "Update lease",
+			},
+		),
 	});
 }
 
@@ -182,8 +186,9 @@ export function useDeleteLeaseMutation() {
 				unitQueries.all(),
 				ownerDashboardKeys.all,
 			],
-			removeDetail: (_data, deletedId) =>
+			removeDetail: (_data, deletedId) => [
 				leaseQueries.detail(deletedId).queryKey,
+			],
 			successMessage: "Lease deleted successfully",
 			errorContext: "Delete lease",
 		}),

--- a/src/hooks/api/use-lease.ts
+++ b/src/hooks/api/use-lease.ts
@@ -1,9 +1,4 @@
-import {
-	usePrefetchQuery,
-	useQuery,
-	useQueryClient,
-} from "@tanstack/react-query";
-import { useEffect } from "react";
+import { usePrefetchQuery, useQuery } from "@tanstack/react-query";
 import { useEntityDetail } from "#hooks/use-entity-detail";
 import type { Lease } from "#types/core";
 import { leaseQueries } from "./query-keys/lease-keys";
@@ -19,34 +14,24 @@ export function useLease(id: string) {
 
 export function useLeaseList(params?: {
 	status?: string;
-	search?: string;
 	limit?: number;
 	offset?: number;
 }) {
-	const { status, search, limit = 50, offset = 0 } = params || {};
-	const queryClient = useQueryClient();
+	const { status, limit = 50, offset = 0 } = params || {};
 
-	const listQuery = leaseQueries.list({
-		...(status && { status }),
-		...(search && { search }),
-		limit,
-		offset,
-	});
-
-	const query = useQuery({
-		...listQuery,
+	// No list->detail seeding: the list row shape (aliased embeds) is NOT a
+	// superset of the detail queryFn shape, so seeding it fresh via setQueryData
+	// poisons the detail cache. useLease() already gets instant paint via
+	// useEntityDetail's list-cache placeholderData (which does NOT mark fresh),
+	// so the real detail queryFn still fetches the embed-carrying shape.
+	return useQuery({
+		...leaseQueries.list({
+			...(status && { status }),
+			limit,
+			offset,
+		}),
 		structuralSharing: true,
 	});
-
-	useEffect(() => {
-		if (query.data?.data) {
-			for (const lease of query.data.data) {
-				queryClient.setQueryData(leaseQueries.detail(lease.id).queryKey, lease);
-			}
-		}
-	}, [query.data, queryClient]);
-
-	return query;
 }
 
 export function useExpiringLeases(daysUntilExpiry: number = 30) {

--- a/src/hooks/api/use-properties.ts
+++ b/src/hooks/api/use-properties.ts
@@ -59,10 +59,6 @@ export function usePropertyList(params?: {
 	});
 }
 
-export function usePropertiesWithUnits() {
-	return useQuery(propertyQueries.withUnits());
-}
-
 export function usePropertyStats() {
 	return useQuery(propertyStatsQueries.stats());
 }

--- a/src/hooks/api/use-property-mutations.ts
+++ b/src/hooks/api/use-property-mutations.ts
@@ -139,8 +139,9 @@ export function useDeletePropertyMutation() {
 				unitQueries.lists(),
 				ownerDashboardKeys.all,
 			],
-			removeDetail: (_data, deletedId) =>
+			removeDetail: (_data, deletedId) => [
 				propertyQueries.detail(deletedId).queryKey,
+			],
 			successMessage: "Property deleted successfully",
 			errorContext: "Delete property",
 		}),

--- a/src/hooks/api/use-tenant-mutations.ts
+++ b/src/hooks/api/use-tenant-mutations.ts
@@ -11,6 +11,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createMutationCallbacks } from "#hooks/create-mutation-callbacks";
 import { handleMutationSuccess } from "#lib/mutation-error-handler";
 import { incrementVersion } from "#lib/utils/optimistic-locking";
+import type { TenantUpdate } from "#lib/validation/tenants";
 import type {
 	Tenant,
 	TenantWithLeaseInfo,
@@ -43,15 +44,23 @@ export function useUpdateTenantMutation() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		...tenantMutations.update(),
-		...createMutationCallbacks<TenantWithLeaseInfo>(queryClient, {
-			invalidate: [tenantQueries.lists(), ownerDashboardKeys.all],
-			updateDetail: (tenant) => ({
-				queryKey: tenantQueries.detail(tenant.id).queryKey,
-				data: tenant,
-			}),
-			successMessage: "Tenant updated successfully",
-			errorContext: "Update tenant",
-		}),
+		...createMutationCallbacks<Tenant, { id: string; data: TenantUpdate }>(
+			queryClient,
+			{
+				// update() returns a base Tenant (no lease embed), so it must NOT be
+				// written into the enriched detail/withLease caches (superset rule).
+				// The tenant detail page reads withLease(id) — invalidate both keys so
+				// saved edits refetch through the lease-carrying queryFn.
+				invalidate: ({ id }) => [
+					tenantQueries.lists(),
+					tenantQueries.detail(id).queryKey,
+					tenantQueries.withLease(id).queryKey,
+					ownerDashboardKeys.all,
+				],
+				successMessage: "Tenant updated successfully",
+				errorContext: "Update tenant",
+			},
+		),
 	});
 }
 
@@ -69,8 +78,10 @@ export function useDeleteTenantMutation() {
 				leaseQueries.lists(),
 				ownerDashboardKeys.all,
 			],
-			removeDetail: (_data, deletedId) =>
+			removeDetail: (_data, deletedId) => [
 				tenantQueries.detail(deletedId).queryKey,
+				tenantQueries.withLease(deletedId).queryKey,
+			],
 			successMessage: "Tenant deleted successfully",
 			errorContext: "Delete tenant",
 		}),

--- a/src/hooks/api/use-unit.ts
+++ b/src/hooks/api/use-unit.ts
@@ -131,8 +131,9 @@ export function useDeleteUnitMutation() {
 				leaseQueries.lists(),
 				ownerDashboardKeys.all,
 			],
-			removeDetail: (_data, deletedId) =>
+			removeDetail: (_data, deletedId) => [
 				unitQueries.detail(deletedId).queryKey,
+			],
 			successMessage: "Unit deleted successfully",
 			errorContext: "Delete unit",
 		}),

--- a/src/hooks/create-mutation-callbacks.test.ts
+++ b/src/hooks/create-mutation-callbacks.test.ts
@@ -105,20 +105,27 @@ describe("createMutationCallbacks", () => {
 			expect(qc.setQueryData).toHaveBeenCalledWith(["items", "42"], data);
 		});
 
-		it("onSuccess calls removeQueries when removeDetail config is provided", () => {
+		it("onSuccess calls removeQueries once per key when removeDetail returns an array of keys", () => {
 			const callbacks = createMutationCallbacks<
 				{ id: string },
 				{ deletedId: string }
 			>(qc, {
 				invalidate: [],
 				errorContext: "Test",
-				removeDetail: (_data, vars) => ["items", vars.deletedId],
+				removeDetail: (_data, vars) => [
+					["items", "detail", vars.deletedId],
+					["items", "with-lease", vars.deletedId],
+				],
 			});
 
 			callbacks.onSuccess({ id: "1" }, { deletedId: "99" });
 
+			expect(qc.removeQueries).toHaveBeenCalledTimes(2);
 			expect(qc.removeQueries).toHaveBeenCalledWith({
-				queryKey: ["items", "99"],
+				queryKey: ["items", "detail", "99"],
+			});
+			expect(qc.removeQueries).toHaveBeenCalledWith({
+				queryKey: ["items", "with-lease", "99"],
 			});
 		});
 

--- a/src/hooks/create-mutation-callbacks.ts
+++ b/src/hooks/create-mutation-callbacks.ts
@@ -45,10 +45,24 @@ export interface MutationCallbackConfig<
 	successMessage?: string;
 	/** Context for handleMutationError (e.g., "Create property") */
 	errorContext: string;
-	/** Tier 2: set detail cache on success */
+	/**
+	 * Tier 2: set detail cache on success.
+	 *
+	 * WARNING — superset rule: only use `updateDetail` when the mutation's
+	 * returned `data` is a SUPERSET of the target key's queryFn return shape.
+	 * `setQueryData` full-replaces the entry AND stamps it fresh, so writing a
+	 * bare row (e.g. a `.select().single()` with no embeds) over an enriched
+	 * detail cache silently drops the missing fields for the whole staleTime.
+	 * If the mutation returns a narrower shape than the detail queryFn, do NOT
+	 * use `updateDetail` — add the detail key to `invalidate` instead so the
+	 * queryFn refetches the full shape.
+	 */
 	updateDetail?: (data: TData) => { queryKey: readonly unknown[]; data: TData };
-	/** Remove detail cache entry on success (for deletes) */
-	removeDetail?: (data: TData, variables: TVariables) => readonly unknown[];
+	/** Remove detail cache entries on success (for deletes). Returns one or more keys. */
+	removeDetail?: (
+		data: TData,
+		variables: TVariables,
+	) => ReadonlyArray<readonly unknown[]>;
 	/** Custom callback after standard operations */
 	onSuccessExtra?: (data: TData) => void;
 	/** When true, use handleMutationSuccess (structured logging) instead of toast.success */
@@ -183,8 +197,10 @@ export function createMutationCallbacks<
 				queryClient.setQueryData(result.queryKey, result.data);
 			}
 			if (config.removeDetail) {
-				const queryKey = config.removeDetail(data, variables);
-				queryClient.removeQueries({ queryKey });
+				const keys = config.removeDetail(data, variables);
+				for (const queryKey of keys) {
+					queryClient.removeQueries({ queryKey });
+				}
 			}
 			invalidateAll(variables);
 			showSuccess();


### PR DESCRIPTION
## v9.0 Phase 39 — Data Layer & Cache Integrity

Fourth phase of the v9.0 Full-Surface Remediation milestone. Fixes all **18 adversarially-validated data-layer findings** (DATA-01..18) from the 2026-07-11 audit. Cleared the perfect-PR gate (two consecutive clean cycles).

### What was broken (and is now fixed)

**Mutations poisoned the detail cache (DATA-01/02/03/06/18)** — after editing a lease, renewing a lease, updating an inspection, or updating a tenant, the app wrote the bare mutation-return row directly over the *enriched* detail-query cache and stamped it fresh for 5 minutes. Result: the lease detail page showed a blank property/address block, the inspection Rooms section collapsed, and tenant edits didn't appear — for up to 5 minutes after a successful save. Root cause was a shape mismatch (bare row ⊄ the detail query's embedded shape). Now these mutations *invalidate* the correct detail key (so the embed-carrying query refetches) instead of overwriting it, tenant delete *removes* both the detail and `withLease` cache entries (a soft-delete would otherwise repopulate them), and lease renew invalidates the tenant/unit views its DB side-effects touch. A JSDoc "superset rule" now guards the pattern from regrowing.

**Unbounded list queries (DATA-04/07/08/09/13/14/15/16/17 + a grep-gate-missed sibling)** — nine list queries fetched with no `.limit()`/`.range()`, silently truncating at PostgREST's 1000-row ceiling (and, for the admin blog queue, shipping hundreds of multi-KB draft bodies per request). All now carry explicit named-constant bounds; the dead `withUnits()` factory + hook were deleted; `*` selects were enumerated. Review caught one more (`propertyStatsQueries.performance()`) that the implementer's own grep gate structurally couldn't find (it has no `.order()`) — now bounded too.

**Wrong/stale query results (DATA-05/10/11/12)** — property stats mixed unit and property denominators (producing >100% occupancy and negative vacancy); the expenses list reported `data.length` as the pagination total (capped at the page size); the leases and maintenance list filters advertised or forked filters they didn't fully apply, caching the wrong rows under the filtered key. All now count the same entity, use the real `count`, and apply every filter on every path.

### Verification
- `bun run typecheck` clean, `bun run lint` clean, **101,869 unit tests pass** (253 files). New spy-based regression tests assert the exact cache-key targeting for all four Tier-2 fixes (a revert dropping a key now fails a test); the unbounded-list sweep was verified with a directory-wide grep gate; the property-stats 2-query shape and expense-count fixes updated their existing tests.

### No owner-run steps
Phase 39 is entirely client-side query/hook code — no edge-function or migration changes.

Sequential-merge discipline: Phase 40 (Type Boundaries) does not branch until this PR is merged to `main`.

[hudsor01]
